### PR TITLE
refactor(repo): extract maybeRefresh — one stale-while-revalidate policy

### DIFF
--- a/internal/repo/sqlite.go
+++ b/internal/repo/sqlite.go
@@ -1098,33 +1098,44 @@ func (r *SQLiteRepository) GetIssueDocuments(ctx context.Context, issueID string
 	return db.DBDocumentsToAPIDocuments(docs)
 }
 
+// staleSince reports whether a cached entity's last-sync instant is older than
+// threshold. A query error or a nil instant (never synced) counts as stale, so
+// the caller refreshes. Pure, so the parseTime/threshold rule — historically a
+// source of timezone-comparison bugs — is unit-tested directly.
+func staleSince(syncedAt interface{}, err error, threshold time.Duration) bool {
+	return err != nil || syncedAt == nil || time.Since(parseTime(syncedAt)) > threshold
+}
+
+// maybeRefresh triggers a deduplicated background refresh when an entity's
+// cached rows are staler than the threshold. syncedAt returns the entity's
+// last-sync instant, key dedups concurrent refreshes, and refresh does the
+// fetch-and-upsert. In fixture mode (nil client) it never fires. The refresh
+// runs in the background so a directory listing (e.g. find) never blocks on
+// the API. This owns the staleness/trigger policy the four Get*Documents and
+// Get*Updates read paths used to each restate.
+func (r *SQLiteRepository) maybeRefresh(key string, syncedAt func() (interface{}, error), refresh func(context.Context) error) {
+	if r.client == nil {
+		return
+	}
+	ts, err := syncedAt()
+	if staleSince(ts, err, r.stalenessThreshold) {
+		r.triggerBackgroundRefresh(key, refresh)
+	}
+}
+
 func (r *SQLiteRepository) GetProjectDocuments(ctx context.Context, projectID string) ([]api.Document, error) {
 	docs, err := r.store.Queries().ListProjectDocuments(ctx, sql.NullString{String: projectID, Valid: true})
 	if err != nil {
 		return nil, fmt.Errorf("list project documents: %w", err)
 	}
 
-	// Check staleness and trigger background refresh if needed
-	r.maybeRefreshProjectDocuments(projectID, len(docs) == 0)
+	r.maybeRefresh("project-docs:"+projectID, func() (interface{}, error) {
+		return r.store.Queries().GetProjectDocumentsSyncedAt(context.Background(), sql.NullString{String: projectID, Valid: true})
+	}, func(ctx context.Context) error {
+		return r.refreshProjectDocuments(ctx, projectID)
+	})
 
 	return db.DBDocumentsToAPIDocuments(docs)
-}
-
-// maybeRefreshProjectDocuments checks if project documents need refreshing
-func (r *SQLiteRepository) maybeRefreshProjectDocuments(projectID string, isEmpty bool) {
-	if r.client == nil {
-		return
-	}
-
-	syncedAt, err := r.store.Queries().GetProjectDocumentsSyncedAt(context.Background(), sql.NullString{String: projectID, Valid: true})
-	isStale := err != nil || syncedAt == nil || time.Since(parseTime(syncedAt)) > r.stalenessThreshold
-
-	// Always refresh in background to avoid blocking on directory listings (e.g., find)
-	if isStale {
-		r.triggerBackgroundRefresh("project-docs:"+projectID, func(ctx context.Context) error {
-			return r.refreshProjectDocuments(ctx, projectID)
-		})
-	}
 }
 
 // refreshProjectDocuments fetches documents from API and stores in SQLite
@@ -1155,27 +1166,13 @@ func (r *SQLiteRepository) GetInitiativeDocuments(ctx context.Context, initiativ
 		return nil, fmt.Errorf("list initiative documents: %w", err)
 	}
 
-	// Check staleness and trigger background refresh if needed
-	r.maybeRefreshInitiativeDocuments(initiativeID, len(docs) == 0)
+	r.maybeRefresh("initiative-docs:"+initiativeID, func() (interface{}, error) {
+		return r.store.Queries().GetInitiativeDocumentsSyncedAt(context.Background(), sql.NullString{String: initiativeID, Valid: true})
+	}, func(ctx context.Context) error {
+		return r.refreshInitiativeDocuments(ctx, initiativeID)
+	})
 
 	return db.DBDocumentsToAPIDocuments(docs)
-}
-
-// maybeRefreshInitiativeDocuments checks if initiative documents need refreshing
-func (r *SQLiteRepository) maybeRefreshInitiativeDocuments(initiativeID string, isEmpty bool) {
-	if r.client == nil {
-		return
-	}
-
-	syncedAt, err := r.store.Queries().GetInitiativeDocumentsSyncedAt(context.Background(), sql.NullString{String: initiativeID, Valid: true})
-	isStale := err != nil || syncedAt == nil || time.Since(parseTime(syncedAt)) > r.stalenessThreshold
-
-	// Always refresh in background to avoid blocking on directory listings (e.g., find)
-	if isStale {
-		r.triggerBackgroundRefresh("initiative-docs:"+initiativeID, func(ctx context.Context) error {
-			return r.refreshInitiativeDocuments(ctx, initiativeID)
-		})
-	}
 }
 
 // refreshInitiativeDocuments fetches documents from API and stores in SQLite
@@ -1260,27 +1257,13 @@ func (r *SQLiteRepository) GetProjectUpdates(ctx context.Context, projectID stri
 		return nil, fmt.Errorf("list project updates: %w", err)
 	}
 
-	// Check staleness and trigger background refresh if needed
-	r.maybeRefreshProjectUpdates(projectID, len(updates) == 0)
+	r.maybeRefresh("project-updates:"+projectID, func() (interface{}, error) {
+		return r.store.Queries().GetProjectUpdatesSyncedAt(context.Background(), projectID)
+	}, func(ctx context.Context) error {
+		return r.refreshProjectUpdates(ctx, projectID)
+	})
 
 	return db.DBProjectUpdatesToAPIUpdates(updates)
-}
-
-// maybeRefreshProjectUpdates checks if project updates need refreshing
-func (r *SQLiteRepository) maybeRefreshProjectUpdates(projectID string, isEmpty bool) {
-	if r.client == nil {
-		return
-	}
-
-	syncedAt, err := r.store.Queries().GetProjectUpdatesSyncedAt(context.Background(), projectID)
-	isStale := err != nil || syncedAt == nil || time.Since(parseTime(syncedAt)) > r.stalenessThreshold
-
-	// Always refresh in background to avoid blocking on directory listings (e.g., find)
-	if isStale {
-		r.triggerBackgroundRefresh("project-updates:"+projectID, func(ctx context.Context) error {
-			return r.refreshProjectUpdates(ctx, projectID)
-		})
-	}
 }
 
 // refreshProjectUpdates fetches updates from API and stores in SQLite
@@ -1311,27 +1294,13 @@ func (r *SQLiteRepository) GetInitiativeUpdates(ctx context.Context, initiativeI
 		return nil, fmt.Errorf("list initiative updates: %w", err)
 	}
 
-	// Check staleness and trigger background refresh if needed
-	r.maybeRefreshInitiativeUpdates(initiativeID, len(updates) == 0)
+	r.maybeRefresh("initiative-updates:"+initiativeID, func() (interface{}, error) {
+		return r.store.Queries().GetInitiativeUpdatesSyncedAt(context.Background(), initiativeID)
+	}, func(ctx context.Context) error {
+		return r.refreshInitiativeUpdates(ctx, initiativeID)
+	})
 
 	return db.DBInitiativeUpdatesToAPIUpdates(updates)
-}
-
-// maybeRefreshInitiativeUpdates checks if initiative updates need refreshing
-func (r *SQLiteRepository) maybeRefreshInitiativeUpdates(initiativeID string, isEmpty bool) {
-	if r.client == nil {
-		return
-	}
-
-	syncedAt, err := r.store.Queries().GetInitiativeUpdatesSyncedAt(context.Background(), initiativeID)
-	isStale := err != nil || syncedAt == nil || time.Since(parseTime(syncedAt)) > r.stalenessThreshold
-
-	// Always refresh in background to avoid blocking on directory listings (e.g., find)
-	if isStale {
-		r.triggerBackgroundRefresh("initiative-updates:"+initiativeID, func(ctx context.Context) error {
-			return r.refreshInitiativeUpdates(ctx, initiativeID)
-		})
-	}
 }
 
 // refreshInitiativeUpdates fetches updates from API and stores in SQLite

--- a/internal/repo/sqlite_test.go
+++ b/internal/repo/sqlite_test.go
@@ -1846,46 +1846,31 @@ func TestSQLiteRepository_MaybeRefreshIssueDetails_NoClient(t *testing.T) {
 	repo.MaybeRefreshIssueDetails("issue-2")
 }
 
-func TestSQLiteRepository_MaybeRefreshProjectDocuments_NoClient(t *testing.T) {
+// The four Get*Documents/Get*Updates read paths must be safe no-ops in fixture
+// mode (nil client): maybeRefresh short-circuits, so the read returns whatever
+// is cached without touching the API. Exercised through the real Get* methods
+// now that the per-entity maybeRefresh* wrappers fold into one helper.
+func TestSQLiteRepository_StaleReadPaths_NoClient(t *testing.T) {
 	t.Parallel()
 	store, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	// Create repo without API client
 	repo := NewSQLiteRepository(store, nil)
 	defer repo.Close()
+	ctx := context.Background()
 
-	// Should be a no-op - no panic
-	repo.maybeRefreshProjectDocuments("project-1", true)
-	repo.maybeRefreshProjectDocuments("project-2", false)
-}
-
-func TestSQLiteRepository_MaybeRefreshProjectUpdates_NoClient(t *testing.T) {
-	t.Parallel()
-	store, cleanup := setupTestDB(t)
-	defer cleanup()
-
-	// Create repo without API client
-	repo := NewSQLiteRepository(store, nil)
-	defer repo.Close()
-
-	// Should be a no-op - no panic
-	repo.maybeRefreshProjectUpdates("project-1", true)
-	repo.maybeRefreshProjectUpdates("project-2", false)
-}
-
-func TestSQLiteRepository_MaybeRefreshInitiativeUpdates_NoClient(t *testing.T) {
-	t.Parallel()
-	store, cleanup := setupTestDB(t)
-	defer cleanup()
-
-	// Create repo without API client
-	repo := NewSQLiteRepository(store, nil)
-	defer repo.Close()
-
-	// Should be a no-op - no panic
-	repo.maybeRefreshInitiativeUpdates("init-1", true)
-	repo.maybeRefreshInitiativeUpdates("init-2", false)
+	if _, err := repo.GetProjectDocuments(ctx, "project-1"); err != nil {
+		t.Errorf("GetProjectDocuments (nil client): %v", err)
+	}
+	if _, err := repo.GetInitiativeDocuments(ctx, "init-1"); err != nil {
+		t.Errorf("GetInitiativeDocuments (nil client): %v", err)
+	}
+	if _, err := repo.GetProjectUpdates(ctx, "project-1"); err != nil {
+		t.Errorf("GetProjectUpdates (nil client): %v", err)
+	}
+	if _, err := repo.GetInitiativeUpdates(ctx, "init-1"); err != nil {
+		t.Errorf("GetInitiativeUpdates (nil client): %v", err)
+	}
 }
 
 // =============================================================================
@@ -2658,6 +2643,47 @@ func TestReconcileAgainst_DeletesOrphans(t *testing.T) {
 	}
 	if len(want) != 0 {
 		t.Errorf("orphans not deleted: %v", want)
+	}
+}
+
+// TestStaleSince pins the staleness rule the four Get*Documents/Get*Updates
+// read paths share via maybeRefresh — the parseTime/threshold comparison that
+// has historically hidden timezone bugs.
+func TestStaleSince(t *testing.T) {
+	t.Parallel()
+	const threshold = time.Hour
+	cases := []struct {
+		name     string
+		syncedAt interface{}
+		err      error
+		want     bool
+	}{
+		{"query error is stale", nil, fmt.Errorf("boom"), true},
+		{"never synced (nil) is stale", nil, nil, true},
+		{"recently synced is fresh", time.Now(), nil, false},
+		{"older than threshold is stale", time.Now().Add(-2 * threshold), nil, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := staleSince(c.syncedAt, c.err, threshold); got != c.want {
+				t.Errorf("staleSince(%v, %v) = %v, want %v", c.syncedAt, c.err, got, c.want)
+			}
+		})
+	}
+}
+
+// TestMaybeRefreshNilClientNoop: in fixture mode (nil client) maybeRefresh must
+// short-circuit before even querying syncedAt — no refresh, no query.
+func TestMaybeRefreshNilClientNoop(t *testing.T) {
+	t.Parallel()
+	repo := &SQLiteRepository{} // nil client
+	queried := false
+	repo.maybeRefresh("k",
+		func() (interface{}, error) { queried = true; return nil, nil },
+		func(_ context.Context) error { return nil },
+	)
+	if queried {
+		t.Error("maybeRefresh queried syncedAt with a nil client; want a no-op")
 	}
 }
 


### PR DESCRIPTION
Seventh review, candidate #4 — the stale-while-revalidate read helper.

## Problem
`GetProjectDocuments`, `GetInitiativeDocuments`, `GetProjectUpdates`, and `GetInitiativeUpdates` each had a `maybeRefresh<Entity>` wrapper restating the *identical* staleness/trigger policy: nil-client guard → `err != nil || syncedAt == nil || time.Since(parseTime(syncedAt)) > threshold` → deduplicated background refresh. Only the synced_at query, the dedup key, and the refresh func varied. Every wrapper also carried an `isEmpty` param that nothing read.

## Fix
Collapse the four wrappers into one `maybeRefresh(key, syncedAt, refresh)`. The policy lives once; each `Get*` passes three thin closures; the dead `isEmpty` is gone. The entity-specific `refresh*` bodies (different API calls + upsert params) **stay separate** — they're not the duplication, so the deletion test only applies to the staleness layer. `MaybeRefreshIssueDetails` and `maybeRefreshHistory` use a different "changed-since" staleness model and are left alone.

## Testability
Pulled the staleness rule out as a pure `staleSince(syncedAt, err, threshold)` predicate with a direct table test — the `parseTime`/threshold comparison has historically hidden timezone bugs. The four per-entity nil-client no-op tests collapse into one that drives the real `Get*` read paths in fixture mode.

Net −31 lines in sqlite.go; full suite + vet green; additions gofmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)