### PR TITLE
refactor(fs): the writable-collection kit — createFileNode + collectionTrio

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -100,6 +100,31 @@ unit-tested with recording closures (no FUSE mount, SQLite, or API). Persisting 
 junction row inline (rather than the old deferred batch a mid-loop failure skipped)
 keeps SQLite consistent with whatever the API actually accepted on a partial failure.
 
+### Create trigger (`createFileNode`)
+The **deep module** owning the write-only `_create` file (and the named-file
+`Create` paths that share its mechanics): buffer written bytes, and on close hand
+the complete content to a per-surface **`onFlush`** closure — the module's whole
+interface — which parses and calls the Create tail. The buffer lives on the
+**per-open FileHandle**, so its lifetime is one open-write-close cycle: a dup'd
+descriptor's second flush sees a consumed buffer and no-ops, while a genuinely
+new open through the same kernel-cached inode gets a fresh buffer and really
+creates. This replaced nine hand-copied `New*Node` types, two of which (the old
+per-node buffers') `created` latch silently swallowed the second create — and
+issues/_create's zero-lookup-timeout hack existed only to dodge that bug. Lives
+in `internal/fs/createfile.go`; buffer edge cases unit-tested once with a
+recording closure, no FUSE mount.
+
+### Writable-collection trio (`collectionTrio`)
+The **deep module** owning which virtual files a writable collection directory
+serves: `_create`, `.error`, `.last`. A directory declares a spec (`kind`,
+`parentID`, `onFlush`) and delegates its Readdir header to `entries()` and the
+three special names in Lookup to `lookupCollectionTrio` — so the trio is
+module-guaranteed the way `InvalidateCreated` is, and a new collection cannot
+drift (the updates directories shipped without `.error`/`.last` for months
+because each dir restated the trio by hand). mkdir-created collections
+(projects) set `onFlush` nil and serve just the two sidecars. Lives in
+`internal/fs/collection.go`.
+
 ### ErrorSink
 The minimal seam the WriteBack tail uses to record validation/divergence messages for
 `.error` files: `SetWriteError(key, msg)` / `ClearWriteError(key)`. `*LinearFS`

--- a/internal/fs/attachments.go
+++ b/internal/fs/attachments.go
@@ -105,10 +105,7 @@ func (n *AttachmentsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Er
 func (n *AttachmentsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
 	// Handle _create trigger file
 	if name == "_create" {
-		node := &NewAttachmentNode{
-			BaseNode: BaseNode{lfs: n.lfs},
-			issueID:  n.issueID,
-		}
+		node := newCreateFile(n.lfs, n.createAttachment)
 		now := time.Now()
 		out.Attr.Mode = 0200 | syscall.S_IFREG // Write-only
 		out.Attr.Uid = n.lfs.uid
@@ -362,64 +359,10 @@ func (n *ExternalAttachmentNode) Unlink(ctx context.Context, name string) syscal
 	})
 }
 
-// NewAttachmentNode represents the _create file for creating new attachments
-type NewAttachmentNode struct {
-	BaseNode
-	issueID string
-}
-
-var _ fs.NodeGetattrer = (*NewAttachmentNode)(nil)
-var _ fs.NodeSetattrer = (*NewAttachmentNode)(nil)
-var _ fs.NodeOpener = (*NewAttachmentNode)(nil)
-var _ fs.NodeWriter = (*NewAttachmentNode)(nil)
-var _ fs.NodeFlusher = (*NewAttachmentNode)(nil)
-var _ fs.NodeFsyncer = (*NewAttachmentNode)(nil)
-
-func (n *NewAttachmentNode) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0200 // Write-only
-	n.SetOwner(out)
-	out.Size = 0
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
-
-func (n *NewAttachmentNode) Setattr(ctx context.Context, fh fs.FileHandle, in *fuse.SetAttrIn, out *fuse.AttrOut) syscall.Errno {
-	// Allow truncation (for > redirect) - just return success
-	out.Mode = 0200
-	n.SetOwner(out)
-	out.Size = 0
-	return 0
-}
-
-func (n *NewAttachmentNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	return &attachmentCreateHandle{}, fuse.FOPEN_DIRECT_IO, 0
-}
-
-func (n *NewAttachmentNode) Write(ctx context.Context, fh fs.FileHandle, data []byte, off int64) (uint32, syscall.Errno) {
-	handle, ok := fh.(*attachmentCreateHandle)
-	if !ok {
-		return 0, syscall.EIO
-	}
-	handle.buffer = append(handle.buffer, data...)
-	return uint32(len(data)), 0
-}
-
-// Fsync is a no-op; actual persistence happens in Flush. It must be
-// implemented (not return ENOTSUP) so editors that write-then-fsync
-// (e.g. Claude Code's Edit tool, vim, VS Code) can save the _create file.
-func (n *NewAttachmentNode) Fsync(ctx context.Context, fh fs.FileHandle, flags uint32) syscall.Errno {
-	return 0
-}
-
-func (n *NewAttachmentNode) Flush(ctx context.Context, fh fs.FileHandle) syscall.Errno {
-	handle, ok := fh.(*attachmentCreateHandle)
-	if !ok || len(handle.buffer) == 0 {
-		return 0
-	}
-
-	content := strings.TrimSpace(string(handle.buffer))
-	handle.buffer = nil
+// createAttachment is the attachments create surface's onFlush: parse
+// "url [title]" and run the create tail.
+func (n *AttachmentsNode) createAttachment(ctx context.Context, raw []byte) syscall.Errno {
+	content := strings.TrimSpace(string(raw))
 
 	// Idempotency (#146): if the URL is already attached, linking it again is a
 	// success, not a failure. Linear rejects the duplicate with an opaque
@@ -493,7 +436,7 @@ func (n *NewAttachmentNode) Flush(ctx context.Context, fh fs.FileHandle) syscall
 
 // upsertAttachment writes an attachment to SQLite for immediate visibility.
 // Failures are logged, not fatal: the sync worker will reconcile.
-func (n *NewAttachmentNode) upsertAttachment(ctx context.Context, att api.Attachment) {
+func (n *AttachmentsNode) upsertAttachment(ctx context.Context, att api.Attachment) {
 	data, _ := json.Marshal(att)
 	if err := n.lfs.store.Queries().UpsertAttachment(ctx, db.UpsertAttachmentParams{
 		ID:         att.ID,
@@ -516,8 +459,4 @@ func (n *NewAttachmentNode) upsertAttachment(ctx context.Context, att api.Attach
 // to recognize a duplicate without false positives.
 func attachmentURLsEqual(a, b string) bool {
 	return strings.TrimRight(strings.TrimSpace(a), "/") == strings.TrimRight(strings.TrimSpace(b), "/")
-}
-
-type attachmentCreateHandle struct {
-	buffer []byte
 }

--- a/internal/fs/attachments.go
+++ b/internal/fs/attachments.go
@@ -38,13 +38,6 @@ func externalAttachmentIno(attachmentID string) uint64 {
 	return h.Sum64()
 }
 
-// attachmentsCreateIno generates a stable inode for the _create trigger file
-func attachmentsCreateIno(issueID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("attachments-create:" + issueID))
-	return h.Sum64()
-}
-
 // AttachmentsNode represents the /teams/{KEY}/issues/{ID}/attachments directory
 type AttachmentsNode struct {
 	BaseNode
@@ -67,12 +60,7 @@ func (n *AttachmentsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Er
 	// Trigger background refresh of sub-resources if stale
 	n.lfs.MaybeRefreshIssueDetails(n.issueID)
 
-	// Start with _create, .error, and .last entries
-	entries := []fuse.DirEntry{
-		{Name: "_create", Mode: syscall.S_IFREG},
-		{Name: ".error", Mode: syscall.S_IFREG},
-		{Name: ".last", Mode: syscall.S_IFREG},
-	}
+	entries := n.trio().entries()
 
 	// Add embedded files (images, etc.)
 	files, err := n.lfs.GetIssueEmbeddedFiles(ctx, n.issueID)
@@ -102,31 +90,14 @@ func (n *AttachmentsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Er
 	return fs.NewListDirStream(entries), 0
 }
 
-func (n *AttachmentsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	// Handle _create trigger file
-	if name == "_create" {
-		node := newCreateFile(n.lfs, n.createAttachment)
-		now := time.Now()
-		out.Attr.Mode = 0200 | syscall.S_IFREG // Write-only
-		out.Attr.Uid = n.lfs.uid
-		out.Attr.Gid = n.lfs.gid
-		out.Attr.Size = 0
-		out.SetAttrTimeout(1 * time.Second)
-		out.SetEntryTimeout(1 * time.Second)
-		out.Attr.SetTimes(&now, &now, &now)
-		return n.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFREG,
-			Ino:  attachmentsCreateIno(n.issueID),
-		}), 0
-	}
+// trio declares the attachments collection's writable surfaces.
+func (n *AttachmentsNode) trio() collectionTrio {
+	return collectionTrio{kind: "attachments", parentID: n.issueID, onFlush: n.createAttachment}
+}
 
-	// Handle .error feedback file (last failed attachment write in this dir)
-	if name == ".error" {
-		return n.lfs.lookupErrorFile(ctx, n, collectionErrorKey("attachments", n.issueID), out), 0
-	}
-	// Handle .last feedback file (recent successful attachment creations)
-	if name == ".last" {
-		return n.lfs.lookupSuccessFile(ctx, n, collectionSuccessKey("attachments", n.issueID), out), 0
+func (n *AttachmentsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+	if inode, ok := n.lfs.lookupCollectionTrio(ctx, n, n.trio(), name, out); ok {
+		return inode, 0
 	}
 
 	// Handle .link files (external attachments)

--- a/internal/fs/attachments_test.go
+++ b/internal/fs/attachments_test.go
@@ -36,12 +36,12 @@ func TestAttachmentURLsEqual(t *testing.T) {
 	}
 }
 
-// TestNewAttachmentNode_FlushIdempotentOnDuplicate covers #146: writing a URL
-// that is already attached to the issue must be an idempotent no-op success
-// (errno 0, no .error set), not an opaque API failure. The duplicate is caught
-// by the local pre-check, which returns before ever touching the API client —
-// so this exercises the fix end-to-end without a live client.
-func TestNewAttachmentNode_FlushIdempotentOnDuplicate(t *testing.T) {
+// TestCreateAttachmentIdempotentOnDuplicate covers #146: writing a URL that is
+// already attached to the issue must be an idempotent no-op success (errno 0,
+// no .error set), not an opaque API failure. The duplicate is caught by the
+// local pre-check, which returns before ever touching the API client — so this
+// exercises the fix end-to-end without a live client.
+func TestCreateAttachmentIdempotentOnDuplicate(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Config{APIKey: "test-key", Cache: config.CacheConfig{TTL: 100 * time.Millisecond, MaxEntries: 100}}
@@ -74,12 +74,10 @@ func TestNewAttachmentNode_FlushIdempotentOnDuplicate(t *testing.T) {
 	attErrKey := collectionErrorKey("attachments", issueID)
 	lfs.SetWriteError(attErrKey, "stale error from a prior failure")
 
-	node := &NewAttachmentNode{BaseNode: BaseNode{lfs: lfs}, issueID: issueID}
+	dir := &AttachmentsNode{BaseNode: BaseNode{lfs: lfs}, issueID: issueID}
 	// A trailing slash must still be recognized as the same URL.
-	handle := &attachmentCreateHandle{buffer: []byte(url + "/\n")}
-
-	if errno := node.Flush(ctx, handle); errno != 0 {
-		t.Fatalf("Flush() on duplicate URL errno = %d, want 0 (idempotent no-op)", errno)
+	if errno := dir.createAttachment(ctx, []byte(url+"/\n")); errno != 0 {
+		t.Fatalf("createAttachment() on duplicate URL errno = %d, want 0 (idempotent no-op)", errno)
 	}
 	if e := lfs.GetWriteError(attErrKey); e != nil {
 		t.Errorf("expected .error cleared after idempotent no-op, got %q", e.Message)

--- a/internal/fs/collection.go
+++ b/internal/fs/collection.go
@@ -1,0 +1,82 @@
+package fs
+
+import (
+	"context"
+	"syscall"
+	"time"
+
+	"github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
+)
+
+// The writable-collection trio.
+//
+// Every writable collection directory serves the same three virtual files:
+// the `_create` trigger, the `.error` feedback file, and the `.last` sidecar
+// of recent creations. Which files a directory serves is a contract the
+// generated README documents globally ("every writable directory has a .error
+// feedback file") — but restating it in every Readdir and Lookup let surfaces
+// drift: the updates directories shipped without .error/.last entirely until
+// the contract was re-audited. collectionTrio owns the trio once, so a new
+// collection can't forget it, the same way InvalidateCreated is guaranteed by
+// the create tail.
+//
+// A directory declares its trio with a spec and delegates:
+//
+//	func (n *CommentsNode) trio() collectionTrio {
+//		return collectionTrio{kind: "comments", parentID: n.issueID, onFlush: n.createComment}
+//	}
+//	// Readdir: entries := n.trio().entries(); append per-entity items…
+//	// Lookup:  if inode, ok := n.lfs.lookupCollectionTrio(ctx, n, n.trio(), name, out); ok { return inode, 0 }
+//
+// Collections created by mkdir instead of _create (projects) set onFlush nil
+// and serve only .error/.last.
+type collectionTrio struct {
+	// kind namespaces the .error/.last keys (collectionErrorKey/SuccessKey).
+	kind string
+	// parentID scopes the collection (issue, team, project, initiative ID).
+	parentID string
+	// onFlush is the create surface behind _create (see createFileNode).
+	// nil means the collection has no _create trigger.
+	onFlush func(ctx context.Context, content []byte) syscall.Errno
+}
+
+// entries returns the virtual-file header every writable collection's Readdir
+// starts with.
+func (t collectionTrio) entries() []fuse.DirEntry {
+	entries := make([]fuse.DirEntry, 0, 3)
+	if t.onFlush != nil {
+		entries = append(entries, fuse.DirEntry{Name: "_create", Mode: syscall.S_IFREG})
+	}
+	return append(entries,
+		fuse.DirEntry{Name: ".error", Mode: syscall.S_IFREG},
+		fuse.DirEntry{Name: ".last", Mode: syscall.S_IFREG},
+	)
+}
+
+// lookupCollectionTrio serves the trio names for one collection. It returns
+// (inode, true) when name was one of them; (nil, false) otherwise, so the
+// caller falls through to its per-entity lookup.
+func (lfs *LinearFS) lookupCollectionTrio(ctx context.Context, parent fs.InodeEmbedder, t collectionTrio, name string, out *fuse.EntryOut) (*fs.Inode, bool) {
+	switch name {
+	case "_create":
+		if t.onFlush == nil {
+			return nil, false
+		}
+		now := time.Now()
+		node := newCreateFile(lfs, t.onFlush)
+		out.Attr.Mode = 0200 | syscall.S_IFREG
+		out.Attr.Uid = lfs.uid
+		out.Attr.Gid = lfs.gid
+		out.Attr.Size = 0
+		out.Attr.SetTimes(&now, &now, &now)
+		out.SetAttrTimeout(1 * time.Second)
+		out.SetEntryTimeout(1 * time.Second)
+		return parent.EmbeddedInode().NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG}), true
+	case ".error":
+		return lfs.lookupErrorFile(ctx, parent, collectionErrorKey(t.kind, t.parentID), out), true
+	case ".last":
+		return lfs.lookupSuccessFile(ctx, parent, collectionSuccessKey(t.kind, t.parentID), out), true
+	}
+	return nil, false
+}

--- a/internal/fs/collection_test.go
+++ b/internal/fs/collection_test.go
@@ -1,0 +1,32 @@
+package fs
+
+import (
+	"context"
+	"syscall"
+	"testing"
+)
+
+func TestCollectionTrioEntries(t *testing.T) {
+	t.Parallel()
+
+	withCreate := collectionTrio{kind: "comments", parentID: "issue-1",
+		onFlush: func(context.Context, []byte) syscall.Errno { return 0 }}
+	names := []string{}
+	for _, e := range withCreate.entries() {
+		names = append(names, e.Name)
+	}
+	if len(names) != 3 || names[0] != "_create" || names[1] != ".error" || names[2] != ".last" {
+		t.Errorf("entries() with onFlush = %v, want [_create .error .last]", names)
+	}
+
+	// mkdir-created collections (projects) have no _create trigger; the trio
+	// degrades to the two feedback sidecars.
+	mkdirOnly := collectionTrio{kind: "projects", parentID: "team-1"}
+	names = names[:0]
+	for _, e := range mkdirOnly.entries() {
+		names = append(names, e.Name)
+	}
+	if len(names) != 2 || names[0] != ".error" || names[1] != ".last" {
+		t.Errorf("entries() without onFlush = %v, want [.error .last]", names)
+	}
+}

--- a/internal/fs/comments.go
+++ b/internal/fs/comments.go
@@ -95,11 +95,7 @@ func (n *CommentsNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 	// Handle _create for creating comments
 	if name == "_create" {
 		now := time.Now()
-		node := &NewCommentNode{
-			BaseNode: BaseNode{lfs: n.lfs},
-			issueID:  n.issueID,
-			teamID:   n.teamID,
-		}
+		node := newCreateFile(n.lfs, n.createComment)
 		out.Attr.Mode = 0200 | syscall.S_IFREG
 		out.Attr.Uid = n.lfs.uid
 		out.Attr.Gid = n.lfs.gid
@@ -213,15 +209,10 @@ func (n *CommentsNode) Create(ctx context.Context, name string, flags uint32, mo
 		return nil, nil, 0, syscall.EINVAL
 	}
 
-	node := &NewCommentNode{
-		BaseNode: BaseNode{lfs: n.lfs},
-		issueID:  n.issueID,
-		teamID:   n.teamID,
-	}
-
+	node := newCreateFile(n.lfs, n.createComment)
 	inode := n.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG})
 
-	return inode, nil, fuse.FOPEN_DIRECT_IO, 0
+	return inode, &createFileHandle{}, fuse.FOPEN_DIRECT_IO, 0
 }
 
 // CommentNode represents a single comment file (read-write)
@@ -414,94 +405,10 @@ func extractCommentBody(content []byte) string {
 	return strings.TrimSpace(body)
 }
 
-// NewCommentNode handles creating new comments
-type NewCommentNode struct {
-	BaseNode
-	issueID string
-	teamID  string
-
-	mu      sync.Mutex
-	content []byte
-	created bool
-}
-
-var _ fs.NodeGetattrer = (*NewCommentNode)(nil)
-var _ fs.NodeOpener = (*NewCommentNode)(nil)
-var _ fs.NodeReader = (*NewCommentNode)(nil)
-var _ fs.NodeWriter = (*NewCommentNode)(nil)
-var _ fs.NodeFlusher = (*NewCommentNode)(nil)
-var _ fs.NodeFsyncer = (*NewCommentNode)(nil)
-var _ fs.NodeSetattrer = (*NewCommentNode)(nil)
-
-func (n *NewCommentNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	now := time.Now()
-	out.Mode = 0200
-	n.SetOwner(out)
-	out.Size = uint64(len(n.content))
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
-
-func (n *NewCommentNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	return nil, fuse.FOPEN_DIRECT_IO, 0
-}
-
-func (n *NewCommentNode) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	// _create is write-only - return permission denied
-	return nil, syscall.EACCES
-}
-
-func (n *NewCommentNode) Write(ctx context.Context, f fs.FileHandle, data []byte, off int64) (uint32, syscall.Errno) {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	if n.lfs.debug {
-		log.Printf("Write new comment: offset=%d len=%d", off, len(data))
-	}
-
-	// Expand buffer if needed
-	newLen := int(off) + len(data)
-	if newLen > len(n.content) {
-		newContent := make([]byte, newLen)
-		copy(newContent, n.content)
-		n.content = newContent
-	}
-
-	copy(n.content[off:], data)
-	return uint32(len(data)), 0
-}
-
-func (n *NewCommentNode) Setattr(ctx context.Context, f fs.FileHandle, in *fuse.SetAttrIn, out *fuse.AttrOut) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	if sz, ok := in.GetSize(); ok {
-		if int(sz) < len(n.content) {
-			n.content = n.content[:sz]
-		} else if int(sz) > len(n.content) {
-			newContent := make([]byte, sz)
-			copy(newContent, n.content)
-			n.content = newContent
-		}
-	}
-
-	out.Mode = 0200
-	out.Size = uint64(len(n.content))
-	return 0
-}
-
-func (n *NewCommentNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	if n.created || len(n.content) == 0 {
-		return 0
-	}
-
-	body := strings.TrimSpace(string(n.content))
+// createComment is the comments create surface's onFlush: parse the body and
+// run the create tail.
+func (n *CommentsNode) createComment(ctx context.Context, content []byte) syscall.Errno {
+	body := strings.TrimSpace(string(content))
 	if body == "" {
 		return 0
 	}
@@ -526,16 +433,7 @@ func (n *NewCommentNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Err
 		},
 		dir: commentsDirIno(n.issueID),
 	})
-	if errno != 0 {
-		return errno
-	}
-	n.created = true
-	return 0
-}
-
-func (n *NewCommentNode) Fsync(ctx context.Context, f fs.FileHandle, flags uint32) syscall.Errno {
-	// Fsync is a no-op; actual persistence happens in Flush
-	return 0
+	return errno
 }
 
 // commentToMarkdown converts a comment to markdown with YAML frontmatter

--- a/internal/fs/comments.go
+++ b/internal/fs/comments.go
@@ -60,19 +60,11 @@ func (n *CommentsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno
 	// Fetch comments (uses cache if available)
 	comments, err := n.lfs.GetIssueComments(ctx, n.issueID)
 	if err != nil {
-		// On error, return just _create and .error
-		return fs.NewListDirStream([]fuse.DirEntry{
-			{Name: "_create", Mode: syscall.S_IFREG},
-			{Name: ".error", Mode: syscall.S_IFREG},
-		}), 0
+		// On error, still serve the trio
+		return fs.NewListDirStream(n.trio().entries()), 0
 	}
 
-	// Always include _create for creating comments and .error for feedback
-	entries := []fuse.DirEntry{
-		{Name: "_create", Mode: syscall.S_IFREG},
-		{Name: ".error", Mode: syscall.S_IFREG},
-		{Name: ".last", Mode: syscall.S_IFREG},
-	}
+	entries := n.trio().entries()
 
 	// Sort comments by creation time
 	sort.Slice(comments, func(i, j int) bool {
@@ -91,30 +83,14 @@ func (n *CommentsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno
 	return fs.NewListDirStream(entries), 0
 }
 
-func (n *CommentsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	// Handle _create for creating comments
-	if name == "_create" {
-		now := time.Now()
-		node := newCreateFile(n.lfs, n.createComment)
-		out.Attr.Mode = 0200 | syscall.S_IFREG
-		out.Attr.Uid = n.lfs.uid
-		out.Attr.Gid = n.lfs.gid
-		out.Attr.Size = 0
-		out.Attr.SetTimes(&now, &now, &now)
-		out.SetAttrTimeout(1 * time.Second)
-		out.SetEntryTimeout(1 * time.Second)
-		return n.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFREG,
-		}), 0
-	}
+// trio declares the comments collection's writable surfaces.
+func (n *CommentsNode) trio() collectionTrio {
+	return collectionTrio{kind: "comments", parentID: n.issueID, onFlush: n.createComment}
+}
 
-	// Handle .error feedback file (last failed comment write in this dir)
-	if name == ".error" {
-		return n.lfs.lookupErrorFile(ctx, n, collectionErrorKey("comments", n.issueID), out), 0
-	}
-	// Handle .last feedback file (recent successful comment creations)
-	if name == ".last" {
-		return n.lfs.lookupSuccessFile(ctx, n, collectionSuccessKey("comments", n.issueID), out), 0
+func (n *CommentsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+	if inode, ok := n.lfs.lookupCollectionTrio(ctx, n, n.trio(), name, out); ok {
+		return inode, 0
 	}
 
 	comments, err := n.lfs.GetIssueComments(ctx, n.issueID)

--- a/internal/fs/createfile.go
+++ b/internal/fs/createfile.go
@@ -1,0 +1,141 @@
+package fs
+
+import (
+	"context"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
+)
+
+// The write-only create trigger.
+//
+// Every collection exposes a `_create` file (and the named-file Create paths —
+// docs/"Title.md", comments, updates — reuse the same mechanics): bytes written
+// are buffered, and the close-time Flush hands the complete buffer to a
+// per-surface onFlush closure that parses it and runs the create tail.
+// createFileNode is the one deep module owning that contract; the closure is
+// its only per-surface part. It replaces nine hand-copied New*Node types.
+//
+// The buffer lives on the per-open FileHandle, not the node, so its lifetime
+// is one open-write-close cycle (the pattern attachments/relations proved).
+// That prevents double-creates without a latch: Flush consumes the buffer, so
+// a dup'd descriptor's second flush sees it empty and no-ops, while a
+// genuinely new open — even through the same kernel-cached inode — gets a
+// fresh buffer and really creates. The old per-node buffers needed a `created`
+// latch that silently swallowed the second create through a cached node, and
+// issues/_create needed zero lookup timeouts to dodge the same bug.
+type createFileNode struct {
+	BaseNode
+	// onFlush receives the complete written content once per open-write-close
+	// cycle and owns parsing plus the create-tail call. Empty writes never
+	// reach it; whitespace-only handling is the surface's decision.
+	onFlush func(ctx context.Context, content []byte) syscall.Errno
+}
+
+// newCreateFile builds the write-only trigger node for one create surface.
+func newCreateFile(lfs *LinearFS, onFlush func(ctx context.Context, content []byte) syscall.Errno) *createFileNode {
+	return &createFileNode{BaseNode: BaseNode{lfs: lfs}, onFlush: onFlush}
+}
+
+// createFileHandle is the per-open write buffer. Open (and the directories'
+// Create handlers) mint a fresh one per cycle.
+type createFileHandle struct {
+	mu      sync.Mutex
+	content []byte
+}
+
+var _ fs.NodeGetattrer = (*createFileNode)(nil)
+var _ fs.NodeSetattrer = (*createFileNode)(nil)
+var _ fs.NodeOpener = (*createFileNode)(nil)
+var _ fs.NodeReader = (*createFileNode)(nil)
+var _ fs.NodeWriter = (*createFileNode)(nil)
+var _ fs.NodeFlusher = (*createFileNode)(nil)
+var _ fs.NodeFsyncer = (*createFileNode)(nil)
+
+func (n *createFileNode) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
+	now := time.Now()
+	out.Mode = 0200 // Write-only
+	n.SetOwner(out)
+	out.Size = 0 // reads always see an empty file, as the README documents
+	out.SetTimes(&now, &now, &now)
+	return 0
+}
+
+func (n *createFileNode) Setattr(ctx context.Context, fh fs.FileHandle, in *fuse.SetAttrIn, out *fuse.AttrOut) syscall.Errno {
+	// Truncation (the O_TRUNC of a `>` redirect) applies to the open handle's
+	// buffer when the kernel passes one; a handle-less setattr is accepted as
+	// a no-op — every open starts with a fresh, empty buffer anyway.
+	if handle, ok := fh.(*createFileHandle); ok {
+		if sz, ok := in.GetSize(); ok {
+			handle.mu.Lock()
+			if int(sz) < len(handle.content) {
+				handle.content = handle.content[:sz]
+			} else if int(sz) > len(handle.content) {
+				grown := make([]byte, sz)
+				copy(grown, handle.content)
+				handle.content = grown
+			}
+			handle.mu.Unlock()
+		}
+	}
+	out.Mode = 0200
+	n.SetOwner(out)
+	out.Size = 0
+	return 0
+}
+
+func (n *createFileNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
+	return &createFileHandle{}, fuse.FOPEN_DIRECT_IO, 0
+}
+
+func (n *createFileNode) Read(ctx context.Context, fh fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
+	// _create is write-only - return permission denied
+	return nil, syscall.EACCES
+}
+
+func (n *createFileNode) Write(ctx context.Context, fh fs.FileHandle, data []byte, off int64) (uint32, syscall.Errno) {
+	handle, ok := fh.(*createFileHandle)
+	if !ok {
+		return 0, syscall.EIO
+	}
+	handle.mu.Lock()
+	defer handle.mu.Unlock()
+
+	if newLen := int(off) + len(data); newLen > len(handle.content) {
+		grown := make([]byte, newLen)
+		copy(grown, handle.content)
+		handle.content = grown
+	}
+	copy(handle.content[off:], data)
+	return uint32(len(data)), 0
+}
+
+func (n *createFileNode) Flush(ctx context.Context, fh fs.FileHandle) syscall.Errno {
+	handle, ok := fh.(*createFileHandle)
+	if !ok {
+		return 0
+	}
+
+	// Consume the buffer atomically so concurrent flushes of dup'd descriptors
+	// hand the content to onFlush exactly once, then run the (network-bound)
+	// create outside the lock.
+	handle.mu.Lock()
+	content := handle.content
+	handle.content = nil
+	handle.mu.Unlock()
+
+	if len(content) == 0 {
+		return 0
+	}
+	return n.onFlush(ctx, content)
+}
+
+// Fsync is a no-op; actual persistence happens in Flush. It must be
+// implemented (not return ENOTSUP) so editors that write-then-fsync
+// (e.g. Claude Code's Edit tool, vim, VS Code) can save the _create file.
+func (n *createFileNode) Fsync(ctx context.Context, fh fs.FileHandle, flags uint32) syscall.Errno {
+	return 0
+}

--- a/internal/fs/createfile_test.go
+++ b/internal/fs/createfile_test.go
@@ -1,0 +1,158 @@
+package fs
+
+import (
+	"context"
+	"syscall"
+	"testing"
+
+	"github.com/hanwen/go-fuse/v2/fuse"
+)
+
+// newTestCreateFile returns a createFileNode whose onFlush records what it
+// receives, plus the recorder.
+func newTestCreateFile(errno syscall.Errno) (*createFileNode, *[][]byte) {
+	var got [][]byte
+	node := newCreateFile(nil, func(ctx context.Context, content []byte) syscall.Errno {
+		got = append(got, content)
+		return errno
+	})
+	return node, &got
+}
+
+func TestCreateFileWriteThenFlush(t *testing.T) {
+	t.Parallel()
+	node, got := newTestCreateFile(0)
+	ctx := context.Background()
+
+	fh, _, errno := node.Open(ctx, 0)
+	if errno != 0 {
+		t.Fatalf("Open() = %v", errno)
+	}
+	if _, errno := node.Write(ctx, fh, []byte("hello "), 0); errno != 0 {
+		t.Fatalf("Write() = %v", errno)
+	}
+	if _, errno := node.Write(ctx, fh, []byte("world"), 6); errno != 0 {
+		t.Fatalf("Write() = %v", errno)
+	}
+	if errno := node.Flush(ctx, fh); errno != 0 {
+		t.Fatalf("Flush() = %v", errno)
+	}
+	if len(*got) != 1 || string((*got)[0]) != "hello world" {
+		t.Errorf("onFlush got %q, want one call with %q", *got, "hello world")
+	}
+}
+
+func TestCreateFileEmptyFlushSkipsOnFlush(t *testing.T) {
+	t.Parallel()
+	node, got := newTestCreateFile(0)
+	ctx := context.Background()
+
+	fh, _, _ := node.Open(ctx, 0)
+	if errno := node.Flush(ctx, fh); errno != 0 {
+		t.Fatalf("Flush() = %v", errno)
+	}
+	if errno := node.Flush(ctx, nil); errno != 0 {
+		t.Fatalf("Flush(nil handle) = %v", errno)
+	}
+	if len(*got) != 0 {
+		t.Errorf("onFlush called %d times for empty flushes, want 0", len(*got))
+	}
+}
+
+func TestCreateFileDoubleFlushCreatesOnce(t *testing.T) {
+	t.Parallel()
+	node, got := newTestCreateFile(0)
+	ctx := context.Background()
+
+	fh, _, _ := node.Open(ctx, 0)
+	_, _ = node.Write(ctx, fh, []byte("payload"), 0)
+	if errno := node.Flush(ctx, fh); errno != 0 {
+		t.Fatalf("first Flush() = %v", errno)
+	}
+	// A dup'd descriptor flushes the same handle again: consumed buffer, no-op.
+	if errno := node.Flush(ctx, fh); errno != 0 {
+		t.Fatalf("second Flush() = %v", errno)
+	}
+	if len(*got) != 1 {
+		t.Errorf("onFlush called %d times, want 1", len(*got))
+	}
+}
+
+func TestCreateFileSecondOpenCreatesAgain(t *testing.T) {
+	t.Parallel()
+	node, got := newTestCreateFile(0)
+	ctx := context.Background()
+
+	// The kernel reuses the cached inode for a second open-write-close cycle;
+	// each cycle's fresh handle must produce its own create. (The old
+	// node-level buffers latched `created` and silently swallowed this.)
+	for _, payload := range []string{"first", "second"} {
+		fh, _, _ := node.Open(ctx, 0)
+		_, _ = node.Write(ctx, fh, []byte(payload), 0)
+		if errno := node.Flush(ctx, fh); errno != 0 {
+			t.Fatalf("Flush(%q) = %v", payload, errno)
+		}
+	}
+	if len(*got) != 2 || string((*got)[0]) != "first" || string((*got)[1]) != "second" {
+		t.Errorf("onFlush got %q, want [first second]", *got)
+	}
+}
+
+func TestCreateFileFlushErrnoPropagates(t *testing.T) {
+	t.Parallel()
+	node, got := newTestCreateFile(syscall.EINVAL)
+	ctx := context.Background()
+
+	fh, _, _ := node.Open(ctx, 0)
+	_, _ = node.Write(ctx, fh, []byte("bad input"), 0)
+	if errno := node.Flush(ctx, fh); errno != syscall.EINVAL {
+		t.Fatalf("Flush() = %v, want EINVAL", errno)
+	}
+	if len(*got) != 1 {
+		t.Fatalf("onFlush called %d times, want 1", len(*got))
+	}
+	// The buffer was consumed by the failed attempt; a retry needs a new
+	// open-write-close cycle, not a re-flush of the dead handle.
+	if errno := node.Flush(ctx, fh); errno != 0 {
+		t.Errorf("Flush() after failure = %v, want 0 (consumed buffer)", errno)
+	}
+}
+
+func TestCreateFileReadDenied(t *testing.T) {
+	t.Parallel()
+	node, _ := newTestCreateFile(0)
+	if _, errno := node.Read(context.Background(), nil, make([]byte, 8), 0); errno != syscall.EACCES {
+		t.Errorf("Read() = %v, want EACCES", errno)
+	}
+}
+
+func TestCreateFileWriteWrongHandle(t *testing.T) {
+	t.Parallel()
+	node, _ := newTestCreateFile(0)
+	if _, errno := node.Write(context.Background(), nil, []byte("x"), 0); errno != syscall.EIO {
+		t.Errorf("Write(nil handle) = %v, want EIO", errno)
+	}
+}
+
+func TestCreateFileSetattrTruncatesHandle(t *testing.T) {
+	t.Parallel()
+	node, got := newTestCreateFile(0)
+	ctx := context.Background()
+
+	fh, _, _ := node.Open(ctx, 0)
+	_, _ = node.Write(ctx, fh, []byte("stale content"), 0)
+	// The O_TRUNC of a `>` redirect arrives as Setattr(size=0) on the handle.
+	in := &fuse.SetAttrIn{}
+	in.Valid = fuse.FATTR_SIZE
+	in.Size = 0
+	if errno := node.Setattr(ctx, fh, in, &fuse.AttrOut{}); errno != 0 {
+		t.Fatalf("Setattr() = %v", errno)
+	}
+	_, _ = node.Write(ctx, fh, []byte("fresh"), 0)
+	if errno := node.Flush(ctx, fh); errno != 0 {
+		t.Fatalf("Flush() = %v", errno)
+	}
+	if len(*got) != 1 || string((*got)[0]) != "fresh" {
+		t.Errorf("onFlush got %q, want [fresh]", *got)
+	}
+}

--- a/internal/fs/documents.go
+++ b/internal/fs/documents.go
@@ -123,13 +123,7 @@ func (n *DocsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 	// Handle _create for creating documents
 	if name == "_create" {
 		now := time.Now()
-		node := &NewDocumentNode{
-			BaseNode:     BaseNode{lfs: n.lfs},
-			issueID:      n.issueID,
-			teamID:       n.teamID,
-			projectID:    n.projectID,
-			initiativeID: n.initiativeID,
-		}
+		node := newCreateFile(n.lfs, n.createDocument(""))
 		out.Attr.Mode = 0200 | syscall.S_IFREG
 		out.Attr.Uid = n.lfs.uid
 		out.Attr.Gid = n.lfs.gid
@@ -316,18 +310,11 @@ func (n *DocsNode) Create(ctx context.Context, name string, flags uint32, mode u
 		}
 	}
 
-	node := &NewDocumentNode{
-		BaseNode:     BaseNode{lfs: n.lfs},
-		issueID:      n.issueID,
-		teamID:       n.teamID,
-		projectID:    n.projectID,
-		initiativeID: n.initiativeID,
-		filename:     name, // Store filename for use as title
-	}
-
+	// The user-chosen filename feeds the title fallback.
+	node := newCreateFile(n.lfs, n.createDocument(name))
 	inode := n.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG})
 
-	return inode, nil, fuse.FOPEN_DIRECT_IO, 0
+	return inode, &createFileHandle{}, fuse.FOPEN_DIRECT_IO, 0
 }
 
 // documentFilename returns the filename for a document
@@ -517,156 +504,64 @@ func (n *DocumentFileNode) Fsync(ctx context.Context, f fs.FileHandle, flags uin
 	return 0
 }
 
-// NewDocumentNode handles creating new documents
-type NewDocumentNode struct {
-	BaseNode
-	issueID      string
-	teamID       string
-	projectID    string
-	initiativeID string
-	filename     string // Original filename (used as title if none in content)
-
-	mu      sync.Mutex
-	content []byte
-	created bool
-}
-
-var _ fs.NodeGetattrer = (*NewDocumentNode)(nil)
-var _ fs.NodeOpener = (*NewDocumentNode)(nil)
-var _ fs.NodeReader = (*NewDocumentNode)(nil)
-var _ fs.NodeWriter = (*NewDocumentNode)(nil)
-var _ fs.NodeFlusher = (*NewDocumentNode)(nil)
-var _ fs.NodeFsyncer = (*NewDocumentNode)(nil)
-var _ fs.NodeSetattrer = (*NewDocumentNode)(nil)
-
-func (n *NewDocumentNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	now := time.Now()
-	out.Mode = 0200
-	n.SetOwner(out)
-	out.Size = uint64(len(n.content))
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
-
-func (n *NewDocumentNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	return nil, fuse.FOPEN_DIRECT_IO, 0
-}
-
-func (n *NewDocumentNode) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	// _create is write-only - return permission denied
-	return nil, syscall.EACCES
-}
-
-func (n *NewDocumentNode) Write(ctx context.Context, f fs.FileHandle, data []byte, off int64) (uint32, syscall.Errno) {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	if n.lfs.debug {
-		log.Printf("Write new document: offset=%d len=%d", off, len(data))
-	}
-
-	// Expand buffer if needed
-	newLen := int(off) + len(data)
-	if newLen > len(n.content) {
-		newContent := make([]byte, newLen)
-		copy(newContent, n.content)
-		n.content = newContent
-	}
-
-	copy(n.content[off:], data)
-	return uint32(len(data)), 0
-}
-
-func (n *NewDocumentNode) Setattr(ctx context.Context, f fs.FileHandle, in *fuse.SetAttrIn, out *fuse.AttrOut) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	if sz, ok := in.GetSize(); ok {
-		if int(sz) < len(n.content) {
-			n.content = n.content[:sz]
-		} else if int(sz) > len(n.content) {
-			newContent := make([]byte, sz)
-			copy(newContent, n.content)
-			n.content = newContent
-		}
-	}
-
-	out.Mode = 0200
-	out.Size = uint64(len(n.content))
-	return 0
-}
-
-func (n *NewDocumentNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	if n.created || len(n.content) == 0 {
-		return 0
-	}
-
-	parentID := docParentID(n.issueID, n.teamID, n.projectID, n.initiativeID)
-	_, errno := commitCreate(ctx, n.lfs, createSpec[api.Document]{
-		op:  "create document",
-		key: collectionErrorKey("docs", parentID),
-		mutate: func(ctx context.Context) (*api.Document, error) {
-			title, body, err := marshal.ParseNewDocument(n.content)
-			if err != nil {
-				return nil, &FieldError{Field: "content", Message: "parse error: " + err.Error()}
-			}
-			// If no title in content, use filename (unless it's _create):
-			// remove .md, replace dashes with spaces.
-			if title == "" || title == "Untitled" {
-				if n.filename != "" && n.filename != "_create" {
-					title = strings.TrimSuffix(n.filename, ".md")
-					title = strings.ReplaceAll(title, "-", " ")
+// createDocument returns the docs create surface's onFlush for one write
+// cycle. filename is the user-chosen name from a named Create ("" for the
+// _create trigger); it becomes the title fallback when the content carries no
+// '# Title' heading.
+func (n *DocsNode) createDocument(filename string) func(ctx context.Context, content []byte) syscall.Errno {
+	return func(ctx context.Context, content []byte) syscall.Errno {
+		parentID := n.parentID()
+		_, errno := commitCreate(ctx, n.lfs, createSpec[api.Document]{
+			op:  "create document",
+			key: collectionErrorKey("docs", parentID),
+			mutate: func(ctx context.Context) (*api.Document, error) {
+				title, body, err := marshal.ParseNewDocument(content)
+				if err != nil {
+					return nil, &FieldError{Field: "content", Message: "parse error: " + err.Error()}
 				}
-			}
-			if title == "" {
-				return nil, &FieldError{Field: "title", Message: "document has no title. Add a '# Title' heading or name the file <title>.md."}
-			}
+				// If no title in content, use filename: remove .md, replace
+				// dashes with spaces.
+				if title == "" || title == "Untitled" {
+					if filename != "" {
+						title = strings.TrimSuffix(filename, ".md")
+						title = strings.ReplaceAll(title, "-", " ")
+					}
+				}
+				if title == "" {
+					return nil, &FieldError{Field: "title", Message: "document has no title. Add a '# Title' heading or name the file <title>.md."}
+				}
 
-			input := map[string]any{
-				"title":   title,
-				"content": body,
-			}
-			if n.issueID != "" {
-				input["issueId"] = n.issueID
-			}
-			if n.teamID != "" {
-				input["teamId"] = n.teamID
-			}
-			if n.projectID != "" {
-				input["projectId"] = n.projectID
-			}
-			if n.initiativeID != "" {
-				input["initiativeId"] = n.initiativeID
-			}
-			return n.lfs.mutator().CreateDocument(ctx, input)
-		},
-		result: func(d *api.Document) WriteResult {
-			return WriteResult{
-				URL:   d.URL,
-				Path:  documentFilename(*d),
-				Title: d.Title,
-			}
-		},
-		persist: func(ctx context.Context, d *api.Document) error {
-			return n.lfs.UpsertDocument(ctx, *d)
-		},
-		dir:       docsDirIno(parentID),
-		entryName: func(d *api.Document) string { return documentFilename(*d) },
-	})
-	if errno != 0 {
+				input := map[string]any{
+					"title":   title,
+					"content": body,
+				}
+				if n.issueID != "" {
+					input["issueId"] = n.issueID
+				}
+				if n.teamID != "" {
+					input["teamId"] = n.teamID
+				}
+				if n.projectID != "" {
+					input["projectId"] = n.projectID
+				}
+				if n.initiativeID != "" {
+					input["initiativeId"] = n.initiativeID
+				}
+				return n.lfs.mutator().CreateDocument(ctx, input)
+			},
+			result: func(d *api.Document) WriteResult {
+				return WriteResult{
+					URL:   d.URL,
+					Path:  documentFilename(*d),
+					Title: d.Title,
+				}
+			},
+			persist: func(ctx context.Context, d *api.Document) error {
+				return n.lfs.UpsertDocument(ctx, *d)
+			},
+			dir:       docsDirIno(parentID),
+			entryName: func(d *api.Document) string { return documentFilename(*d) },
+		})
 		return errno
 	}
-	n.created = true
-	return 0
-}
-
-func (n *NewDocumentNode) Fsync(ctx context.Context, f fs.FileHandle, flags uint32) syscall.Errno {
-	// Fsync is a no-op; actual persistence happens in Flush
-	return 0
 }

--- a/internal/fs/documents.go
+++ b/internal/fs/documents.go
@@ -95,19 +95,11 @@ func (n *DocsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	// Fetch documents (uses cache if available)
 	docs, err := n.getDocuments(ctx)
 	if err != nil {
-		// On error, return just _create and .error
-		return fs.NewListDirStream([]fuse.DirEntry{
-			{Name: "_create", Mode: syscall.S_IFREG},
-			{Name: ".error", Mode: syscall.S_IFREG},
-		}), 0
+		// On error, still serve the trio
+		return fs.NewListDirStream(n.trio().entries()), 0
 	}
 
-	// Always include _create for creating documents and .error for feedback
-	entries := []fuse.DirEntry{
-		{Name: "_create", Mode: syscall.S_IFREG},
-		{Name: ".error", Mode: syscall.S_IFREG},
-		{Name: ".last", Mode: syscall.S_IFREG},
-	}
+	entries := n.trio().entries()
 
 	for _, doc := range docs {
 		entries = append(entries, fuse.DirEntry{
@@ -119,30 +111,15 @@ func (n *DocsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	return fs.NewListDirStream(entries), 0
 }
 
-func (n *DocsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	// Handle _create for creating documents
-	if name == "_create" {
-		now := time.Now()
-		node := newCreateFile(n.lfs, n.createDocument(""))
-		out.Attr.Mode = 0200 | syscall.S_IFREG
-		out.Attr.Uid = n.lfs.uid
-		out.Attr.Gid = n.lfs.gid
-		out.Attr.Size = 0
-		out.Attr.SetTimes(&now, &now, &now)
-		out.SetAttrTimeout(1 * time.Second)
-		out.SetEntryTimeout(1 * time.Second)
-		return n.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFREG,
-		}), 0
-	}
+// trio declares the docs collection's writable surfaces. The _create trigger
+// has no user-chosen filename, so the title must come from the content.
+func (n *DocsNode) trio() collectionTrio {
+	return collectionTrio{kind: "docs", parentID: n.parentID(), onFlush: n.createDocument("")}
+}
 
-	// Handle .error feedback file (last failed doc write in this dir)
-	if name == ".error" {
-		return n.lfs.lookupErrorFile(ctx, n, collectionErrorKey("docs", n.parentID()), out), 0
-	}
-	// Handle .last feedback file (recent successful doc creations)
-	if name == ".last" {
-		return n.lfs.lookupSuccessFile(ctx, n, collectionSuccessKey("docs", n.parentID()), out), 0
+func (n *DocsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+	if inode, ok := n.lfs.lookupCollectionTrio(ctx, n, n.trio(), name, out); ok {
+		return inode, 0
 	}
 
 	docs, err := n.getDocuments(ctx)

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -712,12 +712,7 @@ func (n *InitiativeUpdatesNode) Readdir(ctx context.Context) (fs.DirStream, sysc
 		return nil, syscall.EIO
 	}
 
-	// Always include the create feedback trio
-	entries := []fuse.DirEntry{
-		{Name: "_create", Mode: syscall.S_IFREG},
-		{Name: ".error", Mode: syscall.S_IFREG},
-		{Name: ".last", Mode: syscall.S_IFREG},
-	}
+	entries := n.trio().entries()
 
 	// Sort updates by creation time
 	sort.Slice(updates, func(i, j int) bool {
@@ -737,26 +732,14 @@ func (n *InitiativeUpdatesNode) Readdir(ctx context.Context) (fs.DirStream, sysc
 	return fs.NewListDirStream(entries), 0
 }
 
-func (n *InitiativeUpdatesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	// Handle _create for creating updates
-	if name == "_create" {
-		now := time.Now()
-		node := newCreateFile(n.lfs, n.createUpdate)
-		out.Attr.Mode = 0200 | syscall.S_IFREG
-		out.Attr.Uid = n.lfs.uid
-		out.Attr.Gid = n.lfs.gid
-		out.Attr.Size = 0
-		out.Attr.SetTimes(&now, &now, &now)
-		out.SetAttrTimeout(1 * time.Second)
-		out.SetEntryTimeout(1 * time.Second)
-		return n.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG}), 0
-	}
+// trio declares the initiative-updates collection's writable surfaces.
+func (n *InitiativeUpdatesNode) trio() collectionTrio {
+	return collectionTrio{kind: "updates", parentID: n.initiativeID, onFlush: n.createUpdate}
+}
 
-	if name == ".error" {
-		return n.lfs.lookupErrorFile(ctx, n, collectionErrorKey("updates", n.initiativeID), out), 0
-	}
-	if name == ".last" {
-		return n.lfs.lookupSuccessFile(ctx, n, collectionSuccessKey("updates", n.initiativeID), out), 0
+func (n *InitiativeUpdatesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+	if inode, ok := n.lfs.lookupCollectionTrio(ctx, n, n.trio(), name, out); ok {
+		return inode, 0
 	}
 
 	updates, err := n.lfs.GetInitiativeUpdates(ctx, n.initiativeID)

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -741,10 +741,7 @@ func (n *InitiativeUpdatesNode) Lookup(ctx context.Context, name string, out *fu
 	// Handle _create for creating updates
 	if name == "_create" {
 		now := time.Now()
-		node := &NewInitiativeUpdateNode{
-			BaseNode:     BaseNode{lfs: n.lfs},
-			initiativeID: n.initiativeID,
-		}
+		node := newCreateFile(n.lfs, n.createUpdate)
 		out.Attr.Mode = 0200 | syscall.S_IFREG
 		out.Attr.Uid = n.lfs.uid
 		out.Attr.Gid = n.lfs.gid
@@ -808,13 +805,9 @@ func (n *InitiativeUpdatesNode) Create(ctx context.Context, name string, flags u
 		return nil, nil, 0, syscall.EINVAL
 	}
 
-	node := &NewInitiativeUpdateNode{
-		BaseNode:     BaseNode{lfs: n.lfs},
-		initiativeID: n.initiativeID,
-	}
-
+	node := newCreateFile(n.lfs, n.createUpdate)
 	inode := n.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG})
-	return inode, nil, fuse.FOPEN_DIRECT_IO, 0
+	return inode, &createFileHandle{}, fuse.FOPEN_DIRECT_IO, 0
 }
 
 // InitiativeUpdateNode represents a single initiative update file (read-only)
@@ -853,96 +846,12 @@ func (n *InitiativeUpdateNode) Read(ctx context.Context, f fs.FileHandle, dest [
 	return fuse.ReadResultData(n.content[off:end]), 0
 }
 
-// NewInitiativeUpdateNode handles creating new initiative updates
-type NewInitiativeUpdateNode struct {
-	BaseNode
-	initiativeID string
-
-	mu      sync.Mutex
-	content []byte
-	created bool
-}
-
-var _ fs.NodeGetattrer = (*NewInitiativeUpdateNode)(nil)
-var _ fs.NodeOpener = (*NewInitiativeUpdateNode)(nil)
-var _ fs.NodeReader = (*NewInitiativeUpdateNode)(nil)
-var _ fs.NodeWriter = (*NewInitiativeUpdateNode)(nil)
-var _ fs.NodeFlusher = (*NewInitiativeUpdateNode)(nil)
-var _ fs.NodeFsyncer = (*NewInitiativeUpdateNode)(nil)
-var _ fs.NodeSetattrer = (*NewInitiativeUpdateNode)(nil)
-
-func (n *NewInitiativeUpdateNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	now := time.Now()
-	out.Mode = 0200
-	n.SetOwner(out)
-	out.Size = uint64(len(n.content))
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
-
-func (n *NewInitiativeUpdateNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	return nil, fuse.FOPEN_DIRECT_IO, 0
-}
-
-func (n *NewInitiativeUpdateNode) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	// _create is write-only - return permission denied
-	return nil, syscall.EACCES
-}
-
-func (n *NewInitiativeUpdateNode) Write(ctx context.Context, f fs.FileHandle, data []byte, off int64) (uint32, syscall.Errno) {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	if n.lfs.debug {
-		log.Printf("Write new initiative update: offset=%d len=%d", off, len(data))
-	}
-
-	// Expand buffer if needed
-	newLen := int(off) + len(data)
-	if newLen > len(n.content) {
-		newContent := make([]byte, newLen)
-		copy(newContent, n.content)
-		n.content = newContent
-	}
-
-	copy(n.content[off:], data)
-	return uint32(len(data)), 0
-}
-
-func (n *NewInitiativeUpdateNode) Setattr(ctx context.Context, f fs.FileHandle, in *fuse.SetAttrIn, out *fuse.AttrOut) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	if sz, ok := in.GetSize(); ok {
-		if int(sz) < len(n.content) {
-			n.content = n.content[:sz]
-		} else if int(sz) > len(n.content) {
-			newContent := make([]byte, sz)
-			copy(newContent, n.content)
-			n.content = newContent
-		}
-	}
-
-	out.Mode = 0200
-	out.Size = uint64(len(n.content))
-	return 0
-}
-
-func (n *NewInitiativeUpdateNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	if n.created || len(n.content) == 0 {
-		return 0
-	}
-
-	// Parse the content - could be plain text or markdown with frontmatter.
-	// A parse error still goes through the create tail so it lands in .error;
-	// only whitespace-with-no-frontmatter is flush noise and no-ops.
-	body, health, perr := parseUpdateContent(n.content)
+// createUpdate is the initiative-updates create surface's onFlush: parse the
+// content and run the create tail. A parse error goes through the tail so it
+// lands in .error; only whitespace-with-no-frontmatter is flush noise and
+// no-ops.
+func (n *InitiativeUpdatesNode) createUpdate(ctx context.Context, content []byte) syscall.Errno {
+	body, health, perr := parseUpdateContent(content)
 	if perr == nil && body == "" {
 		return 0
 	}
@@ -971,15 +880,7 @@ func (n *NewInitiativeUpdateNode) Flush(ctx context.Context, f fs.FileHandle) sy
 		},
 		dir: initiativeUpdatesDirIno(n.initiativeID),
 	})
-	if errno != 0 {
-		return errno
-	}
-	n.created = true
-	return 0
-}
-
-func (n *NewInitiativeUpdateNode) Fsync(ctx context.Context, f fs.FileHandle, flags uint32) syscall.Errno {
-	return 0
+	return errno
 }
 
 // initiativeUpdateToMarkdown converts an initiative update to markdown with YAML frontmatter

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -159,20 +159,19 @@ func (n *IssuesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) 
 }
 
 func (n *IssuesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	// Handle _create trigger (full-object issue creation). The kernel may reuse
-	// this node across opens, so correctness does not depend on node identity:
-	// Flush consumes the buffer (success or failure), so each `echo spec >
-	// _create` starts clean and a spent/failed spec never bleeds into the next.
+	// Handle _create trigger (full-object issue creation). The buffer lives on
+	// the per-open handle, so kernel node reuse is harmless and the lookup can
+	// use the standard cache timeouts.
 	if name == "_create" {
 		now := time.Now()
-		node := &NewIssueCreateNode{BaseNode: BaseNode{lfs: n.lfs}, team: n.team}
+		node := newCreateFile(n.lfs, n.createIssue)
 		out.Attr.Mode = 0200 | syscall.S_IFREG
 		out.Attr.Uid = n.lfs.uid
 		out.Attr.Gid = n.lfs.gid
 		out.Attr.Size = 0
 		out.Attr.SetTimes(&now, &now, &now)
-		out.SetAttrTimeout(0)
-		out.SetEntryTimeout(0)
+		out.SetAttrTimeout(1 * time.Second)
+		out.SetEntryTimeout(1 * time.Second)
 		return n.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG}), 0
 	}
 	// Handle .error feedback file (last failed issue creation in this team)
@@ -293,92 +292,10 @@ func (n *IssuesNode) Mkdir(ctx context.Context, name string, mode uint32, out *f
 	}), 0
 }
 
-// NewIssueCreateNode is the write-only issues/_create trigger: writing a full
-// issue spec (frontmatter + body) creates one issue with all fields set at birth,
+// createIssue is the issues/_create surface's onFlush: writing a full issue
+// spec (frontmatter + body) creates one issue with all fields set at birth,
 // resolving names to IDs and reporting the new identity to issues/.last (#151).
-type NewIssueCreateNode struct {
-	BaseNode
-	team api.Team
-
-	mu      sync.Mutex
-	content []byte
-}
-
-var _ fs.NodeGetattrer = (*NewIssueCreateNode)(nil)
-var _ fs.NodeOpener = (*NewIssueCreateNode)(nil)
-var _ fs.NodeReader = (*NewIssueCreateNode)(nil)
-var _ fs.NodeWriter = (*NewIssueCreateNode)(nil)
-var _ fs.NodeFlusher = (*NewIssueCreateNode)(nil)
-var _ fs.NodeFsyncer = (*NewIssueCreateNode)(nil)
-var _ fs.NodeSetattrer = (*NewIssueCreateNode)(nil)
-
-func (n *NewIssueCreateNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	now := time.Now()
-	out.Mode = 0200
-	n.SetOwner(out)
-	out.Size = uint64(len(n.content))
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
-
-func (n *NewIssueCreateNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	return nil, fuse.FOPEN_DIRECT_IO, 0
-}
-
-func (n *NewIssueCreateNode) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	return nil, syscall.EACCES // write-only
-}
-
-func (n *NewIssueCreateNode) Write(ctx context.Context, f fs.FileHandle, data []byte, off int64) (uint32, syscall.Errno) {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	newLen := int(off) + len(data)
-	if newLen > len(n.content) {
-		grown := make([]byte, newLen)
-		copy(grown, n.content)
-		n.content = grown
-	}
-	copy(n.content[off:], data)
-	return uint32(len(data)), 0
-}
-
-func (n *NewIssueCreateNode) Setattr(ctx context.Context, f fs.FileHandle, in *fuse.SetAttrIn, out *fuse.AttrOut) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	if sz, ok := in.GetSize(); ok {
-		if int(sz) < len(n.content) {
-			n.content = n.content[:sz]
-		} else if int(sz) > len(n.content) {
-			grown := make([]byte, sz)
-			copy(grown, n.content)
-			n.content = grown
-		}
-	}
-	out.Mode = 0200
-	out.Size = uint64(len(n.content))
-	return 0
-}
-
-func (n *NewIssueCreateNode) Fsync(ctx context.Context, f fs.FileHandle, flags uint32) syscall.Errno {
-	return 0
-}
-
-func (n *NewIssueCreateNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	if len(n.content) == 0 {
-		return 0
-	}
-
-	// Consume the buffer up front so this spec can never bleed into a later write
-	// (go-fuse may hand the same node to a subsequent `echo spec > _create`, and a
-	// failed create must not leave leftovers that prepend to the next one).
-	content := n.content
-	n.content = nil
-
+func (n *IssuesNode) createIssue(ctx context.Context, content []byte) syscall.Errno {
 	_, errno := commitCreate(ctx, n.lfs, n.lfs.issueCreateSpec(
 		n.team.ID,
 		"create issue from spec",

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -142,12 +142,8 @@ func (n *IssuesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) 
 		return nil, syscall.EIO
 	}
 
-	// _create accepts a full issue spec; .error reports the last failed issue
-	// creation, .last the identities of recent successful creations (#149/#151).
-	entries := make([]fuse.DirEntry, 0, len(issues)+3)
-	entries = append(entries, fuse.DirEntry{Name: "_create", Mode: syscall.S_IFREG})
-	entries = append(entries, fuse.DirEntry{Name: ".error", Mode: syscall.S_IFREG})
-	entries = append(entries, fuse.DirEntry{Name: ".last", Mode: syscall.S_IFREG})
+	// _create accepts a full issue spec (#149/#151).
+	entries := n.trio().entries()
 	for _, issue := range issues {
 		entries = append(entries, fuse.DirEntry{
 			Name: issue.Identifier,
@@ -158,29 +154,15 @@ func (n *IssuesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) 
 	return fs.NewListDirStream(entries), 0
 }
 
+// trio declares the issues collection's writable surfaces: _create takes a
+// full issue spec (frontmatter + body).
+func (n *IssuesNode) trio() collectionTrio {
+	return collectionTrio{kind: "issues", parentID: n.team.ID, onFlush: n.createIssue}
+}
+
 func (n *IssuesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	// Handle _create trigger (full-object issue creation). The buffer lives on
-	// the per-open handle, so kernel node reuse is harmless and the lookup can
-	// use the standard cache timeouts.
-	if name == "_create" {
-		now := time.Now()
-		node := newCreateFile(n.lfs, n.createIssue)
-		out.Attr.Mode = 0200 | syscall.S_IFREG
-		out.Attr.Uid = n.lfs.uid
-		out.Attr.Gid = n.lfs.gid
-		out.Attr.Size = 0
-		out.Attr.SetTimes(&now, &now, &now)
-		out.SetAttrTimeout(1 * time.Second)
-		out.SetEntryTimeout(1 * time.Second)
-		return n.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG}), 0
-	}
-	// Handle .error feedback file (last failed issue creation in this team)
-	if name == ".error" {
-		return n.lfs.lookupErrorFile(ctx, n, collectionErrorKey("issues", n.team.ID), out), 0
-	}
-	// Handle .last feedback file (identities of recent successful creations)
-	if name == ".last" {
-		return n.lfs.lookupSuccessFile(ctx, n, collectionSuccessKey("issues", n.team.ID), out), 0
+	if inode, ok := n.lfs.lookupCollectionTrio(ctx, n, n.trio(), name, out); ok {
+		return inode, 0
 	}
 
 	// Check if name looks like a valid issue identifier (e.g., "ENG-123")

--- a/internal/fs/labels.go
+++ b/internal/fs/labels.go
@@ -57,57 +57,25 @@ func (n *LabelsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) 
 		return nil, syscall.EIO
 	}
 
-	// +3 for _create, .error and .last
-	entries := make([]fuse.DirEntry, len(labels)+3)
-
-	// Always include _create for creating labels and .error/.last for feedback
-	entries[0] = fuse.DirEntry{
-		Name: "_create",
-		Mode: syscall.S_IFREG,
-	}
-	entries[1] = fuse.DirEntry{
-		Name: ".error",
-		Mode: syscall.S_IFREG,
-	}
-	entries[2] = fuse.DirEntry{
-		Name: ".last",
-		Mode: syscall.S_IFREG,
-	}
-
-	for i, label := range labels {
-		entries[i+3] = fuse.DirEntry{
+	entries := n.trio().entries()
+	for _, label := range labels {
+		entries = append(entries, fuse.DirEntry{
 			Name: labelFilename(label),
 			Mode: syscall.S_IFREG,
-		}
+		})
 	}
 
 	return fs.NewListDirStream(entries), 0
 }
 
-func (n *LabelsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	// Handle _create for creating labels
-	if name == "_create" {
-		now := time.Now()
-		node := newCreateFile(n.lfs, n.createLabel)
-		out.Attr.Mode = 0200 | syscall.S_IFREG
-		out.Attr.Uid = n.lfs.uid
-		out.Attr.Gid = n.lfs.gid
-		out.Attr.Size = 0
-		out.Attr.SetTimes(&now, &now, &now)
-		out.SetAttrTimeout(1 * time.Second)
-		out.SetEntryTimeout(1 * time.Second)
-		return n.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFREG,
-		}), 0
-	}
+// trio declares the labels collection's writable surfaces.
+func (n *LabelsNode) trio() collectionTrio {
+	return collectionTrio{kind: "labels", parentID: n.teamID, onFlush: n.createLabel}
+}
 
-	// Handle .error feedback file (last failed label write in this dir)
-	if name == ".error" {
-		return n.lfs.lookupErrorFile(ctx, n, collectionErrorKey("labels", n.teamID), out), 0
-	}
-	// Handle .last feedback file (recent successful label creations)
-	if name == ".last" {
-		return n.lfs.lookupSuccessFile(ctx, n, collectionSuccessKey("labels", n.teamID), out), 0
+func (n *LabelsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+	if inode, ok := n.lfs.lookupCollectionTrio(ctx, n, n.trio(), name, out); ok {
+		return inode, 0
 	}
 
 	labels, err := n.lfs.GetTeamLabels(ctx, n.teamID)

--- a/internal/fs/labels.go
+++ b/internal/fs/labels.go
@@ -88,10 +88,7 @@ func (n *LabelsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut
 	// Handle _create for creating labels
 	if name == "_create" {
 		now := time.Now()
-		node := &NewLabelNode{
-			BaseNode: BaseNode{lfs: n.lfs},
-			teamID:   n.teamID,
-		}
+		node := newCreateFile(n.lfs, n.createLabel)
 		out.Attr.Mode = 0200 | syscall.S_IFREG
 		out.Attr.Uid = n.lfs.uid
 		out.Attr.Gid = n.lfs.gid
@@ -274,14 +271,10 @@ func (n *LabelsNode) Create(ctx context.Context, name string, flags uint32, mode
 		}
 	}
 
-	node := &NewLabelNode{
-		BaseNode: BaseNode{lfs: n.lfs},
-		teamID:   n.teamID,
-	}
-
+	node := newCreateFile(n.lfs, n.createLabel)
 	inode := n.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG})
 
-	return inode, nil, fuse.FOPEN_DIRECT_IO, 0
+	return inode, &createFileHandle{}, fuse.FOPEN_DIRECT_IO, 0
 }
 
 // labelFilename returns the filename for a label
@@ -491,97 +484,14 @@ func (n *LabelFileNode) Fsync(ctx context.Context, f fs.FileHandle, flags uint32
 	return 0
 }
 
-// NewLabelNode handles creating new labels
-type NewLabelNode struct {
-	BaseNode
-	teamID string
-
-	mu      sync.Mutex
-	content []byte
-	created bool
-}
-
-var _ fs.NodeGetattrer = (*NewLabelNode)(nil)
-var _ fs.NodeOpener = (*NewLabelNode)(nil)
-var _ fs.NodeReader = (*NewLabelNode)(nil)
-var _ fs.NodeWriter = (*NewLabelNode)(nil)
-var _ fs.NodeFlusher = (*NewLabelNode)(nil)
-var _ fs.NodeFsyncer = (*NewLabelNode)(nil)
-var _ fs.NodeSetattrer = (*NewLabelNode)(nil)
-
-func (n *NewLabelNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	now := time.Now()
-	out.Mode = 0200
-	n.SetOwner(out)
-	out.Size = uint64(len(n.content))
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
-
-func (n *NewLabelNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	return nil, fuse.FOPEN_DIRECT_IO, 0
-}
-
-func (n *NewLabelNode) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	// _create is write-only - return permission denied
-	return nil, syscall.EACCES
-}
-
-func (n *NewLabelNode) Write(ctx context.Context, f fs.FileHandle, data []byte, off int64) (uint32, syscall.Errno) {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	if n.lfs.debug {
-		log.Printf("Write new label: offset=%d len=%d", off, len(data))
-	}
-
-	// Expand buffer if needed
-	newLen := int(off) + len(data)
-	if newLen > len(n.content) {
-		newContent := make([]byte, newLen)
-		copy(newContent, n.content)
-		n.content = newContent
-	}
-
-	copy(n.content[off:], data)
-	return uint32(len(data)), 0
-}
-
-func (n *NewLabelNode) Setattr(ctx context.Context, f fs.FileHandle, in *fuse.SetAttrIn, out *fuse.AttrOut) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	if sz, ok := in.GetSize(); ok {
-		if int(sz) < len(n.content) {
-			n.content = n.content[:sz]
-		} else if int(sz) > len(n.content) {
-			newContent := make([]byte, sz)
-			copy(newContent, n.content)
-			n.content = newContent
-		}
-	}
-
-	out.Mode = 0200
-	out.Size = uint64(len(n.content))
-	return 0
-}
-
-func (n *NewLabelNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	if n.created || len(n.content) == 0 {
-		return 0
-	}
-
+// createLabel is the labels create surface's onFlush: parse the frontmatter
+// and run the create tail.
+func (n *LabelsNode) createLabel(ctx context.Context, content []byte) syscall.Errno {
 	_, errno := commitCreate(ctx, n.lfs, createSpec[api.Label]{
 		op:  "create label",
 		key: collectionErrorKey("labels", n.teamID),
 		mutate: func(ctx context.Context) (*api.Label, error) {
-			name, color, description, err := parseNewLabelMarkdown(n.content)
+			name, color, description, err := parseNewLabelMarkdown(content)
 			if err != nil {
 				return nil, &FieldError{Field: "content", Message: "parse error: " + err.Error()}
 			}
@@ -612,15 +522,7 @@ func (n *NewLabelNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno
 		dir:       labelsDirIno(n.teamID),
 		entryName: func(l *api.Label) string { return labelFilename(*l) },
 	})
-	if errno != 0 {
-		return errno
-	}
-	n.created = true
-	return 0
-}
-
-func (n *NewLabelNode) Fsync(ctx context.Context, f fs.FileHandle, flags uint32) syscall.Errno {
-	return 0
+	return errno
 }
 
 // parseLabelMarkdown parses markdown and returns fields that changed

--- a/internal/fs/milestones.go
+++ b/internal/fs/milestones.go
@@ -29,13 +29,6 @@ func milestoneIno(milestoneID string) uint64 {
 	return h.Sum64()
 }
 
-// milestonesCreateIno generates a stable inode for the _create trigger file
-func milestonesCreateIno(projectID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("milestones-create:" + projectID))
-	return h.Sum64()
-}
-
 // MilestonesNode represents a milestones/ directory within a project
 type MilestonesNode struct {
 	BaseNode
@@ -58,20 +51,11 @@ func (n *MilestonesNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse
 func (n *MilestonesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	milestones, err := n.lfs.GetProjectMilestones(ctx, n.projectID)
 	if err != nil {
-		// On error, return just _create and .error
-		return fs.NewListDirStream([]fuse.DirEntry{
-			{Name: "_create", Mode: syscall.S_IFREG},
-			{Name: ".error", Mode: syscall.S_IFREG},
-		}), 0
+		// On error, still serve the trio
+		return fs.NewListDirStream(n.trio().entries()), 0
 	}
 
-	// Always include _create for creating milestones and .error for feedback
-	entries := []fuse.DirEntry{
-		{Name: "_create", Mode: syscall.S_IFREG},
-		{Name: ".error", Mode: syscall.S_IFREG},
-		{Name: ".last", Mode: syscall.S_IFREG},
-	}
-
+	entries := n.trio().entries()
 	for _, m := range milestones {
 		entries = append(entries, fuse.DirEntry{
 			Name: milestoneFilename(m),
@@ -82,31 +66,14 @@ func (n *MilestonesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Err
 	return fs.NewListDirStream(entries), 0
 }
 
-func (n *MilestonesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	// Handle _create for creating milestones
-	if name == "_create" {
-		now := time.Now()
-		node := newCreateFile(n.lfs, n.createMilestone)
-		out.Attr.Mode = 0200 | syscall.S_IFREG
-		out.Attr.Uid = n.lfs.uid
-		out.Attr.Gid = n.lfs.gid
-		out.Attr.Size = 0
-		out.Attr.SetTimes(&now, &now, &now)
-		out.SetAttrTimeout(1 * time.Second)
-		out.SetEntryTimeout(1 * time.Second)
-		return n.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFREG,
-			Ino:  milestonesCreateIno(n.projectID),
-		}), 0
-	}
+// trio declares the milestones collection's writable surfaces.
+func (n *MilestonesNode) trio() collectionTrio {
+	return collectionTrio{kind: "milestones", parentID: n.projectID, onFlush: n.createMilestone}
+}
 
-	// Handle .error feedback file (last failed milestone write in this dir)
-	if name == ".error" {
-		return n.lfs.lookupErrorFile(ctx, n, collectionErrorKey("milestones", n.projectID), out), 0
-	}
-	// Handle .last feedback file (recent successful milestone creations)
-	if name == ".last" {
-		return n.lfs.lookupSuccessFile(ctx, n, collectionSuccessKey("milestones", n.projectID), out), 0
+func (n *MilestonesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+	if inode, ok := n.lfs.lookupCollectionTrio(ctx, n, n.trio(), name, out); ok {
+		return inode, 0
 	}
 
 	milestones, err := n.lfs.GetProjectMilestones(ctx, n.projectID)

--- a/internal/fs/milestones.go
+++ b/internal/fs/milestones.go
@@ -86,10 +86,7 @@ func (n *MilestonesNode) Lookup(ctx context.Context, name string, out *fuse.Entr
 	// Handle _create for creating milestones
 	if name == "_create" {
 		now := time.Now()
-		node := &NewMilestoneNode{
-			BaseNode:  BaseNode{lfs: n.lfs},
-			projectID: n.projectID,
-		}
+		node := newCreateFile(n.lfs, n.createMilestone)
 		out.Attr.Mode = 0200 | syscall.S_IFREG
 		out.Attr.Uid = n.lfs.uid
 		out.Attr.Gid = n.lfs.gid
@@ -378,97 +375,14 @@ func (n *MilestoneFileNode) Fsync(ctx context.Context, f fs.FileHandle, flags ui
 	return 0
 }
 
-// NewMilestoneNode handles creating new milestones
-type NewMilestoneNode struct {
-	BaseNode
-	projectID string
-
-	mu      sync.Mutex
-	content []byte
-	created bool
-}
-
-var _ fs.NodeGetattrer = (*NewMilestoneNode)(nil)
-var _ fs.NodeOpener = (*NewMilestoneNode)(nil)
-var _ fs.NodeReader = (*NewMilestoneNode)(nil)
-var _ fs.NodeWriter = (*NewMilestoneNode)(nil)
-var _ fs.NodeFlusher = (*NewMilestoneNode)(nil)
-var _ fs.NodeFsyncer = (*NewMilestoneNode)(nil)
-var _ fs.NodeSetattrer = (*NewMilestoneNode)(nil)
-
-func (n *NewMilestoneNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	now := time.Now()
-	out.Mode = 0200
-	n.SetOwner(out)
-	out.Size = uint64(len(n.content))
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
-
-func (n *NewMilestoneNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	return nil, fuse.FOPEN_DIRECT_IO, 0
-}
-
-func (n *NewMilestoneNode) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	// _create is write-only
-	return nil, syscall.EACCES
-}
-
-func (n *NewMilestoneNode) Write(ctx context.Context, f fs.FileHandle, data []byte, off int64) (uint32, syscall.Errno) {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	if n.lfs.debug {
-		log.Printf("Write new milestone: offset=%d len=%d", off, len(data))
-	}
-
-	// Expand buffer if needed
-	newLen := int(off) + len(data)
-	if newLen > len(n.content) {
-		newContent := make([]byte, newLen)
-		copy(newContent, n.content)
-		n.content = newContent
-	}
-
-	copy(n.content[off:], data)
-	return uint32(len(data)), 0
-}
-
-func (n *NewMilestoneNode) Setattr(ctx context.Context, f fs.FileHandle, in *fuse.SetAttrIn, out *fuse.AttrOut) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	if sz, ok := in.GetSize(); ok {
-		if int(sz) < len(n.content) {
-			n.content = n.content[:sz]
-		} else if int(sz) > len(n.content) {
-			newContent := make([]byte, sz)
-			copy(newContent, n.content)
-			n.content = newContent
-		}
-	}
-
-	out.Mode = 0200
-	out.Size = uint64(len(n.content))
-	return 0
-}
-
-func (n *NewMilestoneNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	if n.created || len(n.content) == 0 {
-		return 0
-	}
-
+// createMilestone is the milestones create surface's onFlush: parse the
+// frontmatter and run the create tail.
+func (n *MilestonesNode) createMilestone(ctx context.Context, content []byte) syscall.Errno {
 	_, errno := commitCreate(ctx, n.lfs, createSpec[api.ProjectMilestone]{
 		op:  "create milestone",
 		key: collectionErrorKey("milestones", n.projectID),
 		mutate: func(ctx context.Context) (*api.ProjectMilestone, error) {
-			name, description := marshal.ParseNewMilestone(n.content)
+			name, description := marshal.ParseNewMilestone(content)
 			if name == "" {
 				return nil, &FieldError{Field: "name", Message: "milestone has no name. Add a 'name:' field to the frontmatter."}
 			}
@@ -486,13 +400,5 @@ func (n *NewMilestoneNode) Flush(ctx context.Context, f fs.FileHandle) syscall.E
 		dir:       milestonesDirIno(n.projectID),
 		entryName: func(m *api.ProjectMilestone) string { return milestoneFilename(*m) },
 	})
-	if errno != 0 {
-		return errno
-	}
-	n.created = true
-	return 0
-}
-
-func (n *NewMilestoneNode) Fsync(ctx context.Context, f fs.FileHandle, flags uint32) syscall.Errno {
-	return 0
+	return errno
 }

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -66,11 +66,9 @@ func (p *ProjectsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno
 		return nil, syscall.EIO
 	}
 
-	// .error reports the last failed project creation in this team; .last reports
-	// the identities of recent successful creations (#149).
-	entries := make([]fuse.DirEntry, 0, len(projects)+2)
-	entries = append(entries, fuse.DirEntry{Name: ".error", Mode: syscall.S_IFREG})
-	entries = append(entries, fuse.DirEntry{Name: ".last", Mode: syscall.S_IFREG})
+	// Projects are created by mkdir, so the collection has no _create; the
+	// trio degrades to .error/.last (#149).
+	entries := p.trio().entries()
 	for _, project := range projects {
 		entries = append(entries, fuse.DirEntry{
 			Name: projectDirName(project),
@@ -81,14 +79,15 @@ func (p *ProjectsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno
 	return fs.NewListDirStream(entries), 0
 }
 
+// trio declares the projects collection's feedback surfaces. Projects are
+// created by mkdir rather than a _create trigger, so onFlush stays nil.
+func (p *ProjectsNode) trio() collectionTrio {
+	return collectionTrio{kind: "projects", parentID: p.team.ID}
+}
+
 func (p *ProjectsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	// Handle .error feedback file (last failed project creation in this team)
-	if name == ".error" {
-		return p.lfs.lookupErrorFile(ctx, p, collectionErrorKey("projects", p.team.ID), out), 0
-	}
-	// Handle .last feedback file (recent successful project creations)
-	if name == ".last" {
-		return p.lfs.lookupSuccessFile(ctx, p, collectionSuccessKey("projects", p.team.ID), out), 0
+	if inode, ok := p.lfs.lookupCollectionTrio(ctx, p, p.trio(), name, out); ok {
+		return inode, 0
 	}
 
 	projects, err := p.lfs.GetTeamProjects(ctx, p.team.ID)
@@ -791,12 +790,7 @@ func (n *UpdatesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno)
 		return nil, syscall.EIO
 	}
 
-	// Always include the create feedback trio
-	entries := []fuse.DirEntry{
-		{Name: "_create", Mode: syscall.S_IFREG},
-		{Name: ".error", Mode: syscall.S_IFREG},
-		{Name: ".last", Mode: syscall.S_IFREG},
-	}
+	entries := n.trio().entries()
 
 	// Sort updates by creation time
 	sort.Slice(updates, func(i, j int) bool {
@@ -816,26 +810,14 @@ func (n *UpdatesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno)
 	return fs.NewListDirStream(entries), 0
 }
 
-func (n *UpdatesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	// Handle _create for creating updates
-	if name == "_create" {
-		now := time.Now()
-		node := newCreateFile(n.lfs, n.createUpdate)
-		out.Attr.Mode = 0200 | syscall.S_IFREG
-		out.Attr.Uid = n.lfs.uid
-		out.Attr.Gid = n.lfs.gid
-		out.Attr.Size = 0
-		out.Attr.SetTimes(&now, &now, &now)
-		out.SetAttrTimeout(1 * time.Second)
-		out.SetEntryTimeout(1 * time.Second)
-		return n.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG}), 0
-	}
+// trio declares the project-updates collection's writable surfaces.
+func (n *UpdatesNode) trio() collectionTrio {
+	return collectionTrio{kind: "updates", parentID: n.projectID, onFlush: n.createUpdate}
+}
 
-	if name == ".error" {
-		return n.lfs.lookupErrorFile(ctx, n, collectionErrorKey("updates", n.projectID), out), 0
-	}
-	if name == ".last" {
-		return n.lfs.lookupSuccessFile(ctx, n, collectionSuccessKey("updates", n.projectID), out), 0
+func (n *UpdatesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+	if inode, ok := n.lfs.lookupCollectionTrio(ctx, n, n.trio(), name, out); ok {
+		return inode, 0
 	}
 
 	updates, err := n.lfs.GetProjectUpdates(ctx, n.projectID)

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -820,10 +820,7 @@ func (n *UpdatesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOu
 	// Handle _create for creating updates
 	if name == "_create" {
 		now := time.Now()
-		node := &NewUpdateNode{
-			BaseNode:  BaseNode{lfs: n.lfs},
-			projectID: n.projectID,
-		}
+		node := newCreateFile(n.lfs, n.createUpdate)
 		out.Attr.Mode = 0200 | syscall.S_IFREG
 		out.Attr.Uid = n.lfs.uid
 		out.Attr.Gid = n.lfs.gid
@@ -884,13 +881,9 @@ func (n *UpdatesNode) Create(ctx context.Context, name string, flags uint32, mod
 		return nil, nil, 0, syscall.EINVAL
 	}
 
-	node := &NewUpdateNode{
-		BaseNode:  BaseNode{lfs: n.lfs},
-		projectID: n.projectID,
-	}
-
+	node := newCreateFile(n.lfs, n.createUpdate)
 	inode := n.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG})
-	return inode, nil, fuse.FOPEN_DIRECT_IO, 0
+	return inode, &createFileHandle{}, fuse.FOPEN_DIRECT_IO, 0
 }
 
 // UpdateNode represents a single project update file (read-only)
@@ -928,96 +921,12 @@ func (n *UpdateNode) Read(ctx context.Context, f fs.FileHandle, dest []byte, off
 	return fuse.ReadResultData(n.content[off:end]), 0
 }
 
-// NewUpdateNode handles creating new project updates
-type NewUpdateNode struct {
-	BaseNode
-	projectID string
-
-	mu      sync.Mutex
-	content []byte
-	created bool
-}
-
-var _ fs.NodeGetattrer = (*NewUpdateNode)(nil)
-var _ fs.NodeOpener = (*NewUpdateNode)(nil)
-var _ fs.NodeReader = (*NewUpdateNode)(nil)
-var _ fs.NodeWriter = (*NewUpdateNode)(nil)
-var _ fs.NodeFlusher = (*NewUpdateNode)(nil)
-var _ fs.NodeFsyncer = (*NewUpdateNode)(nil)
-var _ fs.NodeSetattrer = (*NewUpdateNode)(nil)
-
-func (n *NewUpdateNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	now := time.Now()
-	out.Mode = 0200
-	n.SetOwner(out)
-	out.Size = uint64(len(n.content))
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
-
-func (n *NewUpdateNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	return nil, fuse.FOPEN_DIRECT_IO, 0
-}
-
-func (n *NewUpdateNode) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	// _create is write-only - return permission denied
-	return nil, syscall.EACCES
-}
-
-func (n *NewUpdateNode) Write(ctx context.Context, f fs.FileHandle, data []byte, off int64) (uint32, syscall.Errno) {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	if n.lfs.debug {
-		log.Printf("Write new update: offset=%d len=%d", off, len(data))
-	}
-
-	// Expand buffer if needed
-	newLen := int(off) + len(data)
-	if newLen > len(n.content) {
-		newContent := make([]byte, newLen)
-		copy(newContent, n.content)
-		n.content = newContent
-	}
-
-	copy(n.content[off:], data)
-	return uint32(len(data)), 0
-}
-
-func (n *NewUpdateNode) Setattr(ctx context.Context, f fs.FileHandle, in *fuse.SetAttrIn, out *fuse.AttrOut) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	if sz, ok := in.GetSize(); ok {
-		if int(sz) < len(n.content) {
-			n.content = n.content[:sz]
-		} else if int(sz) > len(n.content) {
-			newContent := make([]byte, sz)
-			copy(newContent, n.content)
-			n.content = newContent
-		}
-	}
-
-	out.Mode = 0200
-	out.Size = uint64(len(n.content))
-	return 0
-}
-
-func (n *NewUpdateNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	if n.created || len(n.content) == 0 {
-		return 0
-	}
-
-	// Parse the content - could be plain text or markdown with frontmatter.
-	// A parse error still goes through the create tail so it lands in .error;
-	// only whitespace-with-no-frontmatter is flush noise and no-ops.
-	body, health, perr := parseUpdateContent(n.content)
+// createUpdate is the project-updates create surface's onFlush: parse the
+// content and run the create tail. A parse error goes through the tail so it
+// lands in .error; only whitespace-with-no-frontmatter is flush noise and
+// no-ops.
+func (n *UpdatesNode) createUpdate(ctx context.Context, content []byte) syscall.Errno {
+	body, health, perr := parseUpdateContent(content)
 	if perr == nil && body == "" {
 		return 0
 	}
@@ -1046,15 +955,7 @@ func (n *NewUpdateNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errn
 		},
 		dir: updatesDirIno(n.projectID),
 	})
-	if errno != 0 {
-		return errno
-	}
-	n.created = true
-	return 0
-}
-
-func (n *NewUpdateNode) Fsync(ctx context.Context, f fs.FileHandle, flags uint32) syscall.Errno {
-	return 0
+	return errno
 }
 
 // parseUpdateContent extracts body and health from update content (shared by

--- a/internal/fs/relations.go
+++ b/internal/fs/relations.go
@@ -95,10 +95,7 @@ func (n *RelationsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errn
 
 func (n *RelationsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
 	if name == "_create" {
-		node := &NewRelationNode{
-			BaseNode: BaseNode{lfs: n.lfs},
-			issueID:  n.issueID,
-		}
+		node := newCreateFile(n.lfs, n.createRelation)
 		now := time.Now()
 		out.Attr.Mode = 0200 | syscall.S_IFREG // Write-only
 		out.Attr.Uid = n.lfs.uid
@@ -272,65 +269,11 @@ func (n *RelationFileNode) Unlink(ctx context.Context, name string) syscall.Errn
 	})
 }
 
-// NewRelationNode represents the _create file for creating new relations
-type NewRelationNode struct {
-	BaseNode
-	issueID string
-}
-
-var _ fs.NodeGetattrer = (*NewRelationNode)(nil)
-var _ fs.NodeSetattrer = (*NewRelationNode)(nil)
-var _ fs.NodeOpener = (*NewRelationNode)(nil)
-var _ fs.NodeWriter = (*NewRelationNode)(nil)
-var _ fs.NodeFlusher = (*NewRelationNode)(nil)
-var _ fs.NodeFsyncer = (*NewRelationNode)(nil)
-
-func (n *NewRelationNode) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0200 // Write-only
-	n.SetOwner(out)
-	out.Size = 0
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
-
-func (n *NewRelationNode) Setattr(ctx context.Context, fh fs.FileHandle, in *fuse.SetAttrIn, out *fuse.AttrOut) syscall.Errno {
-	// Allow truncation (for > redirect) - just return success
-	out.Mode = 0200
-	n.SetOwner(out)
-	out.Size = 0
-	return 0
-}
-
-func (n *NewRelationNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	return &relationCreateHandle{}, fuse.FOPEN_DIRECT_IO, 0
-}
-
-func (n *NewRelationNode) Write(ctx context.Context, fh fs.FileHandle, data []byte, off int64) (uint32, syscall.Errno) {
-	handle, ok := fh.(*relationCreateHandle)
-	if !ok {
-		return 0, syscall.EIO
-	}
-	handle.buffer = append(handle.buffer, data...)
-	return uint32(len(data)), 0
-}
-
-// Fsync is a no-op; actual persistence happens in Flush. It must be
-// implemented (not return ENOTSUP) so editors that write-then-fsync
-// (e.g. Claude Code's Edit tool, vim, VS Code) can save the _create file.
-func (n *NewRelationNode) Fsync(ctx context.Context, fh fs.FileHandle, flags uint32) syscall.Errno {
-	return 0
-}
-
-func (n *NewRelationNode) Flush(ctx context.Context, fh fs.FileHandle) syscall.Errno {
-	handle, ok := fh.(*relationCreateHandle)
-	if !ok || len(handle.buffer) == 0 {
-		return 0
-	}
-
-	// Parse the content: "type identifier" or just "identifier" (defaults to "related")
-	content := strings.TrimSpace(string(handle.buffer))
-	handle.buffer = nil
+// createRelation is the relations create surface's onFlush: parse
+// "type identifier" (or just "identifier", defaulting to "related") and run
+// the create tail.
+func (n *RelationsNode) createRelation(ctx context.Context, raw []byte) syscall.Errno {
+	content := strings.TrimSpace(string(raw))
 
 	// relatedID carries the resolved target issue's ID from mutate to persist
 	// (the API's echoed relation doesn't include it).
@@ -391,8 +334,4 @@ func (n *NewRelationNode) Flush(ctx context.Context, fh fs.FileHandle) syscall.E
 		},
 	})
 	return errno
-}
-
-type relationCreateHandle struct {
-	buffer []byte
 }

--- a/internal/fs/relations.go
+++ b/internal/fs/relations.go
@@ -29,13 +29,6 @@ func relationIno(relationID string) uint64 {
 	return h.Sum64()
 }
 
-// relationsCreateIno generates a stable inode for the _create trigger file
-func relationsCreateIno(issueID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("relations-create:" + issueID))
-	return h.Sum64()
-}
-
 // RelationsNode represents the /teams/{KEY}/issues/{ID}/relations directory
 type RelationsNode struct {
 	BaseNode
@@ -66,12 +59,7 @@ func (n *RelationsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errn
 		return nil, syscall.EIO
 	}
 
-	// Build entries: _create + .error + .last + relation files
-	entries := []fuse.DirEntry{
-		{Name: "_create", Mode: syscall.S_IFREG},
-		{Name: ".error", Mode: syscall.S_IFREG},
-		{Name: ".last", Mode: syscall.S_IFREG},
-	}
+	entries := n.trio().entries()
 
 	// Add outgoing relations (e.g., "blocks-ENG-123.rel")
 	for _, rel := range relations {
@@ -93,30 +81,14 @@ func (n *RelationsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errn
 	return fs.NewListDirStream(entries), 0
 }
 
-func (n *RelationsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	if name == "_create" {
-		node := newCreateFile(n.lfs, n.createRelation)
-		now := time.Now()
-		out.Attr.Mode = 0200 | syscall.S_IFREG // Write-only
-		out.Attr.Uid = n.lfs.uid
-		out.Attr.Gid = n.lfs.gid
-		out.Attr.Size = 0
-		out.SetAttrTimeout(1 * time.Second)
-		out.SetEntryTimeout(1 * time.Second)
-		out.Attr.SetTimes(&now, &now, &now)
-		return n.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFREG,
-			Ino:  relationsCreateIno(n.issueID),
-		}), 0
-	}
+// trio declares the relations collection's writable surfaces.
+func (n *RelationsNode) trio() collectionTrio {
+	return collectionTrio{kind: "relations", parentID: n.issueID, onFlush: n.createRelation}
+}
 
-	// Handle .error feedback file (last failed relation write in this dir)
-	if name == ".error" {
-		return n.lfs.lookupErrorFile(ctx, n, collectionErrorKey("relations", n.issueID), out), 0
-	}
-	// Handle .last feedback file (recent successful relation creations)
-	if name == ".last" {
-		return n.lfs.lookupSuccessFile(ctx, n, collectionSuccessKey("relations", n.issueID), out), 0
+func (n *RelationsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+	if inode, ok := n.lfs.lookupCollectionTrio(ctx, n, n.trio(), name, out); ok {
+		return inode, 0
 	}
 
 	// Parse relation filename: "type-IDENTIFIER.rel"

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -290,8 +290,11 @@ _create is a write-only trigger file (like /proc/sysrq-trigger):
 - Use piped output: echo "text" > _create, cat file > _create
 - Created items appear as separate files (e.g., 001-2025-01-15.md). Every create
   surface (issues, children, comments, docs, labels, projects, milestones,
-  attachments, relations) exposes a sibling .last with the new identity; read
-  .error for a failure.
+  attachments, relations, updates) exposes a sibling .last with the new identity;
+  read .error for a failure.
+- Each open-write-close cycle creates one item: writing to _create again creates
+  another item, so a repeated identical write creates a duplicate. After a failed
+  write (.error explains it), simply write the corrected content again.
 - For docs/, prefer named files: echo "x" > docs/"Title.md"
 </_create_behavior>
 

--- a/internal/integration/readme_test.go
+++ b/internal/integration/readme_test.go
@@ -28,7 +28,11 @@ func TestGeneratedReadmeMatchesBehavior(t *testing.T) {
 	// "recent created updates" guards the updates trio: updates/ directories were
 	// the last create surface without .error/.last, which made the README's global
 	// "every writable directory has a .error" claim false there.
-	for _, want := range []string{".last", "issue.meta", "initiative.meta", "recent/", "recent created updates"} {
+	// "relations, updates" pins updates' membership in the .last surface list;
+	// "creates one item" pins the per-write-cycle semantics (each write to
+	// _create creates another item — the old node-level buffers silently
+	// swallowed the second write, so nothing documented it).
+	for _, want := range []string{".last", "issue.meta", "initiative.meta", "recent/", "recent created updates", "relations, updates", "creates one item"} {
 		if !strings.Contains(readme, want) {
 			t.Errorf("README does not mention %q", want)
 		}

--- a/internal/integration/t6_conformance_test.go
+++ b/internal/integration/t6_conformance_test.go
@@ -191,8 +191,6 @@ func TestWriteContractCreateTrioUniform(t *testing.T) {
 	// Updates were the last surface hand-rolling the create tail with no
 	// .error/.last at all. An unrecognized health value is rejected (EINVAL),
 	// not silently coerced to onTrack, and the reason lands in updates/.error.
-	// (The failing probe runs first: the kernel caches the _create node, and a
-	// successful create latches its double-flush guard.)
 	if err := os.WriteFile(filepath.Join(projectUpdatesDir, "_create"), []byte("---\nhealth: critical\n---\nOn fire"), 0200); err == nil {
 		t.Error("invalid health accepted; want EINVAL")
 	}
@@ -221,6 +219,24 @@ func TestWriteContractCreateTrioUniform(t *testing.T) {
 		t.Fatalf("read updates/.error after success: %v", err)
 	} else if len(errContent) != 0 {
 		t.Errorf("updates/.error not cleared by a successful create: %s", errContent)
+	}
+
+	// Consecutive creates through the same _create path both land: the write
+	// buffer lives on the per-open handle, so the kernel reusing the cached
+	// node for a second open-write-close cycle must not swallow the create
+	// (the old per-node buffers latched after the first success and silently
+	// no-op'd every create after it).
+	if err := os.WriteFile(filepath.Join(projectUpdatesDir, "_create"), []byte("Back-to-back probe"), 0200); err != nil {
+		t.Fatalf("second consecutive update create: %v", err)
+	}
+	bfound := false
+	for _, e := range parseLastSidecar(t, filepath.Join(projectUpdatesDir, ".last")) {
+		if e["title"] == "Back-to-back probe" {
+			bfound = true
+		}
+	}
+	if !bfound {
+		t.Error("second consecutive create through the same _create node was swallowed (no .last entry)")
 	}
 }
 


### PR DESCRIPTION
## Summary

Two deepening refactors from the architecture review, landing as two commits:

**Commit 1 — `createFileNode` (one write-only create trigger).** Nine hand-copied `New*Node` types each carried ~80 lines of buffer scaffolding; only `Flush` differed, and two buffer designs coexisted. The new module standardizes on the per-open FileHandle buffer (the pattern attachments/relations already proved): `Open` mints a fresh buffer, `Flush` consumes it exactly once and hands it to the surface's `onFlush(ctx, content)` closure — the module's whole interface.

**Deliberate behavior change:** a second `echo > _create` through the same kernel-cached node now *creates* instead of silently no-oping (the old per-node `created` latch swallowed it). Dup'd-descriptor double-flushes still no-op via the consumed buffer. A new conformance probe pins consecutive creates; issues/_create drops its zero-lookup-timeout hack, which existed only to dodge the latch bug.

**Commit 2 — `collectionTrio` (the `_create`/`.error`/`.last` contract).** Which virtual files a writable collection serves was restated in 9 Readdirs + 9 Lookups, and the copies had drifted (fetch-error paths missing `.last`; updates shipped with no `.error`/`.last` at all; three bespoke `_create` inodes). A directory now declares a spec (`kind`, `parentID`, `onFlush`) and delegates — the trio is module-guaranteed the way `InvalidateCreated` is. Projects (mkdir-created) use a nil-`onFlush` spec serving just the sidecars.

## Numbers

Net **−572 lines** across the two commits while adding two tested modules and two CONTEXT.md concepts.

## Testing

- `createfile_test.go`: 8 unit tests on the buffer contract (offset writes, truncate-on-handle, empty/double flush, per-cycle reuse, errno propagation, EACCES reads).
- `collection_test.go`: trio header incl. the nil-onFlush degradation.
- `TestWriteContractCreateTrioUniform` extended with a consecutive-creates probe; its old "failing probe must run first" ordering workaround is obsolete and removed.
- The #146 attachment-idempotency test now exercises `createAttachment` directly (buffer mechanics are covered by the module's own tests).
- Full suite green (`go test ./...`), run 6× to shake out ordering flakes. One non-reproducing failure of `TestFixtureAttachmentsDirectoryListing` was observed once in an early full-suite run and never again in 6 subsequent fresh runs — noting for transparency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)