### PR TITLE
refactor(repo): extract reconcileAgainst — one tested diff-and-delete seam

### DIFF
--- a/internal/repo/sqlite.go
+++ b/internal/repo/sqlite.go
@@ -228,25 +228,42 @@ func (r *SQLiteRepository) reconcileIssues(ctx context.Context) int {
 	return deleted
 }
 
+// reconcileAgainst diffs a provably-complete authoritative ID set (apiIDs)
+// against the local IDs from getLocal, deletes every local orphan through
+// deleteOrphan, and returns the count removed. The diff-and-delete that can
+// mass-delete rows lives here once, behind the getLocal/deleteOrphan seam;
+// each caller owns only the budget-gated authoritative fetch and its
+// per-entity local query and orphan delete. label names the entity in the
+// log line when the local query fails.
+func (r *SQLiteRepository) reconcileAgainst(ctx context.Context, label string, apiIDs []string, getLocal func() ([]string, error), deleteOrphan func(context.Context, string)) int {
+	localIDs, err := getLocal()
+	if err != nil {
+		log.Printf("[reconcile] list local %s: %v", label, err)
+		return 0
+	}
+	deleted := 0
+	for _, id := range setDiff(localIDs, apiIDs) {
+		deleteOrphan(ctx, id)
+		deleted++
+	}
+	return deleted
+}
+
 // reconcileIssuesForTeam diffs apiIDs against SQLite's issue IDs for the
 // given team and deletes any locals missing from the API set. Split out
 // so tests can drive the diff/delete logic without needing a live client.
 func (r *SQLiteRepository) reconcileIssuesForTeam(ctx context.Context, teamID string, apiIDs []string) int {
-	rows, err := r.store.Queries().ListTeamIssueIDs(ctx, teamID)
-	if err != nil {
-		log.Printf("[reconcile] list local issues for team %s: %v", teamID, err)
-		return 0
-	}
-	localIDs := make([]string, 0, len(rows))
-	for _, row := range rows {
-		localIDs = append(localIDs, row.ID)
-	}
-	deleted := 0
-	for _, id := range setDiff(localIDs, apiIDs) {
-		r.deleteOrphanIssue(ctx, id)
-		deleted++
-	}
-	return deleted
+	return r.reconcileAgainst(ctx, "issues for team "+teamID, apiIDs, func() ([]string, error) {
+		rows, err := r.store.Queries().ListTeamIssueIDs(ctx, teamID)
+		if err != nil {
+			return nil, err
+		}
+		ids := make([]string, 0, len(rows))
+		for _, row := range rows {
+			ids = append(ids, row.ID)
+		}
+		return ids, nil
+	}, r.deleteOrphanIssue)
 }
 
 // reconcileProjects fetches the authoritative project ID set from Linear,
@@ -261,21 +278,17 @@ func (r *SQLiteRepository) reconcileProjects(ctx context.Context) int {
 		log.Printf("[reconcile] projects fetch: %v (skipping)", err)
 		return 0
 	}
-	rows, err := r.store.Queries().ListProjects(ctx)
-	if err != nil {
-		log.Printf("[reconcile] list local projects: %v", err)
-		return 0
-	}
-	localIDs := make([]string, 0, len(rows))
-	for _, p := range rows {
-		localIDs = append(localIDs, p.ID)
-	}
-	deleted := 0
-	for _, id := range setDiff(localIDs, apiIDs) {
-		r.deleteOrphanProject(ctx, id)
-		deleted++
-	}
-	return deleted
+	return r.reconcileAgainst(ctx, "projects", apiIDs, func() ([]string, error) {
+		rows, err := r.store.Queries().ListProjects(ctx)
+		if err != nil {
+			return nil, err
+		}
+		ids := make([]string, 0, len(rows))
+		for _, p := range rows {
+			ids = append(ids, p.ID)
+		}
+		return ids, nil
+	}, r.deleteOrphanProject)
 }
 
 // reconcileInitiatives fetches the authoritative initiative ID set,
@@ -290,21 +303,17 @@ func (r *SQLiteRepository) reconcileInitiatives(ctx context.Context) int {
 		log.Printf("[reconcile] initiatives fetch: %v (skipping)", err)
 		return 0
 	}
-	rows, err := r.store.Queries().ListInitiatives(ctx)
-	if err != nil {
-		log.Printf("[reconcile] list local initiatives: %v", err)
-		return 0
-	}
-	localIDs := make([]string, 0, len(rows))
-	for _, i := range rows {
-		localIDs = append(localIDs, i.ID)
-	}
-	deleted := 0
-	for _, id := range setDiff(localIDs, apiIDs) {
-		r.deleteOrphanInitiative(ctx, id)
-		deleted++
-	}
-	return deleted
+	return r.reconcileAgainst(ctx, "initiatives", apiIDs, func() ([]string, error) {
+		rows, err := r.store.Queries().ListInitiatives(ctx)
+		if err != nil {
+			return nil, err
+		}
+		ids := make([]string, 0, len(rows))
+		for _, i := range rows {
+			ids = append(ids, i.ID)
+		}
+		return ids, nil
+	}, r.deleteOrphanInitiative)
 }
 
 // setDiff returns elements in `local` that are not in `api`. Used by the

--- a/internal/repo/sqlite_test.go
+++ b/internal/repo/sqlite_test.go
@@ -2627,3 +2627,55 @@ func TestReconcileIssuesForTeam_DeletesOrphans(t *testing.T) {
 		t.Errorf("alsogone issue still present: err=%v", err)
 	}
 }
+
+// TestReconcileAgainst_DeletesOrphans drives the shared diff-and-delete seam
+// that reconcileIssuesForTeam, reconcileProjects, and reconcileInitiatives
+// now route through — with closures, no live client or store. This is the
+// coverage projects/initiatives never had (their fetch needed a real client).
+func TestReconcileAgainst_DeletesOrphans(t *testing.T) {
+	t.Parallel()
+	repo := &SQLiteRepository{}
+	ctx := context.Background()
+
+	var deleted []string
+	n := repo.reconcileAgainst(ctx, "test",
+		[]string{"alive", "also-alive"}, // authoritative set
+		func() ([]string, error) {
+			return []string{"alive", "gone", "also-alive", "gone2"}, nil
+		},
+		func(_ context.Context, id string) { deleted = append(deleted, id) },
+	)
+
+	if n != 2 {
+		t.Errorf("deleted count = %d, want 2", n)
+	}
+	want := map[string]bool{"gone": true, "gone2": true}
+	for _, id := range deleted {
+		if !want[id] {
+			t.Errorf("deleted %q, which is in the authoritative set", id)
+		}
+		delete(want, id)
+	}
+	if len(want) != 0 {
+		t.Errorf("orphans not deleted: %v", want)
+	}
+}
+
+// TestReconcileAgainst_LocalQueryErrorDeletesNothing: a failed local read must
+// delete nothing — an empty/partial local set must never read as "everything
+// is an orphan".
+func TestReconcileAgainst_LocalQueryErrorDeletesNothing(t *testing.T) {
+	t.Parallel()
+	repo := &SQLiteRepository{}
+	ctx := context.Background()
+
+	called := false
+	n := repo.reconcileAgainst(ctx, "test",
+		[]string{"alive"},
+		func() ([]string, error) { return nil, fmt.Errorf("db down") },
+		func(_ context.Context, _ string) { called = true },
+	)
+	if n != 0 || called {
+		t.Errorf("deleted=%d called=%v, want 0 deletes on local-query error", n, called)
+	}
+}


### PR DESCRIPTION
Seventh review, candidate #2 — a reconcile-by-ID seam.

## Problem
`reconcileIssuesForTeam`, `reconcileProjects`, and `reconcileInitiatives` each re-state the same safety-critical loop: map local rows → IDs, `setDiff` against the authoritative API set, delete every orphan, count. Only the local query and the orphan-delete vary. And because `reconcileProjects`/`reconcileInitiatives` fetch through a live client, their mass-delete logic had **no direct test** — it rode along untested.

## Fix
Extract `reconcileAgainst(ctx, label, apiIDs, getLocal, deleteOrphan)`. The diff-and-delete that can mass-delete rows lives once, behind the `getLocal`/`deleteOrphan` seam. Each caller keeps only its budget-gated fetch (per-team for issues, single workspace fetch for projects/initiatives) and its per-entity local query + orphan delete, passed as closures.

## Tests
`TestReconcileAgainst_DeletesOrphans` and `_LocalQueryErrorDeletesNothing` drive the shared guard directly with closures — no live client, the coverage projects/initiatives never had. The existing `TestReconcileIssuesForTeam` still exercises the wrapper end to end.

Net: the mass-delete guard is tested once instead of copied three times. Full suite + vet green; my additions gofmt-clean (pre-existing sqlite_test.go alignment left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)