### PR TITLE
fix(fs): wait for mount readiness in MountFS to end CI flake

### DIFF
--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -894,6 +894,16 @@ func MountFS(mountpoint string, lfs *LinearFS, debug bool) (*fuse.Server, error)
 		return nil, err
 	}
 
+	// Block until the kernel has completed the mount handshake. fs.Mount
+	// returns as soon as the serve loop starts in the background, so without
+	// this the first operation against the mount can race the handshake and
+	// get EIO — observed as a flaky "readdirent teams: input/output error"
+	// in CI's integration suite.
+	if err := server.WaitMount(); err != nil {
+		_ = server.Unmount()
+		return nil, fmt.Errorf("wait for mount: %w", err)
+	}
+
 	lfs.SetServer(server)
 	lfs.mountPoint = mountpoint
 	return server, nil


### PR DESCRIPTION
## Problem
PR #165's Unit Tests job flaked on `TestTeamsListing`:
```
--- FAIL: TestTeamsListing (0.00s)
    read_test.go:117: Failed to read teams directory: readdirent .../teams: input/output error
```
Passed on rerun and 3/3 locally — a race, not a regression.

## Root cause
`fs.Mount()` returns as soon as the serve loop starts in the background; the kernel mount handshake may not be complete. The first op against the mount then races the handshake and gets EIO. Nothing called go-fuse's `server.WaitMount()`.

## Fix
Call `server.WaitMount()` in `MountFS` after `fs.Mount` succeeds, so it returns only once the mount is serving. `MountFS` is the single mount helper — both integration setups and the real command route through it — so every mount path becomes deterministic, production included (cmd previously only called `server.Wait()`, which waits for *unmount*, never readiness).

## Verification
Integration suite 5/5 green locally; `WaitMount` doesn't hang; full suite + gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)