### PR TITLE
fix: support atomic save-via-rename and stop EIO on normalized writes (#145)

### DIFF
--- a/internal/fs/atomicwrite.go
+++ b/internal/fs/atomicwrite.go
@@ -1,0 +1,166 @@
+package fs
+
+import (
+	"context"
+	"hash/fnv"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
+)
+
+// Atomic save-via-rename support (#145).
+//
+// Editors and the Claude Code Edit/Write tools never write a file in place.
+// They create a sibling temp file (e.g. issue.md.tmp.<pid>.<rand>), write the
+// full new contents into it, then rename(2) it over the real file. LinearFS
+// can't materialize arbitrary persistent files inside an issue/project/initiative
+// directory, so go-fuse rejected the temp-file create with a misleading EROFS
+// ("read-only file system") even though the mount is rw — making the documented
+// "use your editor / Edit tool" path unusable.
+//
+// The fix: accept the temp-file create as an in-memory scratch buffer
+// (scratchFileNode), then have the directory's Rename handler route the buffered
+// bytes into the same write path a direct in-place write uses when the scratch
+// file is renamed onto the canonical editable file.
+
+// scratchFileNode is an in-memory scratch file backing an editor's atomic-save
+// temp file. It only buffers bytes; it performs no Linear I/O of its own. The
+// parent directory's Rename handler is responsible for persisting the buffer
+// when the scratch file is renamed onto the directory's editable file.
+type scratchFileNode struct {
+	BaseNode
+
+	mu  sync.Mutex
+	buf []byte
+}
+
+var (
+	_ fs.NodeOpener    = (*scratchFileNode)(nil)
+	_ fs.NodeReader    = (*scratchFileNode)(nil)
+	_ fs.NodeWriter    = (*scratchFileNode)(nil)
+	_ fs.NodeGetattrer = (*scratchFileNode)(nil)
+	_ fs.NodeSetattrer = (*scratchFileNode)(nil)
+	_ fs.NodeFlusher   = (*scratchFileNode)(nil)
+	_ fs.NodeFsyncer   = (*scratchFileNode)(nil)
+)
+
+func (n *scratchFileNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
+	return nil, fuse.FOPEN_DIRECT_IO, 0
+}
+
+func (n *scratchFileNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	out.Mode = 0644
+	n.SetOwner(out)
+	out.Size = uint64(len(n.buf))
+	return 0
+}
+
+func (n *scratchFileNode) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if off >= int64(len(n.buf)) {
+		return fuse.ReadResultData(nil), 0
+	}
+	end := min(off+int64(len(dest)), int64(len(n.buf)))
+	return fuse.ReadResultData(n.buf[off:end]), 0
+}
+
+func (n *scratchFileNode) Write(ctx context.Context, f fs.FileHandle, data []byte, off int64) (uint32, syscall.Errno) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if newLen := int(off) + len(data); newLen > len(n.buf) {
+		grown := make([]byte, newLen)
+		copy(grown, n.buf)
+		n.buf = grown
+	}
+	copy(n.buf[off:], data)
+	return uint32(len(data)), 0
+}
+
+func (n *scratchFileNode) Setattr(ctx context.Context, f fs.FileHandle, in *fuse.SetAttrIn, out *fuse.AttrOut) syscall.Errno {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if sz, ok := in.GetSize(); ok {
+		switch {
+		case int(sz) < len(n.buf):
+			n.buf = n.buf[:sz]
+		case int(sz) > len(n.buf):
+			grown := make([]byte, sz)
+			copy(grown, n.buf)
+			n.buf = grown
+		}
+	}
+	out.Mode = 0644
+	out.Size = uint64(len(n.buf))
+	return 0
+}
+
+func (n *scratchFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno { return 0 }
+
+func (n *scratchFileNode) Fsync(ctx context.Context, f fs.FileHandle, flags uint32) syscall.Errno {
+	return 0
+}
+
+// bytes returns a copy-free snapshot of the buffered contents. Safe to read once
+// the writer has closed; used by the parent's Rename handler.
+func (n *scratchFileNode) bytes() []byte {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.buf
+}
+
+// scratchIno derives a stable inode number for a scratch file from its parent
+// directory inode and name, keeping concurrent temp files in different
+// directories from colliding.
+func scratchIno(parentIno uint64, name string) uint64 {
+	h := fnv.New64a()
+	var p [8]byte
+	for i := range 8 {
+		p[i] = byte(parentIno >> (8 * i))
+	}
+	h.Write(p[:])
+	h.Write([]byte("scratch:" + name))
+	return h.Sum64()
+}
+
+// newScratchInode builds the in-memory scratch inode a directory's Create
+// handler returns for an editor's atomic-save temp file. parentIno is the
+// directory's inode (used only to derive a stable, collision-free scratch ino).
+func newScratchInode(ctx context.Context, parent *BaseNode, parentIno uint64, name string, out *fuse.EntryOut) (*fs.Inode, fs.FileHandle, uint32, syscall.Errno) {
+	node := &scratchFileNode{BaseNode: BaseNode{lfs: parent.lfs}}
+	out.Attr.Mode = 0644 | syscall.S_IFREG
+	out.Attr.Uid = parent.lfs.uid
+	out.Attr.Gid = parent.lfs.gid
+	out.Attr.Size = 0
+	// Short timeouts: the scratch file is transient and should not linger in the
+	// kernel cache after the rename consumes it.
+	out.SetAttrTimeout(time.Second)
+	out.SetEntryTimeout(time.Second)
+	inode := parent.NewInode(ctx, node, fs.StableAttr{
+		Mode: syscall.S_IFREG,
+		Ino:  scratchIno(parentIno, name),
+	})
+	return inode, nil, fuse.FOPEN_DIRECT_IO, 0
+}
+
+// scratchRenameBytes reports the buffered contents of the scratch file named
+// oldName under parent, and whether oldName actually refers to a scratch file
+// this filesystem created. A directory's Rename handler uses it to decide
+// whether a rename is an editor's atomic save (ok == true, persist the bytes) or
+// something it should reject (ok == false).
+func scratchRenameBytes(parent fs.InodeEmbedder, oldName string) (content []byte, ok bool) {
+	child := parent.EmbeddedInode().GetChild(oldName)
+	if child == nil {
+		return nil, false
+	}
+	scratch, isScratch := child.Operations().(*scratchFileNode)
+	if !isScratch {
+		return nil, false
+	}
+	return scratch.bytes(), true
+}

--- a/internal/fs/atomicwrite_test.go
+++ b/internal/fs/atomicwrite_test.go
@@ -1,0 +1,105 @@
+package fs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hanwen/go-fuse/v2/fuse"
+)
+
+// writeScratch applies a Write at the given offset and fails the test on error.
+func writeScratch(t *testing.T, n *scratchFileNode, off int64, data string) {
+	t.Helper()
+	got, errno := n.Write(context.Background(), nil, []byte(data), off)
+	if errno != 0 {
+		t.Fatalf("Write(off=%d) errno=%v", off, errno)
+	}
+	if int(got) != len(data) {
+		t.Fatalf("Write(off=%d) wrote %d, want %d", off, got, len(data))
+	}
+}
+
+func TestScratchFileNode_WriteRead(t *testing.T) {
+	t.Parallel()
+	n := &scratchFileNode{}
+
+	// Sequential writes accumulate.
+	writeScratch(t, n, 0, "hello ")
+	writeScratch(t, n, 6, "world")
+	if got := string(n.bytes()); got != "hello world" {
+		t.Fatalf("bytes() = %q, want %q", got, "hello world")
+	}
+
+	// An offset write past the end grows the buffer (zero-filled gap).
+	n2 := &scratchFileNode{}
+	writeScratch(t, n2, 3, "abc")
+	if got := n2.bytes(); len(got) != 6 || string(got[3:]) != "abc" {
+		t.Fatalf("offset write = %q, want 3 zero bytes then \"abc\"", got)
+	}
+
+	// Read returns the requested window.
+	dest := make([]byte, 5)
+	res, errno := n.Read(context.Background(), nil, dest, 6)
+	if errno != 0 {
+		t.Fatalf("Read errno=%v", errno)
+	}
+	out, _ := res.Bytes(dest)
+	if string(out) != "world" {
+		t.Fatalf("Read(off=6) = %q, want %q", out, "world")
+	}
+
+	// Read past EOF yields no data, not an error.
+	if _, errno := n.Read(context.Background(), nil, dest, 100); errno != 0 {
+		t.Fatalf("Read past EOF errno=%v", errno)
+	}
+}
+
+func TestScratchFileNode_Truncate(t *testing.T) {
+	t.Parallel()
+	n := &scratchFileNode{}
+	writeScratch(t, n, 0, "hello world")
+
+	// Shrink via Setattr size.
+	var in fuse.SetAttrIn
+	in.Size = 5
+	in.Valid = fuse.FATTR_SIZE
+	var out fuse.AttrOut
+	if errno := n.Setattr(context.Background(), nil, &in, &out); errno != 0 {
+		t.Fatalf("Setattr truncate errno=%v", errno)
+	}
+	if got := string(n.bytes()); got != "hello" {
+		t.Fatalf("after truncate to 5: %q, want %q", got, "hello")
+	}
+	if out.Size != 5 {
+		t.Fatalf("Setattr out.Size = %d, want 5", out.Size)
+	}
+
+	// O_TRUNC-style truncate to 0 clears the buffer so a save-over replaces
+	// rather than appends.
+	in.Size = 0
+	if errno := n.Setattr(context.Background(), nil, &in, &out); errno != 0 {
+		t.Fatalf("Setattr truncate-to-0 errno=%v", errno)
+	}
+	if got := n.bytes(); len(got) != 0 {
+		t.Fatalf("after truncate to 0: %q, want empty", got)
+	}
+}
+
+func TestScratchIno_StableAndDistinct(t *testing.T) {
+	t.Parallel()
+	const parentA, parentB = uint64(111), uint64(222)
+
+	// Stable: same parent+name => same ino across calls.
+	first := scratchIno(parentA, "issue.md.tmp.1")
+	if second := scratchIno(parentA, "issue.md.tmp.1"); first != second {
+		t.Errorf("scratchIno not stable: %d != %d", first, second)
+	}
+	// Distinct by name within a directory (concurrent temp files must not collide).
+	if scratchIno(parentA, "a.tmp") == scratchIno(parentA, "b.tmp") {
+		t.Error("scratchIno collided for distinct names in the same directory")
+	}
+	// Distinct by parent (same temp name in two issue dirs must not collide).
+	if scratchIno(parentA, "issue.md.tmp.1") == scratchIno(parentB, "issue.md.tmp.1") {
+		t.Error("scratchIno collided for the same name across directories")
+	}
+}

--- a/internal/fs/comments.go
+++ b/internal/fs/comments.go
@@ -370,7 +370,7 @@ func (n *CommentNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno 
 
 	// Read-your-writes verification on the comment body (free text). The update
 	// returns the persisted comment, so compare directly against what we sent.
-	divergence := writeBackDivergence("comment body", body, updatedComment.Body, n.comment.Body)
+	divergence, fatal := writeBackError(writeBackDivergence("comment body", body, updatedComment.Body, n.comment.Body))
 
 	// Upsert to SQLite so it's immediately visible
 	if err := n.lfs.UpsertComment(ctx, n.issueID, *updatedComment); err != nil {
@@ -385,11 +385,14 @@ func (n *CommentNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno 
 	n.contentReady = false // Force regenerate on next read
 
 	if divergence != "" {
-		log.Printf("Read-your-writes violation on comment %s:\n%s", n.comment.ID, divergence)
-		n.lfs.SetWriteError(commentErrKey, "Read-your-writes violation: your write was accepted by Linear but did not persist as written.\n"+divergence)
-		return syscall.EIO
+		log.Printf("Read-your-writes %s on comment %s:\n%s", writeBackKind(fatal), n.comment.ID, divergence)
+		n.lfs.SetWriteError(commentErrKey, divergence)
+		if fatal {
+			return syscall.EIO
+		}
+	} else {
+		n.lfs.ClearWriteError(commentErrKey)
 	}
-	n.lfs.ClearWriteError(commentErrKey)
 
 	if n.lfs.debug {
 		log.Printf("Comment updated successfully")

--- a/internal/fs/documents.go
+++ b/internal/fs/documents.go
@@ -482,17 +482,14 @@ func (n *DocumentFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.E
 
 	// Read-your-writes verification on the free-text fields we sent. The update
 	// returns the persisted document, so compare directly against what we sent.
-	var divergence []string
+	var results []writeBackResult
 	if want, ok := update["title"].(string); ok {
-		if d := writeBackDivergence("title", want, updatedDoc.Title, n.document.Title); d != "" {
-			divergence = append(divergence, d)
-		}
+		results = append(results, writeBackDivergence("title", want, updatedDoc.Title, n.document.Title))
 	}
 	if want, ok := update["content"].(string); ok {
-		if d := writeBackDivergence("content (body)", want, updatedDoc.Content, n.document.Content); d != "" {
-			divergence = append(divergence, d)
-		}
+		results = append(results, writeBackDivergence("content (body)", want, updatedDoc.Content, n.document.Content))
 	}
+	divergence, fatal := writeBackError(results...)
 
 	// Upsert to SQLite so it's immediately visible
 	if err := n.lfs.UpsertDocument(ctx, *updatedDoc); err != nil {
@@ -506,12 +503,15 @@ func (n *DocumentFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.E
 	n.dirty = false
 	n.contentReady = false // Force regenerate on next read
 
-	if len(divergence) > 0 {
-		log.Printf("Read-your-writes violation on document %s:\n%s", n.document.ID, strings.Join(divergence, "\n"))
-		n.lfs.SetWriteError(docErrKey, "Read-your-writes violation: your write was accepted by Linear but did not persist as written.\n"+strings.Join(divergence, "\n"))
-		return syscall.EIO
+	if divergence != "" {
+		log.Printf("Read-your-writes %s on document %s:\n%s", writeBackKind(fatal), n.document.ID, divergence)
+		n.lfs.SetWriteError(docErrKey, divergence)
+		if fatal {
+			return syscall.EIO
+		}
+	} else {
+		n.lfs.ClearWriteError(docErrKey)
 	}
-	n.lfs.ClearWriteError(docErrKey)
 
 	if n.lfs.debug {
 		log.Printf("Document updated successfully")

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -118,6 +118,9 @@ type InitiativeNode struct {
 var _ fs.NodeReaddirer = (*InitiativeNode)(nil)
 var _ fs.NodeLookuper = (*InitiativeNode)(nil)
 var _ fs.NodeGetattrer = (*InitiativeNode)(nil)
+var _ fs.NodeCreater = (*InitiativeNode)(nil)
+var _ fs.NodeRenamer = (*InitiativeNode)(nil)
+var _ fs.NodeUnlinker = (*InitiativeNode)(nil)
 
 func (i *InitiativeNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
 	out.Mode = 0755 | syscall.S_IFDIR
@@ -184,6 +187,69 @@ func (i *InitiativeNode) Lookup(ctx context.Context, name string, out *fuse.Entr
 	}
 
 	return nil, syscall.ENOENT
+}
+
+// Create accepts an editor's atomic-save temp file (e.g. initiative.md.tmp.<pid>.<rand>)
+// as an in-memory scratch buffer so Rename can route its bytes into
+// initiative.md's write path. Without it, go-fuse rejects the temp-file create
+// with a misleading EROFS on the rw mount (#145).
+func (i *InitiativeNode) Create(ctx context.Context, name string, flags uint32, mode uint32, out *fuse.EntryOut) (*fs.Inode, fs.FileHandle, uint32, syscall.Errno) {
+	if i.lfs.debug {
+		log.Printf("Create scratch file in initiative %s: %s", i.initiative.Name, name)
+	}
+	return newScratchInode(ctx, &i.BaseNode, i.EmbeddedInode().StableAttr().Ino, name, out)
+}
+
+// Rename persists an editor's atomic save: a scratch temp file renamed onto
+// initiative.md is written through initiative.md's normal Flush path.
+// initiative.md is the only writable file here, so other targets are rejected.
+func (i *InitiativeNode) Rename(ctx context.Context, name string, newParent fs.InodeEmbedder, newName string, flags uint32) syscall.Errno {
+	if i.lfs.debug {
+		log.Printf("Rename in initiative %s: %s -> %s", i.initiative.Name, name, newName)
+	}
+
+	dirIno := i.EmbeddedInode().StableAttr().Ino
+	if newParent.EmbeddedInode().StableAttr().Ino != dirIno {
+		return syscall.EXDEV
+	}
+
+	content, ok := scratchRenameBytes(i, name)
+	if !ok {
+		return syscall.ENOTSUP
+	}
+
+	if newName != "initiative.md" {
+		i.lfs.SetWriteError(i.initiative.ID, fmt.Sprintf("Operation: rename %s -> %s\nError: only initiative.md is writable in this directory; save your changes onto initiative.md (atomic save-via-rename onto initiative.md is supported).", name, newName))
+		return syscall.ENOTSUP
+	}
+
+	fileNode := &InitiativeInfoNode{
+		BaseNode:     BaseNode{lfs: i.lfs},
+		initiative:   i.initiative,
+		initiativeID: i.initiative.ID,
+		content:      content,
+		contentReady: true,
+		dirty:        true,
+	}
+	errno := fileNode.Flush(ctx, nil)
+
+	if errno == 0 || errno == syscall.EIO {
+		i.initiative = fileNode.initiative
+		i.lfs.InvalidateKernelEntry(dirIno, name)
+		i.lfs.InvalidateKernelEntry(dirIno, newName)
+		i.lfs.InvalidateKernelInode(initiativeInfoIno(i.initiative.ID))
+	}
+
+	return errno
+}
+
+// Unlink lets editors clean up an abandoned atomic-save temp file. Only scratch
+// files we created are removable; the canonical entries are not.
+func (i *InitiativeNode) Unlink(ctx context.Context, name string) syscall.Errno {
+	if _, ok := scratchRenameBytes(i, name); ok {
+		return 0
+	}
+	return syscall.EPERM
 }
 
 // InitiativeInfoNode is a virtual file containing initiative metadata
@@ -485,22 +551,21 @@ func (i *InitiativeInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall
 
 	// Fetch fresh initiative from API and upsert to SQLite for immediate visibility
 	freshInitiative, err := i.lfs.client.GetInitiative(ctx, i.initiativeID)
-	var divergence []string
+	var divergence string
+	var fatal bool
 	if err != nil {
 		log.Printf("Warning: failed to fetch fresh initiative after update: %v", err)
 	} else {
 		// Read-your-writes verification on the free-text fields we sent, using
 		// the pre-write values (i.initiative) to classify the divergence.
+		var results []writeBackResult
 		if initiativeInput.Name != nil {
-			if d := writeBackDivergence("name", *initiativeInput.Name, freshInitiative.Name, i.initiative.Name); d != "" {
-				divergence = append(divergence, d)
-			}
+			results = append(results, writeBackDivergence("name", *initiativeInput.Name, freshInitiative.Name, i.initiative.Name))
 		}
 		if initiativeInput.Description != nil {
-			if d := writeBackDivergence("description (body)", *initiativeInput.Description, freshInitiative.Description, i.initiative.Description); d != "" {
-				divergence = append(divergence, d)
-			}
+			results = append(results, writeBackDivergence("description (body)", *initiativeInput.Description, freshInitiative.Description, i.initiative.Description))
 		}
+		divergence, fatal = writeBackError(results...)
 		i.initiative = *freshInitiative
 		if err := i.lfs.UpsertInitiative(ctx, *freshInitiative); err != nil {
 			log.Printf("Warning: failed to upsert initiative to SQLite: %v", err)
@@ -542,10 +607,13 @@ func (i *InitiativeInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall
 	i.dirty = false
 	i.contentReady = false // Force re-generate on next read
 
-	if len(divergence) > 0 {
-		log.Printf("Read-your-writes violation on initiative %s:\n%s", i.initiative.Name, strings.Join(divergence, "\n"))
-		i.lfs.SetWriteError(i.initiativeID, "Read-your-writes violation: your write was accepted by Linear but did not persist as written.\n"+strings.Join(divergence, "\n"))
-		return syscall.EIO
+	if divergence != "" {
+		log.Printf("Read-your-writes %s on initiative %s:\n%s", writeBackKind(fatal), i.initiative.Name, divergence)
+		i.lfs.SetWriteError(i.initiativeID, divergence)
+		if fatal {
+			return syscall.EIO
+		}
+		return 0
 	}
 
 	i.lfs.ClearWriteError(i.initiativeID)

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -286,6 +286,9 @@ type IssueDirectoryNode struct {
 var _ fs.NodeReaddirer = (*IssueDirectoryNode)(nil)
 var _ fs.NodeLookuper = (*IssueDirectoryNode)(nil)
 var _ fs.NodeGetattrer = (*IssueDirectoryNode)(nil)
+var _ fs.NodeCreater = (*IssueDirectoryNode)(nil)
+var _ fs.NodeRenamer = (*IssueDirectoryNode)(nil)
+var _ fs.NodeUnlinker = (*IssueDirectoryNode)(nil)
 
 func (n *IssueDirectoryNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
 	out.Mode = 0755 | syscall.S_IFDIR
@@ -460,6 +463,84 @@ func (n *IssueDirectoryNode) Lookup(ctx context.Context, name string, out *fuse.
 	}
 
 	return nil, syscall.ENOENT
+}
+
+// Create accepts an editor's atomic-save temp file (e.g. issue.md.tmp.<pid>.<rand>)
+// as an in-memory scratch buffer. Rename then routes its bytes into issue.md's
+// write path. Without this, go-fuse rejects the temp-file create with a
+// misleading EROFS even though the mount is rw and issue.md is writable (#145).
+func (n *IssueDirectoryNode) Create(ctx context.Context, name string, flags uint32, mode uint32, out *fuse.EntryOut) (*fs.Inode, fs.FileHandle, uint32, syscall.Errno) {
+	if n.lfs.debug {
+		log.Printf("Create scratch file in %s: %s", n.issue.Identifier, name)
+	}
+	return newScratchInode(ctx, &n.BaseNode, issueDirIno(n.issue.ID), name, out)
+}
+
+// Rename persists an editor's atomic save: when a scratch temp file is renamed
+// onto issue.md, its buffered bytes are written through the same path a direct
+// in-place edit uses (frontmatter validation, read-your-writes verification,
+// .error handling, cache invalidation). issue.md is the only writable file here,
+// so renames onto any other target — or of the canonical files themselves — are
+// rejected.
+func (n *IssueDirectoryNode) Rename(ctx context.Context, name string, newParent fs.InodeEmbedder, newName string, flags uint32) syscall.Errno {
+	if n.lfs.debug {
+		log.Printf("Rename in %s: %s -> %s", n.issue.Identifier, name, newName)
+	}
+
+	// The atomic-save pattern keeps the temp file a sibling of issue.md.
+	if newParent.EmbeddedInode().StableAttr().Ino != n.EmbeddedInode().StableAttr().Ino {
+		return syscall.EXDEV
+	}
+
+	content, ok := scratchRenameBytes(n, name)
+	if !ok {
+		// name isn't a scratch file we created — e.g. an attempt to rename issue.md
+		// itself. The canonical files aren't renamable.
+		return syscall.ENOTSUP
+	}
+
+	if newName != "issue.md" {
+		// A scratch file only has somewhere to persist when renamed onto issue.md,
+		// the one editable file in this directory.
+		n.lfs.SetIssueError(n.issue.ID, fmt.Sprintf("Operation: rename %s -> %s\nError: only issue.md is writable in this directory; save your changes onto issue.md (atomic save-via-rename onto issue.md is supported).", name, newName))
+		return syscall.ENOTSUP
+	}
+
+	// Route the buffered bytes through the normal issue write path via a transient
+	// file node. Flush returns 0 on success, EINVAL on a parse/validation error,
+	// and EIO only on a fatal read-your-writes divergence (the write still reached
+	// Linear in that case).
+	fileNode := &IssueFileNode{
+		BaseNode:     BaseNode{lfs: n.lfs},
+		issue:        n.issue,
+		content:      content,
+		contentReady: true,
+		dirty:        true,
+	}
+	errno := fileNode.Flush(ctx, nil)
+
+	if errno == 0 || errno == syscall.EIO {
+		// The write reached Linear. Adopt the fresh issue so issue.md re-renders the
+		// stored content, and drop the kernel caches: go-fuse will MvChild the spent
+		// scratch inode over issue.md, so issue.md must re-Lookup to a fresh
+		// IssueFileNode rather than serve the consumed scratch node.
+		n.issue = fileNode.issue
+		n.lfs.InvalidateKernelEntry(issueDirIno(n.issue.ID), name)
+		n.lfs.InvalidateKernelEntry(issueDirIno(n.issue.ID), newName)
+		n.lfs.InvalidateKernelInode(issueIno(n.issue.ID))
+	}
+
+	return errno
+}
+
+// Unlink lets editors clean up an abandoned atomic-save temp file (when a save
+// is aborted before the rename). Only scratch files we created are removable;
+// the canonical entries (issue.md, comments, etc.) are not.
+func (n *IssueDirectoryNode) Unlink(ctx context.Context, name string) syscall.Errno {
+	if _, ok := scratchRenameBytes(n, name); ok {
+		return 0
+	}
+	return syscall.EPERM
 }
 
 // IssueFileNode represents an issue.md file inside /teams/{KEY}/issues/{ID}/
@@ -821,7 +902,7 @@ func (i *IssueFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errn
 	// actually persisted. Compare against the fresh fetch using the pre-write
 	// values (i.issue, not yet overwritten) to distinguish a silent revert from
 	// a truncation. This catches #136 (large body silently reverts).
-	divergence := i.verifyWriteBack(updates, freshIssue)
+	divergence, fatal := i.verifyWriteBack(updates, freshIssue)
 
 	// Update local copy with fresh data (reflects reality, even on divergence)
 	i.issue = *freshIssue
@@ -832,10 +913,15 @@ func (i *IssueFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errn
 	i.dirty = false
 	i.contentReady = false // Force re-generate on next read
 
+	// The error was already cleared on the successful API update above; only
+	// re-set it here when the persisted value diverged. A fatal divergence
+	// (revert/truncation) fails the close; a benign reformat just leaves a note.
 	if divergence != "" {
-		log.Printf("Read-your-writes violation on %s:\n%s", i.issue.Identifier, divergence)
-		i.lfs.SetIssueError(i.issue.ID, "Read-your-writes violation: your write was accepted by Linear but did not persist as written.\n"+divergence)
-		return syscall.EIO
+		log.Printf("Read-your-writes %s on %s:\n%s", writeBackKind(fatal), i.issue.Identifier, divergence)
+		i.lfs.SetIssueError(i.issue.ID, divergence)
+		if fatal {
+			return syscall.EIO
+		}
 	}
 
 	return 0
@@ -843,20 +929,18 @@ func (i *IssueFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errn
 
 // verifyWriteBack compares the free-text fields we sent (title, description) in
 // updates against what persisted in fresh, using the pre-write values on i.issue
-// to classify the divergence. Returns "" when everything persisted faithfully.
-func (i *IssueFileNode) verifyWriteBack(updates map[string]any, fresh *api.Issue) string {
-	var problems []string
+// to classify the divergence. Returns ("", false) when everything persisted
+// faithfully, and reports whether any divergence is fatal (real loss) vs a
+// benign server-side reformat.
+func (i *IssueFileNode) verifyWriteBack(updates map[string]any, fresh *api.Issue) (string, bool) {
+	var results []writeBackResult
 	if want, ok := updates["title"].(string); ok {
-		if d := writeBackDivergence("title", want, fresh.Title, i.issue.Title); d != "" {
-			problems = append(problems, d)
-		}
+		results = append(results, writeBackDivergence("title", want, fresh.Title, i.issue.Title))
 	}
 	if want, ok := updates["description"].(string); ok {
-		if d := writeBackDivergence("description (body)", want, fresh.Description, i.issue.Description); d != "" {
-			problems = append(problems, d)
-		}
+		results = append(results, writeBackDivergence("description (body)", want, fresh.Description, i.issue.Description))
 	}
-	return strings.Join(problems, "\n")
+	return writeBackError(results...)
 }
 
 func (i *IssueFileNode) Fsync(ctx context.Context, f fs.FileHandle, flags uint32) syscall.Errno {

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -214,6 +214,9 @@ type ProjectNode struct {
 var _ fs.NodeReaddirer = (*ProjectNode)(nil)
 var _ fs.NodeLookuper = (*ProjectNode)(nil)
 var _ fs.NodeGetattrer = (*ProjectNode)(nil)
+var _ fs.NodeCreater = (*ProjectNode)(nil)
+var _ fs.NodeRenamer = (*ProjectNode)(nil)
+var _ fs.NodeUnlinker = (*ProjectNode)(nil)
 
 func (p *ProjectNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
 	out.Mode = 0755 | syscall.S_IFDIR
@@ -336,6 +339,69 @@ func (p *ProjectNode) Lookup(ctx context.Context, name string, out *fuse.EntryOu
 	}
 
 	return nil, syscall.ENOENT
+}
+
+// Create accepts an editor's atomic-save temp file (e.g. project.md.tmp.<pid>.<rand>)
+// as an in-memory scratch buffer so Rename can route its bytes into project.md's
+// write path. Without it, go-fuse rejects the temp-file create with a misleading
+// EROFS on the rw mount (#145).
+func (p *ProjectNode) Create(ctx context.Context, name string, flags uint32, mode uint32, out *fuse.EntryOut) (*fs.Inode, fs.FileHandle, uint32, syscall.Errno) {
+	if p.lfs.debug {
+		log.Printf("Create scratch file in project %s: %s", p.project.Name, name)
+	}
+	return newScratchInode(ctx, &p.BaseNode, p.EmbeddedInode().StableAttr().Ino, name, out)
+}
+
+// Rename persists an editor's atomic save: a scratch temp file renamed onto
+// project.md is written through project.md's normal Flush path. project.md is the
+// only writable file here, so other rename targets are rejected.
+func (p *ProjectNode) Rename(ctx context.Context, name string, newParent fs.InodeEmbedder, newName string, flags uint32) syscall.Errno {
+	if p.lfs.debug {
+		log.Printf("Rename in project %s: %s -> %s", p.project.Name, name, newName)
+	}
+
+	dirIno := p.EmbeddedInode().StableAttr().Ino
+	if newParent.EmbeddedInode().StableAttr().Ino != dirIno {
+		return syscall.EXDEV
+	}
+
+	content, ok := scratchRenameBytes(p, name)
+	if !ok {
+		return syscall.ENOTSUP
+	}
+
+	if newName != "project.md" {
+		p.lfs.SetWriteError(p.project.ID, fmt.Sprintf("Operation: rename %s -> %s\nError: only project.md is writable in this directory; save your changes onto project.md (atomic save-via-rename onto project.md is supported).", name, newName))
+		return syscall.ENOTSUP
+	}
+
+	fileNode := &ProjectInfoNode{
+		BaseNode:     BaseNode{lfs: p.lfs},
+		team:         p.team,
+		project:      p.project,
+		content:      content,
+		contentReady: true,
+		dirty:        true,
+	}
+	errno := fileNode.Flush(ctx, nil)
+
+	if errno == 0 || errno == syscall.EIO {
+		p.project = fileNode.project
+		p.lfs.InvalidateKernelEntry(dirIno, name)
+		p.lfs.InvalidateKernelEntry(dirIno, newName)
+		p.lfs.InvalidateKernelInode(projectInfoIno(p.project.ID))
+	}
+
+	return errno
+}
+
+// Unlink lets editors clean up an abandoned atomic-save temp file. Only scratch
+// files we created are removable; the canonical entries are not.
+func (p *ProjectNode) Unlink(ctx context.Context, name string) syscall.Errno {
+	if _, ok := scratchRenameBytes(p, name); ok {
+		return 0
+	}
+	return syscall.EPERM
 }
 
 // ProjectIssueSymlink is a symlink pointing to an issue directory
@@ -670,22 +736,21 @@ func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Er
 
 	// Fetch fresh project from API and upsert to SQLite for immediate visibility
 	freshProject, err := p.lfs.client.GetProject(ctx, p.project.ID)
-	var divergence []string
+	var divergence string
+	var fatal bool
 	if err != nil {
 		log.Printf("Warning: failed to fetch fresh project after update: %v", err)
 	} else {
 		// Read-your-writes verification on the free-text fields we sent, using
 		// the pre-write values (p.project) to classify the divergence.
+		var results []writeBackResult
 		if projectInput.Name != nil {
-			if d := writeBackDivergence("name", *projectInput.Name, freshProject.Name, p.project.Name); d != "" {
-				divergence = append(divergence, d)
-			}
+			results = append(results, writeBackDivergence("name", *projectInput.Name, freshProject.Name, p.project.Name))
 		}
 		if projectInput.Description != nil {
-			if d := writeBackDivergence("description (body)", *projectInput.Description, freshProject.Description, p.project.Description); d != "" {
-				divergence = append(divergence, d)
-			}
+			results = append(results, writeBackDivergence("description (body)", *projectInput.Description, freshProject.Description, p.project.Description))
 		}
+		divergence, fatal = writeBackError(results...)
 		p.project = *freshProject
 		if err := p.lfs.UpsertProject(ctx, p.team.ID, *freshProject); err != nil {
 			log.Printf("Warning: failed to upsert project to SQLite: %v", err)
@@ -727,10 +792,13 @@ func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Er
 	p.dirty = false
 	p.contentReady = false // Force re-generate on next read
 
-	if len(divergence) > 0 {
-		log.Printf("Read-your-writes violation on project %s:\n%s", p.project.Name, strings.Join(divergence, "\n"))
-		p.lfs.SetWriteError(p.project.ID, "Read-your-writes violation: your write was accepted by Linear but did not persist as written.\n"+strings.Join(divergence, "\n"))
-		return syscall.EIO
+	if divergence != "" {
+		log.Printf("Read-your-writes %s on project %s:\n%s", writeBackKind(fatal), p.project.Name, divergence)
+		p.lfs.SetWriteError(p.project.ID, divergence)
+		if fatal {
+			return syscall.EIO
+		}
+		return 0
 	}
 
 	p.lfs.ClearWriteError(p.project.ID)

--- a/internal/fs/writeback.go
+++ b/internal/fs/writeback.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -18,33 +19,122 @@ import (
 // rejects bad values outright (handled by the resolve+EINVAL paths), so they
 // cannot silently revert. Free-text fields (title, description/body) are the
 // ones prone to silent loss, and they are what an agent most needs verified.
+//
+// Linear also reformats markdown server-side on store (#146): it flips unordered
+// list markers (`*`/`+` ↔ `-`), trims trailing per-line whitespace, collapses
+// blank-line runs, and occasionally mangles markup like bold spanning a newline.
+// These are not data loss, so they must not surface as a hard EIO — otherwise a
+// clean save reads as a failure and triggers retries/escalation. We therefore
+// (1) normalize the known-benign transforms before comparing, and (2) classify
+// any residual difference: a silent revert or substantial shrinkage is fatal
+// (real loss), while a minor markup rewrite is reported as a non-fatal note.
 
-// textEquivalent reports whether two free-text values are the same modulo
-// leading/trailing whitespace. Linear trims trailing whitespace on store, so a
-// whitespace-only difference is not a divergence.
-func textEquivalent(a, b string) bool {
-	return strings.TrimSpace(a) == strings.TrimSpace(b)
+var (
+	// bulletRe matches an unordered-list bullet (`*`, `+`, or `-`) and the space
+	// after it, capturing the leading indent. Linear flips between markers.
+	bulletRe = regexp.MustCompile(`(?m)^(\s*)[*+-][ \t]+`)
+	// blankRunRe matches a run of 3+ newlines (2+ blank lines), which markdown
+	// renders identically to a single blank line.
+	blankRunRe = regexp.MustCompile(`\n{3,}`)
+)
+
+// normalizeMarkdown canonicalizes the server-side markdown transforms Linear
+// applies on store so a faithful save doesn't read as a divergence. It is
+// deliberately conservative: every transform here preserves the text, so it can
+// never hide truncation or a revert.
+func normalizeMarkdown(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		line = strings.TrimRight(line, " \t")     // Linear strips trailing whitespace
+		line = bulletRe.ReplaceAllString(line, "$1- ") // canonicalize bullet markers
+		lines[i] = line
+	}
+	s = strings.Join(lines, "\n")
+	s = blankRunRe.ReplaceAllString(s, "\n\n") // collapse blank-line runs
+	return strings.TrimSpace(s)
 }
 
-// writeBackDivergence reports a read-your-writes violation for a single free-text
-// field, or "" when the value persisted faithfully. want is what we sent, got is
-// what the fresh fetch returned, prev is the value before the write.
-//
-// It distinguishes the two failure modes so the .error message is actionable:
-//   - silent revert: got matches prev — the change was dropped entirely.
-//   - lossy persist: got matches neither want nor prev — e.g. truncation or
-//     server-side rewriting.
-func writeBackDivergence(field, want, got, prev string) string {
-	if textEquivalent(want, got) {
-		return "" // persisted faithfully
+// writeBackResult is the outcome of a read-your-writes check on one field.
+// message is empty when the value persisted faithfully. When non-empty, fatal
+// reports whether the divergence is real data loss (surface as EIO) or a benign
+// server-side reformat (record an informational note but let the write succeed).
+type writeBackResult struct {
+	message string
+	fatal   bool
+}
+
+// writeBackDivergence classifies how a single free-text field persisted. want is
+// what we sent, got is what the fresh fetch returned, prev is the value before
+// the write.
+func writeBackDivergence(field, want, got, prev string) writeBackResult {
+	// Equal modulo Linear's known-benign markdown reformatting => faithful.
+	if normalizeMarkdown(want) == normalizeMarkdown(got) {
+		return writeBackResult{}
 	}
 
 	wantLen := len(strings.TrimSpace(want))
 	gotLen := len(strings.TrimSpace(got))
 
-	if textEquivalent(got, prev) {
-		return fmt.Sprintf("Field: %s\nError: the write was accepted but the value reverted to its previous content (you wrote %d chars, %d persisted). This is a silent revert — re-read the file to see the stored value.", field, wantLen, gotLen)
+	// Silent revert (#136): the persisted value matches the pre-write content —
+	// the change was dropped entirely. Always fatal.
+	if normalizeMarkdown(got) == normalizeMarkdown(prev) {
+		return writeBackResult{
+			message: fmt.Sprintf("Field: %s\nError: the write was accepted but the value reverted to its previous content (you wrote %d chars, %d persisted). This is a silent revert — re-read the file to see the stored value.", field, wantLen, gotLen),
+			fatal:   true,
+		}
 	}
 
-	return fmt.Sprintf("Field: %s\nError: the persisted value differs from what you wrote (you wrote %d chars, %d persisted). The change may have been truncated or rewritten server-side — re-read the file to see the stored value.", field, wantLen, gotLen)
+	// Substantial shrinkage signals truncation rather than reflow. Linear's
+	// normalization nudges length by a handful of chars; a real truncation drops
+	// a large fraction. Fatal when the persisted value lost more than ~10% of the
+	// written length (and more than a few chars).
+	if lost := wantLen - gotLen; lost > 16 && lost*10 > wantLen {
+		return writeBackResult{
+			message: fmt.Sprintf("Field: %s\nError: the persisted value is substantially shorter than what you wrote (you wrote %d chars, %d persisted — %d lost). The change may have been truncated server-side — re-read the file to see the stored value.", field, wantLen, gotLen, lost),
+			fatal:   true,
+		}
+	}
+
+	// Otherwise the text survived but Linear reformatted markup we don't
+	// normalize (e.g. bold spanning a newline). The write succeeded; report a
+	// non-fatal note rather than failing the close.
+	return writeBackResult{
+		message: fmt.Sprintf("Field: %s\nNote: saved, but Linear reformatted the markdown server-side (you wrote %d chars, %d persisted). The text is intact; re-read the file to see the stored formatting.", field, wantLen, gotLen),
+		fatal:   false,
+	}
+}
+
+// writeBackError combines per-field results into the .error payload and reports
+// whether the overall outcome is fatal. Returns ("", false) when every field
+// persisted faithfully.
+func writeBackError(results ...writeBackResult) (string, bool) {
+	var msgs []string
+	fatal := false
+	for _, r := range results {
+		if r.message == "" {
+			continue
+		}
+		msgs = append(msgs, r.message)
+		if r.fatal {
+			fatal = true
+		}
+	}
+	if len(msgs) == 0 {
+		return "", false
+	}
+	header := "Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).\n"
+	if fatal {
+		header = "Read-your-writes violation: your write was accepted by Linear but did not persist as written.\n"
+	}
+	return header + strings.Join(msgs, "\n"), fatal
+}
+
+// writeBackKind returns a word for log lines describing a divergence outcome.
+func writeBackKind(fatal bool) string {
+	if fatal {
+		return "violation"
+	}
+	return "note"
 }

--- a/internal/fs/writeback_test.go
+++ b/internal/fs/writeback_test.go
@@ -5,59 +5,131 @@ import (
 	"testing"
 )
 
-func TestTextEquivalent(t *testing.T) {
+func TestNormalizeMarkdown(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
+		name string
 		a, b string
-		want bool
+		want bool // whether normalized forms are equal
 	}{
-		{"hello", "hello", true},
-		{"hello", "hello\n", true},          // trailing newline trimmed
-		{"  hello  ", "hello", true},        // surrounding whitespace trimmed
-		{"hello world", "hello  world", false}, // internal whitespace is significant
-		{"hello", "goodbye", false},
-		{"", "", true},
-		{"", "  \n ", true}, // both blank
+		{"trailing newline", "hello", "hello\n", true},
+		{"surrounding whitespace", "  hello  ", "hello", true},
+		{"bullet marker flip", "* one\n* two", "- one\n- two", true},
+		{"mixed bullet markers", "+ one\n* two", "- one\n- two", true},
+		{"trailing per-line whitespace", "line one   \nline two\t", "line one\nline two", true},
+		{"blank-line run collapse", "a\n\n\n\nb", "a\n\nb", true},
+		{"CRLF vs LF", "a\r\nb", "a\nb", true},
+		{"internal whitespace is significant", "hello world", "hello  world", false},
+		{"different text", "hello", "goodbye", false},
 	}
 	for _, c := range cases {
-		if got := textEquivalent(c.a, c.b); got != c.want {
-			t.Errorf("textEquivalent(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			got := normalizeMarkdown(c.a) == normalizeMarkdown(c.b)
+			if got != c.want {
+				t.Errorf("normalizeMarkdown(%q)==normalizeMarkdown(%q) = %v, want %v", c.a, c.b, got, c.want)
+			}
+		})
 	}
 }
 
 func TestWriteBackDivergence_Faithful(t *testing.T) {
+	t.Parallel()
 	// Persisted exactly what we wrote (modulo trailing newline) → no divergence.
-	if d := writeBackDivergence("description (body)", "new body", "new body\n", "old body"); d != "" {
-		t.Errorf("expected no divergence on faithful persist, got: %q", d)
+	if r := writeBackDivergence("description (body)", "new body", "new body\n", "old body"); r.message != "" {
+		t.Errorf("expected no divergence on faithful persist, got: %q", r.message)
+	}
+	// Linear flipping bullet markers is a benign reformat, not a divergence.
+	if r := writeBackDivergence("description (body)", "* a\n* b", "- a\n- b", "old"); r.message != "" {
+		t.Errorf("expected bullet reflow to be faithful, got: %q", r.message)
 	}
 }
 
 func TestWriteBackDivergence_SilentRevert(t *testing.T) {
+	t.Parallel()
 	// We asked to change the body, the API accepted, but the stored value is
-	// still the previous content — the #136 silent revert.
-	d := writeBackDivergence("description (body)", "a much larger new body", "old body", "old body")
-	if d == "" {
+	// still the previous content — the #136 silent revert. Always fatal.
+	r := writeBackDivergence("description (body)", "a much larger new body", "old body", "old body")
+	if r.message == "" {
 		t.Fatal("expected a divergence for a silent revert, got none")
 	}
-	if !strings.Contains(d, "reverted to its previous content") {
-		t.Errorf("expected silent-revert wording, got: %q", d)
+	if !r.fatal {
+		t.Error("a silent revert must be fatal")
 	}
-	if !strings.Contains(d, "Field: description (body)") {
-		t.Errorf("expected field name in message, got: %q", d)
+	if !strings.Contains(r.message, "reverted to its previous content") {
+		t.Errorf("expected silent-revert wording, got: %q", r.message)
+	}
+	if !strings.Contains(r.message, "Field: description (body)") {
+		t.Errorf("expected field name in message, got: %q", r.message)
 	}
 }
 
-func TestWriteBackDivergence_LossyPersist(t *testing.T) {
-	// Persisted value matches neither what we wrote nor the previous value
-	// (e.g. truncation) → reported as a lossy persist, not a revert.
-	d := writeBackDivergence("description (body)", "the full long body text here", "the full long", "totally different previous")
-	if d == "" {
+func TestWriteBackDivergence_Truncation(t *testing.T) {
+	t.Parallel()
+	// Persisted value is substantially shorter than what we wrote, and matches
+	// neither the written nor the previous value → real truncation, fatal.
+	want := strings.Repeat("content line\n", 20) // ~260 chars
+	got := "content line\n"                       // almost everything dropped
+	r := writeBackDivergence("description (body)", want, got, "totally different previous")
+	if r.message == "" {
 		t.Fatal("expected a divergence for a truncated persist, got none")
 	}
-	if strings.Contains(d, "reverted to its previous content") {
-		t.Errorf("truncation should not be reported as a revert, got: %q", d)
+	if !r.fatal {
+		t.Error("substantial truncation must be fatal")
 	}
-	if !strings.Contains(d, "truncated or rewritten") {
-		t.Errorf("expected truncation wording, got: %q", d)
+	if strings.Contains(r.message, "reverted to its previous content") {
+		t.Errorf("truncation should not be reported as a revert, got: %q", r.message)
+	}
+	if !strings.Contains(r.message, "truncated server-side") {
+		t.Errorf("expected truncation wording, got: %q", r.message)
+	}
+}
+
+func TestWriteBackDivergence_BenignReformat(t *testing.T) {
+	t.Parallel()
+	// A small markup rewrite that survives normalization (e.g. Linear mangling
+	// bold across a newline) is reported as a non-fatal note, not an EIO: the
+	// text is intact and the close must succeed (#146).
+	want := "intro text **without checking out\nthat branch** more text"
+	got := "intro text **without checking out****\n****that branch** more text"
+	r := writeBackDivergence("description (body)", want, got, "old body")
+	if r.message == "" {
+		t.Fatal("expected a note for a server-side markup rewrite, got none")
+	}
+	if r.fatal {
+		t.Error("a benign markup reformat must not be fatal")
+	}
+	if !strings.Contains(r.message, "reformatted the markdown server-side") {
+		t.Errorf("expected reformat wording, got: %q", r.message)
+	}
+}
+
+func TestWriteBackError_Aggregation(t *testing.T) {
+	t.Parallel()
+	// All faithful → empty, non-fatal.
+	if msg, fatal := writeBackError(writeBackResult{}, writeBackResult{}); msg != "" || fatal {
+		t.Errorf("all-faithful should be empty/non-fatal, got msg=%q fatal=%v", msg, fatal)
+	}
+
+	// A note alone → non-fatal, "note" header.
+	note := writeBackResult{message: "Field: x\nNote: reformatted", fatal: false}
+	msg, fatal := writeBackError(note)
+	if fatal {
+		t.Error("a note alone must not be fatal")
+	}
+	if !strings.Contains(msg, "Read-your-writes note") {
+		t.Errorf("expected note header, got: %q", msg)
+	}
+
+	// Any fatal field makes the whole outcome fatal with the violation header.
+	bad := writeBackResult{message: "Field: y\nError: reverted", fatal: true}
+	msg, fatal = writeBackError(note, bad)
+	if !fatal {
+		t.Error("any fatal field must make the outcome fatal")
+	}
+	if !strings.Contains(msg, "Read-your-writes violation") {
+		t.Errorf("expected violation header, got: %q", msg)
+	}
+	if !strings.Contains(msg, "reformatted") || !strings.Contains(msg, "reverted") {
+		t.Errorf("expected both field messages joined, got: %q", msg)
 	}
 }

--- a/internal/integration/claude_tools_test.go
+++ b/internal/integration/claude_tools_test.go
@@ -281,6 +281,95 @@ func TestWriteContractAtomicRenameNoCorruption(t *testing.T) {
 	}
 }
 
+// TestWriteContractAtomicRenameCreateNoEROFS covers #145 symptom #1 on every
+// single-editable-file surface: an editor's atomic save (create a sibling temp
+// file, write it, rename it over the editable file) must not be rejected with a
+// misleading EROFS ("read-only file system") on an rw mount. The decisive
+// assertion is that *creating* the temp file in the directory succeeds — that
+// was the EROFS the Claude Code Edit tool, vim, and VS Code all hit. The rename
+// itself may fail in fixture mode (no live API), but it must never leave the
+// target unreadable/corrupted.
+func TestWriteContractAtomicRenameCreateNoEROFS(t *testing.T) {
+	cases := []struct {
+		name    string
+		dirFile func(t *testing.T) (dir, file string) // directory + editable filename
+	}{
+		{
+			name: "issue",
+			dirFile: func(t *testing.T) (string, string) {
+				return issueDirPath(testTeamKey, "TST-1"), "issue.md"
+			},
+		},
+		{
+			name: "project",
+			dirFile: func(t *testing.T) (string, string) {
+				return filepath.Join(projectsPath(testTeamKey), "test-project"), "project.md"
+			},
+		},
+		{
+			name: "initiative",
+			dirFile: func(t *testing.T) (string, string) {
+				dir, err := firstInitiativeDir()
+				if err != nil {
+					t.Skipf("no initiative fixture: %v", err)
+				}
+				return dir, "initiative.md"
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir, editable := tc.dirFile(t)
+			target := filepath.Join(dir, editable)
+
+			orig, err := os.ReadFile(target)
+			if err != nil {
+				t.Fatalf("read %s: %v", editable, err)
+			}
+
+			// Create a sibling temp file the way an atomic-save editor does. Before
+			// #145 this returned EROFS even though the mount is rw and the editable
+			// file is writable.
+			tmp := filepath.Join(dir, editable+".tmp.999.deadbeef")
+			f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+			if err != nil {
+				if errors.Is(err, syscall.EROFS) {
+					t.Fatalf("creating an atomic-save temp file returned EROFS on an rw mount (#145 regression): %v", err)
+				}
+				t.Fatalf("create temp file in %s dir: %v", tc.name, err)
+			}
+			if _, err := f.Write(orig); err != nil {
+				_ = f.Close()
+				t.Fatalf("write temp file: %v", err)
+			}
+			if err := f.Close(); err != nil {
+				t.Fatalf("close temp file: %v", err)
+			}
+
+			// The temp file must read back what we wrote while it's still a scratch file.
+			if got, err := os.ReadFile(tmp); err != nil {
+				t.Fatalf("read scratch temp file: %v", err)
+			} else if string(got) != string(orig) {
+				t.Fatalf("scratch temp file content mismatch: wrote %d bytes, read %d", len(orig), len(got))
+			}
+
+			// Rename it over the editable file. In fixture mode the persisting write
+			// fails (no API), so the rename may return an error; what matters is no
+			// corruption.
+			_ = os.Rename(tmp, target)
+			_ = os.Remove(tmp) // best-effort cleanup if the rename did not consume it
+
+			if _, err := os.ReadFile(target); err != nil {
+				if errors.Is(err, syscall.EACCES) {
+					t.Fatalf("%s became unreadable after rename-over (#145 corruption): %v", editable, err)
+				}
+				t.Fatalf("%s not readable after rename-over: %v", editable, err)
+			}
+		})
+	}
+}
+
 // TestErrorFileExposedOnWritableSurfaces is the #140 structural guard: every
 // writable entity directory must expose a readable `.error` feedback file so a
 // failed write is legible to an LLM/script instead of a bare errno. It asserts


### PR DESCRIPTION
Closes #145.

Writing `issue.md` failed on both common write paths, and the fallback reported failure on success.

## Symptom #1 — atomic tmp+rename → misleading `EROFS` (asks #1/#2)
Editors and the Claude Code Edit/Write tools never write in place: they create a sibling temp file (`issue.md.tmp.<pid>.<rand>`), write it, then `rename()` it over the target. go-fuse returns `EROFS` whenever a directory node lacks `Create`, so the temp-file create was rejected with a misleading "read-only file system" error even though the mount is `rw`.

- New `scratchFileNode` (in-memory buffer) in `internal/fs/atomicwrite.go`.
- `IssueDirectoryNode`, `ProjectNode`, `InitiativeNode` gain `Create` (accept the temp file as scratch), `Rename` (route the buffered bytes onto `issue.md`/`project.md`/`initiative.md` through a transient file node's `Flush`, reusing all validation, read-your-writes, `.error`, and cache logic), and `Unlink` (drop an abandoned temp file). A rename onto anything other than the editable file returns `ENOTSUP` with a descriptive `.error` instead of the bogus `EROFS`.

## Symptom #2 — `EIO` on a successful, normalized write (ask #3)
A direct write returned `EIO` whenever Linear merely normalized the markdown server-side (bullet markers, trailing whitespace), reporting a successful write as a hard failure.

- `normalizeMarkdown` canonicalizes Linear's known-benign reformatting before comparing; `writeBackError` classifies the residual: a silent revert or substantial shrinkage stays fatal (`EIO`), while a minor markup rewrite is a non-fatal `.error` note and the write succeeds.

## Tests
- `internal/fs/atomicwrite_test.go` — scratch buffer + inode hashing.
- Integration `TestWriteContractAtomicRenameCreateNoEROFS` — asserts the temp create no longer returns `EROFS` and the target stays readable, across issue/project/initiative.

## Verified live
Tested against the running mount on TST-429: an atomic tmp+rename write persisted to Linear, Linear normalized `-` bullets to `*`, and the write returned exit 0 with a clean `.error` (previously `EROFS` on create, then `EIO` on the normalized body). Reverted afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)