### PR TITLE
Drain every Linear connection: paginate module, complete metadata sync, association prunes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -155,6 +155,35 @@ something that doesn't exist -> `ENOENT` at Lookup, never a dangling
 placeholder. Lives in `internal/fs/symlink.go`;
 unit-tested directly, no FUSE mount.
 
+### Connection drain (`paginate`)
+The **deep module** owning cursor pagination of Linear GraphQL connections —
+the read-side counterpart to `execMutation`. Linear silently caps a
+connection without a `first:` argument at 50 nodes (and any page at 250), so
+"fetch the projects" without draining is a lie past one page: the team
+metadata sync shipped that lie for months (a 50-project cap that dangled a
+third of the live initiative symlinks), and the reconcile ID fetches carried
+a worse one (a truncated "authoritative" set feeding a diff-and-delete).
+`drainFrom` (`internal/api/paginate.go`) owns the invariant tail — cursor
+threading, termination, a stalled-cursor guard, an `ErrBudget` abort between
+pages, and an **all-or-nothing result** (a nil-error return is the complete
+set; diff-and-delete callers rely on this) — over a `pageFetch` closure, its
+test seam. The `fetchAll`/`drain` spellings walk the response by path the way
+`execMutation` does; `drain` resumes a connection whose first page arrived
+embedded in a combined query (`queryTeamMetadata`, `queryWorkspace`) and
+costs zero API calls when nothing overflowed. The envelope type carries
+`*PageInfo` so a query that forgets to select `pageInfo` is a loud error,
+never a silent single-page truncation. Page sizes are complexity-budgeted:
+Linear scores a query's cost, and `team.projects`' nested selections price it
+out of the combined metadata query entirely (~187 points/node; 50/page max —
+measured live, documented at the query).
+
+Completeness is what licenses the **association prunes**: after a drained
+fetch, `project_teams` (per team) and `initiative_projects` (per initiative)
+rows the response no longer contains are deleted, using the Delete-tail
+prune's pre-fetch `synced_at` cutoff so mid-sync writes survive, and skipped
+whenever the fetch or any upsert failed. Prune only against a drained fetch —
+a truncated list reads as removals.
+
 ### ErrorSink
 The minimal seam the WriteBack tail uses to record validation/divergence messages for
 `.error` files: `SetWriteError(key, msg)` / `ClearWriteError(key)`. `*LinearFS`

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -57,8 +57,13 @@ func NewClient(apiKey string) *Client {
 
 func NewClientWithOptions(apiKey string, opts ClientOptions) *Client {
 	// Linear allows 1,500 requests/hour (0.417/sec sustained).
-	// Burst of 10 absorbs brief spikes; sustained rate stays within budget.
-	limiter := rate.NewLimiter(rate.Limit(1500.0/3600.0), 10)
+	// The burst absorbs one sync cycle's spike; sustained rate stays within
+	// budget regardless of burst size. Sizing: a cycle is workspace (1) +
+	// per-team metadata (2: combined query + paginated projects) + issues
+	// (1+) for every team, and the write-reserve gate defers reads below 2
+	// tokens — at burst 10 a 4-team cycle spent exactly ~10 before the last
+	// team, which therefore never synced (its reads deferred every cycle).
+	limiter := rate.NewLimiter(rate.Limit(1500.0/3600.0), 16)
 
 	return &Client{
 		apiKey:     apiKey,
@@ -719,30 +724,23 @@ func (c *Client) ArchiveIssue(ctx context.Context, issueID string) error {
 	return execMutationOK(ctx, c, mutationArchiveIssue, map[string]any{"id": issueID}, "issueArchive")
 }
 
-// GetTeamMetadata fetches all metadata for a team in a single query:
-// states, labels (team + workspace, deduplicated), cycles, projects (with milestones), and members.
+// GetTeamMetadata fetches all metadata for a team: states, labels (team +
+// workspace, deduplicated), cycles, members — one combined query, with any
+// connection reporting hasNextPage drained to completion — and projects via
+// the paginated GetTeamProjects (too complexity-expensive to share the
+// combined query; see queryTeamMetadata). The returned sets are complete:
+// the sync worker prunes against them.
 func (c *Client) GetTeamMetadata(ctx context.Context, teamID string) (*TeamMetadata, error) {
 	var result struct {
 		Team struct {
 			States struct {
 				Nodes []State `json:"nodes"`
 			} `json:"states"`
-			Labels struct {
-				Nodes []Label `json:"nodes"`
-			} `json:"labels"`
-			Cycles struct {
-				Nodes []Cycle `json:"nodes"`
-			} `json:"cycles"`
-			Projects struct {
-				Nodes []Project `json:"nodes"`
-			} `json:"projects"`
-			Members struct {
-				Nodes []User `json:"nodes"`
-			} `json:"members"`
+			Labels  conn[Label] `json:"labels"`
+			Cycles  conn[Cycle] `json:"cycles"`
+			Members conn[User]  `json:"members"`
 		} `json:"team"`
-		IssueLabels struct {
-			Nodes []Label `json:"nodes"`
-		} `json:"issueLabels"`
+		IssueLabels conn[Label] `json:"issueLabels"`
 	}
 
 	vars := map[string]any{
@@ -754,16 +752,49 @@ func (c *Client) GetTeamMetadata(ctx context.Context, teamID string) (*TeamMetad
 		return nil, err
 	}
 
+	teamLabels := result.Team.Labels.Nodes
+	moreLabels, err := drain[Label](ctx, c, queryTeamLabelsPage, vars, result.Team.Labels.PageInfo, "team", "labels")
+	if err != nil {
+		return nil, fmt.Errorf("drain team labels: %w", err)
+	}
+	teamLabels = append(teamLabels, moreLabels...)
+
+	cycles := result.Team.Cycles.Nodes
+	moreCycles, err := drain[Cycle](ctx, c, queryTeamCyclesPage, vars, result.Team.Cycles.PageInfo, "team", "cycles")
+	if err != nil {
+		return nil, fmt.Errorf("drain team cycles: %w", err)
+	}
+	cycles = append(cycles, moreCycles...)
+
+	members := result.Team.Members.Nodes
+	moreMembers, err := drain[User](ctx, c, queryTeamMembersPage, vars, result.Team.Members.PageInfo, "team", "members")
+	if err != nil {
+		return nil, fmt.Errorf("drain team members: %w", err)
+	}
+	members = append(members, moreMembers...)
+
+	workspaceLabels := result.IssueLabels.Nodes
+	moreWorkspace, err := drain[Label](ctx, c, queryWorkspaceLabelsPage, nil, result.IssueLabels.PageInfo, "issueLabels")
+	if err != nil {
+		return nil, fmt.Errorf("drain workspace labels: %w", err)
+	}
+	workspaceLabels = append(workspaceLabels, moreWorkspace...)
+
+	projects, err := c.GetTeamProjects(ctx, teamID)
+	if err != nil {
+		return nil, fmt.Errorf("fetch team projects: %w", err)
+	}
+
 	// Combine team labels and workspace labels, deduplicating by ID
 	seen := make(map[string]bool)
 	var labels []Label
-	for _, l := range result.Team.Labels.Nodes {
+	for _, l := range teamLabels {
 		if !seen[l.ID] {
 			seen[l.ID] = true
 			labels = append(labels, l)
 		}
 	}
-	for _, l := range result.IssueLabels.Nodes {
+	for _, l := range workspaceLabels {
 		if !seen[l.ID] {
 			seen[l.ID] = true
 			labels = append(labels, l)
@@ -773,21 +804,22 @@ func (c *Client) GetTeamMetadata(ctx context.Context, teamID string) (*TeamMetad
 	return &TeamMetadata{
 		States:   result.Team.States.Nodes,
 		Labels:   labels,
-		Cycles:   result.Team.Cycles.Nodes,
-		Projects: result.Team.Projects.Nodes,
-		Members:  result.Team.Members.Nodes,
+		Cycles:   cycles,
+		Projects: projects,
+		Members:  members,
 	}, nil
 }
 
-// GetWorkspace fetches workspace-level entities (users and initiatives) in a single query.
+// GetWorkspace fetches workspace-level entities (users and initiatives),
+// drained to completion — including each initiative's nested projects
+// connection, whose completeness is load-bearing: the sync worker prunes
+// initiative_projects junction rows against it, so a truncated list would
+// read as removals. Every returned Initiative has a complete Projects.Nodes
+// and a nil Projects.PageInfo.
 func (c *Client) GetWorkspace(ctx context.Context) (*WorkspaceData, error) {
 	var result struct {
-		Users struct {
-			Nodes []User `json:"nodes"`
-		} `json:"users"`
-		Initiatives struct {
-			Nodes []Initiative `json:"nodes"`
-		} `json:"initiatives"`
+		Users       conn[User]       `json:"users"`
+		Initiatives conn[Initiative] `json:"initiatives"`
 	}
 
 	err := c.query(ctx, queryWorkspace, nil, &result)
@@ -795,9 +827,34 @@ func (c *Client) GetWorkspace(ctx context.Context) (*WorkspaceData, error) {
 		return nil, err
 	}
 
+	users := result.Users.Nodes
+	moreUsers, err := drain[User](ctx, c, queryWorkspaceUsersPage, nil, result.Users.PageInfo, "users")
+	if err != nil {
+		return nil, fmt.Errorf("drain users: %w", err)
+	}
+	users = append(users, moreUsers...)
+
+	initiatives := result.Initiatives.Nodes
+	moreInitiatives, err := drain[Initiative](ctx, c, queryWorkspaceInitiativesPage, nil, result.Initiatives.PageInfo, "initiatives")
+	if err != nil {
+		return nil, fmt.Errorf("drain initiatives: %w", err)
+	}
+	initiatives = append(initiatives, moreInitiatives...)
+
+	for i := range initiatives {
+		init := &initiatives[i]
+		moreProjects, err := drain[InitiativeProject](ctx, c, queryInitiativeProjectsPage,
+			map[string]any{"id": init.ID}, init.Projects.PageInfo, "initiative", "projects")
+		if err != nil {
+			return nil, fmt.Errorf("drain initiative %s projects: %w", init.Slug, err)
+		}
+		init.Projects.Nodes = append(init.Projects.Nodes, moreProjects...)
+		init.Projects.PageInfo = nil
+	}
+
 	return &WorkspaceData{
-		Users:       result.Users.Nodes,
-		Initiatives: result.Initiatives.Nodes,
+		Users:       users,
+		Initiatives: initiatives,
 	}, nil
 }
 
@@ -823,26 +880,12 @@ func (c *Client) GetTeamStates(ctx context.Context, teamID string) ([]State, err
 	return result.Team.States.Nodes, nil
 }
 
-// GetTeamProjects fetches projects for a team
+// GetTeamProjects fetches all projects for a team. Paginated: a team's
+// projects connection was the first observed to overflow a page (silently
+// truncating teams/ views and dangling initiative symlinks).
 func (c *Client) GetTeamProjects(ctx context.Context, teamID string) ([]Project, error) {
-	var result struct {
-		Team struct {
-			Projects struct {
-				Nodes []Project `json:"nodes"`
-			} `json:"projects"`
-		} `json:"team"`
-	}
-
-	vars := map[string]any{
-		"teamId": teamID,
-	}
-
-	err := c.query(ctx, queryTeamProjects, vars, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.Team.Projects.Nodes, nil
+	return fetchAll[Project](ctx, c, queryTeamProjects,
+		map[string]any{"teamId": teamID}, "team", "projects")
 }
 
 // GetProjectIssues fetches issues for a project
@@ -1652,39 +1695,36 @@ func (c *Client) GetTeamIssueIDs(ctx context.Context, teamID string) ([]string, 
 	return ids, nil
 }
 
+// idNode is the projection the reconcile ID sweeps decode.
+type idNode struct {
+	ID string `json:"id"`
+}
+
 // GetWorkspaceProjectIDs returns IDs of every project in the workspace.
+// All-or-nothing: the reconcile pass diffs-and-deletes against this set,
+// so a partial result must surface as an error, never as a short list
+// (fetchAll guarantees it).
 func (c *Client) GetWorkspaceProjectIDs(ctx context.Context) ([]string, error) {
-	var result struct {
-		Projects struct {
-			Nodes []struct {
-				ID string `json:"id"`
-			} `json:"nodes"`
-		} `json:"projects"`
-	}
-	if err := c.query(ctx, queryWorkspaceProjectIDs, nil, &result); err != nil {
+	nodes, err := fetchAll[idNode](ctx, c, queryWorkspaceProjectIDs, nil, "projects")
+	if err != nil {
 		return nil, err
 	}
-	ids := make([]string, 0, len(result.Projects.Nodes))
-	for _, n := range result.Projects.Nodes {
+	ids := make([]string, 0, len(nodes))
+	for _, n := range nodes {
 		ids = append(ids, n.ID)
 	}
 	return ids, nil
 }
 
-// GetWorkspaceInitiativeIDs returns IDs of every initiative in the workspace.
+// GetWorkspaceInitiativeIDs returns IDs of every initiative in the
+// workspace. Complete or error, like GetWorkspaceProjectIDs.
 func (c *Client) GetWorkspaceInitiativeIDs(ctx context.Context) ([]string, error) {
-	var result struct {
-		Initiatives struct {
-			Nodes []struct {
-				ID string `json:"id"`
-			} `json:"nodes"`
-		} `json:"initiatives"`
-	}
-	if err := c.query(ctx, queryWorkspaceInitiativeIDs, nil, &result); err != nil {
+	nodes, err := fetchAll[idNode](ctx, c, queryWorkspaceInitiativeIDs, nil, "initiatives")
+	if err != nil {
 		return nil, err
 	}
-	ids := make([]string, 0, len(result.Initiatives.Nodes))
-	for _, n := range result.Initiatives.Nodes {
+	ids := make([]string, 0, len(nodes))
+	for _, n := range nodes {
 		ids = append(ids, n.ID)
 	}
 	return ids, nil

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1399,8 +1399,9 @@ func TestMutationPriorityReservesTokensForWrites(t *testing.T) {
 	client := NewClient("test-api-key")
 	client.SetAPIURL(server.URL)
 
-	// Drain the token bucket to near-empty (burst=10, drain all but 1)
-	for i := 0; i < 10; i++ {
+	// Drain the token bucket to near-empty (below the 2-token write
+	// reserve), whatever the burst size.
+	for client.limiter.Tokens() >= 2 {
 		client.limiter.Allow()
 	}
 
@@ -1424,12 +1425,12 @@ func TestMutationPriorityReservesTokensForWrites(t *testing.T) {
 
 func TestClient_LowBudget(t *testing.T) {
 	c := NewClient("test-key")
-	// Fresh limiter has full burst (10 tokens). Should not be low.
+	// Fresh limiter has a full burst. Should not be low.
 	if c.LowBudget() {
 		t.Error("LowBudget true with full burst")
 	}
-	// Drain burst.
-	for i := 0; i < 9; i++ {
+	// Drain the burst to just under the threshold, whatever its size.
+	for c.limiter.Tokens() >= 5 {
 		c.limiter.Reserve()
 	}
 	if !c.LowBudget() {
@@ -1459,7 +1460,7 @@ func TestClient_GetTeamIssueIDs(t *testing.T) {
 func TestClient_GetWorkspaceProjectIDs(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":{"projects":{"nodes":[{"id":"p1"},{"id":"p2"}]}}}`))
+		_, _ = w.Write([]byte(`{"data":{"projects":{"pageInfo":{"hasNextPage":false,"endCursor":""},"nodes":[{"id":"p1"},{"id":"p2"}]}}}`))
 	}))
 	defer server.Close()
 
@@ -1478,7 +1479,7 @@ func TestClient_GetWorkspaceProjectIDs(t *testing.T) {
 func TestClient_GetWorkspaceInitiativeIDs(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":{"initiatives":{"nodes":[{"id":"i1"}]}}}`))
+		_, _ = w.Write([]byte(`{"data":{"initiatives":{"pageInfo":{"hasNextPage":false,"endCursor":""},"nodes":[{"id":"i1"}]}}}`))
 	}))
 	defer server.Close()
 

--- a/internal/api/drain_e2e_test.go
+++ b/internal/api/drain_e2e_test.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jra3/linear-fuse/internal/testutil"
+)
+
+// End-to-end drain tests: real queries through the mock server, multi-page
+// sequences scripted with SetResponseSequence (a single static SetResponse
+// can never terminate a pagination loop whose first page says hasNextPage).
+
+func pf(hasNext bool, cursor string) map[string]any {
+	return map[string]any{"hasNextPage": hasNext, "endCursor": cursor}
+}
+
+func connOf(pageInfo map[string]any, nodes ...map[string]any) map[string]any {
+	if nodes == nil {
+		nodes = []map[string]any{}
+	}
+	return map[string]any{"pageInfo": pageInfo, "nodes": nodes}
+}
+
+func TestGetTeamProjectsPaginates(t *testing.T) {
+	t.Parallel()
+	mock := testutil.NewMockLinearServer()
+	defer mock.Close()
+
+	pageA := map[string]any{"team": map[string]any{"projects": connOf(pf(true, "cursor-1"),
+		map[string]any{"id": "proj-a", "name": "Alpha", "slugId": "alpha"})}}
+	pageB := map[string]any{"team": map[string]any{"projects": connOf(pf(false, ""),
+		map[string]any{"id": "proj-b", "name": "Beta", "slugId": "beta"})}}
+	mock.SetResponseSequence("TeamProjects", pageA, pageB)
+
+	c := NewClient("test")
+	c.SetAPIURL(mock.URL())
+
+	projects, err := c.GetTeamProjects(context.Background(), "team-1")
+	if err != nil {
+		t.Fatalf("GetTeamProjects: %v", err)
+	}
+	if len(projects) != 2 || projects[0].Name != "Alpha" || projects[1].Name != "Beta" {
+		t.Fatalf("projects = %+v, want [Alpha Beta]", projects)
+	}
+
+	calls := mock.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("calls = %d, want 2", len(calls))
+	}
+	if calls[0].Variables["after"] != nil {
+		t.Errorf("first page sent after=%v, want omitted", calls[0].Variables["after"])
+	}
+	if calls[1].Variables["after"] != "cursor-1" {
+		t.Errorf("second page after = %v, want cursor-1", calls[1].Variables["after"])
+	}
+}
+
+func TestGetTeamMetadataDrainsOverflowingConnections(t *testing.T) {
+	t.Parallel()
+	mock := testutil.NewMockLinearServer()
+	defer mock.Close()
+
+	// Combined query: labels overflow (hasNextPage), everything else fits.
+	mock.SetResponse("TeamMetadata", map[string]any{
+		"team": map[string]any{
+			"states": map[string]any{"nodes": []map[string]any{{"id": "s1", "name": "Todo", "type": "unstarted"}}},
+			"labels": connOf(pf(true, "lab-cursor"),
+				map[string]any{"id": "l1", "name": "bug", "color": "#f00"}),
+			"cycles":  connOf(pf(false, "")),
+			"members": connOf(pf(false, "")),
+		},
+		"issueLabels": connOf(pf(false, ""),
+			map[string]any{"id": "l3", "name": "workspace", "color": "#00f"}),
+	})
+	// The labels drain resumes from lab-cursor.
+	mock.SetResponse("TeamLabelsPage", map[string]any{
+		"team": map[string]any{
+			"labels": connOf(pf(false, ""),
+				map[string]any{"id": "l2", "name": "perf", "color": "#0f0"}),
+		},
+	})
+	mock.SetResponse("TeamProjects", testutil.TeamProjectsResponse())
+
+	c := NewClient("test")
+	c.SetAPIURL(mock.URL())
+
+	meta, err := c.GetTeamMetadata(context.Background(), "team-1")
+	if err != nil {
+		t.Fatalf("GetTeamMetadata: %v", err)
+	}
+	if len(meta.Labels) != 3 {
+		t.Fatalf("labels = %+v, want 3 (combined page + drained page + workspace)", meta.Labels)
+	}
+	if meta.Labels[0].ID != "l1" || meta.Labels[1].ID != "l2" || meta.Labels[2].ID != "l3" {
+		t.Errorf("label order = %v %v %v, want l1 l2 l3 (drained tail before workspace merge)",
+			meta.Labels[0].ID, meta.Labels[1].ID, meta.Labels[2].ID)
+	}
+
+	// The drain must have resumed from the combined query's cursor.
+	var drainCall *testutil.GraphQLCall
+	for i, call := range mock.Calls() {
+		if call.Operation == "TeamLabelsPage" {
+			drainCall = &mock.Calls()[i]
+		}
+	}
+	if drainCall == nil {
+		t.Fatal("no TeamLabelsPage drain call recorded")
+	}
+	if drainCall.Variables["after"] != "lab-cursor" {
+		t.Errorf("drain after = %v, want lab-cursor", drainCall.Variables["after"])
+	}
+}
+
+func TestGetWorkspaceDrainsNestedInitiativeProjects(t *testing.T) {
+	t.Parallel()
+	mock := testutil.NewMockLinearServer()
+	defer mock.Close()
+
+	mock.SetResponse("Workspace", map[string]any{
+		"users": connOf(pf(false, ""),
+			map[string]any{"id": "u1", "name": "User", "email": "u@example.com"}),
+		"initiatives": connOf(pf(false, ""),
+			map[string]any{
+				"id": "init-1", "name": "Big Initiative", "slugId": "big",
+				"projects": connOf(pf(true, "proj-cursor"),
+					map[string]any{"id": "p1", "name": "One", "slugId": "one"}),
+			}),
+	})
+	mock.SetResponse("InitiativeProjectsPage", map[string]any{
+		"initiative": map[string]any{
+			"projects": connOf(pf(false, ""),
+				map[string]any{"id": "p2", "name": "Two", "slugId": "two"}),
+		},
+	})
+
+	c := NewClient("test")
+	c.SetAPIURL(mock.URL())
+
+	ws, err := c.GetWorkspace(context.Background())
+	if err != nil {
+		t.Fatalf("GetWorkspace: %v", err)
+	}
+	if len(ws.Initiatives) != 1 {
+		t.Fatalf("initiatives = %d, want 1", len(ws.Initiatives))
+	}
+	init := ws.Initiatives[0]
+	if len(init.Projects.Nodes) != 2 || init.Projects.Nodes[0].ID != "p1" || init.Projects.Nodes[1].ID != "p2" {
+		t.Fatalf("initiative projects = %+v, want [p1 p2]", init.Projects.Nodes)
+	}
+	if init.Projects.PageInfo != nil {
+		t.Error("initiative Projects.PageInfo should be cleared after drain")
+	}
+}
+
+func TestGetWorkspaceProjectIDsPaginates(t *testing.T) {
+	t.Parallel()
+	mock := testutil.NewMockLinearServer()
+	defer mock.Close()
+
+	mock.SetResponseSequence("WorkspaceProjectIDs",
+		map[string]any{"projects": connOf(pf(true, "id-cursor"), map[string]any{"id": "p1"})},
+		map[string]any{"projects": connOf(pf(false, ""), map[string]any{"id": "p2"})},
+	)
+
+	c := NewClient("test")
+	c.SetAPIURL(mock.URL())
+
+	ids, err := c.GetWorkspaceProjectIDs(context.Background())
+	if err != nil {
+		t.Fatalf("GetWorkspaceProjectIDs: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != "p1" || ids[1] != "p2" {
+		t.Fatalf("ids = %v, want [p1 p2]", ids)
+	}
+}

--- a/internal/api/paginate.go
+++ b/internal/api/paginate.go
@@ -1,0 +1,207 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// The connection drain core.
+//
+// Every Linear GraphQL connection answers with the same envelope:
+// {pageInfo {hasNextPage endCursor}, nodes [...]}. The thread-cursor /
+// append / terminate loop was hand-copied 13 times across client.go — with
+// no guard against a non-advancing cursor and no respect for the rate-limit
+// budget — and skipped entirely in the reconcile ID fetches, where a
+// silently truncated "authoritative" set feeds a diff-and-delete. These
+// helpers own the invariant once, the way exec.go owns the mutation
+// envelope. Call sites keep only what genuinely varies: the query constant,
+// the variable map, and the JSON path from the response root to the
+// connection.
+//
+// The result is all-or-nothing: a non-nil error means no nodes are
+// returned, never a silent partial set. Callers that diff-and-delete
+// against a drained result may trust any nil-error return completely.
+
+// ErrBudget reports a drain refused before its first fetch because the
+// rate-limit budget was already low (see Client.LowBudget) — nothing was
+// spent, so deferring to the next sync cycle costs nothing. A drain that
+// has started runs to completion instead: aborting between pages would
+// discard pages already paid for, and observed live it burned one token
+// per cycle on a page-1 fetch it then threw away, forever. The transport's
+// own write-reserve gate (reads deferred under 2 tokens) remains the hard
+// floor under a running drain. Exported so schedulers (the reconcile pass
+// in internal/repo) can distinguish "retry later" from "broken" with
+// errors.Is; treating it as an ordinary error is always safe.
+var ErrBudget = errors.New("pagination deferred: rate-limit budget low")
+
+// errStalledCursor reports a connection that claims more pages but supplies
+// no advancing cursor — returned rather than looping forever.
+var errStalledCursor = errors.New("pagination stalled: hasNextPage with non-advancing endCursor")
+
+// maxDrainPages is a defence-in-depth backstop behind the stall guard; no
+// real connection approaches it.
+const maxDrainPages = 10000
+
+// conn is the standard Linear connection envelope, decoded at the end of a
+// path. PageInfo is a pointer so that a query which forgot to select
+// pageInfo is distinguishable from hasNextPage=false — the former is an
+// error, never a silent single-page truncation. Also usable directly in
+// hand-written result structs (the combined metadata queries) in place of
+// anonymous {Nodes} pairs.
+type conn[N any] struct {
+	PageInfo *PageInfo `json:"pageInfo"`
+	Nodes    []N       `json:"nodes"`
+}
+
+// pageFetch returns one page of a connection, resuming immediately after
+// the given cursor; after == "" means the start of the connection. It is
+// the module's seam: drainFrom never touches HTTP, GraphQL, or JSON — only
+// pageFetches. Implementations must return the connection's PageInfo
+// verbatim.
+type pageFetch[N any] func(ctx context.Context, after string) (conn[N], error)
+
+// drainFrom fetches every remaining page of a connection, starting after
+// `after` ("" = from the beginning), and returns the concatenated nodes in
+// the order the API produced them.
+//
+// Error modes (each returns nil nodes — all-or-nothing):
+//   - ErrBudget if the rate-limit budget is already low before the first
+//     fetch (nothing is spent; a started drain runs to completion);
+//   - any error from fetch, wrapped with the page number and cursor;
+//   - a missing pageInfo (the query did not select it);
+//   - errStalledCursor if a page reports hasNextPage with an empty or
+//     non-advancing endCursor;
+//   - ctx cancellation between pages.
+func drainFrom[N any](ctx context.Context, c *Client, after string, fetch pageFetch[N]) ([]N, error) {
+	if c.LowBudget() {
+		return nil, fmt.Errorf("paginate: %w", ErrBudget)
+	}
+	var all []N
+	for page := 1; ; page++ {
+		if page > maxDrainPages {
+			return nil, fmt.Errorf("paginate: exceeded %d pages", maxDrainPages)
+		}
+		if page > 1 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
+		cn, err := fetch(ctx, after)
+		if err != nil {
+			return nil, fmt.Errorf("paginate: page %d (after %q): %w", page, after, err)
+		}
+		if cn.PageInfo == nil {
+			return nil, fmt.Errorf("paginate: page %d: response missing pageInfo (query must select it)", page)
+		}
+		all = append(all, cn.Nodes...)
+		if !cn.PageInfo.HasNextPage {
+			return all, nil
+		}
+		next := cn.PageInfo.EndCursor
+		if next == "" || next == after {
+			return nil, fmt.Errorf("paginate: page %d (cursor %q): %w", page, next, errStalledCursor)
+		}
+		after = next
+	}
+}
+
+// fetchAll fetches every node of the connection at path, from the start.
+//
+// Query contract: the query text must declare `$after: String` (nullable),
+// pass it as the connection's `after` argument, and select
+// `pageInfo { hasNextPage endCursor }` alongside `nodes`. Page size stays
+// in the query text (first: 50 etc.); fetchAll does not set it.
+//
+// Vars: fetchAll owns the "after" key — vars must not contain it. vars may
+// be nil; the caller's map is never mutated.
+//
+// All drainFrom invariants and error modes apply; walk failures (a missing
+// or null path element) name the path element that failed.
+func fetchAll[N any](ctx context.Context, c *Client, query string, vars map[string]any, path ...string) ([]N, error) {
+	if _, ok := vars["after"]; ok {
+		return nil, fmt.Errorf("paginate: vars must not contain %q (owned by the module)", "after")
+	}
+	return drainFrom(ctx, c, "", connFetch[N](c, query, vars, path))
+}
+
+// drain fetches the REMAINDER of a connection whose first page was already
+// obtained by another query (the combined metadata queries select pageInfo
+// per connection; drain resumes from that cursor) and returns only the
+// remaining nodes; the caller appends them to the nodes it already holds.
+//
+// pi is the PageInfo of the last consumed page, exactly as decoded — pass
+// result.Team.Labels.PageInfo. nil pi is an error (the combined query
+// forgot to select pageInfo). If pi.HasNextPage is false, drain returns
+// (nil, nil) without any API call — the common case costs nothing.
+//
+// Same query contract, vars rules, ordering, all-or-nothing result, and
+// error modes as fetchAll.
+func drain[N any](ctx context.Context, c *Client, query string, vars map[string]any, pi *PageInfo, path ...string) ([]N, error) {
+	if pi == nil {
+		return nil, fmt.Errorf("paginate: connection %q missing pageInfo (query must select it)", strings.Join(path, "."))
+	}
+	if !pi.HasNextPage {
+		return nil, nil
+	}
+	if pi.EndCursor == "" {
+		return nil, fmt.Errorf("paginate: connection %q: %w", strings.Join(path, "."), errStalledCursor)
+	}
+	if _, ok := vars["after"]; ok {
+		return nil, fmt.Errorf("paginate: vars must not contain %q (owned by the module)", "after")
+	}
+	return drainFrom(ctx, c, pi.EndCursor, connFetch[N](c, query, vars, path))
+}
+
+// connFetch adapts one GraphQL query on c into a pageFetch: it copies vars
+// for every page (the caller's map is never mutated), sets "after" only
+// when the cursor is non-empty, executes via c.query, and walks path from
+// the data root to the connection envelope.
+func connFetch[N any](c *Client, query string, vars map[string]any, path []string) pageFetch[N] {
+	return func(ctx context.Context, after string) (conn[N], error) {
+		pv := make(map[string]any, len(vars)+1)
+		for k, v := range vars {
+			pv[k] = v
+		}
+		if after != "" {
+			pv["after"] = after
+		}
+		var root map[string]json.RawMessage
+		if err := c.query(ctx, query, pv, &root); err != nil {
+			return conn[N]{}, err
+		}
+		return walkConn[N](root, path)
+	}
+}
+
+// walkConn descends path from the decoded data root and decodes the
+// terminal value as a connection envelope. A missing or null element
+// errors with the path walked so far.
+func walkConn[N any](root map[string]json.RawMessage, path []string) (conn[N], error) {
+	if len(path) == 0 {
+		return conn[N]{}, fmt.Errorf("paginate: empty connection path")
+	}
+	cur := root
+	for i, elem := range path {
+		raw, ok := cur[elem]
+		if !ok || string(raw) == "null" {
+			return conn[N]{}, fmt.Errorf("paginate: %q missing or null in response", strings.Join(path[:i+1], "."))
+		}
+		if i == len(path)-1 {
+			var cn conn[N]
+			if err := json.Unmarshal(raw, &cn); err != nil {
+				return conn[N]{}, fmt.Errorf("paginate: decode connection at %q: %w", strings.Join(path, "."), err)
+			}
+			return cn, nil
+		}
+		next := make(map[string]json.RawMessage)
+		if err := json.Unmarshal(raw, &next); err != nil {
+			return conn[N]{}, fmt.Errorf("paginate: decode object at %q: %w", strings.Join(path[:i+1], "."), err)
+		}
+		cur = next
+	}
+	// Unreachable: the loop returns on the last element.
+	return conn[N]{}, fmt.Errorf("paginate: empty connection path")
+}

--- a/internal/api/paginate_test.go
+++ b/internal/api/paginate_test.go
@@ -1,0 +1,290 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jra3/linear-fuse/internal/testutil"
+)
+
+// pi builds a *PageInfo literal.
+func pi(hasNext bool, cursor string) *PageInfo {
+	return &PageInfo{HasNextPage: hasNext, EndCursor: cursor}
+}
+
+// scriptedFetch serves canned pages keyed by the after cursor and records
+// the cursors it was asked for.
+func scriptedFetch(t *testing.T, script map[string]conn[string], afters *[]string) pageFetch[string] {
+	t.Helper()
+	return func(_ context.Context, after string) (conn[string], error) {
+		*afters = append(*afters, after)
+		cn, ok := script[after]
+		if !ok {
+			t.Fatalf("unexpected cursor %q", after)
+		}
+		return cn, nil
+	}
+}
+
+func TestDrainFromThreadsCursorAndMerges(t *testing.T) {
+	var afters []string
+	script := map[string]conn[string]{
+		"":   {PageInfo: pi(true, "c1"), Nodes: []string{"a", "b"}},
+		"c1": {PageInfo: pi(true, "c2"), Nodes: []string{"c"}},
+		"c2": {PageInfo: pi(false, ""), Nodes: []string{"d"}},
+	}
+	got, err := drainFrom(context.Background(), NewClient("test"), "", scriptedFetch(t, script, &afters))
+	if err != nil {
+		t.Fatalf("drainFrom: %v", err)
+	}
+	if want := []string{"a", "b", "c", "d"}; !equalStrings(got, want) {
+		t.Errorf("nodes = %v, want %v", got, want)
+	}
+	if want := []string{"", "c1", "c2"}; !equalStrings(afters, want) {
+		t.Errorf("cursors fetched = %v, want %v", afters, want)
+	}
+}
+
+func TestDrainFromResumesFromCursor(t *testing.T) {
+	var afters []string
+	script := map[string]conn[string]{
+		"resume": {PageInfo: pi(false, ""), Nodes: []string{"tail"}},
+	}
+	got, err := drainFrom(context.Background(), NewClient("test"), "resume", scriptedFetch(t, script, &afters))
+	if err != nil {
+		t.Fatalf("drainFrom: %v", err)
+	}
+	if len(got) != 1 || got[0] != "tail" {
+		t.Errorf("nodes = %v, want [tail]", got)
+	}
+	if len(afters) != 1 || afters[0] != "resume" {
+		t.Errorf("cursors fetched = %v, want [resume]", afters)
+	}
+}
+
+func TestDrainFromStalledCursorFailsLoudly(t *testing.T) {
+	// hasNextPage=true with the same cursor echoed back: previously an
+	// infinite loop, now a loud error.
+	fetch := func(_ context.Context, after string) (conn[int], error) {
+		return conn[int]{PageInfo: pi(true, after), Nodes: []int{1}}, nil
+	}
+	_, err := drainFrom(context.Background(), NewClient("test"), "stuck", fetch)
+	if !errors.Is(err, errStalledCursor) {
+		t.Fatalf("err = %v, want errStalledCursor", err)
+	}
+
+	// Empty endCursor with hasNextPage=true is the same defect.
+	fetch = func(_ context.Context, _ string) (conn[int], error) {
+		return conn[int]{PageInfo: pi(true, ""), Nodes: []int{1}}, nil
+	}
+	_, err = drainFrom(context.Background(), NewClient("test"), "", fetch)
+	if !errors.Is(err, errStalledCursor) {
+		t.Fatalf("err = %v, want errStalledCursor", err)
+	}
+}
+
+func TestDrainFromMissingPageInfoIsError(t *testing.T) {
+	fetch := func(_ context.Context, _ string) (conn[int], error) {
+		return conn[int]{Nodes: []int{1}}, nil // no pageInfo selected
+	}
+	_, err := drainFrom(context.Background(), NewClient("test"), "", fetch)
+	if err == nil || !strings.Contains(err.Error(), "missing pageInfo") {
+		t.Fatalf("err = %v, want missing-pageInfo error", err)
+	}
+}
+
+func TestDrainFromAllOrNothing(t *testing.T) {
+	boom := errors.New("page 2 boom")
+	fetch := func(_ context.Context, after string) (conn[int], error) {
+		if after == "" {
+			return conn[int]{PageInfo: pi(true, "c1"), Nodes: []int{1, 2}}, nil
+		}
+		return conn[int]{}, boom
+	}
+	got, err := drainFrom(context.Background(), NewClient("test"), "", fetch)
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want wrapped page-2 error", err)
+	}
+	if got != nil {
+		t.Errorf("nodes = %v, want nil (all-or-nothing)", got)
+	}
+	if !strings.Contains(err.Error(), "page 2") {
+		t.Errorf("err %q should name the failing page", err)
+	}
+}
+
+func TestDrainFromBudgetRefusesToStart(t *testing.T) {
+	c := NewClient("test")
+	for !c.LowBudget() {
+		c.limiter.Reserve() // drain burst below the LowBudget threshold
+	}
+	calls := 0
+	fetch := func(_ context.Context, _ string) (conn[int], error) {
+		calls++
+		return conn[int]{PageInfo: pi(true, "next"), Nodes: []int{calls}}, nil
+	}
+	got, err := drainFrom(context.Background(), c, "", fetch)
+	if !errors.Is(err, ErrBudget) {
+		t.Fatalf("err = %v, want ErrBudget", err)
+	}
+	if got != nil {
+		t.Errorf("nodes = %v, want nil", got)
+	}
+	if calls != 0 {
+		t.Errorf("fetch calls = %d, want 0 (refusal spends nothing)", calls)
+	}
+}
+
+func TestDrainFromStartedDrainIgnoresBudget(t *testing.T) {
+	// A drain that begins with budget runs to completion even if the
+	// budget dips mid-way — aborting would discard pages already paid for.
+	c := NewClient("test")
+	fetch := func(_ context.Context, after string) (conn[int], error) {
+		if after == "" {
+			for !c.LowBudget() {
+				c.limiter.Reserve() // budget collapses after page 1
+			}
+			return conn[int]{PageInfo: pi(true, "c1"), Nodes: []int{1}}, nil
+		}
+		return conn[int]{PageInfo: pi(false, ""), Nodes: []int{2}}, nil
+	}
+	got, err := drainFrom(context.Background(), c, "", fetch)
+	if err != nil {
+		t.Fatalf("drainFrom: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("nodes = %v, want both pages", got)
+	}
+}
+
+func TestDrainFromCancelledContextBetweenPages(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	fetch := func(_ context.Context, _ string) (conn[int], error) {
+		cancel() // cancel after the first page is served
+		return conn[int]{PageInfo: pi(true, "next"), Nodes: []int{1}}, nil
+	}
+	got, err := drainFrom(ctx, NewClient("test"), "", fetch)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if got != nil {
+		t.Errorf("nodes = %v, want nil", got)
+	}
+}
+
+func TestDrainCompleteFirstPageCostsNothing(t *testing.T) {
+	// HasNextPage=false: no API call may happen — an unusable query proves it.
+	got, err := drain[int](context.Background(), NewClient("test"),
+		"query Broken { broken }", nil, pi(false, "ignored"), "team", "labels")
+	if err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if got != nil {
+		t.Errorf("nodes = %v, want nil (nothing to drain)", got)
+	}
+}
+
+func TestDrainNilPageInfoIsLoudError(t *testing.T) {
+	_, err := drain[int](context.Background(), NewClient("test"),
+		"query Broken { broken }", nil, nil, "team", "labels")
+	if err == nil || !strings.Contains(err.Error(), "team.labels") || !strings.Contains(err.Error(), "missing pageInfo") {
+		t.Fatalf("err = %v, want loud missing-pageInfo error naming team.labels", err)
+	}
+}
+
+func TestFetchAllAndDrainRejectAfterVar(t *testing.T) {
+	vars := map[string]any{"after": "smuggled"}
+	if _, err := fetchAll[int](context.Background(), NewClient("test"), "q", vars, "x"); err == nil {
+		t.Error("fetchAll accepted caller-supplied after var")
+	}
+	if _, err := drain[int](context.Background(), NewClient("test"), "q", vars, pi(true, "c"), "x"); err == nil {
+		t.Error("drain accepted caller-supplied after var")
+	}
+}
+
+func TestFetchAllWalksPathAndPaginates(t *testing.T) {
+	mock := testutil.NewMockLinearServer()
+	defer mock.Close()
+	mock.SetResponse("TeamThings", map[string]any{
+		"team": map[string]any{
+			"things": map[string]any{
+				"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+				"nodes":    []map[string]any{{"id": "t1"}, {"id": "t2"}},
+			},
+		},
+	})
+
+	c := NewClient("test")
+	c.SetAPIURL(mock.URL())
+
+	type idNode struct {
+		ID string `json:"id"`
+	}
+	got, err := fetchAll[idNode](context.Background(), c,
+		`query TeamThings($teamId: String!, $after: String) { team(id: $teamId) { things(first: 50, after: $after) { pageInfo { hasNextPage endCursor } nodes { id } } } }`,
+		map[string]any{"teamId": "team-1"}, "team", "things")
+	if err != nil {
+		t.Fatalf("fetchAll: %v", err)
+	}
+	if len(got) != 2 || got[0].ID != "t1" || got[1].ID != "t2" {
+		t.Errorf("nodes = %v, want [t1 t2]", got)
+	}
+	// First page must not send after at all.
+	if call := mock.LastCall(); call != nil {
+		if _, ok := call.Variables["after"]; ok {
+			t.Errorf("first page sent after=%v, want omitted", call.Variables["after"])
+		}
+	}
+}
+
+func TestFetchAllNullPathElementIsError(t *testing.T) {
+	mock := testutil.NewMockLinearServer()
+	defer mock.Close()
+	mock.SetResponse("TeamThings", map[string]any{"team": nil})
+
+	c := NewClient("test")
+	c.SetAPIURL(mock.URL())
+
+	_, err := fetchAll[struct{}](context.Background(), c,
+		`query TeamThings($after: String) { team { things(after: $after) { pageInfo { hasNextPage endCursor } nodes { __typename } } } }`,
+		nil, "team", "things")
+	if err == nil || !strings.Contains(err.Error(), `"team"`) {
+		t.Fatalf("err = %v, want error naming the null path element", err)
+	}
+}
+
+func TestFetchAllMissingPageInfoInResponseIsError(t *testing.T) {
+	// A response whose connection lacks pageInfo (query text forgot to
+	// select it) must fail loudly — this is the silent-truncation bug class.
+	mock := testutil.NewMockLinearServer()
+	defer mock.Close()
+	mock.SetResponse("Things", map[string]any{
+		"things": map[string]any{
+			"nodes": []map[string]any{{"id": "t1"}},
+		},
+	})
+
+	c := NewClient("test")
+	c.SetAPIURL(mock.URL())
+
+	_, err := fetchAll[struct{}](context.Background(), c,
+		`query Things($after: String) { things(after: $after) { nodes { id } } }`,
+		nil, "things")
+	if err == nil || !strings.Contains(err.Error(), "missing pageInfo") {
+		t.Fatalf("err = %v, want missing-pageInfo error", err)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -205,8 +205,15 @@ query MyActiveIssues($after: String) {
 }
 ` + issueFieldsFragmentLite
 
-// queryTeamMetadata fetches all team metadata in a single query:
-// states, labels, cycles, projects (with milestones), members, and workspace labels.
+// queryTeamMetadata fetches team metadata in a single query: states,
+// labels, cycles, members, and workspace labels. Projects deliberately live
+// in their own paginated query (queryTeamProjects): their nested selections
+// cost ~187 complexity points per node, so even 50 of them consume nearly
+// the whole 10k complexity budget Linear allows a single query.
+//
+// Every unbounded connection selects pageInfo and is drained to completion
+// by GetTeamMetadata when hasNextPage reports more (Linear caps a page at
+// 250 nodes); states are workflow-bounded (~a dozen) and stay undrained.
 var queryTeamMetadata = `
 query TeamMetadata($teamId: String!) {
   team(id: $teamId) {
@@ -217,10 +224,12 @@ query TeamMetadata($teamId: String!) {
         type
       }
     }
-    labels {
+    labels(first: 250) {
+      pageInfo { hasNextPage endCursor }
       nodes { ...LabelFields }
     }
-    cycles {
+    cycles(first: 250) {
+      pageInfo { hasNextPage endCursor }
       nodes {
         id
         number
@@ -231,45 +240,8 @@ query TeamMetadata($teamId: String!) {
         issueCountHistory
       }
     }
-    projects {
-      nodes {
-        id
-        name
-        slugId
-        description
-        url
-        state
-        startDate
-        targetDate
-        createdAt
-        updatedAt
-        lead {
-          id
-          name
-          email
-        }
-        status {
-          id
-          name
-        }
-        initiatives {
-          nodes {
-            id
-            name
-          }
-        }
-        projectMilestones {
-          nodes {
-            id
-            name
-            description
-            targetDate
-            sortOrder
-          }
-        }
-      }
-    }
-    members {
+    members(first: 250) {
+      pageInfo { hasNextPage endCursor }
       nodes {
         id
         name
@@ -279,7 +251,67 @@ query TeamMetadata($teamId: String!) {
       }
     }
   }
-  issueLabels {
+  issueLabels(first: 250) {
+    pageInfo { hasNextPage endCursor }
+    nodes { ...LabelFields }
+  }
+}
+` + labelFieldsFragment
+
+// Per-connection drain queries: resumed from the combined query's endCursor
+// when a connection reports hasNextPage (see the paginate module).
+
+var queryTeamLabelsPage = `
+query TeamLabelsPage($teamId: String!, $after: String) {
+  team(id: $teamId) {
+    labels(first: 250, after: $after) {
+      pageInfo { hasNextPage endCursor }
+      nodes { ...LabelFields }
+    }
+  }
+}
+` + labelFieldsFragment
+
+const queryTeamCyclesPage = `
+query TeamCyclesPage($teamId: String!, $after: String) {
+  team(id: $teamId) {
+    cycles(first: 250, after: $after) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id
+        number
+        name
+        startsAt
+        endsAt
+        completedIssueCountHistory
+        issueCountHistory
+      }
+    }
+  }
+}
+`
+
+const queryTeamMembersPage = `
+query TeamMembersPage($teamId: String!, $after: String) {
+  team(id: $teamId) {
+    members(first: 250, after: $after) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id
+        name
+        email
+        displayName
+        active
+      }
+    }
+  }
+}
+`
+
+var queryWorkspaceLabelsPage = `
+query WorkspaceLabelsPage($after: String) {
+  issueLabels(first: 250, after: $after) {
+    pageInfo { hasNextPage endCursor }
     nodes { ...LabelFields }
   }
 }
@@ -354,10 +386,15 @@ query CycleIssues($cycleId: String!, $after: String) {
 }
 `
 
+// queryTeamProjects pages at 50: the nested initiatives/projectMilestones
+// selections cost ~187 complexity points per project node, so 50 is the
+// largest page that fits Linear's 10k complexity budget (measured live:
+// first:100 scores 18751).
 const queryTeamProjects = `
-query TeamProjects($teamId: String!) {
+query TeamProjects($teamId: String!, $after: String) {
   team(id: $teamId) {
-    projects {
+    projects(first: 50, after: $after) {
+      pageInfo { hasNextPage endCursor }
       nodes {
         id
         name
@@ -660,10 +697,16 @@ mutation InitiativeToProjectDelete($initiativeId: String!, $projectId: String!) 
 }
 `
 
-// queryWorkspace fetches workspace-level entities (users and initiatives) in a single query.
+// queryWorkspace fetches workspace-level entities (users and initiatives)
+// in a single query. Initiatives page at 50 because each node carries a
+// nested projects connection; that nested connection selects pageInfo too,
+// and GetWorkspace drains it per initiative (an initiative's junction rows
+// feed a prune, so its project list must be provably complete — a
+// truncated list would read as removals).
 const queryWorkspace = `
 query Workspace {
-  users {
+  users(first: 250) {
+    pageInfo { hasNextPage endCursor }
     nodes {
       id
       name
@@ -672,7 +715,8 @@ query Workspace {
       active
     }
   }
-  initiatives {
+  initiatives(first: 50) {
+    pageInfo { hasNextPage endCursor }
     nodes {
       id
       name
@@ -690,12 +734,77 @@ query Workspace {
         name
         email
       }
-      projects {
+      projects(first: 50) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           id
           name
           slugId
         }
+      }
+    }
+  }
+}
+`
+
+const queryWorkspaceUsersPage = `
+query WorkspaceUsersPage($after: String) {
+  users(first: 250, after: $after) {
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      id
+      name
+      email
+      displayName
+      active
+    }
+  }
+}
+`
+
+const queryWorkspaceInitiativesPage = `
+query WorkspaceInitiativesPage($after: String) {
+  initiatives(first: 50, after: $after) {
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      id
+      name
+      slugId
+      description
+      status
+      color
+      icon
+      targetDate
+      url
+      createdAt
+      updatedAt
+      owner {
+        id
+        name
+        email
+      }
+      projects(first: 50) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          name
+          slugId
+        }
+      }
+    }
+  }
+}
+`
+
+const queryInitiativeProjectsPage = `
+query InitiativeProjectsPage($id: String!, $after: String) {
+  initiative(id: $id) {
+    projects(first: 250, after: $after) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id
+        name
+        slugId
       }
     }
   }
@@ -1205,22 +1314,26 @@ query TeamIssueIDs($teamId: String!, $first: Int!, $after: String) {
 }
 `
 
-// queryWorkspaceProjectIDs returns IDs of all projects in the workspace.
-// first: 250 matches Linear's max page size — workspaces with more than
-// 250 active projects would need pagination here.
+// queryWorkspaceProjectIDs returns IDs of all projects in the workspace,
+// paginated. The reconcile pass diffs-and-deletes against this set, so it
+// must be complete or fail loudly — a truncated page would read as mass
+// deletion (the paginate module guarantees all-or-nothing).
 const queryWorkspaceProjectIDs = `
-query WorkspaceProjectIDs {
-  projects(first: 250) {
+query WorkspaceProjectIDs($after: String) {
+  projects(first: 250, after: $after) {
+    pageInfo { hasNextPage endCursor }
     nodes { id }
   }
 }
 `
 
-// queryWorkspaceInitiativeIDs returns IDs of all initiatives in the workspace.
-// See queryWorkspaceProjectIDs for the first: 250 rationale.
+// queryWorkspaceInitiativeIDs returns IDs of all initiatives in the
+// workspace, paginated. See queryWorkspaceProjectIDs for why completeness
+// is load-bearing.
 const queryWorkspaceInitiativeIDs = `
-query WorkspaceInitiativeIDs {
-  initiatives(first: 250) {
+query WorkspaceInitiativeIDs($after: String) {
+  initiatives(first: 250, after: $after) {
+    pageInfo { hasNextPage endCursor }
     nodes { id }
   }
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -171,9 +171,9 @@ type InitiativeUpdateInput struct {
 
 // ProjectMilestoneUpdateInput is the input for updating a project milestone
 type ProjectMilestoneUpdateInput struct {
-	Name        *string `json:"name,omitempty"`
-	Description *string `json:"description,omitempty"`
-	TargetDate  *string `json:"targetDate,omitempty"`
+	Name        *string  `json:"name,omitempty"`
+	Description *string  `json:"description,omitempty"`
+	TargetDate  *string  `json:"targetDate,omitempty"`
 	SortOrder   *float64 `json:"sortOrder,omitempty"`
 }
 
@@ -265,7 +265,12 @@ type Initiative struct {
 }
 
 type InitiativeProjects struct {
-	Nodes []InitiativeProject `json:"nodes"`
+	// PageInfo is populated by queries that select it (queryWorkspace and
+	// its drain pages) and consumed by GetWorkspace, which drains any
+	// remainder and then clears it — callers downstream of GetWorkspace
+	// always see a complete Nodes list and a nil PageInfo.
+	PageInfo *PageInfo           `json:"pageInfo,omitempty"`
+	Nodes    []InitiativeProject `json:"nodes"`
 }
 
 type InitiativeProject struct {

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -429,6 +429,12 @@ VALUES (?, ?, ?)
 ON CONFLICT(project_id, team_id) DO UPDATE SET
     synced_at = excluded.synced_at;
 
+-- Delete a team's associations the metadata sync no longer sees. Only safe
+-- against a provably complete (drained) projects fetch, with the cutoff
+-- taken before the sync's upserts, so rows written mid-sync survive.
+-- name: PruneProjectTeams :exec
+DELETE FROM project_teams WHERE team_id = ? AND synced_at < ?;
+
 -- name: DeleteProjectTeam :exec
 DELETE FROM project_teams WHERE project_id = ? AND team_id = ?;
 
@@ -630,6 +636,14 @@ INSERT INTO initiative_projects (initiative_id, project_id, synced_at)
 VALUES (?, ?, ?)
 ON CONFLICT(initiative_id, project_id) DO UPDATE SET
     synced_at = excluded.synced_at;
+
+-- Delete an initiative's junction rows the workspace sync no longer sees.
+-- Only safe against a provably complete (drained) initiative projects
+-- fetch, with the cutoff taken before the sync's upserts: a link the user
+-- creates mid-sync (persistInitiativeProjectLink stamps a fresh synced_at)
+-- survives.
+-- name: PruneInitiativeProjects :exec
+DELETE FROM initiative_projects WHERE initiative_id = ? AND synced_at < ?;
 
 -- name: DeleteInitiativeProject :exec
 DELETE FROM initiative_projects WHERE initiative_id = ? AND project_id = ?;

--- a/internal/db/queries.sql.go
+++ b/internal/db/queries.sql.go
@@ -3919,6 +3919,25 @@ func (q *Queries) ListWorkspaceLabels(ctx context.Context) ([]Label, error) {
 	return items, nil
 }
 
+const pruneInitiativeProjects = `-- name: PruneInitiativeProjects :exec
+DELETE FROM initiative_projects WHERE initiative_id = ? AND synced_at < ?
+`
+
+type PruneInitiativeProjectsParams struct {
+	InitiativeID string    `json:"initiative_id"`
+	SyncedAt     time.Time `json:"synced_at"`
+}
+
+// Delete an initiative's junction rows the workspace sync no longer sees.
+// Only safe against a provably complete (drained) initiative projects
+// fetch, with the cutoff taken before the sync's upserts: a link the user
+// creates mid-sync (persistInitiativeProjectLink stamps a fresh synced_at)
+// survives.
+func (q *Queries) PruneInitiativeProjects(ctx context.Context, arg PruneInitiativeProjectsParams) error {
+	_, err := q.db.ExecContext(ctx, pruneInitiativeProjects, arg.InitiativeID, arg.SyncedAt)
+	return err
+}
+
 const pruneIssueAttachments = `-- name: PruneIssueAttachments :exec
 DELETE FROM attachments WHERE issue_id = ? AND synced_at < ?
 `
@@ -3962,6 +3981,23 @@ type PruneIssueDocumentsParams struct {
 
 func (q *Queries) PruneIssueDocuments(ctx context.Context, arg PruneIssueDocumentsParams) error {
 	_, err := q.db.ExecContext(ctx, pruneIssueDocuments, arg.IssueID, arg.SyncedAt)
+	return err
+}
+
+const pruneProjectTeams = `-- name: PruneProjectTeams :exec
+DELETE FROM project_teams WHERE team_id = ? AND synced_at < ?
+`
+
+type PruneProjectTeamsParams struct {
+	TeamID   string    `json:"team_id"`
+	SyncedAt time.Time `json:"synced_at"`
+}
+
+// Delete a team's associations the metadata sync no longer sees. Only safe
+// against a provably complete (drained) projects fetch, with the cutoff
+// taken before the sync's upserts, so rows written mid-sync survive.
+func (q *Queries) PruneProjectTeams(ctx context.Context, arg PruneProjectTeamsParams) error {
+	_, err := q.db.ExecContext(ctx, pruneProjectTeams, arg.TeamID, arg.SyncedAt)
 	return err
 }
 

--- a/internal/sync/prune_test.go
+++ b/internal/sync/prune_test.go
@@ -1,0 +1,226 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jra3/linear-fuse/internal/api"
+	"github.com/jra3/linear-fuse/internal/db"
+)
+
+// Association prunes: the metadata and workspace syncs fetch provably
+// complete sets (every connection drained), which is what makes deleting
+// rows absent from the response safe. These tests pin the three properties
+// the cutoff pattern guarantees: stale rows go, rows written mid-sync
+// survive, and a failed fetch prunes nothing.
+
+// Seeds must pass db.Now()-derived (UTC) times: synced_at strings carry
+// their zone verbatim and compare textually, so the codebase-wide invariant
+// is that every synced_at write goes through db.Now(). A local-zone seed
+// here would order against the UTC cutoff by wall-clock face, not instant.
+func seedProjectTeam(t *testing.T, store *db.Store, projectID, teamID string, syncedAt time.Time) {
+	t.Helper()
+	if err := store.Queries().UpsertProjectTeam(context.Background(), db.UpsertProjectTeamParams{
+		ProjectID: projectID,
+		TeamID:    teamID,
+		SyncedAt:  syncedAt,
+	}); err != nil {
+		t.Fatalf("seed project_team %s-%s: %v", projectID, teamID, err)
+	}
+}
+
+func seedInitiativeProject(t *testing.T, store *db.Store, initiativeID, projectID string, syncedAt time.Time) {
+	t.Helper()
+	if err := store.Queries().UpsertInitiativeProject(context.Background(), db.UpsertInitiativeProjectParams{
+		InitiativeID: initiativeID,
+		ProjectID:    projectID,
+		SyncedAt:     syncedAt,
+	}); err != nil {
+		t.Fatalf("seed initiative_project %s-%s: %v", initiativeID, projectID, err)
+	}
+}
+
+func projectTeamIDs(t *testing.T, store *db.Store, projectID string) []string {
+	t.Helper()
+	ids, err := store.Queries().ListProjectTeamIDs(context.Background(), projectID)
+	if err != nil {
+		t.Fatalf("list project teams: %v", err)
+	}
+	return ids
+}
+
+func initiativeProjectIDs(t *testing.T, store *db.Store, initiativeID string) []string {
+	t.Helper()
+	ids, err := store.Queries().ListInitiativeProjectIDs(context.Background(), initiativeID)
+	if err != nil {
+		t.Fatalf("list initiative projects: %v", err)
+	}
+	return ids
+}
+
+// TestTeamMetadataSyncPrunesStaleProjectTeams: an association the (complete)
+// projects fetch no longer returns — the project moved off the team or was
+// deleted — must go, while returned associations and other teams' rows stay.
+func TestTeamMetadataSyncPrunesStaleProjectTeams(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	old := db.Now().Add(-time.Minute)
+	seedProjectTeam(t, store, "proj-live", "team-1", old)
+	seedProjectTeam(t, store, "proj-stale", "team-1", old)
+	seedProjectTeam(t, store, "proj-elsewhere", "team-2", old) // other team: out of scope
+
+	mock := newMockAPIClient()
+	mock.projectsByTeam["team-1"] = []api.Project{{ID: "proj-live", Name: "Live", Slug: "live"}}
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	if err := worker.syncTeamMetadata(ctx, api.Team{ID: "team-1", Key: "T1"}); err != nil {
+		t.Fatalf("syncTeamMetadata: %v", err)
+	}
+
+	if got := projectTeamIDs(t, store, "proj-live"); len(got) != 1 || got[0] != "team-1" {
+		t.Errorf("proj-live teams = %v, want [team-1] (returned row re-stamped)", got)
+	}
+	if got := projectTeamIDs(t, store, "proj-stale"); len(got) != 0 {
+		t.Errorf("proj-stale teams = %v, want [] (stale association pruned)", got)
+	}
+	if got := projectTeamIDs(t, store, "proj-elsewhere"); len(got) != 1 || got[0] != "team-2" {
+		t.Errorf("proj-elsewhere teams = %v, want [team-2] (other team untouched)", got)
+	}
+}
+
+// TestTeamMetadataPruneSparesMidSyncAssociation: an association written
+// while the metadata fetch is in flight postdates the pre-fetch cutoff and
+// must survive, even though the fetch response doesn't contain it.
+func TestTeamMetadataPruneSparesMidSyncAssociation(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	mock := newMockAPIClient()
+	mock.projectsByTeam["team-1"] = []api.Project{} // fetch returns nothing…
+	mock.onTeamMetadata = func() {
+		// …but mid-fetch, an association lands (e.g. a user linking a
+		// project through the FUSE write path).
+		seedProjectTeam(t, store, "proj-raced", "team-1", db.Now())
+	}
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	if err := worker.syncTeamMetadata(ctx, api.Team{ID: "team-1", Key: "T1"}); err != nil {
+		t.Fatalf("syncTeamMetadata: %v", err)
+	}
+
+	if got := projectTeamIDs(t, store, "proj-raced"); len(got) != 1 {
+		t.Errorf("proj-raced teams = %v, want the mid-sync association to survive pruning", got)
+	}
+}
+
+// TestTeamMetadataFetchErrorPrunesNothing: no fetch, no prune — a failed
+// metadata call must leave every association untouched.
+func TestTeamMetadataFetchErrorPrunesNothing(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	seedProjectTeam(t, store, "proj-stale", "team-1", db.Now().Add(-time.Minute))
+
+	mock := newMockAPIClient()
+	mock.simulateError = errors.New("api down")
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	if err := worker.syncTeamMetadata(ctx, api.Team{ID: "team-1", Key: "T1"}); err == nil {
+		t.Fatal("syncTeamMetadata should surface the fetch error")
+	}
+
+	if got := projectTeamIDs(t, store, "proj-stale"); len(got) != 1 {
+		t.Errorf("proj-stale teams = %v, want untouched after failed fetch", got)
+	}
+}
+
+// TestWorkspaceSyncPrunesStaleInitiativeProjects: a junction row the drained
+// initiative projects list no longer contains — the project was unlinked in
+// Linear — must go; returned links and initiatives absent from the response
+// stay untouched.
+func TestWorkspaceSyncPrunesStaleInitiativeProjects(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	old := db.Now().Add(-time.Minute)
+	seedInitiativeProject(t, store, "init-1", "proj-live", old)
+	seedInitiativeProject(t, store, "init-1", "proj-unlinked", old)
+	seedInitiativeProject(t, store, "init-2", "proj-keep", old) // not in response: out of scope
+
+	mock := newMockAPIClient()
+	mock.initiatives = []api.Initiative{{
+		ID: "init-1", Name: "One", Slug: "one",
+		Projects: api.InitiativeProjects{Nodes: []api.InitiativeProject{{ID: "proj-live", Name: "Live", Slug: "live"}}},
+	}}
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	if err := worker.syncWorkspace(ctx); err != nil {
+		t.Fatalf("syncWorkspace: %v", err)
+	}
+
+	if got := initiativeProjectIDs(t, store, "init-1"); len(got) != 1 || got[0] != "proj-live" {
+		t.Errorf("init-1 projects = %v, want [proj-live] (unlinked row pruned)", got)
+	}
+	if got := initiativeProjectIDs(t, store, "init-2"); len(got) != 1 || got[0] != "proj-keep" {
+		t.Errorf("init-2 projects = %v, want [proj-keep] (absent initiative untouched)", got)
+	}
+}
+
+// TestWorkspaceSyncPruneSparesMidSyncLink: a link the user creates while the
+// workspace fetch is in flight (persistInitiativeProjectLink stamps a fresh
+// synced_at) postdates the cutoff and must survive.
+func TestWorkspaceSyncPruneSparesMidSyncLink(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	mock := newMockAPIClient()
+	mock.initiatives = []api.Initiative{{ID: "init-1", Name: "One", Slug: "one"}}
+	mock.onWorkspace = func() {
+		seedInitiativeProject(t, store, "init-1", "proj-raced", db.Now())
+	}
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	if err := worker.syncWorkspace(ctx); err != nil {
+		t.Fatalf("syncWorkspace: %v", err)
+	}
+
+	if got := initiativeProjectIDs(t, store, "init-1"); len(got) != 1 || got[0] != "proj-raced" {
+		t.Errorf("init-1 projects = %v, want the mid-sync link to survive pruning", got)
+	}
+}
+
+// TestWorkspaceFetchErrorPrunesNothing: a failed workspace fetch must leave
+// every junction row untouched.
+func TestWorkspaceFetchErrorPrunesNothing(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	seedInitiativeProject(t, store, "init-1", "proj-stale", db.Now().Add(-time.Minute))
+
+	mock := newMockAPIClient()
+	mock.simulateError = errors.New("api down")
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	if err := worker.syncWorkspace(ctx); err == nil {
+		t.Fatal("syncWorkspace should surface the fetch error")
+	}
+
+	if got := initiativeProjectIDs(t, store, "init-1"); len(got) != 1 {
+		t.Errorf("init-1 projects = %v, want untouched after failed fetch", got)
+	}
+}

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -17,6 +17,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jra3/linear-fuse/internal/api"
@@ -78,8 +79,9 @@ type Worker struct {
 	mu       sync.RWMutex
 	running  bool
 	lastSync time.Time
-	budget  BudgetReporter     // optional: for rate limit budget logging
-	catchUp CatchUpModeToggler // optional: controls repo staleness during catch-up
+	budget   BudgetReporter     // optional: for rate limit budget logging
+	catchUp  CatchUpModeToggler // optional: controls repo staleness during catch-up
+	cycle    atomic.Int64       // sync-cycle counter; rotates the team order
 
 	// Rate limit tracking for issue details sync
 	rateLimitMu     sync.RWMutex
@@ -230,6 +232,20 @@ func (w *Worker) syncAllTeams(ctx context.Context) error {
 		return fmt.Errorf("get teams: %w", err)
 	}
 
+	// Rotate the starting team each cycle. Teams sync in order against one
+	// token bucket, so under budget pressure the deferrals always land on
+	// whoever is last — with a fixed order that is the same team every
+	// cycle, which starved it permanently (observed live once metadata
+	// went from one call per team to two). Rotation bounds any team's
+	// worst-case staleness at len(teams) cycles instead.
+	if n := len(teams); n > 0 {
+		start := int(w.cycle.Add(1)-1) % n
+		rotated := make([]api.Team, 0, n)
+		rotated = append(rotated, teams[start:]...)
+		rotated = append(rotated, teams[:start]...)
+		teams = rotated
+	}
+
 	for _, team := range teams {
 		// Upsert team
 		if err := w.store.Queries().UpsertTeam(ctx, db.APITeamToDBTeam(team)); err != nil {
@@ -257,11 +273,11 @@ func (w *Worker) syncAllTeams(ctx context.Context) error {
 
 // SyncTeamResult contains the results of syncing a single team
 type SyncTeamResult struct {
-	TeamID       string
-	IssuesAdded  int
+	TeamID        string
+	IssuesAdded   int
 	IssuesUpdated int
-	PagesFetched int
-	Duration     time.Duration
+	PagesFetched  int
+	Duration      time.Duration
 }
 
 func (w *Worker) syncTeam(ctx context.Context, team api.Team) error {
@@ -432,8 +448,16 @@ func (w *Worker) CleanupArchivedIssues(ctx context.Context, teamID string) (int6
 // Workspace-Level Sync
 // =============================================================================
 
-// syncWorkspace syncs workspace-level entities (users + initiatives) in a single API call.
+// syncWorkspace syncs workspace-level entities (users + initiatives).
+// GetWorkspace drains every connection — including each initiative's
+// nested projects — so the junction prune in syncInitiativeProjects runs
+// against the complete server-side truth.
 func (w *Worker) syncWorkspace(ctx context.Context) error {
+	// The prune cutoff is taken BEFORE the fetch: any junction row upserted
+	// after this instant (this pass, or a user linking a project mid-sync)
+	// survives.
+	pruneCutoff := db.Now()
+
 	data, err := w.client.GetWorkspace(ctx)
 	if err != nil {
 		return fmt.Errorf("get workspace: %w", err)
@@ -467,7 +491,7 @@ func (w *Worker) syncWorkspace(ctx context.Context) error {
 		}
 
 		// Sync initiative-project associations
-		if err := w.syncInitiativeProjects(ctx, initiative); err != nil {
+		if err := w.syncInitiativeProjects(ctx, initiative, pruneCutoff); err != nil {
 			log.Printf("[sync] sync initiative %s projects failed: %v", initiative.Slug, err)
 		}
 	}
@@ -479,8 +503,13 @@ func (w *Worker) syncWorkspace(ctx context.Context) error {
 	return nil
 }
 
-func (w *Worker) syncInitiativeProjects(ctx context.Context, initiative api.Initiative) error {
-	// Get projects from the initiative's Projects field
+// syncInitiativeProjects upserts an initiative's junction rows and prunes
+// the ones the fetch no longer returned (a project unlinked in Linear).
+// The prune only runs after every upsert succeeded — a row that merely
+// failed to refresh must not read as a removal — and initiative.Projects
+// is complete by GetWorkspace's contract, which is what makes pruning
+// against it safe.
+func (w *Worker) syncInitiativeProjects(ctx context.Context, initiative api.Initiative, pruneCutoff time.Time) error {
 	for _, project := range initiative.Projects.Nodes {
 		if err := w.store.Queries().UpsertInitiativeProject(ctx, db.UpsertInitiativeProjectParams{
 			InitiativeID: initiative.ID,
@@ -490,6 +519,12 @@ func (w *Worker) syncInitiativeProjects(ctx context.Context, initiative api.Init
 			return fmt.Errorf("upsert initiative-project %s-%s: %w", initiative.ID, project.ID, err)
 		}
 	}
+	if err := w.store.Queries().PruneInitiativeProjects(ctx, db.PruneInitiativeProjectsParams{
+		InitiativeID: initiative.ID,
+		SyncedAt:     pruneCutoff,
+	}); err != nil {
+		return fmt.Errorf("prune initiative-projects %s: %w", initiative.ID, err)
+	}
 	return nil
 }
 
@@ -497,9 +532,15 @@ func (w *Worker) syncInitiativeProjects(ctx context.Context, initiative api.Init
 // Team Metadata Sync
 // =============================================================================
 
-// syncTeamMetadata syncs all metadata for a team in a single API call:
-// states, labels, cycles, projects (with milestones), and members.
+// syncTeamMetadata syncs all metadata for a team: states, labels, cycles,
+// projects (with milestones), and members. GetTeamMetadata drains every
+// unbounded connection, so meta is the complete server-side truth — which
+// is what makes the project_teams prune below safe.
 func (w *Worker) syncTeamMetadata(ctx context.Context, team api.Team) error {
+	// The prune cutoff is taken BEFORE the fetch: any association upserted
+	// after this instant (this pass, or a concurrent user edit) survives.
+	pruneCutoff := db.Now()
+
 	meta, err := w.client.GetTeamMetadata(ctx, team.ID)
 	if err != nil {
 		return fmt.Errorf("get team metadata: %w", err)
@@ -542,14 +583,17 @@ func (w *Worker) syncTeamMetadata(ctx context.Context, team api.Team) error {
 	}
 
 	// Process projects (includes milestones)
+	projectsClean := true
 	for _, project := range meta.Projects {
 		params, err := db.APIProjectToDBProject(project)
 		if err != nil {
 			log.Printf("[sync] convert project %s failed: %v", project.Slug, err)
+			projectsClean = false
 			continue
 		}
 		if err := w.store.Queries().UpsertProject(ctx, params); err != nil {
 			log.Printf("[sync] upsert project %s failed: %v", project.Slug, err)
+			projectsClean = false
 			continue
 		}
 
@@ -560,6 +604,7 @@ func (w *Worker) syncTeamMetadata(ctx context.Context, team api.Team) error {
 			SyncedAt:  db.Now(),
 		}); err != nil {
 			log.Printf("[sync] upsert project-team %s-%s failed: %v", project.ID, team.ID, err)
+			projectsClean = false
 		}
 
 		// Upsert milestones inline from the metadata query (no extra API calls)
@@ -574,6 +619,19 @@ func (w *Worker) syncTeamMetadata(ctx context.Context, team api.Team) error {
 					log.Printf("[sync] upsert milestone %s failed: %v", milestone.Name, err)
 				}
 			}
+		}
+	}
+
+	// Prune associations the (complete) fetch no longer returned — a project
+	// moved off this team, or deleted in Linear. Skipped when any upsert
+	// above failed: a row that merely failed to refresh must not read as a
+	// removal.
+	if projectsClean {
+		if err := w.store.Queries().PruneProjectTeams(ctx, db.PruneProjectTeamsParams{
+			TeamID:   team.ID,
+			SyncedAt: pruneCutoff,
+		}); err != nil {
+			log.Printf("[sync] prune project-teams %s: %v", team.Key, err)
 		}
 	}
 
@@ -876,7 +934,6 @@ func (w *Worker) drainPendingDetailSync(ctx context.Context) {
 		w.syncIssueDetailsBatch(ctx, batchArg)
 	}
 }
-
 
 // =============================================================================
 // Embedded Files Extraction

--- a/internal/sync/worker_test.go
+++ b/internal/sync/worker_test.go
@@ -41,6 +41,8 @@ type mockAPIClient struct {
 	rateLimitResetAt time.Time                    // M-3: configurable reset time for adaptive backoff tests
 	detailsByIssue   map[string]*api.IssueDetails // issueID -> canned details for GetIssueDetailsBatch
 	onDetailsBatch   func()                       // if set, runs inside GetIssueDetailsBatch (simulates writes racing the fetch)
+	onTeamMetadata   func()                       // if set, runs inside GetTeamMetadata (simulates writes racing the fetch)
+	onWorkspace      func()                       // if set, runs inside GetWorkspace (simulates writes racing the fetch)
 }
 
 func newMockAPIClient() *mockAPIClient {
@@ -116,6 +118,9 @@ func (m *mockAPIClient) GetTeamMetadata(ctx context.Context, teamID string) (*ap
 	if m.simulateError != nil {
 		return nil, m.simulateError
 	}
+	if m.onTeamMetadata != nil {
+		m.onTeamMetadata()
+	}
 	return &api.TeamMetadata{
 		States:   m.statesByTeam[teamID],
 		Labels:   m.labelsByTeam[teamID],
@@ -128,6 +133,9 @@ func (m *mockAPIClient) GetTeamMetadata(ctx context.Context, teamID string) (*ap
 func (m *mockAPIClient) GetWorkspace(ctx context.Context) (*api.WorkspaceData, error) {
 	if m.simulateError != nil {
 		return nil, m.simulateError
+	}
+	if m.onWorkspace != nil {
+		m.onWorkspace()
 	}
 	return &api.WorkspaceData{
 		Users:       m.users,

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -402,12 +402,15 @@ func CreateIssueResponse(issue map[string]any) map[string]any {
 	}
 }
 
-// TeamProjectsResponse returns a response for GetTeamProjects.
+// TeamProjectsResponse returns a response for GetTeamProjects. The
+// pageInfo is required: connections without it fail the paginate module's
+// silent-truncation guard.
 func TeamProjectsResponse(projects ...map[string]any) map[string]any {
 	return map[string]any{
 		"team": map[string]any{
 			"projects": map[string]any{
-				"nodes": projects,
+				"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+				"nodes":    projects,
 			},
 		},
 	}

--- a/internal/testutil/mockserver.go
+++ b/internal/testutil/mockserver.go
@@ -16,6 +16,7 @@ type MockLinearServer struct {
 
 	mu        sync.RWMutex
 	responses map[string]any   // query/mutation name -> response data
+	sequences map[string][]any // query/mutation name -> per-call responses
 	errors    map[string]error // query/mutation name -> error to return
 	calls     []GraphQLCall    // recorded calls for assertions
 }
@@ -31,6 +32,7 @@ type GraphQLCall struct {
 func NewMockLinearServer() *MockLinearServer {
 	m := &MockLinearServer{
 		responses: make(map[string]any),
+		sequences: make(map[string][]any),
 		errors:    make(map[string]error),
 	}
 
@@ -54,6 +56,17 @@ func (m *MockLinearServer) SetResponse(operation string, data any) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.responses[operation] = data
+}
+
+// SetResponseSequence configures the mock to return one response per call
+// for an operation, in order — how a cursor-paginated connection is
+// scripted (SetResponse's single static response can never terminate a
+// pagination loop whose first page says hasNextPage). Calls beyond the last
+// response repeat it. A sequence takes precedence over SetResponse.
+func (m *MockLinearServer) SetResponseSequence(operation string, pages ...any) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sequences[operation] = pages
 }
 
 // SetError configures the mock to return an error for a specific operation.
@@ -85,6 +98,7 @@ func (m *MockLinearServer) Reset() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.responses = make(map[string]any)
+	m.sequences = make(map[string][]any)
 	m.errors = make(map[string]error)
 	m.calls = nil
 }
@@ -116,13 +130,20 @@ func (m *MockLinearServer) handleRequest(w http.ResponseWriter, r *http.Request)
 	// Extract operation name
 	operation := extractOperation(req.Query)
 
-	// Record the call
+	// Record the call and note how many calls this operation has seen,
+	// which indexes its response sequence (if one is configured).
 	m.mu.Lock()
 	m.calls = append(m.calls, GraphQLCall{
 		Query:     req.Query,
 		Variables: req.Variables,
 		Operation: operation,
 	})
+	opCalls := 0
+	for _, c := range m.calls {
+		if c.Operation == operation {
+			opCalls++
+		}
+	}
 	m.mu.Unlock()
 
 	// Check for configured error
@@ -139,8 +160,19 @@ func (m *MockLinearServer) handleRequest(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Check for configured response
-	data, ok := m.responses[operation]
+	// A response sequence takes precedence; the last page repeats if the
+	// operation is called more times than pages were scripted.
+	var data any
+	var ok bool
+	if seq, has := m.sequences[operation]; has && len(seq) > 0 {
+		idx := opCalls - 1
+		if idx >= len(seq) {
+			idx = len(seq) - 1
+		}
+		data, ok = seq[idx], true
+	} else {
+		data, ok = m.responses[operation]
+	}
 	m.mu.RUnlock()
 
 	if !ok {


### PR DESCRIPTION
## Problem

Linear silently caps un-argumented GraphQL connections at 50 nodes. `queryTeamMetadata`'s projects connection had neither pagination nor `pageInfo`, so any team past 50 projects silently lost the rest on every sync. Live impact:

- ENG has **187 projects; only 50 ever synced** — `teams/ENG/projects/` was missing two thirds of its entries, and 35 of 53 initiative-project symlinks were dangling (ENOENT).
- Team labels were truncating the same way (ENG has 54).
- Worst latent case: the reconcile ID fetches (`GetWorkspaceProjectIDs`/`InitiativeIDs`) fetched one un-paginated page and fed it to a diff-and-delete — past 250 projects that becomes mass deletion of valid rows.

## Fix — three commits

1. **`paginate` module** (`internal/api/paginate.go`) — the connection-drain counterpart to `execMutation`: `drainFrom` owns cursor threading, termination, a stalled-cursor guard, and an all-or-nothing contract (nil error ⇒ complete set) over a `pageFetch` closure; `fetchAll`/`drain` are path-walking spellings in the `execMutation` idiom. `conn[N]` carries `*PageInfo` so a query that forgets to select `pageInfo` fails loudly instead of truncating silently. Budget policy: refuse before the first fetch (spends nothing), run a started drain to completion — the between-pages abort tried first was observed live burning one token per cycle on a page it then discarded.
2. **Drained queries** — combined metadata query at `first: 250` + `pageInfo` with per-connection resume drains; projects move to their own paginated query (their nested selections cost ~187 complexity points/node against Linear's 10k budget — measured live, `first:100` scores 18751); workspace users/initiatives + each initiative's nested projects drained; reconcile ID queries paginated. Limiter burst 10→16 (sustained rate unchanged) because metadata went from one call per team to two and the last team starved at exactly burst-10. `MockLinearServer.SetResponseSequence` makes multi-page pagination testable for the first time.
3. **Association prunes + rotation** — `project_teams`/`initiative_projects` rows absent from a drained (provably complete) fetch are pruned with the established pre-fetch `synced_at` cutoff; skipped on any fetch/upsert failure. Team sync order rotates per cycle so budget-pressure deferrals never starve a fixed victim.

## Verified live

Temp mount against the real workspace: projects **91 → 205**, dangling junction rows **35 → 0**, **51/51** initiative-project symlinks resolve (two genuinely-unlinked rows correctly pruned), ENG labels complete at 61, prune metrics stable across rotated sync cycles.

Full suite + integration green; `paginate` invariants are pure-closure unit tests, prune semantics pinned by 6 worker tests (stale-removed / mid-sync-write-survives / no-prune-on-error × both tables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)