### PR TITLE
refactor(fs): one construction path for dir/file attrs (nodeAttr/attrNode)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -155,6 +155,40 @@ something that doesn't exist -> `ENOENT` at Lookup, never a dangling
 placeholder. Lives in `internal/fs/symlink.go`;
 unit-tested directly, no FUSE mount.
 
+### Attr construction (`nodeAttr`/`attrNode`)
+The **deep module** owning how a directory or file node's attributes are
+constructed — the non-symlink complement to Symlink views (`symlinkNode`), and
+the same guarantee: construction fixes the reporting data, so a Lookup answer
+and a later `Getattr` render it identically and can never disagree. `nodeAttr`
+(`{mode, size, created, updated}`, `internal/fs/nodeattr.go`) has one
+`fill(*fuse.Attr)` that owns mode/uid/gid/size/times; the `attrNode` mixin
+(`BaseNode` + a stored `nodeAttr`) **provides the default `Getattr`**, so a
+directory node cannot hand-write a divergent one. The `newDirInode`/`newFileInode`
+`BaseNode` constructors stash the `nodeAttr` on the child, fill the Lookup
+`EntryOut` from that same value, take the entry timeout as an explicit param
+(the deliberate 30s/5s/0/1s classes are preserved verbatim, never rationalized
+here), and return `StableAttr{Mode, Ino}`.
+
+This replaced 54 hand-fabricated attribute blocks whose per-site copies had
+already drifted: `DocsNode`/`AttachmentsNode.Getattr` reported `time.Now()`
+(non-deterministic — every `ls -lt` reshuffled, violating the `mtime=updatedAt`
+convention), and `CommentsNode.Getattr` reported a wrong ctime, all disagreeing
+with the times their parent's Lookup answered. The collapsed contract is the
+issue's times uniformly (`atime/mtime = UpdatedAt`, `ctime = CreatedAt`), which
+forced the directory nodes to become self-describing — carry the times they
+report rather than re-derive them per call.
+
+**Directories vs files.** A directory's attributes are wholly static, so it
+gets the mixin and the inherited `Getattr` (true no-drift). A file's `Size` is
+a *legitimately* dynamic edit-buffer value (it grows after a write and is meant
+to diverge from what Lookup first reported), so a file keeps its own `Getattr`
+and reuses only the immutable half of `nodeAttr.fill` (mode/uid/gid/times) — its
+dynamic size stays owned by the node. Unit-tested directly (the `fill` fields
+plus an anti-drift equality test: the Lookup `EntryOut.Attr` and the node's
+`Getattr` `AttrOut.Attr` must be equal for each directory kind), with a mounted
+attr-conformance/stat-determinism test in `internal/integration` guarding the
+real kernel `Getattr` path.
+
 ### Connection drain (`paginate`)
 The **deep module** owning cursor pagination of Linear GraphQL connections —
 the read-side counterpart to `execMutation`. Linear silently caps a

--- a/internal/fs/attachments.go
+++ b/internal/fs/attachments.go
@@ -40,21 +40,13 @@ func externalAttachmentIno(attachmentID string) uint64 {
 
 // AttachmentsNode represents the /teams/{KEY}/issues/{ID}/attachments directory
 type AttachmentsNode struct {
-	BaseNode
+	attrNode
 	issueID string
 }
 
 var _ fs.NodeReaddirer = (*AttachmentsNode)(nil)
 var _ fs.NodeLookuper = (*AttachmentsNode)(nil)
 var _ fs.NodeGetattrer = (*AttachmentsNode)(nil)
-
-func (n *AttachmentsNode) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0755 | syscall.S_IFDIR
-	n.SetOwner(out)
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
 
 func (n *AttachmentsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	// Trigger background refresh of sub-resources if stale

--- a/internal/fs/attachments_test.go
+++ b/internal/fs/attachments_test.go
@@ -74,7 +74,7 @@ func TestCreateAttachmentIdempotentOnDuplicate(t *testing.T) {
 	attErrKey := collectionErrorKey("attachments", issueID)
 	lfs.SetWriteError(attErrKey, "stale error from a prior failure")
 
-	dir := &AttachmentsNode{BaseNode: BaseNode{lfs: lfs}, issueID: issueID}
+	dir := &AttachmentsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}, issueID: issueID}
 	// A trailing slash must still be recognized as the same URL.
 	if errno := dir.createAttachment(ctx, []byte(url+"/\n")); errno != 0 {
 		t.Fatalf("createAttachment() on duplicate URL errno = %d, want 0 (idempotent no-op)", errno)

--- a/internal/fs/comments.go
+++ b/internal/fs/comments.go
@@ -34,10 +34,9 @@ func commentIno(commentID string) uint64 {
 
 // CommentsNode represents /teams/{KEY}/issues/{ID}/comments/
 type CommentsNode struct {
-	BaseNode
-	issueID        string
-	teamID         string
-	issueUpdatedAt time.Time
+	attrNode
+	issueID string
+	teamID  string
 }
 
 var _ fs.NodeReaddirer = (*CommentsNode)(nil)
@@ -45,13 +44,6 @@ var _ fs.NodeLookuper = (*CommentsNode)(nil)
 var _ fs.NodeCreater = (*CommentsNode)(nil)
 var _ fs.NodeUnlinker = (*CommentsNode)(nil)
 var _ fs.NodeGetattrer = (*CommentsNode)(nil)
-
-func (n *CommentsNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	out.Mode = 0755 | syscall.S_IFDIR
-	n.SetOwner(out)
-	out.SetTimes(&n.issueUpdatedAt, &n.issueUpdatedAt, &n.issueUpdatedAt)
-	return 0
-}
 
 func (n *CommentsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	// Trigger background refresh of sub-resources if stale
@@ -116,18 +108,8 @@ func (n *CommentsNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 				content:      content,
 				contentReady: true,
 			}
-			out.Attr.Mode = 0644 | syscall.S_IFREG // Read-write
-			out.Attr.Uid = n.lfs.uid
-			out.Attr.Gid = n.lfs.gid
-			out.Attr.Size = uint64(len(content))
-			out.SetAttrTimeout(5 * time.Second)  // Shorter timeout for writable files
-			out.SetEntryTimeout(5 * time.Second) // Shorter timeout for writable files
-			// Use updatedAt for mtime (comments can be edited)
-			out.Attr.SetTimes(&comment.UpdatedAt, &comment.UpdatedAt, &comment.CreatedAt)
-			return n.NewInode(ctx, node, fs.StableAttr{
-				Mode: syscall.S_IFREG,
-				Ino:  commentIno(comment.ID),
-			}), 0
+			// Shorter timeout for writable files.
+			return n.newFileInode(ctx, out, node, fileAttr(len(content), comment.CreatedAt, comment.UpdatedAt), commentIno(comment.ID), 5*time.Second), 0
 		}
 	}
 

--- a/internal/fs/documents.go
+++ b/internal/fs/documents.go
@@ -31,7 +31,7 @@ func documentIno(docID string) uint64 {
 
 // DocsNode represents a docs/ directory within issues, teams, projects, or initiatives
 type DocsNode struct {
-	BaseNode
+	attrNode
 	issueID      string // Set if issue docs
 	teamID       string // Set if team docs
 	projectID    string // Set if project docs
@@ -44,14 +44,6 @@ var _ fs.NodeCreater = (*DocsNode)(nil)
 var _ fs.NodeUnlinker = (*DocsNode)(nil)
 var _ fs.NodeRenamer = (*DocsNode)(nil)
 var _ fs.NodeGetattrer = (*DocsNode)(nil)
-
-func (n *DocsNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0755 | syscall.S_IFDIR
-	n.SetOwner(out)
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
 
 func (n *DocsNode) getDocuments(ctx context.Context) ([]api.Document, error) {
 	if n.issueID != "" {
@@ -247,17 +239,8 @@ func (n *DocsNode) newDocumentInode(ctx context.Context, doc api.Document, out *
 		content:      content,
 		contentReady: true,
 	}
-	out.Attr.Mode = 0644 | syscall.S_IFREG
-	out.Attr.Uid = n.lfs.uid
-	out.Attr.Gid = n.lfs.gid
-	out.Attr.Size = uint64(len(content))
-	out.SetAttrTimeout(5 * time.Second)  // Shorter timeout for writable files
-	out.SetEntryTimeout(5 * time.Second) // Shorter timeout for writable files
-	out.Attr.SetTimes(&doc.UpdatedAt, &doc.UpdatedAt, &doc.CreatedAt)
-	return n.NewInode(ctx, node, fs.StableAttr{
-		Mode: syscall.S_IFREG,
-		Ino:  documentIno(doc.ID),
-	}), 0
+	// Shorter timeout for writable files.
+	return n.newFileInode(ctx, out, node, fileAttr(len(content), doc.CreatedAt, doc.UpdatedAt), documentIno(doc.ID), 5*time.Second), 0
 }
 
 func (n *DocsNode) Create(ctx context.Context, name string, flags uint32, mode uint32, out *fuse.EntryOut) (*fs.Inode, fs.FileHandle, uint32, syscall.Errno) {

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -143,15 +143,7 @@ func (i *InitiativeNode) Lookup(ctx context.Context, name string, out *fuse.Entr
 	case "initiative.md":
 		node := &InitiativeInfoNode{BaseNode: BaseNode{lfs: i.lfs}, initiative: i.initiative, initiativeID: i.initiative.ID}
 		content := node.generateContent()
-		out.Attr.Mode = 0644 | syscall.S_IFREG
-		out.Attr.Uid = i.lfs.uid
-		out.Attr.Gid = i.lfs.gid
-		out.Attr.Size = uint64(len(content))
-		out.Attr.SetTimes(&i.initiative.UpdatedAt, &i.initiative.UpdatedAt, &i.initiative.CreatedAt)
-		return i.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFREG,
-			Ino:  initiativeInfoIno(i.initiative.ID),
-		}), 0
+		return i.newFileInode(ctx, out, node, fileAttr(len(content), i.initiative.CreatedAt, i.initiative.UpdatedAt), initiativeInfoIno(i.initiative.ID), 0), 0
 
 	case "initiative.meta":
 		// Read-through from the freshest initiative so an edit to initiative.md is
@@ -177,31 +169,16 @@ func (i *InitiativeNode) Lookup(ctx context.Context, name string, out *fuse.Entr
 		return i.lfs.lookupErrorFile(ctx, i, i.initiative.ID, out), 0
 
 	case "docs":
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = i.lfs.uid
-		out.Attr.Gid = i.lfs.gid
-		out.Attr.SetTimes(&i.initiative.UpdatedAt, &i.initiative.UpdatedAt, &i.initiative.CreatedAt)
-		node := &DocsNode{BaseNode: BaseNode{lfs: i.lfs}, initiativeID: i.initiative.ID}
-		return i.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFDIR, Ino: docsDirIno(i.initiative.ID)}), 0
+		node := &DocsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: i.lfs}}, initiativeID: i.initiative.ID}
+		return i.newDirInode(ctx, out, node, dirAttr(i.initiative.CreatedAt, i.initiative.UpdatedAt), docsDirIno(i.initiative.ID), 0), 0
 
 	case "projects":
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = i.lfs.uid
-		out.Attr.Gid = i.lfs.gid
-		out.Attr.SetTimes(&i.initiative.UpdatedAt, &i.initiative.UpdatedAt, &i.initiative.CreatedAt)
-		node := &InitiativeProjectsNode{BaseNode: BaseNode{lfs: i.lfs}, initiative: i.initiative}
-		return i.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFDIR,
-			Ino:  initiativeProjectsIno(i.initiative.ID),
-		}), 0
+		node := &InitiativeProjectsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: i.lfs}}, initiative: i.initiative}
+		return i.newDirInode(ctx, out, node, dirAttr(i.initiative.CreatedAt, i.initiative.UpdatedAt), initiativeProjectsIno(i.initiative.ID), 0), 0
 
 	case "updates":
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = i.lfs.uid
-		out.Attr.Gid = i.lfs.gid
-		out.Attr.SetTimes(&i.initiative.UpdatedAt, &i.initiative.UpdatedAt, &i.initiative.CreatedAt)
-		node := &InitiativeUpdatesNode{BaseNode: BaseNode{lfs: i.lfs}, initiativeID: i.initiative.ID, initiativeUpdatedAt: i.initiative.UpdatedAt}
-		return i.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
+		node := &InitiativeUpdatesNode{attrNode: attrNode{BaseNode: BaseNode{lfs: i.lfs}}, initiativeID: i.initiative.ID}
+		return i.newDirInode(ctx, out, node, dirAttr(i.initiative.CreatedAt, i.initiative.UpdatedAt), initiativeUpdatesDirIno(i.initiative.ID), 0), 0
 	}
 
 	return nil, syscall.ENOENT
@@ -580,20 +557,13 @@ func (i *InitiativeInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall
 
 // InitiativeProjectsNode represents the projects/ directory within an initiative
 type InitiativeProjectsNode struct {
-	BaseNode
+	attrNode
 	initiative api.Initiative
 }
 
 var _ fs.NodeReaddirer = (*InitiativeProjectsNode)(nil)
 var _ fs.NodeLookuper = (*InitiativeProjectsNode)(nil)
 var _ fs.NodeGetattrer = (*InitiativeProjectsNode)(nil)
-
-func (p *InitiativeProjectsNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	out.Mode = 0755 | syscall.S_IFDIR
-	p.SetOwner(out)
-	out.SetTimes(&p.initiative.UpdatedAt, &p.initiative.UpdatedAt, &p.initiative.CreatedAt)
-	return 0
-}
 
 func (p *InitiativeProjectsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	entries := make([]fuse.DirEntry, len(p.initiative.Projects.Nodes))
@@ -664,22 +634,14 @@ func initiativeProjectDirName(proj api.InitiativeProject) string {
 
 // InitiativeUpdatesNode represents /initiatives/{slug}/updates/
 type InitiativeUpdatesNode struct {
-	BaseNode
-	initiativeID        string
-	initiativeUpdatedAt time.Time
+	attrNode
+	initiativeID string
 }
 
 var _ fs.NodeReaddirer = (*InitiativeUpdatesNode)(nil)
 var _ fs.NodeLookuper = (*InitiativeUpdatesNode)(nil)
 var _ fs.NodeCreater = (*InitiativeUpdatesNode)(nil)
 var _ fs.NodeGetattrer = (*InitiativeUpdatesNode)(nil)
-
-func (n *InitiativeUpdatesNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	out.Mode = 0755 | syscall.S_IFDIR
-	n.SetOwner(out)
-	out.SetTimes(&n.initiativeUpdatedAt, &n.initiativeUpdatedAt, &n.initiativeUpdatedAt)
-	return 0
-}
 
 func (n *InitiativeUpdatesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	updates, err := n.lfs.GetInitiativeUpdates(ctx, n.initiativeID)

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -393,17 +393,7 @@ func (n *IssueDirectoryNode) Lookup(ctx context.Context, name string, out *fuse.
 			content:      content,
 			contentReady: true,
 		}
-		out.Attr.Mode = 0644 | syscall.S_IFREG
-		out.Attr.Uid = n.lfs.uid
-		out.Attr.Gid = n.lfs.gid
-		out.Attr.Size = uint64(len(content))
-		out.SetAttrTimeout(30 * time.Second)
-		out.SetEntryTimeout(30 * time.Second)
-		out.Attr.SetTimes(&n.issue.UpdatedAt, &n.issue.UpdatedAt, &n.issue.CreatedAt)
-		return n.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFREG,
-			Ino:  issueIno(n.issue.ID),
-		}), 0
+		return n.newFileInode(ctx, out, node, fileAttr(len(content), n.issue.CreatedAt, n.issue.UpdatedAt), issueIno(n.issue.ID), 30*time.Second), 0
 
 	case "issue.meta":
 		// Read-only server-managed fields (identity, timestamps, links, relations),
@@ -443,17 +433,8 @@ func (n *IssueDirectoryNode) Lookup(ctx context.Context, name string, out *fuse.
 			content:      content,
 			contentReady: true,
 		}
-		out.Attr.Mode = 0444 | syscall.S_IFREG // Read-only
-		out.Attr.Uid = n.lfs.uid
-		out.Attr.Gid = n.lfs.gid
-		out.Attr.Size = uint64(len(content))
-		out.SetAttrTimeout(30 * time.Second)
-		out.SetEntryTimeout(30 * time.Second)
-		out.Attr.SetTimes(&n.issue.UpdatedAt, &n.issue.UpdatedAt, &n.issue.CreatedAt)
-		return n.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFREG,
-			Ino:  historyIno(n.issue.ID),
-		}), 0
+		historyAttr := nodeAttr{mode: 0444 | syscall.S_IFREG, size: uint64(len(content)), created: n.issue.CreatedAt, updated: n.issue.UpdatedAt}
+		return n.newFileInode(ctx, out, node, historyAttr, historyIno(n.issue.ID), 30*time.Second), 0
 
 	case ".error":
 		return n.lfs.lookupErrorFile(ctx, n, n.issue.ID, out), 0
@@ -468,69 +449,32 @@ func (n *IssueDirectoryNode) Lookup(ctx context.Context, name string, out *fuse.
 			teamID = n.issue.Team.ID
 		}
 		node := &CommentsNode{
-			BaseNode:       BaseNode{lfs: n.lfs},
-			issueID:        n.issue.ID,
-			teamID:         teamID,
-			issueUpdatedAt: n.issue.UpdatedAt,
+			attrNode: attrNode{BaseNode: BaseNode{lfs: n.lfs}},
+			issueID:  n.issue.ID,
+			teamID:   teamID,
 		}
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = n.lfs.uid
-		out.Attr.Gid = n.lfs.gid
-		out.Attr.SetTimes(&n.issue.UpdatedAt, &n.issue.UpdatedAt, &n.issue.CreatedAt)
-		out.SetAttrTimeout(30 * time.Second)
-		out.SetEntryTimeout(30 * time.Second)
-		return n.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFDIR,
-			Ino:  commentsDirIno(n.issue.ID),
-		}), 0
+		return n.newDirInode(ctx, out, node, dirAttr(n.issue.CreatedAt, n.issue.UpdatedAt), commentsDirIno(n.issue.ID), 30*time.Second), 0
 
 	case "docs":
 		node := &DocsNode{
-			BaseNode: BaseNode{lfs: n.lfs},
+			attrNode: attrNode{BaseNode: BaseNode{lfs: n.lfs}},
 			issueID:  n.issue.ID,
 		}
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = n.lfs.uid
-		out.Attr.Gid = n.lfs.gid
-		out.Attr.SetTimes(&n.issue.UpdatedAt, &n.issue.UpdatedAt, &n.issue.CreatedAt)
-		out.SetAttrTimeout(30 * time.Second)
-		out.SetEntryTimeout(30 * time.Second)
-		return n.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFDIR,
-			Ino:  docsDirIno(n.issue.ID),
-		}), 0
+		return n.newDirInode(ctx, out, node, dirAttr(n.issue.CreatedAt, n.issue.UpdatedAt), docsDirIno(n.issue.ID), 30*time.Second), 0
 
 	case "children":
 		node := &ChildrenNode{
-			BaseNode: BaseNode{lfs: n.lfs},
+			attrNode: attrNode{BaseNode: BaseNode{lfs: n.lfs}},
 			issue:    n.issue,
 		}
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = n.lfs.uid
-		out.Attr.Gid = n.lfs.gid
-		out.Attr.SetTimes(&n.issue.UpdatedAt, &n.issue.UpdatedAt, &n.issue.CreatedAt)
-		out.SetAttrTimeout(30 * time.Second)
-		out.SetEntryTimeout(30 * time.Second)
-		return n.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFDIR,
-			Ino:  childrenDirIno(n.issue.ID),
-		}), 0
+		return n.newDirInode(ctx, out, node, dirAttr(n.issue.CreatedAt, n.issue.UpdatedAt), childrenDirIno(n.issue.ID), 30*time.Second), 0
 
 	case "attachments":
 		node := &AttachmentsNode{
-			BaseNode: BaseNode{lfs: n.lfs},
+			attrNode: attrNode{BaseNode: BaseNode{lfs: n.lfs}},
 			issueID:  n.issue.ID,
 		}
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = n.lfs.uid
-		out.Attr.Gid = n.lfs.gid
-		out.Attr.SetTimes(&n.issue.UpdatedAt, &n.issue.UpdatedAt, &n.issue.CreatedAt)
-		out.SetAttrTimeout(30 * time.Second)
-		out.SetEntryTimeout(30 * time.Second)
-		return n.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFDIR,
-			Ino:  attachmentsDirIno(n.issue.ID),
-		}), 0
+		return n.newDirInode(ctx, out, node, dirAttr(n.issue.CreatedAt, n.issue.UpdatedAt), attachmentsDirIno(n.issue.ID), 30*time.Second), 0
 
 	case "relations":
 		teamID := ""
@@ -538,20 +482,11 @@ func (n *IssueDirectoryNode) Lookup(ctx context.Context, name string, out *fuse.
 			teamID = n.issue.Team.ID
 		}
 		node := &RelationsNode{
-			BaseNode: BaseNode{lfs: n.lfs},
+			attrNode: attrNode{BaseNode: BaseNode{lfs: n.lfs}},
 			issueID:  n.issue.ID,
 			teamID:   teamID,
 		}
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = n.lfs.uid
-		out.Attr.Gid = n.lfs.gid
-		out.Attr.SetTimes(&n.issue.UpdatedAt, &n.issue.UpdatedAt, &n.issue.CreatedAt)
-		out.SetAttrTimeout(30 * time.Second)
-		out.SetEntryTimeout(30 * time.Second)
-		return n.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFDIR,
-			Ino:  relationsDirIno(n.issue.ID),
-		}), 0
+		return n.newDirInode(ctx, out, node, dirAttr(n.issue.CreatedAt, n.issue.UpdatedAt), relationsDirIno(n.issue.ID), 30*time.Second), 0
 	}
 
 	return nil, syscall.ENOENT
@@ -860,7 +795,7 @@ func (i *IssueFileNode) Fsync(ctx context.Context, f fs.FileHandle, flags uint32
 
 // ChildrenNode represents the /teams/{KEY}/issues/{ID}/children/ directory
 type ChildrenNode struct {
-	BaseNode
+	attrNode
 	issue api.Issue
 }
 
@@ -868,13 +803,6 @@ var _ fs.NodeReaddirer = (*ChildrenNode)(nil)
 var _ fs.NodeLookuper = (*ChildrenNode)(nil)
 var _ fs.NodeGetattrer = (*ChildrenNode)(nil)
 var _ fs.NodeMkdirer = (*ChildrenNode)(nil)
-
-func (n *ChildrenNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	out.Mode = 0755 | syscall.S_IFDIR
-	n.SetOwner(out)
-	out.SetTimes(&n.issue.UpdatedAt, &n.issue.UpdatedAt, &n.issue.CreatedAt)
-	return 0
-}
 
 func (n *ChildrenNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	// Query children from database by parent_id

--- a/internal/fs/labels.go
+++ b/internal/fs/labels.go
@@ -31,7 +31,7 @@ func labelIno(labelID string) uint64 {
 
 // LabelsNode represents the /teams/{KEY}/labels/ directory
 type LabelsNode struct {
-	BaseNode
+	attrNode
 	teamID string
 }
 
@@ -41,14 +41,6 @@ var _ fs.NodeGetattrer = (*LabelsNode)(nil)
 var _ fs.NodeCreater = (*LabelsNode)(nil)
 var _ fs.NodeUnlinker = (*LabelsNode)(nil)
 var _ fs.NodeRenamer = (*LabelsNode)(nil)
-
-func (n *LabelsNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0755 | syscall.S_IFDIR
-	n.SetOwner(out)
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
 
 func (n *LabelsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	labels, err := n.lfs.GetTeamLabels(ctx, n.teamID)

--- a/internal/fs/milestones.go
+++ b/internal/fs/milestones.go
@@ -31,7 +31,7 @@ func milestoneIno(milestoneID string) uint64 {
 
 // MilestonesNode represents a milestones/ directory within a project
 type MilestonesNode struct {
-	BaseNode
+	attrNode
 	projectID string
 }
 
@@ -39,14 +39,6 @@ var _ fs.NodeReaddirer = (*MilestonesNode)(nil)
 var _ fs.NodeLookuper = (*MilestonesNode)(nil)
 var _ fs.NodeUnlinker = (*MilestonesNode)(nil)
 var _ fs.NodeGetattrer = (*MilestonesNode)(nil)
-
-func (n *MilestonesNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0755 | syscall.S_IFDIR
-	n.SetOwner(out)
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
 
 func (n *MilestonesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	milestones, err := n.lfs.GetProjectMilestones(ctx, n.projectID)

--- a/internal/fs/nodeattr.go
+++ b/internal/fs/nodeattr.go
@@ -1,0 +1,102 @@
+package fs
+
+import (
+	"context"
+	"syscall"
+	"time"
+
+	"github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
+)
+
+// nodeAttr is the reporting identity of a directory or file node: the mode,
+// size, and times a Lookup answer and a later Getattr must agree on. Fixing it
+// at construction is what makes the two render identically — the non-symlink
+// complement to symlinkNode. See CONTEXT.md "Attr construction".
+//
+// The time convention matches the rest of the filesystem: atime/mtime report
+// the entity's updatedAt, ctime reports its createdAt.
+type nodeAttr struct {
+	mode    uint32 // full mode incl. the S_IFDIR/S_IFREG type bits
+	size    uint64
+	created time.Time
+	updated time.Time
+}
+
+// fill renders the nodeAttr into a bare fuse.Attr. Both the directory mixin's
+// Getattr and the newDirInode/newFileInode Lookup constructors call this, so a
+// Lookup answer and a subsequent stat cannot disagree. A zero time stays a zero
+// attr (nonZeroTime), never a wrapped year-584-billion timestamp.
+func (na nodeAttr) fill(attr *fuse.Attr, b *BaseNode) {
+	attr.Mode = na.mode
+	b.setOwnerAttr(attr)
+	attr.Size = na.size
+	attr.SetTimes(nonZeroTime(na.updated), nonZeroTime(na.updated), nonZeroTime(na.created))
+}
+
+// dirAttr is the nodeAttr for a standard 0755 directory reporting an entity's
+// times — the shape almost every entity subdirectory (comments/, docs/, …)
+// uses.
+func dirAttr(created, updated time.Time) nodeAttr {
+	return nodeAttr{mode: 0755 | syscall.S_IFDIR, created: created, updated: updated}
+}
+
+// fileAttr is the nodeAttr for a standard 0644 read/write file reporting an
+// entity's times and its current content size.
+func fileAttr(size int, created, updated time.Time) nodeAttr {
+	return nodeAttr{mode: 0644 | syscall.S_IFREG, size: uint64(size), created: created, updated: updated}
+}
+
+// attrNode is the mixin every static-attr directory node embeds instead of
+// BaseNode. It stores the nodeAttr and provides the default Getattr, so a
+// directory node cannot hand-write a divergent one (the drift that had
+// DocsNode/AttachmentsNode reporting time.Now()).
+type attrNode struct {
+	BaseNode
+	na nodeAttr
+}
+
+var _ fs.NodeGetattrer = (*attrNode)(nil)
+
+func (n *attrNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
+	n.fillAttr(&out.Attr)
+	return 0
+}
+
+// fillAttr is the one renderer shared by Getattr and newDirInode.
+func (n *attrNode) fillAttr(attr *fuse.Attr) { n.na.fill(attr, &n.BaseNode) }
+
+// setAttr stashes the reporting identity; called by newDirInode on the child.
+func (n *attrNode) setAttr(na nodeAttr) { n.na = na }
+
+// dirChild is a node that embeds attrNode.
+type dirChild interface {
+	fs.InodeEmbedder
+	setAttr(nodeAttr)
+	fillAttr(*fuse.Attr)
+}
+
+// newDirInode builds a static-attr directory child from a parent's Lookup. It
+// fixes the child's reporting identity, fills the Lookup EntryOut by calling the
+// child's own fillAttr — the exact method its Getattr uses — sets the entry
+// timeout, and returns the inode. A Lookup answer and a later stat therefore
+// render identically by construction.
+func (b *BaseNode) newDirInode(ctx context.Context, out *fuse.EntryOut, child dirChild, na nodeAttr, ino uint64, timeout time.Duration) *fs.Inode {
+	child.setAttr(na)
+	child.fillAttr(&out.Attr)
+	out.SetAttrTimeout(timeout)
+	out.SetEntryTimeout(timeout)
+	return b.NewInode(ctx, child, fs.StableAttr{Mode: na.mode & syscall.S_IFMT, Ino: ino})
+}
+
+// newFileInode fills a file's Lookup EntryOut from a nodeAttr and returns the
+// inode. Unlike a directory a file keeps its own Getattr — its size is a
+// legitimately dynamic edit-buffer value that is meant to diverge from what
+// Lookup first reported — so this installs no inherited Getattr; it only shares
+// the immutable-field construction (mode/uid/gid/times) and the initial size.
+func (b *BaseNode) newFileInode(ctx context.Context, out *fuse.EntryOut, child fs.InodeEmbedder, na nodeAttr, ino uint64, timeout time.Duration) *fs.Inode {
+	na.fill(&out.Attr, b)
+	out.SetAttrTimeout(timeout)
+	out.SetEntryTimeout(timeout)
+	return b.NewInode(ctx, child, fs.StableAttr{Mode: na.mode & syscall.S_IFMT, Ino: ino})
+}

--- a/internal/fs/nodeattr_test.go
+++ b/internal/fs/nodeattr_test.go
@@ -1,0 +1,128 @@
+package fs
+
+import (
+	"context"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/jra3/linear-fuse/internal/config"
+)
+
+func testLFS(t *testing.T) *LinearFS {
+	t.Helper()
+	cfg := &config.Config{APIKey: "test-key", Cache: config.CacheConfig{TTL: 100 * time.Millisecond, MaxEntries: 100}}
+	lfs, err := NewLinearFS(cfg, false)
+	if err != nil {
+		t.Fatalf("NewLinearFS failed: %v", err)
+	}
+	t.Cleanup(func() { lfs.Close() })
+	return lfs
+}
+
+// TestNodeAttrFill pins the field mapping: atime/mtime report updatedAt, ctime
+// reports createdAt, uid/gid come from the mount, and the mode carries through.
+func TestNodeAttrFill(t *testing.T) {
+	t.Parallel()
+	lfs := testLFS(t)
+	created := time.Unix(1_700_000_000, 0)
+	updated := time.Unix(1_700_009_999, 0)
+
+	na := nodeAttr{mode: 0755 | syscall.S_IFDIR, size: 42, created: created, updated: updated}
+	b := &BaseNode{lfs: lfs}
+	var attr fuse.Attr
+	na.fill(&attr, b)
+
+	if attr.Mode != na.mode {
+		t.Errorf("mode = %o, want %o", attr.Mode, na.mode)
+	}
+	if attr.Size != 42 {
+		t.Errorf("size = %d, want 42", attr.Size)
+	}
+	if attr.Uid != lfs.uid || attr.Gid != lfs.gid {
+		t.Errorf("owner = %d/%d, want %d/%d", attr.Uid, attr.Gid, lfs.uid, lfs.gid)
+	}
+	if int64(attr.Mtime) != updated.Unix() {
+		t.Errorf("mtime = %d, want %d (updatedAt)", attr.Mtime, updated.Unix())
+	}
+	if int64(attr.Atime) != updated.Unix() {
+		t.Errorf("atime = %d, want %d (updatedAt)", attr.Atime, updated.Unix())
+	}
+	if int64(attr.Ctime) != created.Unix() {
+		t.Errorf("ctime = %d, want %d (createdAt)", attr.Ctime, created.Unix())
+	}
+}
+
+// TestNodeAttrZeroTimeStaysEpoch guards the nonZeroTime handling: a zero time
+// must render as a zero attr, never a wrapped far-future timestamp.
+func TestNodeAttrZeroTimeStaysEpoch(t *testing.T) {
+	t.Parallel()
+	lfs := testLFS(t)
+	na := nodeAttr{mode: 0755 | syscall.S_IFDIR}
+	b := &BaseNode{lfs: lfs}
+	var attr fuse.Attr
+	na.fill(&attr, b)
+	if attr.Mtime != 0 || attr.Ctime != 0 || attr.Atime != 0 {
+		t.Errorf("zero times must stay 0, got atime=%d mtime=%d ctime=%d", attr.Atime, attr.Mtime, attr.Ctime)
+	}
+}
+
+// dirAttrNode is every constructed directory node: it carries a nodeAttr and
+// reports it through the attrNode mixin's promoted methods. fillAttr is the
+// Lookup-answer path (what newDirInode uses); Getattr is the stat path.
+type dirAttrNode interface {
+	setAttr(nodeAttr)
+	fillAttr(*fuse.Attr)
+	Getattr(context.Context, fs.FileHandle, *fuse.AttrOut) syscall.Errno
+}
+
+// TestDirNodeLookupGetattrAgree is the anti-drift guarantee in executable form:
+// the attributes a directory node's Lookup answer carries must equal what a
+// later Getattr reports, for every constructed directory kind. This is the
+// regression proof for the time.Now()/wrong-ctime bug that had a stat disagree
+// with — and reshuffle against — its own listing. Because both paths render the
+// one stored nodeAttr, a node that hand-wrote a divergent Getattr fails here.
+func TestDirNodeLookupGetattrAgree(t *testing.T) {
+	t.Parallel()
+	lfs := testLFS(t)
+	created := time.Unix(1_650_000_000, 0)
+	updated := time.Unix(1_650_050_000, 0)
+	na := dirAttr(created, updated)
+
+	nodes := map[string]dirAttrNode{
+		"comments":            &CommentsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"docs":                &DocsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"attachments":         &AttachmentsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"relations":           &RelationsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"children":            &ChildrenNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"milestones":          &MilestonesNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"updates":             &UpdatesNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"labels":              &LabelsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"initiative-updates":  &InitiativeUpdatesNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"initiative-projects": &InitiativeProjectsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+	}
+
+	for name, node := range nodes {
+		t.Run(name, func(t *testing.T) {
+			node.setAttr(na)
+
+			var lookup fuse.Attr
+			node.fillAttr(&lookup)
+
+			var stat fuse.AttrOut
+			if errno := node.Getattr(context.Background(), nil, &stat); errno != 0 {
+				t.Fatalf("Getattr errno = %d", errno)
+			}
+
+			if lookup != stat.Attr {
+				t.Errorf("Lookup answer and Getattr disagree:\n lookup=%+v\n getattr=%+v", lookup, stat.Attr)
+			}
+			if int64(stat.Attr.Mtime) != updated.Unix() || int64(stat.Attr.Ctime) != created.Unix() {
+				t.Errorf("times not deterministic: mtime=%d ctime=%d want mtime=%d ctime=%d",
+					stat.Attr.Mtime, stat.Attr.Ctime, updated.Unix(), created.Unix())
+			}
+		})
+	}
+}

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -275,15 +275,7 @@ func (p *ProjectNode) Lookup(ctx context.Context, name string, out *fuse.EntryOu
 	if name == "project.md" {
 		node := &ProjectInfoNode{BaseNode: BaseNode{lfs: p.lfs}, team: p.team, project: p.project}
 		content := node.generateContent()
-		out.Attr.Mode = 0644 | syscall.S_IFREG
-		out.Attr.Uid = p.lfs.uid
-		out.Attr.Gid = p.lfs.gid
-		out.Attr.Size = uint64(len(content))
-		out.Attr.SetTimes(&p.project.UpdatedAt, &p.project.UpdatedAt, &p.project.CreatedAt)
-		return p.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFREG,
-			Ino:  projectInfoIno(p.project.ID),
-		}), 0
+		return p.newFileInode(ctx, out, node, fileAttr(len(content), p.project.CreatedAt, p.project.UpdatedAt), projectInfoIno(p.project.ID), 0), 0
 	}
 
 	// Handle project.meta (read-only server-managed fields), rendered read-through
@@ -315,38 +307,20 @@ func (p *ProjectNode) Lookup(ctx context.Context, name string, out *fuse.EntryOu
 
 	// Handle docs/ directory
 	if name == "docs" {
-		node := &DocsNode{BaseNode: BaseNode{lfs: p.lfs}, projectID: p.project.ID}
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = p.lfs.uid
-		out.Attr.Gid = p.lfs.gid
-		out.Attr.SetTimes(&p.project.UpdatedAt, &p.project.UpdatedAt, &p.project.CreatedAt)
-		return p.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFDIR,
-			Ino:  docsDirIno(p.project.ID),
-		}), 0
+		node := &DocsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: p.lfs}}, projectID: p.project.ID}
+		return p.newDirInode(ctx, out, node, dirAttr(p.project.CreatedAt, p.project.UpdatedAt), docsDirIno(p.project.ID), 0), 0
 	}
 
 	// Handle updates/ directory
 	if name == "updates" {
-		node := &UpdatesNode{BaseNode: BaseNode{lfs: p.lfs}, projectID: p.project.ID, projectUpdatedAt: p.project.UpdatedAt}
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = p.lfs.uid
-		out.Attr.Gid = p.lfs.gid
-		out.Attr.SetTimes(&p.project.UpdatedAt, &p.project.UpdatedAt, &p.project.CreatedAt)
-		return p.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
+		node := &UpdatesNode{attrNode: attrNode{BaseNode: BaseNode{lfs: p.lfs}}, projectID: p.project.ID}
+		return p.newDirInode(ctx, out, node, dirAttr(p.project.CreatedAt, p.project.UpdatedAt), updatesDirIno(p.project.ID), 0), 0
 	}
 
 	// Handle milestones/ directory
 	if name == "milestones" {
-		node := &MilestonesNode{BaseNode: BaseNode{lfs: p.lfs}, projectID: p.project.ID}
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = p.lfs.uid
-		out.Attr.Gid = p.lfs.gid
-		out.Attr.SetTimes(&p.project.UpdatedAt, &p.project.UpdatedAt, &p.project.CreatedAt)
-		return p.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFDIR,
-			Ino:  milestonesDirIno(p.project.ID),
-		}), 0
+		node := &MilestonesNode{attrNode: attrNode{BaseNode: BaseNode{lfs: p.lfs}}, projectID: p.project.ID}
+		return p.newDirInode(ctx, out, node, dirAttr(p.project.CreatedAt, p.project.UpdatedAt), milestonesDirIno(p.project.ID), 0), 0
 	}
 
 	issues, err := p.lfs.GetProjectIssues(ctx, p.project.ID)
@@ -735,22 +709,14 @@ func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Er
 
 // UpdatesNode represents /teams/{KEY}/projects/{slug}/updates/
 type UpdatesNode struct {
-	BaseNode
-	projectID        string
-	projectUpdatedAt time.Time
+	attrNode
+	projectID string
 }
 
 var _ fs.NodeReaddirer = (*UpdatesNode)(nil)
 var _ fs.NodeLookuper = (*UpdatesNode)(nil)
 var _ fs.NodeCreater = (*UpdatesNode)(nil)
 var _ fs.NodeGetattrer = (*UpdatesNode)(nil)
-
-func (n *UpdatesNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	out.Mode = 0755 | syscall.S_IFDIR
-	n.SetOwner(out)
-	out.SetTimes(&n.projectUpdatedAt, &n.projectUpdatedAt, &n.projectUpdatedAt)
-	return 0
-}
 
 func (n *UpdatesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	updates, err := n.lfs.GetProjectUpdates(ctx, n.projectID)

--- a/internal/fs/relations.go
+++ b/internal/fs/relations.go
@@ -31,7 +31,7 @@ func relationIno(relationID string) uint64 {
 
 // RelationsNode represents the /teams/{KEY}/issues/{ID}/relations directory
 type RelationsNode struct {
-	BaseNode
+	attrNode
 	issueID string
 	teamID  string
 }
@@ -39,14 +39,6 @@ type RelationsNode struct {
 var _ fs.NodeReaddirer = (*RelationsNode)(nil)
 var _ fs.NodeLookuper = (*RelationsNode)(nil)
 var _ fs.NodeGetattrer = (*RelationsNode)(nil)
-
-func (n *RelationsNode) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0755 | syscall.S_IFDIR
-	n.SetOwner(out)
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
 
 func (n *RelationsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	// Get both outgoing and incoming relations

--- a/internal/fs/symlink_test.go
+++ b/internal/fs/symlink_test.go
@@ -170,7 +170,7 @@ func TestResolveProjectTargetResolvesTeamAndTimes(t *testing.T) {
 	if err := lfs.InjectTestStore(store); err != nil {
 		t.Fatalf("inject store: %v", err)
 	}
-	node := &InitiativeProjectsNode{BaseNode: BaseNode{lfs: lfs}}
+	node := &InitiativeProjectsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}}
 
 	target, gotCreated, gotUpdated, errno := node.resolveProjectTarget(ctx, "project-1")
 	if errno != 0 {
@@ -214,7 +214,7 @@ func TestResolveProjectTargetMultiTeamIsFirstByKey(t *testing.T) {
 	if err := lfs.InjectTestStore(store); err != nil {
 		t.Fatalf("inject store: %v", err)
 	}
-	node := &InitiativeProjectsNode{BaseNode: BaseNode{lfs: lfs}}
+	node := &InitiativeProjectsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}}
 
 	target, _, _, errno := node.resolveProjectTarget(ctx, "project-shared")
 	if errno != 0 {
@@ -238,7 +238,7 @@ func TestResolveProjectTargetUnsyncedIsENOENT(t *testing.T) {
 	if err := lfs.InjectTestStore(store); err != nil {
 		t.Fatalf("inject store: %v", err)
 	}
-	node := &InitiativeProjectsNode{BaseNode: BaseNode{lfs: lfs}}
+	node := &InitiativeProjectsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}}
 
 	// Project row missing entirely.
 	if _, _, _, errno := node.resolveProjectTarget(ctx, "project-absent"); errno != syscall.ENOENT {

--- a/internal/fs/teams.go
+++ b/internal/fs/teams.go
@@ -185,26 +185,12 @@ func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 		}), 0
 
 	case "docs":
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = t.lfs.uid
-		out.Attr.Gid = t.lfs.gid
-		out.Attr.SetTimes(&now, &now, &now)
-		node := &DocsNode{BaseNode: BaseNode{lfs: t.lfs}, teamID: t.team.ID}
-		return t.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFDIR,
-			Ino:  docsDirIno(t.team.ID),
-		}), 0
+		node := &DocsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: t.lfs}}, teamID: t.team.ID}
+		return t.newDirInode(ctx, out, node, dirAttr(t.team.CreatedAt, t.team.UpdatedAt), docsDirIno(t.team.ID), 0), 0
 
 	case "labels":
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = t.lfs.uid
-		out.Attr.Gid = t.lfs.gid
-		out.Attr.SetTimes(&now, &now, &now)
-		node := &LabelsNode{BaseNode: BaseNode{lfs: t.lfs}, teamID: t.team.ID}
-		return t.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFDIR,
-			Ino:  labelsDirIno(t.team.ID),
-		}), 0
+		node := &LabelsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: t.lfs}}, teamID: t.team.ID}
+		return t.newDirInode(ctx, out, node, dirAttr(t.team.CreatedAt, t.team.UpdatedAt), labelsDirIno(t.team.ID), 0), 0
 	}
 
 	return nil, syscall.ENOENT

--- a/internal/integration/attr_conformance_test.go
+++ b/internal/integration/attr_conformance_test.go
@@ -1,0 +1,73 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestIssueSubdirsReportIssueTimes is the mounted, kernel-level proof of the
+// "Attr construction" contract: every entity subdirectory reports the issue's
+// times (mtime = updatedAt), not time.Now(). Before the nodeAttr refactor,
+// DocsNode/AttachmentsNode.Getattr returned time.Now(), so these stats drifted
+// off the issue and reshuffled on every call. The check is fixture-agnostic: it
+// only asserts each subdir agrees with the issue's own mtime (issue.md, whose
+// mtime is updatedAt), so it holds whatever the fixture's timestamps are.
+func TestIssueSubdirsReportIssueTimes(t *testing.T) {
+	const issueID = "TST-1"
+
+	issueInfo, err := os.Stat(issueFilePath(testTeamKey, issueID))
+	if err != nil {
+		t.Fatalf("stat issue.md: %v", err)
+	}
+	want := issueInfo.ModTime()
+
+	base := issueDirPath(testTeamKey, issueID)
+	subdirs := map[string]string{
+		"comments":    commentsPath(testTeamKey, issueID),
+		"docs":        docsPath(testTeamKey, issueID),
+		"attachments": attachmentsPath(testTeamKey, issueID),
+		"relations":   filepath.Join(base, "relations"),
+		"children":    filepath.Join(base, "children"),
+	}
+
+	for name, path := range subdirs {
+		t.Run(name, func(t *testing.T) {
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("stat %s: %v", name, err)
+			}
+			if !info.IsDir() {
+				t.Fatalf("%s is not a directory", name)
+			}
+			if got := info.ModTime(); !got.Equal(want) {
+				t.Errorf("%s mtime = %v, want issue's %v (subdir must report the issue's times, not time.Now())", name, got, want)
+			}
+		})
+	}
+}
+
+// TestIssueSubdirStatIsDeterministic stats the same subdirectory twice and
+// requires an identical mtime. The old time.Now() Getattr failed this by
+// construction — two stats microseconds apart returned different times, which
+// reshuffled `ls -lt`. This is the observable form of "a Lookup answer and a
+// later stat can never disagree".
+func TestIssueSubdirStatIsDeterministic(t *testing.T) {
+	base := issueDirPath(testTeamKey, "TST-1")
+	for _, name := range []string{"docs", "attachments", "comments", "relations"} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(base, name)
+			first, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("stat %s (1): %v", name, err)
+			}
+			second, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("stat %s (2): %v", name, err)
+			}
+			if !first.ModTime().Equal(second.ModTime()) {
+				t.Errorf("%s mtime not stable across stats: %v vs %v", name, first.ModTime(), second.ModTime())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Collapses 54 hand-fabricated attribute blocks across `internal/fs` into one module — the non-symlink complement to `symlinkNode`. Construction fixes the reporting data, so a Lookup answer and a later `Getattr` render identically and can never disagree.

- **`nodeAttr{mode,size,created,updated}.fill`** owns mode/uid/gid/size/times.
- **`attrNode`** mixin *provides* the default `Getattr` — a directory node cannot hand-write a divergent one.
- **`newDirInode`/`newFileInode`** fill the Lookup `EntryOut` from the same `nodeAttr`, taking the entry timeout as an explicit param (the 30s/5s/0 classes are preserved verbatim — no rationalizing).

## Why — a live drift bug

- `DocsNode`/`AttachmentsNode`/`RelationsNode`/`MilestonesNode`/`LabelsNode` **and team docs/labels** reported `time.Now()` — non-deterministic, so every `ls -lt` reshuffled, violating the `mtime=updatedAt` convention.
- `CommentsNode` reported a wrong ctime.
- `InitiativeProjectsNode` carried a **shadow `Getattr`** reading a different stored field than its Lookup answer.

All now report the entity's times uniformly: `mtime=updatedAt`, `ctime=createdAt`.

## Scope notes

- **Labels/milestones file nodes left as-is**: their API types carry no timestamps, so determinism there would mean epoch-1970 (a UX change, separate decision).
- Folding the already-DRY sidecar helpers (`.error`/`.meta`/`.last`) was deferred — their render-through/read-only semantics aren't a mechanical fit.

## Tests

- **Unit anti-drift equality** (`nodeattr_test.go`): Lookup `EntryOut.Attr` == `Getattr` `AttrOut.Attr` per directory kind — this **caught the `InitiativeProjectsNode` shadow `Getattr` on its first run**. Plus field-mapping and zero-time-stays-epoch.
- **Mounted** (`attr_conformance_test.go`): each subdir's mtime == the issue's; stat-twice determinism.

## LOC

Net **−123 production lines** (a 102-line module absorbing ~230 lines of scattered fabrication), **+201 lines of new tests**. `go test ./...` green; `gofmt`/`vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)