### PR TITLE
fix(sync): derive label team_id from the label's own team, not the syncing team

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -186,10 +186,13 @@ pre-fetch `synced_at` cutoff so mid-sync writes survive, is gated on a
 per-entity clean flag (skipped when that entity's fetch or any upsert failed),
 and runs only against a drained fetch — a truncated list reads as removals.
 `states` are workflow-bounded and fetched single-page, so they stay
-upsert-only. Workspace labels commingle into `labels` under whichever team
-synced them, but every team fetch re-includes all workspace labels (via
-`issueLabels`), so they are always refreshed above the cutoff and never pruned
-by a team that no longer "owns" them.
+upsert-only. A label's `team_id` follows its own `team` (fetched via the
+`LabelFields` fragment) — `nil` means a workspace-level label, stored
+`team_id=NULL` — so a workspace label no longer churns to whichever team's
+sync last touched it (`team.labels` returns workspace labels mixed in, which
+is why stamping the syncing team was wrong). The team prune targets
+`team_id = <team>`, so `NULL` workspace labels are outside every team's prune
+scope.
 
 ### ErrorSink
 The minimal seam the WriteBack tail uses to record validation/divergence messages for

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -139,6 +139,7 @@ fragment LabelFields on IssueLabel {
   name
   color
   description
+  team { id }
 }
 `
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -108,6 +108,11 @@ type Label struct {
 	Name        string `json:"name"`
 	Color       string `json:"color"`
 	Description string `json:"description"`
+	// Team is the label's owning team, or nil for a workspace-level label.
+	// Only the ID is fetched (team { id }); it is the authoritative source for
+	// the labels row's team_id, so a workspace label stays team_id=NULL no
+	// matter which team's sync pass touches it.
+	Team *Team `json:"team,omitempty"`
 }
 
 type Project struct {

--- a/internal/db/convert.go
+++ b/internal/db/convert.go
@@ -210,11 +210,20 @@ func DBStatesToAPIStates(states []State) []api.State {
 // Label Conversion
 // =============================================================================
 
-// APILabelToDBLabel converts an api.Label to UpsertLabelParams
-func APILabelToDBLabel(label api.Label, teamID string) (UpsertLabelParams, error) {
+// APILabelToDBLabel converts an api.Label to UpsertLabelParams. The row's
+// team_id comes from the label's own team — Linear's authoritative source —
+// not the team whose sync pass is running: a nil team is a workspace-level
+// label and stays team_id=NULL, so it no longer churns to whichever team
+// synced it last (team.labels returns workspace labels mixed in, so the old
+// caller-supplied teamID mis-stamped them).
+func APILabelToDBLabel(label api.Label) (UpsertLabelParams, error) {
 	data, err := json.Marshal(label)
 	if err != nil {
 		return UpsertLabelParams{}, err
+	}
+	teamID := ""
+	if label.Team != nil {
+		teamID = label.Team.ID
 	}
 	return UpsertLabelParams{
 		ID:          label.ID,

--- a/internal/db/convert_test.go
+++ b/internal/db/convert_test.go
@@ -175,26 +175,42 @@ func TestDBStatesToAPIStates(t *testing.T) {
 
 func TestAPILabelToDBLabel(t *testing.T) {
 	t.Parallel()
-	label := api.Label{
+
+	// A team-scoped label carries its team; team_id follows label.Team, not a
+	// caller-supplied value.
+	teamLabel := api.Label{
 		ID:          "label-1",
 		Name:        "Bug",
 		Description: "Bug reports",
 		Color:       "#ff0000",
+		Team:        &api.Team{ID: "team-1"},
 	}
-
-	params, err := APILabelToDBLabel(label, "team-1")
+	params, err := APILabelToDBLabel(teamLabel)
 	if err != nil {
 		t.Fatalf("APILabelToDBLabel failed: %v", err)
 	}
-
-	if params.ID != label.ID {
+	if params.ID != teamLabel.ID {
 		t.Errorf("ID mismatch")
 	}
-	if params.Name != label.Name {
+	if params.Name != teamLabel.Name {
 		t.Errorf("Name mismatch")
 	}
-	if params.Color.String != label.Color {
+	if params.Color.String != teamLabel.Color {
 		t.Errorf("Color mismatch")
+	}
+	if !params.TeamID.Valid || params.TeamID.String != "team-1" {
+		t.Errorf("team_id = %+v, want team-1 (from label.Team)", params.TeamID)
+	}
+
+	// A workspace-level label has no team; team_id must stay NULL so it does
+	// not churn to whichever team's sync last touched it.
+	wsLabel := api.Label{ID: "label-2", Name: "Workspace", Team: nil}
+	wsParams, err := APILabelToDBLabel(wsLabel)
+	if err != nil {
+		t.Fatalf("APILabelToDBLabel (workspace) failed: %v", err)
+	}
+	if wsParams.TeamID.Valid {
+		t.Errorf("workspace label team_id = %q, want NULL", wsParams.TeamID.String)
 	}
 }
 

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -438,10 +438,9 @@ DELETE FROM project_teams WHERE team_id = ? AND synced_at < ?;
 -- Prune the team metadata rows the drained (complete) metadata fetch no
 -- longer returned: renamed or deleted labels, cycles, and departed members.
 -- Same contract as PruneProjectTeams, only safe against a complete fetch with
--- the cutoff taken before the sync upserts. Workspace labels commingle into
--- the labels table under whichever team synced them, but every team fetch
--- re-includes all workspace labels (via issueLabels), so they are always
--- refreshed above the cutoff before this prune runs and are never removed here.
+-- the cutoff taken before the sync upserts. A label's team_id follows its own
+-- team, so workspace labels are stored team_id=NULL and sit outside this
+-- team-scoped prune entirely (only genuine team labels are removed here).
 -- name: PruneTeamLabels :exec
 DELETE FROM labels WHERE team_id = ? AND synced_at < ?;
 

--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -327,7 +327,13 @@ func (lfs *LinearFS) UpsertLabel(ctx context.Context, teamID string, label api.L
 	if lfs.store == nil {
 		return nil // SQLite not enabled, skip silently
 	}
-	params, err := db.APILabelToDBLabel(label, teamID)
+	// A label created/edited under teams/{KEY}/labels is team-scoped; if the
+	// mutation response didn't carry team, stamp the known context so it isn't
+	// mistaken for a workspace label. A workspace label keeps team.
+	if label.Team == nil && teamID != "" {
+		label.Team = &api.Team{ID: teamID}
+	}
+	params, err := db.APILabelToDBLabel(label)
 	if err != nil {
 		return err
 	}

--- a/internal/repo/sqlite_test.go
+++ b/internal/repo/sqlite_test.go
@@ -286,7 +286,8 @@ func TestSQLiteRepository_Labels(t *testing.T) {
 		{ID: "l2", Name: "Feature", Color: "#00ff00"},
 	}
 	for _, label := range labels {
-		params, _ := db.APILabelToDBLabel(label, "team-1")
+		label.Team = &api.Team{ID: "team-1"}
+		params, _ := db.APILabelToDBLabel(label)
 		if err := store.Queries().UpsertLabel(ctx, params); err != nil {
 			t.Fatalf("setup: %v", err)
 		}
@@ -590,8 +591,8 @@ func TestSQLiteRepository_IssuesByLabel(t *testing.T) {
 	}
 
 	// Insert label
-	label := api.Label{ID: "label-1", Name: "Bug", Color: "#ff0000"}
-	labelParams, _ := db.APILabelToDBLabel(label, "team-1")
+	label := api.Label{ID: "label-1", Name: "Bug", Color: "#ff0000", Team: &api.Team{ID: "team-1"}}
+	labelParams, _ := db.APILabelToDBLabel(label)
 	if err := store.Queries().UpsertLabel(ctx, labelParams); err != nil {
 		t.Fatalf("setup: %v", err)
 	}

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -561,7 +561,10 @@ func (w *Worker) syncTeamMetadata(ctx context.Context, team api.Team) error {
 	// Process labels (already deduplicated by GetTeamMetadata)
 	labelsClean := true
 	for _, label := range meta.Labels {
-		params, err := db.APILabelToDBLabel(label, team.ID)
+		// team_id comes from label.Team (fetched via the LabelFields fragment),
+		// not team.ID: team.labels returns workspace labels mixed in, so
+		// stamping team.ID here is what churned workspace labels between teams.
+		params, err := db.APILabelToDBLabel(label)
 		if err != nil {
 			log.Printf("[sync] convert label %s failed: %v", label.Name, err)
 			labelsClean = false

--- a/internal/testutil/fixtures/fstest.go
+++ b/internal/testutil/fixtures/fstest.go
@@ -133,7 +133,8 @@ func PopulateTestData(ctx context.Context, store *db.Store) error {
 
 	// Insert labels
 	for _, label := range FixtureAPILabels() {
-		labelParams, err := db.APILabelToDBLabel(label, team.ID)
+		label.Team = &api.Team{ID: team.ID} // team-scoped fixture labels
+		labelParams, err := db.APILabelToDBLabel(label)
 		if err != nil {
 			return err
 		}
@@ -199,7 +200,8 @@ func PopulateTeam(
 
 	// Insert labels
 	for _, label := range labels {
-		labelParams, err := db.APILabelToDBLabel(label, team.ID)
+		label.Team = &api.Team{ID: team.ID} // team-scoped fixture labels
+		labelParams, err := db.APILabelToDBLabel(label)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Seventh review, candidate #6 — the workspace-label `team_id` churn bug.

## Bug
`GetTeamMetadata` fetches `team.labels` and `issueLabels`, merges them (losing the source), and `syncTeamMetadata` stamped every label with the *syncing* team's ID. Since `ListTeamLabels` is `WHERE team_id = ? OR team_id IS NULL`, a workspace label stamped `team_id=ENG` then **vanished** from DES's label list — workspace labels flickered between teams by sync order. A live probe confirmed `team.labels` even returns workspace labels (`team: null`) mixed in, so stamping the syncing team was wrong at the source.

## Fix
Fetch each label's own `team { id }` (added to the shared `LabelFields` fragment) and make it authoritative. `APILabelToDBLabel` drops its `teamID` param and reads `team_id` from `label.Team` — nil ⇒ workspace label ⇒ `team_id=NULL`, so no churn. The fs create path (team-scoped labels under `teams/{KEY}/labels`) stamps the known team when a mutation response omits it; sync never does.

## Live complexity pre-flight
The fattened combined metadata query with `team { id }` on both label connections passes Linear's budget — `team { id }` is a cheap to-one scalar, unlike the nested `team.projects` that had to be moved out earlier.

## Tests
`APILabelToDBLabel` now asserts team-scoped → `team_id` set, and workspace (nil team) → `NULL`. CONTEXT.md + `PruneTeamLabels` comment updated: workspace labels are `team_id=NULL` and sit outside every team-scoped prune.

Full suite + vet + gofmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)