### PR TITLE
fix: delete-forget durability — no more phantom rows

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,10 +61,19 @@ tail: run the caller's `find` closure (locate the target by name, or hand over a
 already-held entity) → run the delete/archive mutation → classify failure through
 the shared classifier (`classifyMutationErr`) → on success clear `.error`,
 **forget the SQLite row** (required — the store is the listing source of truth,
-so a skipped forget resurrects the deleted item until sync), and apply the
-kernel-cache coherence policy (`InvalidateDeleted` is module-guaranteed). An
-unknown name notes itself in `.error` before returning `ENOENT`. Generic over
-`T`, behind the `deleteSink` seam; unit-tested with fakes, no FUSE mount.
+so a skipped forget resurrects the deleted item), and apply the kernel-cache
+coherence policy (`InvalidateDeleted` is module-guaranteed). An unknown name
+notes itself in `.error` before returning `ENOENT`. Generic over `T`, behind the
+`deleteSink` seam; unit-tested with fakes, no FUSE mount.
+
+Durability of the forget (a stress test caught a delete whose forget lost a
+`SQLITE_BUSY` race to the sync worker, leaving a phantom file that resurrected
+forever): the connection-level `busy_timeout` DSN pragma makes the race rare,
+the tail retries a failed forget before giving up, a delete of an entity Linear
+already lacks ("Entity not found") is **idempotent success** — the row is still
+forgotten, so re-`rm`ing a phantom heals it — and the details sync **prunes**
+rows a (provably complete, sub-page-cap) fetch no longer returns, scoped by
+issue and a pre-fetch `synced_at` cutoff so rows created mid-fetch survive.
 
 ### Name→ID resolution (`resolveIssueUpdate`)
 marshal returns an issue update whose relational fields hold *names* (a state name,

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1291,10 +1291,10 @@ func (c *Client) GetIssueDetailsBatch(ctx context.Context, issueIDs []string) (m
 		alias := fmt.Sprintf("i%d", i)
 		varName := fmt.Sprintf("id%d", i)
 		queryParts = append(queryParts, fmt.Sprintf(`%s: issue(id: $%s) {
-			comments(first: 100) { nodes { ...CommentFields } }
-			documents(first: 100) { nodes { ...DocumentFields } }
-			attachments(first: 100) { nodes { ...AttachmentFields } }
-		}`, alias, varName))
+			comments(first: %d) { nodes { ...CommentFields } }
+			documents(first: %d) { nodes { ...DocumentFields } }
+			attachments(first: %d) { nodes { ...AttachmentFields } }
+		}`, alias, varName, IssueDetailsPageSize, IssueDetailsPageSize, IssueDetailsPageSize))
 		vars[varName] = id
 	}
 

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -1,5 +1,7 @@
 package api
 
+import "fmt"
+
 const queryTeams = `
 query Teams {
   teams {
@@ -814,22 +816,30 @@ mutation ArchiveIssue($id: String!) {
 }
 `
 
+// IssueDetailsPageSize is the `first:` page cap on the issue-details queries
+// (single and batch). Exported because the sync worker's stale-row pruning may
+// only treat a fetched set as complete when its length is below this cap — a
+// full page may be truncated, and pruning against a truncated set would delete
+// real rows.
+const IssueDetailsPageSize = 100
+
 // queryIssueDetails fetches comments, documents, and attachments for an issue in one query
-var queryIssueDetails = `
+var queryIssueDetails = fmt.Sprintf(`
 query IssueDetails($issueId: String!) {
   issue(id: $issueId) {
-    comments(first: 100) {
+    comments(first: %d) {
       nodes { ...CommentFields }
     }
-    documents(first: 100) {
+    documents(first: %d) {
       nodes { ...DocumentFields }
     }
-    attachments(first: 100) {
+    attachments(first: %d) {
       nodes { ...AttachmentFields }
     }
   }
 }
-` + CommentFieldsFragment + DocumentFieldsFragment + AttachmentFieldsFragment
+`, IssueDetailsPageSize, IssueDetailsPageSize, IssueDetailsPageSize) +
+	CommentFieldsFragment + DocumentFieldsFragment + AttachmentFieldsFragment
 
 // queryIssueAttachments fetches only attachments for an issue
 var queryIssueAttachments = `

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -503,6 +503,13 @@ DELETE FROM comments WHERE id = ?;
 -- name: DeleteIssueComments :exec
 DELETE FROM comments WHERE issue_id = ?;
 
+-- Prune*: delete rows the details sync no longer sees for an issue. Scoped by
+-- issue and a synced_at cutoff taken before the sync's upserts, so only rows
+-- the fresh fetch did NOT touch are removed (e.g. a comment deleted in Linear,
+-- or a phantom left by a delete whose SQLite forget failed).
+-- name: PruneIssueComments :exec
+DELETE FROM comments WHERE issue_id = ? AND synced_at < ?;
+
 -- name: GetIssueCommentsSyncedAt :one
 SELECT MAX(synced_at) FROM comments WHERE issue_id = ?;
 
@@ -544,6 +551,9 @@ ON CONFLICT(id) DO UPDATE SET
 
 -- name: DeleteDocument :exec
 DELETE FROM documents WHERE id = ?;
+
+-- name: PruneIssueDocuments :exec
+DELETE FROM documents WHERE issue_id = ? AND synced_at < ?;
 
 -- name: DeleteIssueDocuments :exec
 DELETE FROM documents WHERE issue_id = ?;
@@ -734,6 +744,9 @@ ON CONFLICT(id) DO UPDATE SET
 
 -- name: DeleteAttachment :exec
 DELETE FROM attachments WHERE id = ?;
+
+-- name: PruneIssueAttachments :exec
+DELETE FROM attachments WHERE issue_id = ? AND synced_at < ?;
 
 -- name: DeleteIssueAttachments :exec
 DELETE FROM attachments WHERE issue_id = ?;

--- a/internal/db/queries.sql.go
+++ b/internal/db/queries.sql.go
@@ -3901,6 +3901,52 @@ func (q *Queries) ListWorkspaceLabels(ctx context.Context) ([]Label, error) {
 	return items, nil
 }
 
+const pruneIssueAttachments = `-- name: PruneIssueAttachments :exec
+DELETE FROM attachments WHERE issue_id = ? AND synced_at < ?
+`
+
+type PruneIssueAttachmentsParams struct {
+	IssueID  string    `json:"issue_id"`
+	SyncedAt time.Time `json:"synced_at"`
+}
+
+func (q *Queries) PruneIssueAttachments(ctx context.Context, arg PruneIssueAttachmentsParams) error {
+	_, err := q.db.ExecContext(ctx, pruneIssueAttachments, arg.IssueID, arg.SyncedAt)
+	return err
+}
+
+const pruneIssueComments = `-- name: PruneIssueComments :exec
+DELETE FROM comments WHERE issue_id = ? AND synced_at < ?
+`
+
+type PruneIssueCommentsParams struct {
+	IssueID  string    `json:"issue_id"`
+	SyncedAt time.Time `json:"synced_at"`
+}
+
+// Prune*: delete rows the details sync no longer sees for an issue. Scoped by
+// issue and a synced_at cutoff taken before the sync's upserts, so only rows
+// the fresh fetch did NOT touch are removed (e.g. a comment deleted in Linear,
+// or a phantom left by a delete whose SQLite forget failed).
+func (q *Queries) PruneIssueComments(ctx context.Context, arg PruneIssueCommentsParams) error {
+	_, err := q.db.ExecContext(ctx, pruneIssueComments, arg.IssueID, arg.SyncedAt)
+	return err
+}
+
+const pruneIssueDocuments = `-- name: PruneIssueDocuments :exec
+DELETE FROM documents WHERE issue_id = ? AND synced_at < ?
+`
+
+type PruneIssueDocumentsParams struct {
+	IssueID  sql.NullString `json:"issue_id"`
+	SyncedAt time.Time      `json:"synced_at"`
+}
+
+func (q *Queries) PruneIssueDocuments(ctx context.Context, arg PruneIssueDocumentsParams) error {
+	_, err := q.db.ExecContext(ctx, pruneIssueDocuments, arg.IssueID, arg.SyncedAt)
+	return err
+}
+
 const setIssueParent = `-- name: SetIssueParent :exec
 UPDATE issues SET parent_id = ? WHERE id = ?
 `

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -58,22 +58,20 @@ func openDB(dbPath string) (*Store, error) {
 	// Use file: URI format to properly handle paths with spaces and query params
 	// Escape spaces in path for URI format
 	escapedPath := strings.ReplaceAll(dbPath, " ", "%20")
-	connStr := "file:" + escapedPath + "?_time_format=sqlite"
+	// The pragmas ride the DSN because database/sql pools connections: a
+	// `db.Exec("PRAGMA …")` runs on one pooled connection and leaves the rest
+	// unconfigured. busy_timeout in particular must cover every connection —
+	// without it a write that races the sync worker fails instantly with
+	// SQLITE_BUSY (a delete's forget losing that race left a phantom row that
+	// resurrected the deleted file). journal_mode=WAL is persistent per
+	// database but is harmless to re-apply per connection.
+	connStr := "file:" + escapedPath + "?_time_format=sqlite" +
+		"&_pragma=busy_timeout(5000)" +
+		"&_pragma=foreign_keys(1)" +
+		"&_pragma=journal_mode(WAL)"
 	db, err := sql.Open("sqlite", connStr)
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
-	}
-
-	// Enable WAL mode for better concurrent access
-	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("enable WAL mode: %w", err)
-	}
-
-	// Enable foreign keys
-	if _, err := db.Exec("PRAGMA foreign_keys=ON"); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("enable foreign keys: %w", err)
 	}
 
 	// Initialize schema

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -28,6 +28,42 @@ func TestOpenAndClose(t *testing.T) {
 	}
 }
 
+// TestConnectionPragmas asserts the DSN-level pragmas reach every pooled
+// connection. busy_timeout in particular is per-connection: configured via a
+// one-off Exec it covered only one pooled conn, and a delete's SQLite forget
+// racing the sync worker failed instantly with SQLITE_BUSY, leaving a phantom
+// row that resurrected the deleted file.
+func TestConnectionPragmas(t *testing.T) {
+	t.Parallel()
+	store, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer store.Close()
+
+	var busy int
+	if err := store.DB().QueryRow("PRAGMA busy_timeout").Scan(&busy); err != nil {
+		t.Fatalf("query busy_timeout: %v", err)
+	}
+	if busy < 1000 {
+		t.Errorf("busy_timeout = %d, want >= 1000ms so writes wait out the sync worker instead of failing SQLITE_BUSY", busy)
+	}
+	var fk int
+	if err := store.DB().QueryRow("PRAGMA foreign_keys").Scan(&fk); err != nil {
+		t.Fatalf("query foreign_keys: %v", err)
+	}
+	if fk != 1 {
+		t.Errorf("foreign_keys = %d, want 1", fk)
+	}
+	var mode string
+	if err := store.DB().QueryRow("PRAGMA journal_mode").Scan(&mode); err != nil {
+		t.Fatalf("query journal_mode: %v", err)
+	}
+	if mode != "wal" {
+		t.Errorf("journal_mode = %q, want wal", mode)
+	}
+}
+
 func TestUpsertAndGetIssue(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)

--- a/internal/fs/deletecommit.go
+++ b/internal/fs/deletecommit.go
@@ -3,7 +3,9 @@ package fs
 import (
 	"context"
 	"log"
+	"strings"
 	"syscall"
+	"time"
 )
 
 // The delete-commit tail.
@@ -47,8 +49,11 @@ type deleteSpec[T any] struct {
 	// creates: transient -> EAGAIN, else -> EIO, reason in .error.
 	mutate func(ctx context.Context, target *T) error
 	// forget removes the row from SQLite. Required: the store is the source of
-	// truth for listings, so skipping it resurrects the deleted item until the
-	// next sync. Failure is non-fatal (sync will reconcile).
+	// truth for listings, so a skipped forget resurrects the deleted item — and
+	// the details sync is not guaranteed to prune it. The tail retries a failed
+	// forget (SQLITE_BUSY races the sync worker) before giving up; an ultimate
+	// failure is non-fatal for the caller but leaves a phantom until a details
+	// sync prunes it or a repeat rm hits the already-gone self-heal path.
 	forget func(ctx context.Context, target *T) error
 	// dir + name drive the kernel-cache coherence policy: the module always
 	// runs InvalidateDeleted(dir, name).
@@ -84,16 +89,24 @@ func commitDelete[T any](ctx context.Context, sink deleteSink, spec deleteSpec[T
 	}
 
 	if err := spec.mutate(ctx, target); err != nil {
-		msg, errno := classifyMutationErr(spec.op, err)
-		log.Printf("Failed to %s: %v", spec.op, err)
-		sink.SetWriteError(spec.key, msg)
-		return errno
+		if !remoteAlreadyGone(err) {
+			msg, errno := classifyMutationErr(spec.op, err)
+			log.Printf("Failed to %s: %v", spec.op, err)
+			sink.SetWriteError(spec.key, msg)
+			return errno
+		}
+		// The entity no longer exists on Linear, so the delete's outcome is
+		// already true — proceed to the success tail so the local row is
+		// forgotten. This is also the self-heal path for a phantom row left
+		// by an earlier delete whose forget failed: rm the file again and
+		// the listing comes back consistent.
+		log.Printf("%s: entity already deleted on Linear; forgetting the local row", spec.op)
 	}
 
 	sink.ClearWriteError(spec.key)
 
-	if err := spec.forget(ctx, target); err != nil {
-		log.Printf("Warning: failed to delete entity from SQLite (%s): %v", spec.key, err)
+	if err := forgetWithRetry(ctx, spec.forget, target); err != nil {
+		log.Printf("ERROR: failed to delete entity from SQLite after retries (%s): %v — the deleted item will linger until a details sync prunes it or it is rm'd again", spec.key, err)
 	}
 
 	sink.InvalidateDeleted(spec.dir, spec.name)
@@ -101,4 +114,35 @@ func commitDelete[T any](ctx context.Context, sink deleteSink, spec deleteSpec[T
 		spec.invalidateExtra(target)
 	}
 	return 0
+}
+
+// forgetWithRetry runs the spec's forget, retrying twice with backoff. The
+// forget must not be lost to a transient failure: the API delete has already
+// succeeded, so a dropped forget leaves a phantom row the details sync cannot
+// always prune. SQLITE_BUSY from racing the sync worker is the observed
+// transient (now largely prevented by the connection-level busy_timeout).
+func forgetWithRetry[T any](ctx context.Context, forget func(ctx context.Context, target *T) error, target *T) error {
+	var err error
+	for attempt, delay := range []time.Duration{0, 200 * time.Millisecond, time.Second} {
+		if delay > 0 {
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return err
+			}
+		}
+		if err = forget(ctx, target); err == nil {
+			return nil
+		}
+		log.Printf("forget attempt %d failed: %v", attempt+1, err)
+	}
+	return err
+}
+
+// remoteAlreadyGone reports whether a delete mutation failed because Linear no
+// longer has the entity ("Entity not found" is Linear's standard phrasing —
+// the same detection the repo layer uses for reads). For a delete that is
+// success, not failure.
+func remoteAlreadyGone(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "Entity not found")
 }

--- a/internal/fs/deletecommit_test.go
+++ b/internal/fs/deletecommit_test.go
@@ -143,18 +143,71 @@ func TestCommitDelete_Classification(t *testing.T) {
 }
 
 // TestCommitDelete_ForgetFailureNonFatal: a SQLite delete failure must not fail
-// a delete Linear already accepted — and the coherence policy still runs.
+// a delete Linear already accepted — and the coherence policy still runs. The
+// forget is retried before giving up (the stress-tested failure was a
+// transient SQLITE_BUSY racing the sync worker).
 func TestCommitDelete_ForgetFailureNonFatal(t *testing.T) {
 	sink := &fakeDeleteSink{}
 	mutations, forgets, extras := 0, 0, 0
 	spec := okDeleteSpec(&ent{title: "x"}, &mutations, &forgets, &extras)
-	spec.forget = func(context.Context, *ent) error { return errors.New("db down") }
+	spec.forget = func(context.Context, *ent) error { forgets++; return errors.New("db down") }
 
 	if errno := commitDelete(context.Background(), sink, spec); errno != 0 {
 		t.Fatalf("errno = %v, want 0 (forget failure must be non-fatal)", errno)
 	}
+	if forgets != 3 {
+		t.Errorf("forget attempts = %d, want 3 (retried before giving up)", forgets)
+	}
 	if sink.clears != 1 || sink.invalidates != 1 || extras != 1 {
 		t.Errorf("tail after forget failure: clears=%d invalidates=%d extras=%d, want 1 each",
 			sink.clears, sink.invalidates, extras)
+	}
+}
+
+// TestCommitDelete_ForgetRetrySucceeds: a transient forget failure (SQLITE_BUSY)
+// recovers on retry — no phantom row, no error surfaced.
+func TestCommitDelete_ForgetRetrySucceeds(t *testing.T) {
+	sink := &fakeDeleteSink{}
+	mutations, forgets, extras := 0, 0, 0
+	spec := okDeleteSpec(&ent{title: "x"}, &mutations, &forgets, &extras)
+	attempts := 0
+	spec.forget = func(context.Context, *ent) error {
+		attempts++
+		if attempts == 1 {
+			return errors.New("database is locked (5) (SQLITE_BUSY)")
+		}
+		return nil
+	}
+
+	if errno := commitDelete(context.Background(), sink, spec); errno != 0 {
+		t.Fatalf("errno = %v, want 0", errno)
+	}
+	if attempts != 2 {
+		t.Errorf("forget attempts = %d, want 2 (fail once, succeed on retry)", attempts)
+	}
+}
+
+// TestCommitDelete_RemoteAlreadyGone: deleting an entity Linear no longer has
+// is a success, not EIO — the local row is forgotten and the listing re-cohered.
+// This is the self-heal path for a phantom row left by an earlier failed forget.
+func TestCommitDelete_RemoteAlreadyGone(t *testing.T) {
+	sink := &fakeDeleteSink{}
+	mutations, forgets, extras := 0, 0, 0
+	spec := okDeleteSpec(&ent{title: "x"}, &mutations, &forgets, &extras)
+	spec.mutate = func(context.Context, *ent) error {
+		return errors.New(`API error (status 400): {"errors":[{"message":"Entity not found: Comment - Could not find referenced Comment."}]}`)
+	}
+
+	if errno := commitDelete(context.Background(), sink, spec); errno != 0 {
+		t.Fatalf("errno = %v, want 0 (already-gone delete is idempotent success)", errno)
+	}
+	if forgets != 1 {
+		t.Errorf("forgets = %d, want 1 (the phantom row must be forgotten)", forgets)
+	}
+	if sink.clears != 1 || sink.setCalls != 0 {
+		t.Errorf(".error handling: clears=%d sets=%d, want cleared and never set", sink.clears, sink.setCalls)
+	}
+	if sink.invalidates != 1 {
+		t.Errorf("InvalidateDeleted calls = %d, want 1", sink.invalidates)
 	}
 }

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -710,6 +710,12 @@ func (w *Worker) syncIssueDetailsBatch(ctx context.Context, issues []struct {
 		idToIdentifier[issue.ID] = issue.Identifier
 	}
 
+	// The prune cutoff is taken BEFORE the fetch: any row upserted after this
+	// instant (a comment created through FUSE while the fetch was in flight)
+	// carries a newer synced_at and survives pruning even though the fetch
+	// response predates it.
+	pruneCutoff := db.Now()
+
 	// Fetch all details in one API call
 	detailsMap, err := w.client.GetIssueDetailsBatch(ctx, ids)
 	if err != nil {
@@ -769,6 +775,30 @@ func (w *Worker) syncIssueDetailsBatch(ctx context.Context, issues []struct {
 			}
 			if err := w.store.Queries().UpsertAttachment(ctx, params); err != nil {
 				log.Printf("[sync] upsert attachment %s failed: %v", attachment.ID, err)
+			}
+		}
+
+		// Prune rows the fetch no longer returned — a comment/doc/attachment
+		// deleted in Linear, or a phantom left by a delete whose SQLite forget
+		// failed. The upserts above re-stamped every fetched row's synced_at,
+		// so anything still older than the pre-fetch cutoff is stale. Only a
+		// provably complete set may prune: a full page (IssueDetailsPageSize)
+		// may be truncated, and pruning against it would delete real rows.
+		// This must run before the Touch* pass below, which re-stamps ALL of
+		// an issue's rows and would exempt phantoms from the cutoff.
+		if len(details.Comments) < api.IssueDetailsPageSize {
+			if err := w.store.Queries().PruneIssueComments(ctx, db.PruneIssueCommentsParams{IssueID: issueID, SyncedAt: pruneCutoff}); err != nil {
+				log.Printf("[sync] prune comments %s: %v", issueID, err)
+			}
+		}
+		if len(details.Documents) < api.IssueDetailsPageSize {
+			if err := w.store.Queries().PruneIssueDocuments(ctx, db.PruneIssueDocumentsParams{IssueID: sql.NullString{String: issueID, Valid: true}, SyncedAt: pruneCutoff}); err != nil {
+				log.Printf("[sync] prune documents %s: %v", issueID, err)
+			}
+		}
+		if len(details.Attachments) < api.IssueDetailsPageSize {
+			if err := w.store.Queries().PruneIssueAttachments(ctx, db.PruneIssueAttachmentsParams{IssueID: issueID, SyncedAt: pruneCutoff}); err != nil {
+				log.Printf("[sync] prune attachments %s: %v", issueID, err)
 			}
 		}
 	}

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -786,6 +786,12 @@ func (w *Worker) syncIssueDetailsBatch(ctx context.Context, issues []struct {
 		// may be truncated, and pruning against it would delete real rows.
 		// This must run before the Touch* pass below, which re-stamps ALL of
 		// an issue's rows and would exempt phantoms from the cutoff.
+		//
+		// SAFETY: pruning against an empty-but-wrong set relies on the API
+		// client's all-or-nothing batch semantics — c.query fails the WHOLE
+		// batch on any GraphQL error, so a partially-failed response can never
+		// reach this loop as an empty details struct. If that ever relaxes to
+		// "return the data we got", this prune becomes silent data loss.
 		if len(details.Comments) < api.IssueDetailsPageSize {
 			if err := w.store.Queries().PruneIssueComments(ctx, db.PruneIssueCommentsParams{IssueID: issueID, SyncedAt: pruneCutoff}); err != nil {
 				log.Printf("[sync] prune comments %s: %v", issueID, err)

--- a/internal/sync/worker_test.go
+++ b/internal/sync/worker_test.go
@@ -40,6 +40,7 @@ type mockAPIClient struct {
 	simulateError    error
 	rateLimitResetAt time.Time                    // M-3: configurable reset time for adaptive backoff tests
 	detailsByIssue   map[string]*api.IssueDetails // issueID -> canned details for GetIssueDetailsBatch
+	onDetailsBatch   func()                       // if set, runs inside GetIssueDetailsBatch (simulates writes racing the fetch)
 }
 
 func newMockAPIClient() *mockAPIClient {
@@ -149,6 +150,9 @@ func (m *mockAPIClient) GetIssueDetails(ctx context.Context, issueID string) (*a
 func (m *mockAPIClient) GetIssueDetailsBatch(ctx context.Context, issueIDs []string) (map[string]*api.IssueDetails, error) {
 	if m.simulateError != nil {
 		return nil, m.simulateError
+	}
+	if m.onDetailsBatch != nil {
+		m.onDetailsBatch()
 	}
 	result := make(map[string]*api.IssueDetails, len(issueIDs))
 	for _, id := range issueIDs {
@@ -870,6 +874,47 @@ func TestDetailsSyncPrunesStaleRows(t *testing.T) {
 			ids = append(ids, c.ID)
 		}
 		t.Errorf("after details sync comments = %v, want [comment-live] (phantom pruned, live retained)", ids)
+	}
+}
+
+// TestDetailsSyncPruneSparesMidFetchCreates: a comment created through FUSE
+// while the details fetch is in flight is absent from the fetch response but
+// must survive pruning — its synced_at postdates the pre-fetch cutoff. This is
+// the guarantee the cutoff exists for; a naive "delete everything not in the
+// response" would eat the freshly-created comment.
+func TestDetailsSyncPruneSparesMidFetchCreates(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	mock := newMockAPIClient()
+	// The fetch returns no comments for issue-1…
+	mock.detailsByIssue["issue-1"] = &api.IssueDetails{Comments: []api.Comment{}}
+	// …but while it is "in flight", a comment lands through the FUSE write path.
+	mock.onDetailsBatch = func() {
+		params, err := db.APICommentToDBComment(api.Comment{ID: "comment-raced", Body: "created mid-fetch", CreatedAt: time.Now(), UpdatedAt: time.Now()}, "issue-1")
+		if err != nil {
+			t.Errorf("convert raced comment: %v", err)
+			return
+		}
+		if err := store.Queries().UpsertComment(ctx, params); err != nil {
+			t.Errorf("upsert raced comment: %v", err)
+		}
+	}
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	worker.syncIssueDetailsBatch(ctx, []struct {
+		ID         string
+		Identifier string
+	}{{ID: "issue-1", Identifier: "TST-1"}})
+
+	comments, err := store.Queries().ListIssueComments(ctx, "issue-1")
+	if err != nil {
+		t.Fatalf("list comments: %v", err)
+	}
+	if len(comments) != 1 || comments[0].ID != "comment-raced" {
+		t.Errorf("comments = %v, want the mid-fetch create to survive pruning", comments)
 	}
 }
 

--- a/internal/sync/worker_test.go
+++ b/internal/sync/worker_test.go
@@ -25,20 +25,21 @@ func (m *mockBudgetReporter) BudgetSnapshot() (int, float64) {
 
 // mockAPIClient implements APIClient for testing
 type mockAPIClient struct {
-	teams              []api.Team
-	issuesByTeam       map[string][]api.Issue   // teamID -> all issues (will be paginated)
-	statesByTeam       map[string][]api.State   // teamID -> states
-	labelsByTeam       map[string][]api.Label   // teamID -> labels
-	cyclesByTeam       map[string][]api.Cycle   // teamID -> cycles
-	projectsByTeam     map[string][]api.Project // teamID -> projects
-	membersByTeam      map[string][]api.User    // teamID -> members
-	users              []api.User
-	initiatives        []api.Initiative
-	pageSize           int
-	getTeamsCalls      int32
-	getIssuesCalls     int32
-	simulateError      error
-	rateLimitResetAt   time.Time // M-3: configurable reset time for adaptive backoff tests
+	teams            []api.Team
+	issuesByTeam     map[string][]api.Issue   // teamID -> all issues (will be paginated)
+	statesByTeam     map[string][]api.State   // teamID -> states
+	labelsByTeam     map[string][]api.Label   // teamID -> labels
+	cyclesByTeam     map[string][]api.Cycle   // teamID -> cycles
+	projectsByTeam   map[string][]api.Project // teamID -> projects
+	membersByTeam    map[string][]api.User    // teamID -> members
+	users            []api.User
+	initiatives      []api.Initiative
+	pageSize         int
+	getTeamsCalls    int32
+	getIssuesCalls   int32
+	simulateError    error
+	rateLimitResetAt time.Time                    // M-3: configurable reset time for adaptive backoff tests
+	detailsByIssue   map[string]*api.IssueDetails // issueID -> canned details for GetIssueDetailsBatch
 }
 
 func newMockAPIClient() *mockAPIClient {
@@ -51,6 +52,7 @@ func newMockAPIClient() *mockAPIClient {
 		projectsByTeam: make(map[string][]api.Project),
 		membersByTeam:  make(map[string][]api.User),
 		pageSize:       100,
+		detailsByIssue: make(map[string]*api.IssueDetails),
 	}
 }
 
@@ -150,6 +152,10 @@ func (m *mockAPIClient) GetIssueDetailsBatch(ctx context.Context, issueIDs []str
 	}
 	result := make(map[string]*api.IssueDetails, len(issueIDs))
 	for _, id := range issueIDs {
+		if d, ok := m.detailsByIssue[id]; ok {
+			result[id] = d
+			continue
+		}
 		result[id] = &api.IssueDetails{
 			Comments:  []api.Comment{},
 			Documents: []api.Document{},
@@ -817,6 +823,94 @@ func TestPendingDetailSyncQueueAndDrain(t *testing.T) {
 	}
 	if len(pending) != 0 {
 		t.Errorf("expected 0 pending issues after drain, got %d", len(pending))
+	}
+}
+
+// TestDetailsSyncPrunesStaleRows: the details sync must delete rows Linear no
+// longer returns — a comment deleted in Linear, or a phantom left by a delete
+// whose SQLite forget failed (the store is the listing source of truth, so an
+// unpruned phantom resurrects the file forever). Rows the fetch DID return are
+// re-stamped and must survive.
+func TestDetailsSyncPrunesStaleRows(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	live := api.Comment{ID: "comment-live", Body: "still on Linear", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	phantom := api.Comment{ID: "comment-phantom", Body: "deleted on Linear, forget failed", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	for _, c := range []api.Comment{live, phantom} {
+		params, err := db.APICommentToDBComment(c, "issue-1")
+		if err != nil {
+			t.Fatalf("convert comment: %v", err)
+		}
+		// Backdate synced_at so both predate the sync's prune cutoff.
+		params.SyncedAt = time.Now().Add(-time.Minute)
+		if err := store.Queries().UpsertComment(ctx, params); err != nil {
+			t.Fatalf("seed comment: %v", err)
+		}
+	}
+
+	mock := newMockAPIClient()
+	mock.detailsByIssue["issue-1"] = &api.IssueDetails{Comments: []api.Comment{live}}
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	worker.syncIssueDetailsBatch(ctx, []struct {
+		ID         string
+		Identifier string
+	}{{ID: "issue-1", Identifier: "TST-1"}})
+
+	comments, err := store.Queries().ListIssueComments(ctx, "issue-1")
+	if err != nil {
+		t.Fatalf("list comments: %v", err)
+	}
+	if len(comments) != 1 || comments[0].ID != "comment-live" {
+		ids := []string{}
+		for _, c := range comments {
+			ids = append(ids, c.ID)
+		}
+		t.Errorf("after details sync comments = %v, want [comment-live] (phantom pruned, live retained)", ids)
+	}
+}
+
+// TestDetailsSyncFullPageSkipsPrune: a full page (IssueDetailsPageSize rows)
+// may be truncated by the API's page cap, so pruning against it could delete
+// real rows — the guard must skip pruning entirely.
+func TestDetailsSyncFullPageSkipsPrune(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	// A row beyond the page cap: real on Linear, just not in the fetched page.
+	beyond, err := db.APICommentToDBComment(api.Comment{ID: "comment-beyond-page", Body: "real, past the cap", CreatedAt: time.Now(), UpdatedAt: time.Now()}, "issue-1")
+	if err != nil {
+		t.Fatalf("convert comment: %v", err)
+	}
+	beyond.SyncedAt = time.Now().Add(-time.Minute)
+	if err := store.Queries().UpsertComment(ctx, beyond); err != nil {
+		t.Fatalf("seed comment: %v", err)
+	}
+
+	full := make([]api.Comment, api.IssueDetailsPageSize)
+	for i := range full {
+		full[i] = api.Comment{ID: fmt.Sprintf("comment-%03d", i), Body: "page filler", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	}
+	mock := newMockAPIClient()
+	mock.detailsByIssue["issue-1"] = &api.IssueDetails{Comments: full}
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	worker.syncIssueDetailsBatch(ctx, []struct {
+		ID         string
+		Identifier string
+	}{{ID: "issue-1", Identifier: "TST-1"}})
+
+	comments, err := store.Queries().ListIssueComments(ctx, "issue-1")
+	if err != nil {
+		t.Fatalf("list comments: %v", err)
+	}
+	if len(comments) != api.IssueDetailsPageSize+1 {
+		t.Errorf("comments = %d, want %d — a full (possibly truncated) page must not prune", len(comments), api.IssueDetailsPageSize+1)
 	}
 }
 


### PR DESCRIPTION
## The bug (caught live by a stress test)

`rm` a comment → the API delete succeeds → the SQLite forget **races the sync worker and fails with `SQLITE_BUSY`** → the delete tail logs a warning and returns success → the row resurrects the file. And because the details sync was upsert-only, the phantom **never drained**. Retrying the `rm` returned `EIO` since Linear had already deleted the entity. This violated the delete-tail contract (CONTEXT.md: the forget is *required* — the store is the listing source of truth).

## The fix — four complementary layers

1. **`busy_timeout(5000)` in the DSN** (with `foreign_keys` and `journal_mode=WAL`). Per-connection pragmas must ride the DSN: a `db.Exec("PRAGMA …")` configures only one pooled connection. Writes now wait out the sync worker instead of failing instantly. `TestConnectionPragmas` pins all three.
2. **The delete tail retries the forget** (200ms/1s backoff) before giving up; an ultimate failure logs as ERROR with the consequence spelled out.
3. **Already-gone is idempotent success**: a delete mutation failing with Linear's `"Entity not found"` proceeds down the success tail — the row is forgotten and the listing re-cohered — so re-`rm`ing a phantom heals it. (Same phrase detection the repo layer already uses for reads.)
4. **The details sync prunes stale rows**: comments/documents/attachments a fetch no longer returned are deleted, scoped by issue and a **pre-fetch** `synced_at` cutoff so rows created through FUSE mid-fetch survive. Guarded by the new `api.IssueDetailsPageSize`: a full page may be truncated by the API's cap and must not prune. Runs before the `Touch*` pass, which re-stamps all of an issue's rows and would otherwise exempt phantoms.

## Testing

- `TestConnectionPragmas` — DSN pragmas reach pooled connections.
- `TestCommitDelete_ForgetRetrySucceeds` / `_ForgetFailureNonFatal` (extended) — transient failure recovers; ultimate failure retried 3× and still non-fatal.
- `TestCommitDelete_RemoteAlreadyGone` — already-gone delete → errno 0, row forgotten, `.error` cleared.
- `TestDetailsSyncPrunesStaleRows` / `TestDetailsSyncFullPageSkipsPrune` — phantom pruned + live row retained; full-page guard refuses to prune.
- Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)