### PR TITLE
refactor(fs): one symlinkNode module behind every symlink view; marshal round-trip tests

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -134,6 +134,27 @@ because each dir restated the trio by hand). mkdir-created collections
 (projects) set `onFlush` nil and serve just the two sidecars. Lives in
 `internal/fs/collection.go`.
 
+### Symlink views (`symlinkNode`)
+The **deep module** owning every symlink the filesystem serves: the issue
+symlinks under `by/`, `cycles/`, `recent/`, `projects/`, `users/`, `my/`, and
+`children/`, the project symlinks under `initiatives/`, and the
+`cycles/current` alias. Its
+whole interface is construction: a view's Lookup computes the relative target
+where it already holds the entity, and hands `newSymlinkInode` the target plus
+the entity's real created/updated times (cycle views pass a distinct atime —
+the cycle end date — through the same construction). The helper fills the
+Lookup answer's attributes from the same code path that answers a later
+`stat`, so a Lookup answer and a Getattr can never disagree — the drift that had the `current`
+alias reporting `now()` while its Lookup reported cycle times, and the
+initiative project symlink fabricating size/timestamps while re-scanning every
+team's projects on each `readlink`, and the `children/` symlink shipping a
+dangling one-level target with root ownership. Eight hand-copied node types
+collapsed into this one; an unresolvable target (a project whose team
+association hasn't synced yet, an issue whose team hasn't) is a reference to
+something that doesn't exist -> `ENOENT` at Lookup, never a dangling
+placeholder. Lives in `internal/fs/symlink.go`;
+unit-tested directly, no FUSE mount.
+
 ### ErrorSink
 The minimal seam the WriteBack tail uses to record validation/divergence messages for
 `.error` files: `SetWriteError(key, msg)` / `ClearWriteError(key)`. `*LinearFS`

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ fmt:
 lint:
 	golangci-lint run
 
+# Pinned so regeneration doesn't churn version comments in generated files
+sqlc:
+	go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0 generate
+
 # Generate full coverage report (unit + integration tests)
 # Uses -coverpkg to measure cross-package coverage from integration tests
 coverage:

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -438,6 +438,16 @@ DELETE FROM project_teams WHERE project_id = ?;
 -- name: ListProjectTeamIDs :many
 SELECT team_id FROM project_teams WHERE project_id = ?;
 
+-- name: GetProjectPrimaryTeamKey :one
+-- The canonical team for a project that spans teams: first by key order.
+-- This is the one place that rule lives; symlink targets and any future
+-- "which team dir hosts this project" consumer must go through it.
+SELECT t.key FROM teams t
+JOIN project_teams pt ON t.id = pt.team_id
+WHERE pt.project_id = ?
+ORDER BY t.key
+LIMIT 1;
+
 -- =============================================================================
 -- Project Milestones queries
 -- =============================================================================

--- a/internal/db/queries.sql.go
+++ b/internal/db/queries.sql.go
@@ -1128,6 +1128,24 @@ func (q *Queries) GetProjectMilestone(ctx context.Context, id string) (ProjectMi
 	return i, err
 }
 
+const getProjectPrimaryTeamKey = `-- name: GetProjectPrimaryTeamKey :one
+SELECT t.key FROM teams t
+JOIN project_teams pt ON t.id = pt.team_id
+WHERE pt.project_id = ?
+ORDER BY t.key
+LIMIT 1
+`
+
+// The canonical team for a project that spans teams: first by key order.
+// This is the one place that rule lives; symlink targets and any future
+// "which team dir hosts this project" consumer must go through it.
+func (q *Queries) GetProjectPrimaryTeamKey(ctx context.Context, projectID string) (string, error) {
+	row := q.db.QueryRowContext(ctx, getProjectPrimaryTeamKey, projectID)
+	var key string
+	err := row.Scan(&key)
+	return key, err
+}
+
 const getProjectUpdate = `-- name: GetProjectUpdate :one
 
 SELECT id, project_id, body, body_data, health, user_id, user_name, url, edited_at, created_at, updated_at, synced_at, data FROM project_updates WHERE id = ?

--- a/internal/fs/cycles.go
+++ b/internal/fs/cycles.go
@@ -79,14 +79,8 @@ func (c *CyclesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut
 	if name == "current" {
 		for _, cycle := range cycles {
 			if isCurrent(cycle) {
-				target := cycleDirName(cycle)
-				node := &CurrentCycleSymlink{BaseNode: BaseNode{lfs: c.lfs}, target: target}
-				out.Attr.Mode = 0777 | syscall.S_IFLNK
-				out.Attr.Uid = c.lfs.uid
-				out.Attr.Gid = c.lfs.gid
-				out.Attr.Size = uint64(len(target))
-				out.Attr.SetTimes(&cycle.EndsAt, &cycle.StartsAt, &cycle.StartsAt)
-				return c.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFLNK}), 0
+				// atime=EndsAt matches the target CycleDirNode's convention.
+				return c.newSymlinkInodeAtime(ctx, out, cycleDirName(cycle), cycle.StartsAt, cycle.StartsAt, cycle.EndsAt), 0
 			}
 		}
 		return nil, syscall.ENOENT
@@ -105,28 +99,6 @@ func (c *CyclesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut
 	}
 
 	return nil, syscall.ENOENT
-}
-
-// CurrentCycleSymlink represents the /teams/{KEY}/cycles/current symlink
-type CurrentCycleSymlink struct {
-	BaseNode
-	target string
-}
-
-var _ fs.NodeReadlinker = (*CurrentCycleSymlink)(nil)
-var _ fs.NodeGetattrer = (*CurrentCycleSymlink)(nil)
-
-func (s *CurrentCycleSymlink) Readlink(ctx context.Context) ([]byte, syscall.Errno) {
-	return []byte(s.target), 0
-}
-
-func (s *CurrentCycleSymlink) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0777 | syscall.S_IFLNK
-	s.SetOwner(out)
-	out.Size = uint64(len(s.target))
-	out.SetTimes(&now, &now, &now)
-	return 0
 }
 
 // CycleDirNode represents a cycle directory (e.g., /teams/ENG/cycles/71/)
@@ -191,47 +163,13 @@ func (c *CycleDirNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 
 	for _, issue := range issues {
 		if issue.Identifier == name {
-			node := &CycleIssueSymlink{
-				BaseNode:   BaseNode{lfs: c.lfs},
-				identifier: issue.Identifier,
-				createdAt:  issue.CreatedAt,
-				updatedAt:  issue.UpdatedAt,
-			}
-			out.Attr.Mode = 0777 | syscall.S_IFLNK
-			out.Attr.Uid = c.lfs.uid
-			out.Attr.Gid = c.lfs.gid
-			out.Attr.SetTimes(&issue.UpdatedAt, &issue.UpdatedAt, &issue.CreatedAt)
-			return c.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFLNK}), 0
+			// Path from /teams/ENG/cycles/Cycle-22/ENG-123 to /teams/ENG/issues/ENG-123/
+			target := fmt.Sprintf("../../issues/%s", issue.Identifier)
+			return c.newSymlinkInode(ctx, out, target, issue.CreatedAt, issue.UpdatedAt), 0
 		}
 	}
 
 	return nil, syscall.ENOENT
-}
-
-// CycleIssueSymlink represents a symlink from cycle to issue directory
-type CycleIssueSymlink struct {
-	BaseNode
-	identifier string
-	createdAt  time.Time
-	updatedAt  time.Time
-}
-
-var _ fs.NodeReadlinker = (*CycleIssueSymlink)(nil)
-var _ fs.NodeGetattrer = (*CycleIssueSymlink)(nil)
-
-func (s *CycleIssueSymlink) Readlink(ctx context.Context) ([]byte, syscall.Errno) {
-	// Path from /teams/ENG/cycles/Cycle-22/ENG-123 to /teams/ENG/issues/ENG-123/
-	target := fmt.Sprintf("../../issues/%s", s.identifier)
-	return []byte(target), 0
-}
-
-func (s *CycleIssueSymlink) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	target := fmt.Sprintf("../../issues/%s", s.identifier)
-	out.Mode = 0777 | syscall.S_IFLNK
-	s.SetOwner(out)
-	out.Size = uint64(len(target))
-	out.SetTimes(&s.updatedAt, &s.updatedAt, &s.createdAt)
-	return 0
 }
 
 // CycleFileNode represents the cycle.md file inside a cycle directory

--- a/internal/fs/filter.go
+++ b/internal/fs/filter.go
@@ -228,17 +228,9 @@ func (f *FilterValueNode) Lookup(ctx context.Context, name string, out *fuse.Ent
 
 	for _, issue := range issues {
 		if issue.Identifier == name {
-			node := &FilterIssueSymlink{
-				BaseNode:   BaseNode{lfs: f.lfs},
-				identifier: issue.Identifier,
-				createdAt:  issue.CreatedAt,
-				updatedAt:  issue.UpdatedAt,
-			}
-			out.Attr.Mode = 0777 | syscall.S_IFLNK
-			out.Attr.Uid = f.lfs.uid
-			out.Attr.Gid = f.lfs.gid
-			out.Attr.SetTimes(&issue.UpdatedAt, &issue.UpdatedAt, &issue.CreatedAt)
-			return f.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFLNK}), 0
+			// From by/category/value/ go up 3 levels to team dir, then into issues/
+			target := fmt.Sprintf("../../../issues/%s", issue.Identifier)
+			return f.newSymlinkInode(ctx, out, target, issue.CreatedAt, issue.UpdatedAt), 0
 		}
 	}
 	return nil, syscall.ENOENT
@@ -279,31 +271,4 @@ func (f *FilterValueNode) resolveAssigneeID(ctx context.Context) (string, error)
 		}
 	}
 	return "", fmt.Errorf("unknown assignee: %s", f.value)
-}
-
-// FilterIssueSymlink is a symlink pointing to an issue directory
-// Path from by/category/value/ to issues/ is ../../../issues/
-type FilterIssueSymlink struct {
-	BaseNode
-	identifier string
-	createdAt  time.Time
-	updatedAt  time.Time
-}
-
-var _ fs.NodeReadlinker = (*FilterIssueSymlink)(nil)
-var _ fs.NodeGetattrer = (*FilterIssueSymlink)(nil)
-
-func (s *FilterIssueSymlink) Readlink(ctx context.Context) ([]byte, syscall.Errno) {
-	// From by/category/value/ go up 3 levels to team dir, then into issues/
-	target := fmt.Sprintf("../../../issues/%s", s.identifier)
-	return []byte(target), 0
-}
-
-func (s *FilterIssueSymlink) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	target := fmt.Sprintf("../../../issues/%s", s.identifier)
-	out.Mode = 0777 | syscall.S_IFLNK
-	s.SetOwner(out)
-	out.Size = uint64(len(target))
-	out.SetTimes(&s.updatedAt, &s.updatedAt, &s.createdAt)
-	return 0
 }

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"log"
-	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -99,8 +98,7 @@ func initiativeDirName(init api.Initiative) string {
 	// Always derive from name (Linear's slugId for initiatives is not human-readable)
 	name := strings.ToLower(init.Name)
 	name = strings.ReplaceAll(name, " ", "-")
-	reg := regexp.MustCompile(`[^a-z0-9-]`)
-	name = reg.ReplaceAllString(name, "")
+	name = dirNameUnsafe.ReplaceAllString(name, "")
 	if name != "" {
 		return name
 	}
@@ -611,19 +609,41 @@ func (p *InitiativeProjectsNode) Readdir(ctx context.Context) (fs.DirStream, sys
 func (p *InitiativeProjectsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
 	for _, proj := range p.initiative.Projects.Nodes {
 		if initiativeProjectDirName(proj) == name {
-			// We need to find which team this project belongs to
-			// For now, create a symlink that requires resolving the team
-			node := &InitiativeProjectSymlink{
-				BaseNode: BaseNode{lfs: p.lfs},
-				project:  proj,
+			target, createdAt, updatedAt, errno := p.resolveProjectTarget(ctx, proj.ID)
+			if errno != 0 {
+				return nil, errno
 			}
-			out.Attr.Mode = 0777 | syscall.S_IFLNK
-			out.Attr.Uid = p.lfs.uid
-			out.Attr.Gid = p.lfs.gid
-			return p.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFLNK}), 0
+			return p.newSymlinkInode(ctx, out, target, createdAt, updatedAt), 0
 		}
 	}
 	return nil, syscall.ENOENT
+}
+
+// resolveProjectTarget resolves an initiative project's symlink target and
+// timestamps. The initiative payload carries only ID/Name/Slug; the full
+// project row supplies the team-side dir name and real timestamps, and
+// GetProjectPrimaryTeamKey supplies the canonical team. Until sync has both
+// the project and its team association, the name is a reference to something
+// that doesn't exist yet -> ENOENT.
+func (p *InitiativeProjectsNode) resolveProjectTarget(ctx context.Context, projectID string) (string, time.Time, time.Time, syscall.Errno) {
+	full, err := p.lfs.repo.GetProjectByID(ctx, projectID)
+	if err != nil {
+		return "", time.Time{}, time.Time{}, syscall.EIO
+	}
+	if full == nil {
+		return "", time.Time{}, time.Time{}, syscall.ENOENT
+	}
+	teamKey, err := p.lfs.repo.GetProjectPrimaryTeamKey(ctx, projectID)
+	if err != nil {
+		return "", time.Time{}, time.Time{}, syscall.EIO
+	}
+	if teamKey == "" {
+		return "", time.Time{}, time.Time{}, syscall.ENOENT
+	}
+	// The symlink lives at initiatives/{slug}/projects/{name}, three levels
+	// below the mount root.
+	target := fmt.Sprintf("../../../teams/%s/projects/%s", teamKey, projectDirName(*full))
+	return target, full.CreatedAt, full.UpdatedAt, 0
 }
 
 // initiativeProjectDirName returns a safe directory name for an initiative project
@@ -631,8 +651,7 @@ func initiativeProjectDirName(proj api.InitiativeProject) string {
 	// Derive from name (not slugId, which is an opaque hash in Linear)
 	name := strings.ToLower(proj.Name)
 	name = strings.ReplaceAll(name, " ", "-")
-	reg := regexp.MustCompile(`[^a-z0-9-]`)
-	name = reg.ReplaceAllString(name, "")
+	name = dirNameUnsafe.ReplaceAllString(name, "")
 	if name != "" {
 		return name
 	}
@@ -641,50 +660,6 @@ func initiativeProjectDirName(proj api.InitiativeProject) string {
 		return proj.Slug
 	}
 	return proj.ID
-}
-
-// InitiativeProjectSymlink is a symlink pointing to a project directory
-type InitiativeProjectSymlink struct {
-	BaseNode
-	project api.InitiativeProject
-}
-
-var _ fs.NodeReadlinker = (*InitiativeProjectSymlink)(nil)
-var _ fs.NodeGetattrer = (*InitiativeProjectSymlink)(nil)
-
-func (s *InitiativeProjectSymlink) Readlink(ctx context.Context) ([]byte, syscall.Errno) {
-	// Find the project's team by checking all teams
-	teams, err := s.lfs.GetTeams(ctx)
-	if err != nil {
-		return nil, syscall.EIO
-	}
-
-	for _, team := range teams {
-		projects, err := s.lfs.GetTeamProjects(ctx, team.ID)
-		if err != nil {
-			continue
-		}
-		for _, proj := range projects {
-			if proj.ID == s.project.ID {
-				// Found the project - create relative symlink
-				target := fmt.Sprintf("../../teams/%s/projects/%s", team.Key, projectDirName(proj))
-				return []byte(target), 0
-			}
-		}
-	}
-
-	// Fallback: project not found in any team
-	return []byte("broken-link"), syscall.ENOENT
-}
-
-func (s *InitiativeProjectSymlink) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	// Use a reasonable estimate for symlink size
-	out.Mode = 0777 | syscall.S_IFLNK
-	s.SetOwner(out)
-	out.Size = 64
-	out.SetTimes(&now, &now, &now)
-	return 0
 }
 
 // InitiativeUpdatesNode represents /initiatives/{slug}/updates/

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -900,18 +900,10 @@ func (n *ChildrenNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 	}
 	for _, child := range children {
 		if child.Identifier == name {
-			node := &ChildSymlinkNode{
-				child: api.ChildIssue{
-					ID:         child.ID,
-					Identifier: child.Identifier,
-					Title:      child.Title,
-					CreatedAt:  child.CreatedAt,
-					UpdatedAt:  child.UpdatedAt,
-				},
-			}
-			out.Attr.Mode = 0777 | syscall.S_IFLNK
-			out.Attr.SetTimes(&child.UpdatedAt, &child.UpdatedAt, &child.CreatedAt)
-			return n.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFLNK}), 0
+			// The link lives at issues/{PARENT}/children/{ID}; the sibling
+			// issue dir is two levels up.
+			target := "../../" + child.Identifier
+			return n.newSymlinkInode(ctx, out, target, child.CreatedAt, child.UpdatedAt), 0
 		}
 	}
 	return nil, syscall.ENOENT
@@ -969,28 +961,6 @@ func (n *ChildrenNode) Mkdir(ctx context.Context, name string, mode uint32, out 
 		Mode: syscall.S_IFDIR,
 		Ino:  issueDirIno(issue.ID),
 	}), 0
-}
-
-// ChildSymlinkNode is a symlink pointing to a child issue directory
-type ChildSymlinkNode struct {
-	fs.Inode
-	child api.ChildIssue
-}
-
-var _ fs.NodeReadlinker = (*ChildSymlinkNode)(nil)
-var _ fs.NodeGetattrer = (*ChildSymlinkNode)(nil)
-
-func (s *ChildSymlinkNode) Readlink(ctx context.Context) ([]byte, syscall.Errno) {
-	// Point to sibling issue directory: ../ENG-456
-	target := "../" + s.child.Identifier
-	return []byte(target), 0
-}
-
-func (s *ChildSymlinkNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	out.Mode = 0777 | syscall.S_IFLNK
-	out.Size = uint64(len("../") + len(s.child.Identifier))
-	out.SetTimes(&s.child.UpdatedAt, &s.child.UpdatedAt, &s.child.CreatedAt)
-	return 0
 }
 
 // HistoryFileNode represents a history.md file inside /teams/{KEY}/issues/{ID}/

--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -64,9 +64,14 @@ type BaseNode struct {
 // SetOwner sets the UID and GID on the given AttrOut.
 // Call this in every Getattr implementation.
 func (b *BaseNode) SetOwner(out *fuse.AttrOut) {
+	b.setOwnerAttr(&out.Attr)
+}
+
+// setOwnerAttr is SetOwner for a bare fuse.Attr (Lookup EntryOut fills).
+func (b *BaseNode) setOwnerAttr(attr *fuse.Attr) {
 	if b.lfs != nil {
-		out.Uid = b.lfs.uid
-		out.Gid = b.lfs.gid
+		attr.Uid = b.lfs.uid
+		attr.Gid = b.lfs.gid
 	}
 }
 

--- a/internal/fs/my.go
+++ b/internal/fs/my.go
@@ -112,22 +112,11 @@ func (m *MyIssuesNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 
 	for _, issue := range issues {
 		if issue.Identifier == name {
-			teamKey := ""
-			if issue.Team != nil {
-				teamKey = issue.Team.Key
+			target, errno := teamIssueTarget(issue)
+			if errno != 0 {
+				return nil, errno
 			}
-			node := &IssueDirSymlink{
-				BaseNode:   BaseNode{lfs: m.lfs},
-				teamKey:    teamKey,
-				identifier: issue.Identifier,
-				createdAt:  issue.CreatedAt,
-				updatedAt:  issue.UpdatedAt,
-			}
-			out.Attr.Mode = 0777 | syscall.S_IFLNK
-			out.Attr.Uid = m.lfs.uid
-			out.Attr.Gid = m.lfs.gid
-			out.Attr.SetTimes(&issue.UpdatedAt, &issue.UpdatedAt, &issue.CreatedAt)
-			return m.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFLNK}), 0
+			return m.newSymlinkInode(ctx, out, target, issue.CreatedAt, issue.UpdatedAt), 0
 		}
 	}
 

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -190,14 +190,16 @@ func (p *ProjectsNode) Rmdir(ctx context.Context, name string) syscall.Errno {
 	})
 }
 
+// dirNameUnsafe matches the characters stripped from name-derived directory
+// names (projects, initiatives, initiative projects).
+var dirNameUnsafe = regexp.MustCompile(`[^a-z0-9-]`)
+
 // projectDirName returns a safe directory name for a project
 func projectDirName(project api.Project) string {
 	// Sanitize name: lowercase, replace spaces with hyphens, remove special chars
 	name := strings.ToLower(project.Name)
 	name = strings.ReplaceAll(name, " ", "-")
-	// Remove any characters that aren't alphanumeric or hyphen
-	reg := regexp.MustCompile(`[^a-z0-9-]`)
-	name = reg.ReplaceAllString(name, "")
+	name = dirNameUnsafe.ReplaceAllString(name, "")
 	if name != "" {
 		return name
 	}
@@ -354,17 +356,8 @@ func (p *ProjectNode) Lookup(ctx context.Context, name string, out *fuse.EntryOu
 
 	for _, issue := range issues {
 		if issue.Identifier == name {
-			node := &ProjectIssueSymlink{
-				BaseNode:   BaseNode{lfs: p.lfs},
-				identifier: issue.Identifier,
-				createdAt:  issue.CreatedAt,
-				updatedAt:  issue.UpdatedAt,
-			}
-			out.Attr.Mode = 0777 | syscall.S_IFLNK
-			out.Attr.Uid = p.lfs.uid
-			out.Attr.Gid = p.lfs.gid
-			out.Attr.SetTimes(&issue.UpdatedAt, &issue.UpdatedAt, &issue.CreatedAt)
-			return p.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFLNK}), 0
+			target := fmt.Sprintf("../../issues/%s", issue.Identifier)
+			return p.newSymlinkInode(ctx, out, target, issue.CreatedAt, issue.UpdatedAt), 0
 		}
 	}
 
@@ -430,31 +423,6 @@ func (p *ProjectNode) Unlink(ctx context.Context, name string) syscall.Errno {
 		return 0
 	}
 	return syscall.EPERM
-}
-
-// ProjectIssueSymlink is a symlink pointing to an issue directory
-type ProjectIssueSymlink struct {
-	BaseNode
-	identifier string
-	createdAt  time.Time
-	updatedAt  time.Time
-}
-
-var _ fs.NodeReadlinker = (*ProjectIssueSymlink)(nil)
-var _ fs.NodeGetattrer = (*ProjectIssueSymlink)(nil)
-
-func (s *ProjectIssueSymlink) Readlink(ctx context.Context) ([]byte, syscall.Errno) {
-	target := fmt.Sprintf("../../issues/%s", s.identifier)
-	return []byte(target), 0
-}
-
-func (s *ProjectIssueSymlink) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	target := fmt.Sprintf("../../issues/%s", s.identifier)
-	out.Mode = 0777 | syscall.S_IFLNK
-	s.SetOwner(out)
-	out.Size = uint64(len(target))
-	out.SetTimes(&s.updatedAt, &s.updatedAt, &s.createdAt)
-	return 0
 }
 
 // ProjectInfoNode is a virtual file containing project metadata

--- a/internal/fs/recent.go
+++ b/internal/fs/recent.go
@@ -92,37 +92,9 @@ func (n *RecentNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut
 	}
 	for _, issue := range issues {
 		if issue.Identifier == name {
-			node := &RecentIssueSymlink{BaseNode: BaseNode{lfs: n.lfs}, identifier: issue.Identifier, createdAt: issue.CreatedAt, updatedAt: issue.UpdatedAt}
-			out.Attr.Mode = 0777 | syscall.S_IFLNK
-			out.Attr.Uid = n.lfs.uid
-			out.Attr.Gid = n.lfs.gid
-			out.Attr.SetTimes(&issue.UpdatedAt, &issue.UpdatedAt, &issue.CreatedAt)
-			return n.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFLNK}), 0
+			target := fmt.Sprintf("../issues/%s", issue.Identifier)
+			return n.newSymlinkInode(ctx, out, target, issue.CreatedAt, issue.UpdatedAt), 0
 		}
 	}
 	return nil, syscall.ENOENT
-}
-
-// RecentIssueSymlink points from teams/{KEY}/recent/ to ../issues/{identifier}.
-type RecentIssueSymlink struct {
-	BaseNode
-	identifier string
-	createdAt  time.Time
-	updatedAt  time.Time
-}
-
-var _ fs.NodeReadlinker = (*RecentIssueSymlink)(nil)
-var _ fs.NodeGetattrer = (*RecentIssueSymlink)(nil)
-
-func (s *RecentIssueSymlink) Readlink(ctx context.Context) ([]byte, syscall.Errno) {
-	return []byte(fmt.Sprintf("../issues/%s", s.identifier)), 0
-}
-
-func (s *RecentIssueSymlink) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	target := fmt.Sprintf("../issues/%s", s.identifier)
-	out.Mode = 0777 | syscall.S_IFLNK
-	s.SetOwner(out)
-	out.Size = uint64(len(target))
-	out.SetTimes(&s.updatedAt, &s.updatedAt, &s.createdAt)
-	return 0
 }

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -198,7 +198,7 @@ initiatives/{slug}/
   docs/                             [_create=trigger, .error=feedback]
     {slug}.md                       [read/write]
   projects/                         [symlinks to team projects]
-    {project-slug}                  [symlink to ../../teams/{KEY}/projects/{slug}]
+    {project-slug}                  [symlink to ../../../teams/{KEY}/projects/{slug}]
   updates/                          [status updates]
     _create                         [write with health: onTrack|atRisk|offTrack]
     .error                          [read-only: last failed write here]

--- a/internal/fs/symlink.go
+++ b/internal/fs/symlink.go
@@ -1,0 +1,91 @@
+package fs
+
+import (
+	"context"
+	"fmt"
+	"syscall"
+	"time"
+
+	"github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/jra3/linear-fuse/internal/api"
+)
+
+// symlinkNode is the one symlink module behind every symlink view (issue
+// symlinks under by/, cycles/, recent/, projects/, users/, my/; project
+// symlinks under initiatives/; the cycles/current alias). The relative
+// target and entity timestamps are fixed at construction — Readlink and
+// Getattr only report them, so a view cannot grow per-call behaviour.
+type symlinkNode struct {
+	BaseNode
+	target    string
+	createdAt time.Time
+	updatedAt time.Time
+	// accessedAt covers the one view whose convention encodes a second date
+	// in atime: cycle nodes report atime=EndsAt alongside mtime=StartsAt, and
+	// the cycles/current alias must agree with its target directory.
+	accessedAt time.Time
+}
+
+var _ fs.NodeReadlinker = (*symlinkNode)(nil)
+var _ fs.NodeGetattrer = (*symlinkNode)(nil)
+
+func (s *symlinkNode) Readlink(ctx context.Context) ([]byte, syscall.Errno) {
+	return []byte(s.target), 0
+}
+
+func (s *symlinkNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
+	s.fillAttr(&out.Attr)
+	return 0
+}
+
+func (s *symlinkNode) fillAttr(attr *fuse.Attr) {
+	attr.Mode = 0777 | syscall.S_IFLNK
+	s.setOwnerAttr(attr)
+	attr.Size = uint64(len(s.target))
+	// A zero time.Time must stay a zero attr (epoch): uint64(Unix()) on the
+	// zero value wraps negative into a year-584-billion timestamp that would
+	// sort first in `ls -lt`.
+	attr.SetTimes(nonZeroTime(s.accessedAt), nonZeroTime(s.updatedAt), nonZeroTime(s.createdAt))
+}
+
+// nonZeroTime adapts a possibly-zero time for Attr.SetTimes, which skips nil
+// fields.
+func nonZeroTime(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}
+
+// newSymlinkInode builds the symlink child and fills out.Attr with exactly
+// what symlinkNode.Getattr will later report, so a Lookup answer can never
+// disagree with a subsequent stat.
+func (b *BaseNode) newSymlinkInode(ctx context.Context, out *fuse.EntryOut, target string, createdAt, updatedAt time.Time) *fs.Inode {
+	return b.newSymlinkInodeAtime(ctx, out, target, createdAt, updatedAt, updatedAt)
+}
+
+// newSymlinkInodeAtime is newSymlinkInode with an explicit atime, for the
+// cycle views whose atime carries the cycle end date.
+func (b *BaseNode) newSymlinkInodeAtime(ctx context.Context, out *fuse.EntryOut, target string, createdAt, updatedAt, accessedAt time.Time) *fs.Inode {
+	node := &symlinkNode{
+		BaseNode:   BaseNode{lfs: b.lfs},
+		target:     target,
+		createdAt:  createdAt,
+		updatedAt:  updatedAt,
+		accessedAt: accessedAt,
+	}
+	node.fillAttr(&out.Attr)
+	return b.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFLNK})
+}
+
+// teamIssueTarget is the relative target for an issue symlink two levels
+// below the mount root (my/*, users/{name}). An issue whose team hasn't
+// synced is a reference to something that doesn't exist yet -> ENOENT,
+// never a dangling "teams//" placeholder.
+func teamIssueTarget(issue api.Issue) (string, syscall.Errno) {
+	if issue.Team == nil || issue.Team.Key == "" {
+		return "", syscall.ENOENT
+	}
+	return fmt.Sprintf("../../teams/%s/issues/%s", issue.Team.Key, issue.Identifier), 0
+}

--- a/internal/fs/symlink_test.go
+++ b/internal/fs/symlink_test.go
@@ -1,0 +1,260 @@
+package fs
+
+import (
+	"context"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/jra3/linear-fuse/internal/api"
+	"github.com/jra3/linear-fuse/internal/db"
+	"github.com/jra3/linear-fuse/internal/testutil/fixtures"
+)
+
+// TestSymlinkNodeReportsConstructedState pins the module's whole contract:
+// Readlink and Getattr only report what construction fixed — target, size,
+// entity times — so a view cannot grow per-call behaviour (the drift that
+// produced the initiative symlink's fabricated size-64/now() metadata).
+func TestSymlinkNodeReportsConstructedState(t *testing.T) {
+	t.Parallel()
+	created := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+	updated := time.Date(2025, 6, 7, 8, 9, 10, 0, time.UTC)
+	node := &symlinkNode{
+		target:     "../../issues/TST-1",
+		createdAt:  created,
+		updatedAt:  updated,
+		accessedAt: updated,
+	}
+
+	link, errno := node.Readlink(context.Background())
+	if errno != 0 {
+		t.Fatalf("Readlink errno = %v", errno)
+	}
+	if string(link) != "../../issues/TST-1" {
+		t.Errorf("Readlink = %q, want %q", link, "../../issues/TST-1")
+	}
+
+	var out fuse.AttrOut
+	if errno := node.Getattr(context.Background(), nil, &out); errno != 0 {
+		t.Fatalf("Getattr errno = %v", errno)
+	}
+	if out.Mode != 0777|syscall.S_IFLNK {
+		t.Errorf("Mode = %o, want %o", out.Mode, 0777|syscall.S_IFLNK)
+	}
+	if out.Size != uint64(len(node.target)) {
+		t.Errorf("Size = %d, want %d", out.Size, len(node.target))
+	}
+	if got := time.Unix(int64(out.Mtime), 0).UTC(); !got.Equal(updated) {
+		t.Errorf("Mtime = %v, want updatedAt %v", got, updated)
+	}
+	if got := time.Unix(int64(out.Ctime), 0).UTC(); !got.Equal(created) {
+		t.Errorf("Ctime = %v, want createdAt %v", got, created)
+	}
+}
+
+// TestSymlinkNodeZeroTimesStayEpoch pins the zero-time guard: a row whose
+// timestamps failed to parse must stat as epoch, not wrap uint64(negative)
+// into a year-584-billion mtime that sorts first in `ls -lt`.
+func TestSymlinkNodeZeroTimesStayEpoch(t *testing.T) {
+	t.Parallel()
+	node := &symlinkNode{target: "../../issues/TST-1"}
+
+	var out fuse.AttrOut
+	if errno := node.Getattr(context.Background(), nil, &out); errno != 0 {
+		t.Fatalf("Getattr errno = %v", errno)
+	}
+	if out.Mtime != 0 || out.Ctime != 0 || out.Atime != 0 {
+		t.Errorf("zero times must stay 0, got atime=%d mtime=%d ctime=%d", out.Atime, out.Mtime, out.Ctime)
+	}
+}
+
+// TestSymlinkNodeSeparateAtime pins the cycles convention: atime may carry a
+// distinct date (cycle end) while mtime/ctime carry start.
+func TestSymlinkNodeSeparateAtime(t *testing.T) {
+	t.Parallel()
+	starts := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	ends := time.Date(2025, 3, 15, 0, 0, 0, 0, time.UTC)
+	node := &symlinkNode{target: "cycle-7", createdAt: starts, updatedAt: starts, accessedAt: ends}
+
+	var out fuse.AttrOut
+	if errno := node.Getattr(context.Background(), nil, &out); errno != 0 {
+		t.Fatalf("Getattr errno = %v", errno)
+	}
+	if got := time.Unix(int64(out.Atime), 0).UTC(); !got.Equal(ends) {
+		t.Errorf("Atime = %v, want EndsAt %v", got, ends)
+	}
+	if got := time.Unix(int64(out.Mtime), 0).UTC(); !got.Equal(starts) {
+		t.Errorf("Mtime = %v, want StartsAt %v", got, starts)
+	}
+}
+
+// TestSymlinkNodeGetattrMatchesFillAttr pins Lookup/stat parity: the attrs
+// newSymlinkInode puts in a Lookup's EntryOut come from the same fillAttr that
+// answers a later stat, so the two can never disagree (CurrentCycleSymlink's
+// Lookup and Getattr had drifted apart before consolidation).
+func TestSymlinkNodeGetattrMatchesFillAttr(t *testing.T) {
+	t.Parallel()
+	node := &symlinkNode{
+		target:     "../../../teams/TST/projects/test-project",
+		createdAt:  time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC),
+		updatedAt:  time.Date(2024, 9, 1, 0, 0, 0, 0, time.UTC),
+		accessedAt: time.Date(2024, 9, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	var lookupAttr fuse.Attr
+	node.fillAttr(&lookupAttr)
+
+	var statOut fuse.AttrOut
+	if errno := node.Getattr(context.Background(), nil, &statOut); errno != 0 {
+		t.Fatalf("Getattr errno = %v", errno)
+	}
+	if statOut.Attr != lookupAttr {
+		t.Errorf("Getattr attr diverges from Lookup attr:\n stat: %+v\nlookup: %+v", statOut.Attr, lookupAttr)
+	}
+}
+
+// TestTeamIssueTargetUnsyncedTeamIsENOENT pins the shared my/-and-users/
+// target helper: an issue without team data is unresolvable -> ENOENT, never
+// a dangling "../../teams//issues/X" placeholder.
+func TestTeamIssueTargetUnsyncedTeamIsENOENT(t *testing.T) {
+	t.Parallel()
+	issue := api.Issue{Identifier: "TST-1", Team: &api.Team{Key: "TST"}}
+	target, errno := teamIssueTarget(issue)
+	if errno != 0 || target != "../../teams/TST/issues/TST-1" {
+		t.Errorf("resolvable issue: target=%q errno=%v", target, errno)
+	}
+
+	for name, i := range map[string]api.Issue{
+		"nil team":       {Identifier: "TST-2"},
+		"empty team key": {Identifier: "TST-3", Team: &api.Team{}},
+	} {
+		if _, errno := teamIssueTarget(i); errno != syscall.ENOENT {
+			t.Errorf("%s: errno = %v, want ENOENT", name, errno)
+		}
+	}
+}
+
+// =============================================================================
+// Initiative project target resolution
+// =============================================================================
+
+// TestResolveProjectTargetResolvesTeamAndTimes pins the fix for the drifted
+// initiative symlink: the target comes from the canonical-team query (not a
+// teams-by-projects scan), climbs three levels (the symlink lives at
+// initiatives/{slug}/projects/{name}), and the timestamps are the project's
+// real ones.
+func TestResolveProjectTargetResolvesTeamAndTimes(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := fixtures.NewTestSQLiteStore(t)
+
+	created := time.Date(2025, 2, 3, 0, 0, 0, 0, time.UTC)
+	updated := time.Date(2025, 4, 5, 0, 0, 0, 0, time.UTC)
+	project := api.Project{
+		ID:        "project-1",
+		Name:      "Test Project",
+		Slug:      "test-project",
+		CreatedAt: created,
+		UpdatedAt: updated,
+	}
+
+	if err := fixtures.PopulateTeam(ctx, store, api.Team{ID: "team-1", Key: "TST", Name: "Test"}, nil, nil, nil); err != nil {
+		t.Fatalf("populate team: %v", err)
+	}
+	if err := fixtures.PopulateProject(ctx, store, project, "team-1"); err != nil {
+		t.Fatalf("populate project: %v", err)
+	}
+
+	lfs := &LinearFS{}
+	if err := lfs.InjectTestStore(store); err != nil {
+		t.Fatalf("inject store: %v", err)
+	}
+	node := &InitiativeProjectsNode{BaseNode: BaseNode{lfs: lfs}}
+
+	target, gotCreated, gotUpdated, errno := node.resolveProjectTarget(ctx, "project-1")
+	if errno != 0 {
+		t.Fatalf("resolveProjectTarget errno = %v", errno)
+	}
+	if want := "../../../teams/TST/projects/test-project"; target != want {
+		t.Errorf("target = %q, want %q", target, want)
+	}
+	if !gotCreated.Equal(created) {
+		t.Errorf("createdAt = %v, want %v", gotCreated, created)
+	}
+	if !gotUpdated.Equal(updated) {
+		t.Errorf("updatedAt = %v, want %v", gotUpdated, updated)
+	}
+}
+
+// TestResolveProjectTargetMultiTeamIsFirstByKey pins the canonical-team
+// contract (ORDER BY t.key LIMIT 1) that makes multi-team symlink targets
+// deterministic.
+func TestResolveProjectTargetMultiTeamIsFirstByKey(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := fixtures.NewTestSQLiteStore(t)
+
+	project := api.Project{ID: "project-shared", Name: "Shared", Slug: "shared"}
+	if err := fixtures.PopulateTeam(ctx, store, api.Team{ID: "team-z", Key: "ZZZ", Name: "Zulu"}, nil, nil, nil); err != nil {
+		t.Fatalf("populate team-z: %v", err)
+	}
+	if err := fixtures.PopulateTeam(ctx, store, api.Team{ID: "team-a", Key: "AAA", Name: "Alpha"}, nil, nil, nil); err != nil {
+		t.Fatalf("populate team-a: %v", err)
+	}
+	// Link to the later-sorting team first so insertion order can't fake a pass.
+	if err := fixtures.PopulateProject(ctx, store, project, "team-z"); err != nil {
+		t.Fatalf("populate project (team-z): %v", err)
+	}
+	if err := fixtures.PopulateProject(ctx, store, project, "team-a"); err != nil {
+		t.Fatalf("populate project (team-a): %v", err)
+	}
+
+	lfs := &LinearFS{}
+	if err := lfs.InjectTestStore(store); err != nil {
+		t.Fatalf("inject store: %v", err)
+	}
+	node := &InitiativeProjectsNode{BaseNode: BaseNode{lfs: lfs}}
+
+	target, _, _, errno := node.resolveProjectTarget(ctx, "project-shared")
+	if errno != 0 {
+		t.Fatalf("resolveProjectTarget errno = %v", errno)
+	}
+	if want := "../../../teams/AAA/projects/shared"; target != want {
+		t.Errorf("target = %q, want first-by-key %q", target, want)
+	}
+}
+
+// TestResolveProjectTargetUnsyncedIsENOENT pins the failure model: until sync
+// has both the project row and its team association, the name references
+// something that doesn't exist yet -> ENOENT (no dangling "broken-link").
+func TestResolveProjectTargetUnsyncedIsENOENT(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := fixtures.NewTestSQLiteStore(t)
+	q := store.Queries()
+
+	lfs := &LinearFS{}
+	if err := lfs.InjectTestStore(store); err != nil {
+		t.Fatalf("inject store: %v", err)
+	}
+	node := &InitiativeProjectsNode{BaseNode: BaseNode{lfs: lfs}}
+
+	// Project row missing entirely.
+	if _, _, _, errno := node.resolveProjectTarget(ctx, "project-absent"); errno != syscall.ENOENT {
+		t.Errorf("missing project: errno = %v, want ENOENT", errno)
+	}
+
+	// Project row present but no project_teams association yet (deliberately
+	// not fixtures.PopulateProject, which always writes the junction row).
+	params, err := db.APIProjectToDBProject(api.Project{ID: "project-orphan", Name: "Orphan", Slug: "orphan"})
+	if err != nil {
+		t.Fatalf("convert project: %v", err)
+	}
+	if err := q.UpsertProject(ctx, params); err != nil {
+		t.Fatalf("upsert project: %v", err)
+	}
+	if _, _, _, errno := node.resolveProjectTarget(ctx, "project-orphan"); errno != syscall.ENOENT {
+		t.Errorf("teamless project: errno = %v, want ENOENT", errno)
+	}
+}

--- a/internal/fs/users.go
+++ b/internal/fs/users.go
@@ -137,53 +137,15 @@ func (u *UserNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 
 	for _, issue := range issues {
 		if issue.Identifier == name {
-			// Create symlink to team issue directory
-			teamKey := ""
-			if issue.Team != nil {
-				teamKey = issue.Team.Key
+			target, errno := teamIssueTarget(issue)
+			if errno != 0 {
+				return nil, errno
 			}
-			node := &IssueDirSymlink{
-				BaseNode:   BaseNode{lfs: u.lfs},
-				teamKey:    teamKey,
-				identifier: issue.Identifier,
-				createdAt:  issue.CreatedAt,
-				updatedAt:  issue.UpdatedAt,
-			}
-			out.Attr.Mode = 0777 | syscall.S_IFLNK
-			out.Attr.Uid = u.lfs.uid
-			out.Attr.Gid = u.lfs.gid
-			out.Attr.SetTimes(&issue.UpdatedAt, &issue.UpdatedAt, &issue.CreatedAt)
-			return u.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFLNK}), 0
+			return u.newSymlinkInode(ctx, out, target, issue.CreatedAt, issue.UpdatedAt), 0
 		}
 	}
 
 	return nil, syscall.ENOENT
-}
-
-// IssueDirSymlink is a symlink pointing to an issue directory in /teams/<KEY>/issues/<identifier>/
-type IssueDirSymlink struct {
-	BaseNode
-	teamKey    string
-	identifier string
-	createdAt  time.Time
-	updatedAt  time.Time
-}
-
-var _ fs.NodeReadlinker = (*IssueDirSymlink)(nil)
-var _ fs.NodeGetattrer = (*IssueDirSymlink)(nil)
-
-func (s *IssueDirSymlink) Readlink(ctx context.Context) ([]byte, syscall.Errno) {
-	target := fmt.Sprintf("../../teams/%s/issues/%s", s.teamKey, s.identifier)
-	return []byte(target), 0
-}
-
-func (s *IssueDirSymlink) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	out.Mode = 0777 | syscall.S_IFLNK
-	s.SetOwner(out)
-	target := fmt.Sprintf("../../teams/%s/issues/%s", s.teamKey, s.identifier)
-	out.Size = uint64(len(target))
-	out.SetTimes(&s.updatedAt, &s.updatedAt, &s.createdAt)
-	return 0
 }
 
 // UserInfoNode is a virtual file containing user metadata

--- a/internal/integration/fixture_extended_test.go
+++ b/internal/integration/fixture_extended_test.go
@@ -376,9 +376,19 @@ func TestFixtureChildSymlinkTarget(t *testing.T) {
 		t.Fatalf("Failed to read symlink: %v", err)
 	}
 
-	// Should point to ../TST-2
-	if target != "../TST-2" {
-		t.Errorf("Child symlink should point to ../TST-2, got %s", target)
+	// The sibling issue dir is two levels up from children/ (the old
+	// one-level target pointed inside the parent issue dir and dangled).
+	if target != "../../TST-2" {
+		t.Errorf("Child symlink should point to ../../TST-2, got %s", target)
+	}
+
+	// The target must actually resolve to the sibling issue directory.
+	resolved, err := filepath.EvalSymlinks(childLink)
+	if err != nil {
+		t.Fatalf("Child symlink does not resolve: %v", err)
+	}
+	if want, _ := filepath.Abs(issueDirPath(testTeamKey, "TST-2")); resolved != want {
+		t.Errorf("Child symlink resolves to %s, want %s", resolved, want)
 	}
 }
 

--- a/internal/integration/initiatives_test.go
+++ b/internal/integration/initiatives_test.go
@@ -81,7 +81,9 @@ func TestReadInitiativeProjectsDir(t *testing.T) {
 			t.Errorf("Expected %s to be a symlink", entry.Name())
 		}
 
-		// Verify symlink points to valid team project
+		// Verify symlink points to valid team project. HasPrefix (not
+		// Contains) because the old broken 2-level target was a substring
+		// of the correct 3-level one.
 		symlinkPath := filepath.Join(projectsDir, entry.Name())
 		target, err := os.Readlink(symlinkPath)
 		if err != nil {
@@ -89,8 +91,13 @@ func TestReadInitiativeProjectsDir(t *testing.T) {
 			continue
 		}
 
-		if !strings.Contains(target, "../../teams/") {
-			t.Errorf("Expected symlink to point to teams/, got: %s", target)
+		if !strings.HasPrefix(target, "../../../teams/") {
+			t.Errorf("Expected symlink target under ../../../teams/, got: %s", target)
+		}
+
+		// And it must resolve: the target dir really exists under teams/.
+		if _, err := os.Stat(symlinkPath); err != nil {
+			t.Errorf("Symlink %s does not resolve: %v", entry.Name(), err)
 		}
 	}
 }

--- a/internal/marshal/issue_test.go
+++ b/internal/marshal/issue_test.go
@@ -932,3 +932,70 @@ func TestMarkdownToIssueUpdateEmptyDescriptionNoop(t *testing.T) {
 		t.Errorf("no-op rewrite emitted description=%q, want no update (placeholder must not persist)", v)
 	}
 }
+
+// TestIssueRoundtrip pins parse(render(issue)) as a fixpoint across every
+// editable field at once: rendering issue.md and diffing it back against the
+// same issue must report zero changes. A field rendered and parsed
+// asymmetrically surfaces here as a phantom update — the failure that
+// read-your-writes verification would otherwise misreport as a server-side
+// divergence (or that would silently rewrite the field on every no-op save).
+func TestIssueRoundtrip(t *testing.T) {
+	t.Parallel()
+	dueDate := "2025-02-01"
+	estimate := 5.0
+
+	tests := []struct {
+		name  string
+		issue *api.Issue
+	}{
+		{
+			name: "fully populated",
+			issue: &api.Issue{
+				ID:          "issue-123",
+				Identifier:  "ENG-456",
+				Title:       "Fix authentication bug",
+				Description: "Users can't log in with SSO.\n\n## Repro\n\n1. Open the login page.",
+				State:       api.State{ID: "state-1", Name: "In Progress", Type: "started"},
+				Assignee:    &api.User{ID: "user-1", Name: "Alice", Email: "alice@example.com"},
+				Priority:    2, // high
+				Labels: api.Labels{Nodes: []api.Label{
+					{ID: "label-1", Name: "bug", Color: "#FF0000"},
+					{ID: "label-2", Name: "backend", Color: "#00FF00"},
+				}},
+				DueDate:          &dueDate,
+				Estimate:         &estimate,
+				Project:          &api.Project{ID: "proj-1", Name: "Q1 Launch"},
+				ProjectMilestone: &api.ProjectMilestone{ID: "milestone-1", Name: "Phase 1"},
+				Parent:           &api.ParentIssue{ID: "issue-100", Identifier: "ENG-100"},
+				Cycle:            &api.IssueCycle{ID: "cycle-1", Name: "Sprint 42", Number: 42},
+			},
+		},
+		{
+			name: "minimal (empty description placeholder)",
+			issue: &api.Issue{
+				ID:         "issue-min",
+				Identifier: "ENG-1",
+				Title:      "Simple task",
+				State:      api.State{ID: "state-1", Name: "Backlog"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			md, err := IssueToMarkdown(tt.issue)
+			if err != nil {
+				t.Fatalf("IssueToMarkdown() error: %v", err)
+			}
+
+			update, err := MarkdownToIssueUpdate(md, tt.issue)
+			if err != nil {
+				t.Fatalf("MarkdownToIssueUpdate() error: %v", err)
+			}
+
+			if len(update) != 0 {
+				t.Errorf("Roundtrip produced unexpected changes: %v (rendered:\n%s)", update, md)
+			}
+		})
+	}
+}

--- a/internal/marshal/milestone_test.go
+++ b/internal/marshal/milestone_test.go
@@ -1,0 +1,234 @@
+package marshal
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jra3/linear-fuse/internal/api"
+)
+
+func TestMilestoneToMarkdown(t *testing.T) {
+	t.Parallel()
+	targetDate := "2025-06-30"
+
+	m := &api.ProjectMilestone{
+		ID:          "milestone-1",
+		Name:        "Phase 1",
+		Description: "Initial rollout scope.",
+		TargetDate:  &targetDate,
+		SortOrder:   1.5,
+	}
+
+	md, err := MilestoneToMarkdown(m)
+	if err != nil {
+		t.Fatalf("MilestoneToMarkdown() error: %v", err)
+	}
+
+	content := string(md)
+	for _, want := range []string{
+		"id: milestone-1",
+		"name: Phase 1",
+		`targetDate: "2025-06-30"`,
+		"sortOrder: 1.5",
+		"Initial rollout scope.",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("MilestoneToMarkdown() missing %q in:\n%s", want, content)
+		}
+	}
+}
+
+func TestMilestoneToMarkdownOmitsEmptyOptionals(t *testing.T) {
+	t.Parallel()
+	m := &api.ProjectMilestone{
+		ID:   "milestone-2",
+		Name: "Bare",
+	}
+
+	md, err := MilestoneToMarkdown(m)
+	if err != nil {
+		t.Fatalf("MilestoneToMarkdown() error: %v", err)
+	}
+
+	content := string(md)
+	for _, notWant := range []string{"targetDate:", "sortOrder:"} {
+		if strings.Contains(content, notWant) {
+			t.Errorf("MilestoneToMarkdown() should omit %q for zero value:\n%s", notWant, content)
+		}
+	}
+}
+
+func TestMarkdownToMilestoneUpdate(t *testing.T) {
+	t.Parallel()
+	origDate := "2025-06-30"
+	original := &api.ProjectMilestone{
+		ID:          "milestone-1",
+		Name:        "Phase 1",
+		Description: "Initial rollout scope.",
+		TargetDate:  &origDate,
+		SortOrder:   1.5,
+	}
+
+	t.Run("changed fields are emitted", func(t *testing.T) {
+		content := []byte(`---
+id: milestone-1
+name: Phase 1 (revised)
+targetDate: "2025-09-30"
+sortOrder: 2.5
+---
+Revised scope.`)
+
+		input, err := MarkdownToMilestoneUpdate(content, original)
+		if err != nil {
+			t.Fatalf("MarkdownToMilestoneUpdate() error: %v", err)
+		}
+		if input.Name == nil || *input.Name != "Phase 1 (revised)" {
+			t.Errorf("Name = %v, want %q", input.Name, "Phase 1 (revised)")
+		}
+		if input.TargetDate == nil || *input.TargetDate != "2025-09-30" {
+			t.Errorf("TargetDate = %v, want %q", input.TargetDate, "2025-09-30")
+		}
+		if input.SortOrder == nil || *input.SortOrder != 2.5 {
+			t.Errorf("SortOrder = %v, want 2.5", input.SortOrder)
+		}
+		if input.Description == nil || *input.Description != "Revised scope." {
+			t.Errorf("Description = %v, want %q", input.Description, "Revised scope.")
+		}
+	})
+
+	t.Run("unquoted target date parses as date not string", func(t *testing.T) {
+		// YAML resolves a bare 2025-09-30 to a timestamp; the parser must
+		// coerce it back to YYYY-MM-DD instead of silently dropping the edit.
+		content := []byte(`---
+name: Phase 1
+targetDate: 2025-09-30
+---
+Initial rollout scope.`)
+
+		input, err := MarkdownToMilestoneUpdate(content, original)
+		if err != nil {
+			t.Fatalf("MarkdownToMilestoneUpdate() error: %v", err)
+		}
+		if input.TargetDate == nil || *input.TargetDate != "2025-09-30" {
+			t.Errorf("TargetDate = %v, want %q", input.TargetDate, "2025-09-30")
+		}
+	})
+
+	t.Run("removed target date clears it", func(t *testing.T) {
+		content := []byte(`---
+name: Phase 1
+---
+Initial rollout scope.`)
+
+		input, err := MarkdownToMilestoneUpdate(content, original)
+		if err != nil {
+			t.Fatalf("MarkdownToMilestoneUpdate() error: %v", err)
+		}
+		if input.TargetDate == nil || *input.TargetDate != "" {
+			t.Errorf("TargetDate = %v, want cleared (empty string)", input.TargetDate)
+		}
+	})
+}
+
+// TestMilestoneRoundtrip pins parse(render(milestone)) as a fixpoint: rendering
+// milestone.md and parsing it back must report zero changes, or every no-op
+// save would push a phantom update (and read-your-writes verification would
+// flag a divergence that is really a marshal asymmetry).
+func TestMilestoneRoundtrip(t *testing.T) {
+	t.Parallel()
+	targetDate := "2025-06-30"
+
+	tests := []struct {
+		name      string
+		milestone *api.ProjectMilestone
+	}{
+		{
+			name: "fully populated",
+			milestone: &api.ProjectMilestone{
+				ID:          "milestone-1",
+				Name:        "Phase 1",
+				Description: "Initial rollout scope.\n\nWith a second paragraph.",
+				TargetDate:  &targetDate,
+				SortOrder:   1.5,
+			},
+		},
+		{
+			name: "minimal",
+			milestone: &api.ProjectMilestone{
+				ID:   "milestone-2",
+				Name: "Bare",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			md, err := MilestoneToMarkdown(tt.milestone)
+			if err != nil {
+				t.Fatalf("MilestoneToMarkdown() error: %v", err)
+			}
+
+			input, err := MarkdownToMilestoneUpdate(md, tt.milestone)
+			if err != nil {
+				t.Fatalf("MarkdownToMilestoneUpdate() error: %v", err)
+			}
+
+			if input != (api.ProjectMilestoneUpdateInput{}) {
+				t.Errorf("Roundtrip produced unexpected changes: %+v (rendered:\n%s)", input, md)
+			}
+		})
+	}
+}
+
+func TestParseNewMilestone(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		content  string
+		wantName string
+		wantDesc string
+	}{
+		{
+			name:     "name and description",
+			content:  "Phase 1\nInitial milestone",
+			wantName: "Phase 1",
+			wantDesc: "Initial milestone",
+		},
+		{
+			name:     "name only",
+			content:  "Phase 1\n",
+			wantName: "Phase 1",
+			wantDesc: "",
+		},
+		{
+			name:     "multiline description",
+			content:  "Phase 1\nLine one\nLine two",
+			wantName: "Phase 1",
+			wantDesc: "Line one\nLine two",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, desc := ParseNewMilestone([]byte(tt.content))
+			if name != tt.wantName {
+				t.Errorf("name = %q, want %q", name, tt.wantName)
+			}
+			if desc != tt.wantDesc {
+				t.Errorf("description = %q, want %q", desc, tt.wantDesc)
+			}
+		})
+	}
+}
+
+func TestValidateMilestoneUpdate(t *testing.T) {
+	t.Parallel()
+	empty := ""
+	if err := ValidateMilestoneUpdate(api.ProjectMilestoneUpdateInput{Name: &empty}); err == nil {
+		t.Error("expected error for empty name")
+	}
+	name := "Phase 1"
+	if err := ValidateMilestoneUpdate(api.ProjectMilestoneUpdateInput{Name: &name}); err != nil {
+		t.Errorf("unexpected error for valid name: %v", err)
+	}
+}

--- a/internal/repo/mock.go
+++ b/internal/repo/mock.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/jra3/linear-fuse/internal/api"
@@ -347,6 +348,21 @@ func (m *MockRepository) GetCycleByName(ctx context.Context, teamID, name string
 
 func (m *MockRepository) GetTeamProjects(ctx context.Context, teamID string) ([]api.Project, error) {
 	return m.Projects[teamID], nil
+}
+
+func (m *MockRepository) GetProjectPrimaryTeamKey(ctx context.Context, projectID string) (string, error) {
+	primary := ""
+	for teamID, projects := range m.Projects {
+		if !slices.ContainsFunc(projects, func(p api.Project) bool { return p.ID == projectID }) {
+			continue
+		}
+		for _, team := range m.Teams {
+			if team.ID == teamID && (primary == "" || team.Key < primary) {
+				primary = team.Key
+			}
+		}
+	}
+	return primary, nil
 }
 
 func (m *MockRepository) GetProjectBySlug(ctx context.Context, slug string) (*api.Project, error) {

--- a/internal/repo/mock_test.go
+++ b/internal/repo/mock_test.go
@@ -511,5 +511,31 @@ func TestMockRepository_IssuesByLabel(t *testing.T) {
 	}
 }
 
+// TestMockRepository_GetProjectPrimaryTeamKey pins the canonical-team
+// contract (first key in sort order) that the SQLite query enforces with
+// ORDER BY t.key LIMIT 1 — the mock must agree or mock-backed tests
+// diverge from production symlink targets.
+func TestMockRepository_GetProjectPrimaryTeamKey(t *testing.T) {
+	ctx := context.Background()
+	repo := NewMockRepository()
+	repo.Teams = []api.Team{
+		{ID: "team-z", Key: "ZZZ"},
+		{ID: "team-a", Key: "AAA"},
+	}
+	shared := api.Project{ID: "project-shared", Name: "Shared"}
+	repo.Projects["team-z"] = []api.Project{shared}
+	repo.Projects["team-a"] = []api.Project{shared}
+
+	key, err := repo.GetProjectPrimaryTeamKey(ctx, "project-shared")
+	if err != nil || key != "AAA" {
+		t.Errorf("GetProjectPrimaryTeamKey = %q, %v; want first-by-key %q", key, err, "AAA")
+	}
+
+	key, err = repo.GetProjectPrimaryTeamKey(ctx, "project-absent")
+	if err != nil || key != "" {
+		t.Errorf("absent project: got %q, %v; want empty key", key, err)
+	}
+}
+
 // Test interface compliance at compile time
 var _ Repository = (*MockRepository)(nil)

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -146,6 +146,11 @@ type Repository interface {
 	// GetProjectByID returns a project by its ID
 	GetProjectByID(ctx context.Context, id string) (*api.Project, error)
 
+	// GetProjectPrimaryTeamKey returns the key of the canonical team for a
+	// project (first by key order when a project spans teams), or "" when the
+	// project has no team association yet
+	GetProjectPrimaryTeamKey(ctx context.Context, projectID string) (string, error)
+
 	// ==========================================================================
 	// Project Milestones
 	// ==========================================================================

--- a/internal/repo/sqlite.go
+++ b/internal/repo/sqlite.go
@@ -63,6 +63,11 @@ type SQLiteRepository struct {
 	reconcilePending atomic.Bool
 }
 
+// Compile-time interface compliance: without this, a method added to
+// Repository but forgotten here would still build (nothing else consumes
+// the interface with this implementation).
+var _ Repository = (*SQLiteRepository)(nil)
+
 // NewSQLiteRepository creates a new SQLite-backed repository.
 // If client is nil, the repository will only serve data from SQLite.
 func NewSQLiteRepository(store *db.Store, client *api.Client) *SQLiteRepository {
@@ -709,6 +714,17 @@ func (r *SQLiteRepository) GetProjectByID(ctx context.Context, id string) (*api.
 		return nil, err
 	}
 	return &result, nil
+}
+
+func (r *SQLiteRepository) GetProjectPrimaryTeamKey(ctx context.Context, projectID string) (string, error) {
+	key, err := r.store.Queries().GetProjectPrimaryTeamKey(ctx, projectID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", nil
+		}
+		return "", fmt.Errorf("get project primary team key: %w", err)
+	}
+	return key, nil
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Fourth architecture-review round: consolidates all **eight** hand-copied symlink node types into one `symlinkNode` module (`internal/fs/symlink.go`), and pins the marshal `parse(render())` round-trip for issues and milestones.

### Symlink module
- One `symlinkNode{target, createdAt, updatedAt, accessedAt}`; `newSymlinkInode` fills the Lookup `EntryOut` from the same `fillAttr` that answers a later `stat`, so Lookup/Getattr drift is impossible by construction.
- **Fixes live bugs the copies had accumulated:**
  - `children/` symlinks were dangling (target one level short) and stat'd as root-owned — every child link on a live mount was broken.
  - Initiative project symlinks were also one level short, re-derived per-readlink via an all-teams×all-projects scan, and fabricated size/timestamps. Now resolved once at Lookup through the new canonical-team query `GetProjectPrimaryTeamKey` (`ORDER BY t.key LIMIT 1` — the one place that rule lives); unresolvable-until-synced → `ENOENT`.
  - Issues with a nil/unsynced team no longer yield dangling `../../teams//issues/X` placeholders.
  - Zero timestamps stay epoch instead of wrapping `uint64(negative)` into year-584-billion mtimes; `cycles/current` keeps its atime=EndsAt convention.
- Cleanups: hoisted per-call regex compiles, `fuse.Attr`-level owner helper, compile-time `Repository` assertion for `SQLiteRepository`, pinned `make sqlc`, generated README target-depth fix, integration tests now *resolve* symlinks rather than substring-match targets.

### Marshal round-trips
Read-your-writes verification stands on `parse(render(x))` being a fixpoint. `TestIssueRoundtrip` (all 10 editable fields + empty-description placeholder) and a new `milestone_test.go` (first-ever coverage for milestone marshal) pin it against future field additions.

## Review
Reviewed by an 8-angle finder/verifier pass (10 findings, all addressed) plus 3 independent cold reviewers — the cold pass caught the un-migrated `ChildSymlinkNode` and the substring-matching test assertions; both fixed here. `symlinkNode` is now the only `NodeReadlinker` in the package.

## Test plan
- Full suite + fixture integration green; `go vet` clean
- New unit tests: symlink attr contract, zero-time guard, atime override, Lookup/stat parity, canonical-team resolution (single + multi-team + unsynced-ENOENT), mock/SQLite ordering parity
- Integration: child + initiative symlinks now asserted to actually resolve through the mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)