### PR TITLE
feat(sync): prune stale labels, cycles & members; extract deferDetailIssues

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -177,12 +177,19 @@ Linear scores a query's cost, and `team.projects`' nested selections price it
 out of the combined metadata query entirely (~187 points/node; 50/page max —
 measured live, documented at the query).
 
-Completeness is what licenses the **association prunes**: after a drained
-fetch, `project_teams` (per team) and `initiative_projects` (per initiative)
-rows the response no longer contains are deleted, using the Delete-tail
-prune's pre-fetch `synced_at` cutoff so mid-sync writes survive, and skipped
-whenever the fetch or any upsert failed. Prune only against a drained fetch —
-a truncated list reads as removals.
+Completeness is what licenses the **metadata prunes**: after a drained
+fetch, the rows the response no longer contains are deleted — `project_teams`
+and `initiative_projects` junctions (per team / per initiative), and the
+team's own `labels`, `cycles`, and `team_members` (departed members leave the
+junction; the workspace-wide `users` table is never pruned). Each uses the
+pre-fetch `synced_at` cutoff so mid-sync writes survive, is gated on a
+per-entity clean flag (skipped when that entity's fetch or any upsert failed),
+and runs only against a drained fetch — a truncated list reads as removals.
+`states` are workflow-bounded and fetched single-page, so they stay
+upsert-only. Workspace labels commingle into `labels` under whichever team
+synced them, but every team fetch re-includes all workspace labels (via
+`issueLabels`), so they are always refreshed above the cutoff and never pruned
+by a team that no longer "owns" them.
 
 ### ErrorSink
 The minimal seam the WriteBack tail uses to record validation/divergence messages for

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -435,6 +435,22 @@ ON CONFLICT(project_id, team_id) DO UPDATE SET
 -- name: PruneProjectTeams :exec
 DELETE FROM project_teams WHERE team_id = ? AND synced_at < ?;
 
+-- Prune the team metadata rows the drained (complete) metadata fetch no
+-- longer returned: renamed or deleted labels, cycles, and departed members.
+-- Same contract as PruneProjectTeams, only safe against a complete fetch with
+-- the cutoff taken before the sync upserts. Workspace labels commingle into
+-- the labels table under whichever team synced them, but every team fetch
+-- re-includes all workspace labels (via issueLabels), so they are always
+-- refreshed above the cutoff before this prune runs and are never removed here.
+-- name: PruneTeamLabels :exec
+DELETE FROM labels WHERE team_id = ? AND synced_at < ?;
+
+-- name: PruneTeamCycles :exec
+DELETE FROM cycles WHERE team_id = ? AND synced_at < ?;
+
+-- name: PruneTeamMembers :exec
+DELETE FROM team_members WHERE team_id = ? AND synced_at < ?;
+
 -- name: DeleteProjectTeam :exec
 DELETE FROM project_teams WHERE project_id = ? AND team_id = ?;
 

--- a/internal/db/queries.sql.go
+++ b/internal/db/queries.sql.go
@@ -4001,6 +4001,55 @@ func (q *Queries) PruneProjectTeams(ctx context.Context, arg PruneProjectTeamsPa
 	return err
 }
 
+const pruneTeamCycles = `-- name: PruneTeamCycles :exec
+DELETE FROM cycles WHERE team_id = ? AND synced_at < ?
+`
+
+type PruneTeamCyclesParams struct {
+	TeamID   string    `json:"team_id"`
+	SyncedAt time.Time `json:"synced_at"`
+}
+
+func (q *Queries) PruneTeamCycles(ctx context.Context, arg PruneTeamCyclesParams) error {
+	_, err := q.db.ExecContext(ctx, pruneTeamCycles, arg.TeamID, arg.SyncedAt)
+	return err
+}
+
+const pruneTeamLabels = `-- name: PruneTeamLabels :exec
+DELETE FROM labels WHERE team_id = ? AND synced_at < ?
+`
+
+type PruneTeamLabelsParams struct {
+	TeamID   sql.NullString `json:"team_id"`
+	SyncedAt time.Time      `json:"synced_at"`
+}
+
+// Prune the team metadata rows the drained (complete) metadata fetch no
+// longer returned: renamed or deleted labels, cycles, and departed members.
+// Same contract as PruneProjectTeams, only safe against a complete fetch with
+// the cutoff taken before the sync upserts. Workspace labels commingle into
+// the labels table under whichever team synced them, but every team fetch
+// re-includes all workspace labels (via issueLabels), so they are always
+// refreshed above the cutoff before this prune runs and are never removed here.
+func (q *Queries) PruneTeamLabels(ctx context.Context, arg PruneTeamLabelsParams) error {
+	_, err := q.db.ExecContext(ctx, pruneTeamLabels, arg.TeamID, arg.SyncedAt)
+	return err
+}
+
+const pruneTeamMembers = `-- name: PruneTeamMembers :exec
+DELETE FROM team_members WHERE team_id = ? AND synced_at < ?
+`
+
+type PruneTeamMembersParams struct {
+	TeamID   string    `json:"team_id"`
+	SyncedAt time.Time `json:"synced_at"`
+}
+
+func (q *Queries) PruneTeamMembers(ctx context.Context, arg PruneTeamMembersParams) error {
+	_, err := q.db.ExecContext(ctx, pruneTeamMembers, arg.TeamID, arg.SyncedAt)
+	return err
+}
+
 const setIssueParent = `-- name: SetIssueParent :exec
 UPDATE issues SET parent_id = ? WHERE id = ?
 `

--- a/internal/sync/prune_test.go
+++ b/internal/sync/prune_test.go
@@ -2,6 +2,8 @@ package sync
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -140,6 +142,262 @@ func TestTeamMetadataFetchErrorPrunesNothing(t *testing.T) {
 
 	if got := projectTeamIDs(t, store, "proj-stale"); len(got) != 1 {
 		t.Errorf("proj-stale teams = %v, want untouched after failed fetch", got)
+	}
+}
+
+func seedLabel(t *testing.T, store *db.Store, id, teamID string, syncedAt time.Time) {
+	t.Helper()
+	if err := store.Queries().UpsertLabel(context.Background(), db.UpsertLabelParams{
+		ID:       id,
+		TeamID:   sql.NullString{String: teamID, Valid: true},
+		Name:     id,
+		SyncedAt: syncedAt,
+		Data:     json.RawMessage("{}"),
+	}); err != nil {
+		t.Fatalf("seed label %s: %v", id, err)
+	}
+}
+
+func seedCycle(t *testing.T, store *db.Store, id, teamID string, syncedAt time.Time) {
+	t.Helper()
+	if err := store.Queries().UpsertCycle(context.Background(), db.UpsertCycleParams{
+		ID:       id,
+		TeamID:   teamID,
+		Number:   1,
+		Name:     sql.NullString{String: id, Valid: true},
+		SyncedAt: syncedAt,
+		Data:     json.RawMessage("{}"),
+	}); err != nil {
+		t.Fatalf("seed cycle %s: %v", id, err)
+	}
+}
+
+// seedMember writes both the workspace user row and the team_members junction
+// row (ListTeamMembers joins users), so the seeded membership is observable
+// before the prune runs.
+func seedMember(t *testing.T, store *db.Store, teamID, userID string, syncedAt time.Time) {
+	t.Helper()
+	if err := store.Queries().UpsertUser(context.Background(), db.UpsertUserParams{
+		ID:       userID,
+		Email:    userID + "@test.com",
+		Name:     userID,
+		SyncedAt: syncedAt,
+		Data:     json.RawMessage("{}"),
+	}); err != nil {
+		t.Fatalf("seed user %s: %v", userID, err)
+	}
+	if err := store.Queries().UpsertTeamMember(context.Background(), db.UpsertTeamMemberParams{
+		TeamID:   teamID,
+		UserID:   userID,
+		SyncedAt: syncedAt,
+	}); err != nil {
+		t.Fatalf("seed team_member %s-%s: %v", teamID, userID, err)
+	}
+}
+
+func teamLabelIDs(t *testing.T, store *db.Store, teamID string) []string {
+	t.Helper()
+	rows, err := store.Queries().ListTeamLabels(context.Background(), sql.NullString{String: teamID, Valid: true})
+	if err != nil {
+		t.Fatalf("list team labels: %v", err)
+	}
+	ids := make([]string, 0, len(rows))
+	for _, r := range rows {
+		ids = append(ids, r.ID)
+	}
+	return ids
+}
+
+func teamCycleIDs(t *testing.T, store *db.Store, teamID string) []string {
+	t.Helper()
+	rows, err := store.Queries().ListTeamCycles(context.Background(), teamID)
+	if err != nil {
+		t.Fatalf("list team cycles: %v", err)
+	}
+	ids := make([]string, 0, len(rows))
+	for _, r := range rows {
+		ids = append(ids, r.ID)
+	}
+	return ids
+}
+
+func teamMemberIDs(t *testing.T, store *db.Store, teamID string) []string {
+	t.Helper()
+	rows, err := store.Queries().ListTeamMembers(context.Background(), teamID)
+	if err != nil {
+		t.Fatalf("list team members: %v", err)
+	}
+	ids := make([]string, 0, len(rows))
+	for _, r := range rows {
+		ids = append(ids, r.ID)
+	}
+	return ids
+}
+
+// contains reports whether ids includes want.
+func contains(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestTeamMetadataSyncPrunesStaleLabels: a label the drained labels fetch no
+// longer returns — renamed or deleted in Linear — must go; the returned label
+// stays. (Only team-scoped labels are seeded; workspace labels re-arrive on
+// every team fetch and so are always refreshed above the cutoff.)
+func TestTeamMetadataSyncPrunesStaleLabels(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	old := db.Now().Add(-time.Minute)
+	seedLabel(t, store, "label-live", "team-1", old)
+	seedLabel(t, store, "label-stale", "team-1", old)
+
+	mock := newMockAPIClient()
+	mock.labelsByTeam["team-1"] = []api.Label{{ID: "label-live", Name: "Live"}}
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	if err := worker.syncTeamMetadata(ctx, api.Team{ID: "team-1", Key: "T1"}); err != nil {
+		t.Fatalf("syncTeamMetadata: %v", err)
+	}
+
+	got := teamLabelIDs(t, store, "team-1")
+	if !contains(got, "label-live") {
+		t.Errorf("labels = %v, want label-live retained (returned row re-stamped)", got)
+	}
+	if contains(got, "label-stale") {
+		t.Errorf("labels = %v, want label-stale pruned", got)
+	}
+}
+
+// TestTeamMetadataSyncPrunesStaleCycles: a cycle absent from the drained fetch
+// is pruned; a returned cycle survives.
+func TestTeamMetadataSyncPrunesStaleCycles(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	old := db.Now().Add(-time.Minute)
+	seedCycle(t, store, "cycle-live", "team-1", old)
+	seedCycle(t, store, "cycle-stale", "team-1", old)
+	seedCycle(t, store, "cycle-elsewhere", "team-2", old) // other team: out of scope
+
+	mock := newMockAPIClient()
+	mock.cyclesByTeam["team-1"] = []api.Cycle{{ID: "cycle-live", Number: 1, Name: "Live"}}
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	if err := worker.syncTeamMetadata(ctx, api.Team{ID: "team-1", Key: "T1"}); err != nil {
+		t.Fatalf("syncTeamMetadata: %v", err)
+	}
+
+	got := teamCycleIDs(t, store, "team-1")
+	if !contains(got, "cycle-live") || contains(got, "cycle-stale") {
+		t.Errorf("team-1 cycles = %v, want [cycle-live] (stale pruned)", got)
+	}
+	if other := teamCycleIDs(t, store, "team-2"); !contains(other, "cycle-elsewhere") {
+		t.Errorf("team-2 cycles = %v, want cycle-elsewhere untouched", other)
+	}
+}
+
+// TestTeamMetadataSyncPrunesStaleMembers: a departed member is pruned from the
+// team_members junction; the returned member stays and another team's roster is
+// untouched. The workspace users table is not pruned.
+func TestTeamMetadataSyncPrunesStaleMembers(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	old := db.Now().Add(-time.Minute)
+	seedMember(t, store, "team-1", "user-live", old)
+	seedMember(t, store, "team-1", "user-gone", old)
+	seedMember(t, store, "team-2", "user-elsewhere", old) // other team: out of scope
+
+	mock := newMockAPIClient()
+	mock.membersByTeam["team-1"] = []api.User{{ID: "user-live", Email: "user-live@test.com", Name: "Live"}}
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	if err := worker.syncTeamMetadata(ctx, api.Team{ID: "team-1", Key: "T1"}); err != nil {
+		t.Fatalf("syncTeamMetadata: %v", err)
+	}
+
+	got := teamMemberIDs(t, store, "team-1")
+	if !contains(got, "user-live") || contains(got, "user-gone") {
+		t.Errorf("team-1 members = %v, want [user-live] (departed member pruned)", got)
+	}
+	if other := teamMemberIDs(t, store, "team-2"); !contains(other, "user-elsewhere") {
+		t.Errorf("team-2 members = %v, want user-elsewhere untouched", other)
+	}
+}
+
+// TestTeamMetadataFetchErrorSparesMetadata: a failed metadata fetch prunes
+// nothing — labels, cycles, and members all survive.
+func TestTeamMetadataFetchErrorSparesMetadata(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	old := db.Now().Add(-time.Minute)
+	seedLabel(t, store, "label-stale", "team-1", old)
+	seedCycle(t, store, "cycle-stale", "team-1", old)
+	seedMember(t, store, "team-1", "user-stale", old)
+
+	mock := newMockAPIClient()
+	mock.simulateError = errors.New("api down")
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	if err := worker.syncTeamMetadata(ctx, api.Team{ID: "team-1", Key: "T1"}); err == nil {
+		t.Fatal("syncTeamMetadata should surface the fetch error")
+	}
+
+	if !contains(teamLabelIDs(t, store, "team-1"), "label-stale") {
+		t.Error("label-stale pruned after failed fetch, want untouched")
+	}
+	if !contains(teamCycleIDs(t, store, "team-1"), "cycle-stale") {
+		t.Error("cycle-stale pruned after failed fetch, want untouched")
+	}
+	if !contains(teamMemberIDs(t, store, "team-1"), "user-stale") {
+		t.Error("user-stale pruned after failed fetch, want untouched")
+	}
+}
+
+// TestDeferDetailIssues: every issue handed to the shared defer helper lands in
+// pending_detail_sync so a later cycle can retry it.
+func TestDeferDetailIssues(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	worker := NewWorker(newMockAPIClient(), store, Config{Interval: time.Hour})
+	worker.deferDetailIssues(ctx, []struct {
+		ID         string
+		Identifier string
+	}{
+		{ID: "issue-1", Identifier: "TST-1"},
+		{ID: "issue-2", Identifier: "TST-2"},
+	})
+
+	rows, err := store.Queries().ListPendingDetailSync(ctx)
+	if err != nil {
+		t.Fatalf("list pending: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("pending rows = %d, want 2", len(rows))
+	}
+	seen := map[string]string{}
+	for _, r := range rows {
+		seen[r.IssueID] = r.Identifier
+	}
+	if seen["issue-1"] != "TST-1" || seen["issue-2"] != "TST-2" {
+		t.Errorf("pending rows = %v, want issue-1/TST-1 and issue-2/TST-2", seen)
 	}
 }
 

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -559,26 +559,48 @@ func (w *Worker) syncTeamMetadata(ctx context.Context, team api.Team) error {
 	}
 
 	// Process labels (already deduplicated by GetTeamMetadata)
+	labelsClean := true
 	for _, label := range meta.Labels {
 		params, err := db.APILabelToDBLabel(label, team.ID)
 		if err != nil {
 			log.Printf("[sync] convert label %s failed: %v", label.Name, err)
+			labelsClean = false
 			continue
 		}
 		if err := w.store.Queries().UpsertLabel(ctx, params); err != nil {
 			log.Printf("[sync] upsert label %s failed: %v", label.Name, err)
+			labelsClean = false
+		}
+	}
+	if labelsClean {
+		if err := w.store.Queries().PruneTeamLabels(ctx, db.PruneTeamLabelsParams{
+			TeamID:   sql.NullString{String: team.ID, Valid: true},
+			SyncedAt: pruneCutoff,
+		}); err != nil {
+			log.Printf("[sync] prune labels %s: %v", team.Key, err)
 		}
 	}
 
 	// Process cycles
+	cyclesClean := true
 	for _, cycle := range meta.Cycles {
 		params, err := db.APICycleToDBCycle(cycle, team.ID)
 		if err != nil {
 			log.Printf("[sync] convert cycle %s failed: %v", cycle.Name, err)
+			cyclesClean = false
 			continue
 		}
 		if err := w.store.Queries().UpsertCycle(ctx, params); err != nil {
 			log.Printf("[sync] upsert cycle %s failed: %v", cycle.Name, err)
+			cyclesClean = false
+		}
+	}
+	if cyclesClean {
+		if err := w.store.Queries().PruneTeamCycles(ctx, db.PruneTeamCyclesParams{
+			TeamID:   team.ID,
+			SyncedAt: pruneCutoff,
+		}); err != nil {
+			log.Printf("[sync] prune cycles %s: %v", team.Key, err)
 		}
 	}
 
@@ -636,15 +658,18 @@ func (w *Worker) syncTeamMetadata(ctx context.Context, team api.Team) error {
 	}
 
 	// Process members
+	membersClean := true
 	for _, member := range meta.Members {
 		// Ensure user exists in users table
 		params, err := db.APIUserToDBUser(member)
 		if err != nil {
 			log.Printf("[sync] convert member %s failed: %v", member.Email, err)
+			membersClean = false
 			continue
 		}
 		if err := w.store.Queries().UpsertUser(ctx, params); err != nil {
 			log.Printf("[sync] upsert member user %s failed: %v", member.Email, err)
+			membersClean = false
 			continue
 		}
 
@@ -655,6 +680,17 @@ func (w *Worker) syncTeamMetadata(ctx context.Context, team api.Team) error {
 			SyncedAt: db.Now(),
 		}); err != nil {
 			log.Printf("[sync] upsert team member %s failed: %v", member.Email, err)
+			membersClean = false
+		}
+	}
+	// Prune departed members from the team_members junction (not the
+	// workspace-wide users table, which other teams share).
+	if membersClean {
+		if err := w.store.Queries().PruneTeamMembers(ctx, db.PruneTeamMembersParams{
+			TeamID:   team.ID,
+			SyncedAt: pruneCutoff,
+		}); err != nil {
+			log.Printf("[sync] prune members %s: %v", team.Key, err)
 		}
 	}
 
@@ -722,6 +758,24 @@ func (w *Worker) setRateLimited() {
 // Issue Details Sync (Comments and Documents)
 // =============================================================================
 
+// deferDetailIssues enqueues every issue to pending_detail_sync for a later
+// cycle, stamping one QueuedAt for the batch. Shared by the three defer paths
+// (budget low, rate-limited before the fetch, rate-limited mid-fetch) so the
+// enqueue contract lives in one place and a fourth path cannot drift.
+func (w *Worker) deferDetailIssues(ctx context.Context, issues []struct {
+	ID         string
+	Identifier string
+}) {
+	now := db.Now()
+	for _, issue := range issues {
+		_ = w.store.Queries().UpsertPendingDetailSync(ctx, db.UpsertPendingDetailSyncParams{
+			IssueID:    issue.ID,
+			Identifier: issue.Identifier,
+			QueuedAt:   now,
+		})
+	}
+}
+
 // syncOrDeferDetailBatch syncs issue details if budget allows, otherwise
 // defers to pending_detail_sync for a later cycle.
 func (w *Worker) syncOrDeferDetailBatch(ctx context.Context, issues []struct {
@@ -729,14 +783,7 @@ func (w *Worker) syncOrDeferDetailBatch(ctx context.Context, issues []struct {
 	Identifier string
 }) {
 	if w.budgetExceeds(budgetDeferDetailPct) {
-		now := db.Now()
-		for _, issue := range issues {
-			_ = w.store.Queries().UpsertPendingDetailSync(ctx, db.UpsertPendingDetailSyncParams{
-				IssueID:    issue.ID,
-				Identifier: issue.Identifier,
-				QueuedAt:   now,
-			})
-		}
+		w.deferDetailIssues(ctx, issues)
 		return
 	}
 	w.syncIssueDetailsBatch(ctx, issues)
@@ -749,14 +796,7 @@ func (w *Worker) syncIssueDetailsBatch(ctx context.Context, issues []struct {
 }) {
 	// H-5: If rate limited, persist issues to pending_detail_sync so they survive the backoff
 	if w.isRateLimited() {
-		now := db.Now()
-		for _, issue := range issues {
-			_ = w.store.Queries().UpsertPendingDetailSync(ctx, db.UpsertPendingDetailSyncParams{
-				IssueID:    issue.ID,
-				Identifier: issue.Identifier,
-				QueuedAt:   now,
-			})
-		}
+		w.deferDetailIssues(ctx, issues)
 		return
 	}
 
@@ -780,14 +820,7 @@ func (w *Worker) syncIssueDetailsBatch(ctx context.Context, issues []struct {
 		if isRateLimitError(err) {
 			w.setRateLimited()
 			// H-5: Persist the issues we couldn't sync so they survive the backoff
-			now := db.Now()
-			for _, issue := range issues {
-				_ = w.store.Queries().UpsertPendingDetailSync(ctx, db.UpsertPendingDetailSyncParams{
-					IssueID:    issue.ID,
-					Identifier: issue.Identifier,
-					QueuedAt:   now,
-				})
-			}
+			w.deferDetailIssues(ctx, issues)
 			return
 		}
 		log.Printf("[sync] batch fetch details failed: %v", err)


### PR DESCRIPTION
Seventh architecture review, top pick — finish the prune.

## Problem
The paginate drains made team **labels, cycles, and members** fetch to completion every cycle, but `syncTeamMetadata` still only upserted them. A renamed label, a departed member, or a deleted cycle lingered forever — the same staleness gap the `project_teams` prune already closed, still open on three tables.

## Fix
Extend the existing cutoff-before-fetch prune to all three:
- Stamp a pre-fetch `synced_at`, upsert, then `PruneTeamLabels/Cycles/Members` against the cutoff.
- Each gated on a per-entity clean flag (mirrors `projectsClean`), so a failed fetch or upsert never reads as a removal.
- Members prune the `team_members` junction only — never the workspace-wide `users` table.
- `states` stay upsert-only (single-page, workflow-bounded — not drained, so pruning would read a partial page as deletions).
- **Workspace-label safety:** every team's fetch re-includes all workspace labels via `issueLabels`, so a workspace label commingled under a team is always refreshed above the cutoff and never pruned by a team that no longer "owns" it.

## Also
Collapse the defer-to-`pending_detail_sync` loop — hand-copied across three paths (budget low, rate-limited pre-fetch, rate-limited mid-fetch) — into one `deferDetailIssues` helper.

## Tests
Three stale-prune tests (labels/cycles/members), a fetch-error-spares-all test, and a `deferDetailIssues` test. Full suite + vet + gofmt green. CONTEXT.md's Connection-drain concept updated to the wider prune scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)