### PR TITLE
fix: stop initiative.md from folding its title heading into the description

### DIFF
--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -243,8 +243,6 @@ icon: %q
 updated: %q
 ---
 
-# %s
-
 %s
 `,
 		i.initiative.ID,
@@ -259,7 +257,6 @@ updated: %q
 		projectsYAML,
 		i.initiative.CreatedAt.Format(time.RFC3339),
 		i.initiative.UpdatedAt.Format(time.RFC3339),
-		i.initiative.Name,
 		i.initiative.Description,
 	)
 	return []byte(content)

--- a/internal/fs/initiatives_test.go
+++ b/internal/fs/initiatives_test.go
@@ -1,9 +1,11 @@
 package fs
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/jra3/linear-fuse/internal/api"
+	"github.com/jra3/linear-fuse/internal/marshal"
 )
 
 // =============================================================================
@@ -60,6 +62,43 @@ func TestInitiativeUpdatesDirInoStability(t *testing.T) {
 
 	if ino1 == infoIno || ino1 == projectsIno {
 		t.Errorf("Updates inode collides with other inodes")
+	}
+}
+
+// =============================================================================
+// Content Round-Trip Tests
+// =============================================================================
+
+// TestInitiativeContentBodyRoundTripsDescription guards against the description
+// "heading fold" bug: generateContent() must emit the description as the bare
+// body — exactly like project.md — so Flush's body->description mapping is
+// idempotent. Previously the body carried a rendered "# <Name>" H1 heading that
+// Flush (comparing TrimSpace(body) against initiative.Description) folded into
+// the description on every write, doubling the heading with each save.
+func TestInitiativeContentBodyRoundTripsDescription(t *testing.T) {
+	node := &InitiativeInfoNode{
+		initiative: api.Initiative{
+			ID:          "init-1",
+			Name:        "Activate users in the webapp",
+			Description: "Increase webapp adoption to improve the feedback flywheel.",
+		},
+	}
+
+	doc, err := marshal.Parse(node.generateContent())
+	if err != nil {
+		t.Fatalf("parse generated initiative.md: %v", err)
+	}
+
+	// The body Flush would read back must equal the description it would write —
+	// i.e. a no-op save must not mutate the description.
+	if got := strings.TrimSpace(doc.Body); got != node.initiative.Description {
+		t.Fatalf("body does not round-trip to description:\n got: %q\nwant: %q", got, node.initiative.Description)
+	}
+
+	// The rendered name heading must not appear in the body; its presence is the
+	// signature of the fold bug (the title lives in the `name:` frontmatter).
+	if heading := "# " + node.initiative.Name; strings.Contains(doc.Body, heading) {
+		t.Fatalf("body contains rendered name heading %q; it would be folded into the description on write:\n%s", heading, doc.Body)
 	}
 }
 

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -238,7 +238,7 @@ Description body (editable)
 <initiative_frontmatter>
 ---
 id: 719a9756-326e-40cf-935d-38cf899a1f50   [read-only]
-name: "Platform Modernization"              [read-only]
+name: "Platform Modernization"              [editable]
 slug: 77d439e363bb                          [read-only]
 status: Active                              [read-only]
 projects:                                   [editable - project slugs]
@@ -253,9 +253,10 @@ targetDate: "2026-03-31"                    [read-only]
 created: "2026-01-24T22:15:26Z"             [read-only]
 updated: "2026-01-27T16:03:38Z"             [read-only]
 ---
-Initiative description (read-only)
+Initiative description (editable - the body maps to the description)
 
 Usage:
+- Edit name (frontmatter) and description (body); they sync to Linear
 - Edit projects: list to link/unlink projects (use project slugs)
 - Projects are resolved workspace-wide across all teams
 - Changes sync immediately to Linear API and SQLite cache


### PR DESCRIPTION
## Problem

`initiative.md`'s `generateContent()` rendered the body as `# <Name>\n\n<Description>`, but `Flush()` compared `strings.TrimSpace(doc.Body)` directly against `initiative.Description`. The rendered H1 never matched the stored description, so **every write folded `# <Name>\n\n` into the description**, and each subsequent render showed a *doubled* heading — compounding on each save.

Found while exercising the new fsync handling (#139) against the live mount: a single edit to a real initiative via the Claude Edit tool (write+fsync) produced a doubled `# <title>` heading.

`project.md` was immune — its body template is the bare description with no heading. It's the correct template.

## Fix

Drop the `# <Name>` heading from `initiative.go`'s `generateContent` (the title already lives in the `name:` frontmatter), making `initiative.md` symmetric with `project.md`. The body now round-trips to the description, so a no-op save leaves it unchanged.

## Test

`TestInitiativeContentBodyRoundTripsDescription` — deterministic, fixture-mode (no API): parses the generated content and asserts `TrimSpace(body) == Description` with no `# <Name>` heading in the body. Verified it **fails against the old `generateContent`** and **passes with the fix**.

Why a new test: the existing live test `TestClaudeToolEditPersistsInitiativeDescription` passed *despite* the bug — it only checked an appended marker survived, not that the heading wasn't folded in. A persistence test that asserts "my text is present" misses idempotency violations.

Verified live by editing + reverting a real initiative via write+fsync: 0 heading occurrences after edit (was 2 before), marker persisted, clean revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)