### PR TITLE
refactor(fs): one inode namespace (ino) instead of 28 scattered hashers

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -189,6 +189,24 @@ plus an anti-drift equality test: the Lookup `EntryOut.Attr` and the node's
 attr-conformance/stat-determinism test in `internal/integration` guarding the
 real kernel `Getattr` path.
 
+### Inode namespace (`ino`)
+Every virtual inode number the filesystem hands the kernel is
+`fnv64a("kind:"+id)` through the single `ino(kind, id)` function
+(`internal/fs/ino.go`). The kind prefix is a hard invariant — there are **no
+bare hashes** — so two entities that happen to share an id (an issue and its
+`comments/` directory) never collide. The ~28 named one-line wrappers
+(`commentsDirIno`, `issueIno`, …) gathered in that one file **are** the
+namespace: they keep call sites typo-proof (the `"comment:"`/`"comments:"`
+one-character gap is written exactly once) and make the whole set auditable at
+a glance. Adding a virtual file means adding a wrapper here, never hashing
+inline. `issueIno` used to hash the bare id — the lone exception the registry
+removed. `TestInodeNamespaceDistinct` calls every wrapper with one shared id and
+asserts distinct results, guarding against a duplicated or mistyped prefix and
+serving as the checklist a new kind must join. `scratchIno` (`atomicwrite.go`)
+is deliberately **not** a wrapper: its key mixes the parent directory inode with
+the name (so concurrent temp files in different dirs don't collide), a different
+shape than `kind:id`.
+
 ### Connection drain (`paginate`)
 The **deep module** owning cursor pagination of Linear GraphQL connections —
 the read-side counterpart to `execMutation`. Linear silently caps a

--- a/internal/fs/attachments.go
+++ b/internal/fs/attachments.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
 	"log"
 	"strings"
 	"syscall"
@@ -16,27 +15,6 @@ import (
 	"github.com/jra3/linear-fuse/internal/api"
 	"github.com/jra3/linear-fuse/internal/db"
 )
-
-// attachmentsDirIno generates a stable inode for an issue's attachments directory
-func attachmentsDirIno(issueID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("attachments:" + issueID))
-	return h.Sum64()
-}
-
-// embeddedFileIno generates a stable inode for an embedded file
-func embeddedFileIno(fileID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("file:" + fileID))
-	return h.Sum64()
-}
-
-// externalAttachmentIno generates a stable inode for an external attachment (.link file)
-func externalAttachmentIno(attachmentID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("extatt:" + attachmentID))
-	return h.Sum64()
-}
 
 // AttachmentsNode represents the /teams/{KEY}/issues/{ID}/attachments directory
 type AttachmentsNode struct {

--- a/internal/fs/comments.go
+++ b/internal/fs/comments.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"hash/fnv"
 	"log"
 	"sort"
 	"strings"
@@ -17,20 +16,6 @@ import (
 	"github.com/jra3/linear-fuse/internal/api"
 	"gopkg.in/yaml.v3"
 )
-
-// commentsDirIno generates a stable inode number for a comments directory
-func commentsDirIno(issueID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("comments:" + issueID))
-	return h.Sum64()
-}
-
-// commentIno generates a stable inode number for a comment
-func commentIno(commentID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("comment:" + commentID))
-	return h.Sum64()
-}
 
 // CommentsNode represents /teams/{KEY}/issues/{ID}/comments/
 type CommentsNode struct {

--- a/internal/fs/comments_test.go
+++ b/internal/fs/comments_test.go
@@ -8,38 +8,6 @@ import (
 	"github.com/jra3/linear-fuse/internal/api"
 )
 
-func TestCommentsDirIno(t *testing.T) {
-	t.Parallel()
-	// Same issue ID should produce same inode
-	ino1 := commentsDirIno("issue-123")
-	ino2 := commentsDirIno("issue-123")
-	if ino1 != ino2 {
-		t.Errorf("commentsDirIno() not stable: got %d and %d for same input", ino1, ino2)
-	}
-
-	// Different issue IDs should produce different inodes
-	ino3 := commentsDirIno("issue-456")
-	if ino1 == ino3 {
-		t.Errorf("commentsDirIno() collision: got same inode %d for different issues", ino1)
-	}
-}
-
-func TestCommentIno(t *testing.T) {
-	t.Parallel()
-	// Same comment ID should produce same inode
-	ino1 := commentIno("comment-123")
-	ino2 := commentIno("comment-123")
-	if ino1 != ino2 {
-		t.Errorf("commentIno() not stable: got %d and %d for same input", ino1, ino2)
-	}
-
-	// Different comment IDs should produce different inodes
-	ino3 := commentIno("comment-456")
-	if ino1 == ino3 {
-		t.Errorf("commentIno() collision: got same inode %d for different comments", ino1)
-	}
-}
-
 func TestExtractCommentBody(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/fs/documents.go
+++ b/internal/fs/documents.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"context"
-	"hash/fnv"
 	"log"
 	"strings"
 	"sync"
@@ -14,20 +13,6 @@ import (
 	"github.com/jra3/linear-fuse/internal/api"
 	"github.com/jra3/linear-fuse/internal/marshal"
 )
-
-// docsDirIno generates a stable inode number for a docs directory
-func docsDirIno(parentID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("docs:" + parentID))
-	return h.Sum64()
-}
-
-// documentIno generates a stable inode number for a document
-func documentIno(docID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("doc:" + docID))
-	return h.Sum64()
-}
 
 // DocsNode represents a docs/ directory within issues, teams, projects, or initiatives
 type DocsNode struct {

--- a/internal/fs/documents_test.go
+++ b/internal/fs/documents_test.go
@@ -6,38 +6,6 @@ import (
 	"github.com/jra3/linear-fuse/internal/api"
 )
 
-func TestDocsDirIno(t *testing.T) {
-	t.Parallel()
-	// Same parent ID should produce same inode
-	ino1 := docsDirIno("parent-123")
-	ino2 := docsDirIno("parent-123")
-	if ino1 != ino2 {
-		t.Errorf("docsDirIno() not stable: got %d and %d for same input", ino1, ino2)
-	}
-
-	// Different parent IDs should produce different inodes
-	ino3 := docsDirIno("parent-456")
-	if ino1 == ino3 {
-		t.Errorf("docsDirIno() collision: got same inode %d for different parents", ino1)
-	}
-}
-
-func TestDocumentIno(t *testing.T) {
-	t.Parallel()
-	// Same document ID should produce same inode
-	ino1 := documentIno("doc-123")
-	ino2 := documentIno("doc-123")
-	if ino1 != ino2 {
-		t.Errorf("documentIno() not stable: got %d and %d for same input", ino1, ino2)
-	}
-
-	// Different document IDs should produce different inodes
-	ino3 := documentIno("doc-456")
-	if ino1 == ino3 {
-		t.Errorf("documentIno() collision: got same inode %d for different documents", ino1)
-	}
-}
-
 func TestDocumentFilename(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"hash/fnv"
 	"log"
 	"sort"
 	"strings"
@@ -17,27 +16,6 @@ import (
 	"github.com/jra3/linear-fuse/internal/api"
 	"github.com/jra3/linear-fuse/internal/marshal"
 )
-
-// initiativeInfoIno generates a stable inode number for an initiative.md file
-func initiativeInfoIno(initiativeID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("initiative-info:" + initiativeID))
-	return h.Sum64()
-}
-
-// initiativeProjectsIno generates a stable inode number for an initiative projects directory
-func initiativeProjectsIno(initiativeID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("initiative-projects:" + initiativeID))
-	return h.Sum64()
-}
-
-// initiativeUpdatesDirIno generates a stable inode number for an initiative updates directory
-func initiativeUpdatesDirIno(initiativeID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("initiative-updates:" + initiativeID))
-	return h.Sum64()
-}
 
 // InitiativesNode represents the /initiatives directory
 type InitiativesNode struct {

--- a/internal/fs/initiatives_test.go
+++ b/internal/fs/initiatives_test.go
@@ -12,59 +12,6 @@ import (
 // Inode Generation Tests
 // =============================================================================
 
-func TestInitiativeInfoInoStability(t *testing.T) {
-	// Same ID should always produce same inode
-	id := "test-initiative-id-123"
-	ino1 := initiativeInfoIno(id)
-	ino2 := initiativeInfoIno(id)
-
-	if ino1 != ino2 {
-		t.Errorf("Inode not stable: got %d and %d for same ID", ino1, ino2)
-	}
-
-	// Different IDs should produce different inodes
-	id2 := "test-initiative-id-456"
-	ino3 := initiativeInfoIno(id2)
-
-	if ino1 == ino3 {
-		t.Errorf("Different IDs produced same inode: %d", ino1)
-	}
-}
-
-func TestInitiativeProjectsInoStability(t *testing.T) {
-	id := "test-initiative-id-123"
-	ino1 := initiativeProjectsIno(id)
-	ino2 := initiativeProjectsIno(id)
-
-	if ino1 != ino2 {
-		t.Errorf("Projects inode not stable: got %d and %d for same ID", ino1, ino2)
-	}
-
-	// Should be different from info inode
-	infoIno := initiativeInfoIno(id)
-	if ino1 == infoIno {
-		t.Errorf("Projects inode same as info inode: %d", ino1)
-	}
-}
-
-func TestInitiativeUpdatesDirInoStability(t *testing.T) {
-	id := "test-initiative-id-123"
-	ino1 := initiativeUpdatesDirIno(id)
-	ino2 := initiativeUpdatesDirIno(id)
-
-	if ino1 != ino2 {
-		t.Errorf("Updates dir inode not stable: got %d and %d for same ID", ino1, ino2)
-	}
-
-	// Should be different from other initiative inodes
-	infoIno := initiativeInfoIno(id)
-	projectsIno := initiativeProjectsIno(id)
-
-	if ino1 == infoIno || ino1 == projectsIno {
-		t.Errorf("Updates inode collides with other inodes")
-	}
-}
-
 // =============================================================================
 // Content Round-Trip Tests
 // =============================================================================

--- a/internal/fs/ino.go
+++ b/internal/fs/ino.go
@@ -1,0 +1,84 @@
+package fs
+
+import "hash/fnv"
+
+// ino is the one hash behind every virtual inode number in the filesystem: a
+// stable 64-bit value derived from an entity kind and its id. Every inode is
+// namespaced by its kind prefix — there are no bare hashes — so two entities
+// that happen to share an id (an issue and its comments directory, say) never
+// collide. The wrapper list below IS the inode namespace: adding a virtual file
+// means adding a wrapper here, never hashing inline. TestInodeNamespaceDistinct
+// guards that every kind stays distinct. See CONTEXT.md "Inode namespace".
+//
+// scratchIno (atomicwrite.go) is deliberately not a wrapper: its key mixes the
+// parent directory inode with the name, so it hashes differently.
+func ino(kind, id string) uint64 {
+	h := fnv.New64a()
+	h.Write([]byte(kind + ":" + id))
+	return h.Sum64()
+}
+
+// Issue tree ---------------------------------------------------------------
+
+func issueIno(issueID string) uint64       { return ino("issue", issueID) }
+func issueDirIno(issueID string) uint64    { return ino("dir", issueID) }
+func issuesDirIno(teamID string) uint64    { return ino("issues", teamID) }
+func childrenDirIno(issueID string) uint64 { return ino("children", issueID) }
+func historyIno(issueID string) uint64     { return ino("history", issueID) }
+func errorIno(issueID string) uint64       { return ino("error", issueID) }
+
+// Comments -----------------------------------------------------------------
+
+func commentsDirIno(issueID string) uint64 { return ino("comments", issueID) }
+func commentIno(commentID string) uint64   { return ino("comment", commentID) }
+
+// Documents ----------------------------------------------------------------
+
+func docsDirIno(parentID string) uint64 { return ino("docs", parentID) }
+func documentIno(docID string) uint64   { return ino("doc", docID) }
+
+// Attachments --------------------------------------------------------------
+
+func attachmentsDirIno(issueID string) uint64          { return ino("attachments", issueID) }
+func embeddedFileIno(fileID string) uint64             { return ino("file", fileID) }
+func externalAttachmentIno(attachmentID string) uint64 { return ino("extatt", attachmentID) }
+
+// Relations ----------------------------------------------------------------
+
+func relationsDirIno(issueID string) uint64 { return ino("relations", issueID) }
+func relationIno(relationID string) uint64  { return ino("relation", relationID) }
+
+// Labels -------------------------------------------------------------------
+
+func labelsDirIno(teamID string) uint64 { return ino("labels", teamID) }
+func labelIno(labelID string) uint64    { return ino("label", labelID) }
+
+// Projects -----------------------------------------------------------------
+
+func projectsDirIno(teamID string) uint64    { return ino("projects", teamID) }
+func projectInfoIno(projectID string) uint64 { return ino("project-info", projectID) }
+func updatesDirIno(projectID string) uint64  { return ino("updates", projectID) }
+
+// Milestones ---------------------------------------------------------------
+
+func milestonesDirIno(projectID string) uint64 { return ino("milestones", projectID) }
+func milestoneIno(milestoneID string) uint64   { return ino("milestone", milestoneID) }
+
+// Initiatives --------------------------------------------------------------
+
+func initiativeInfoIno(initiativeID string) uint64 { return ino("initiative-info", initiativeID) }
+func initiativeProjectsIno(initiativeID string) uint64 {
+	return ino("initiative-projects", initiativeID)
+}
+func initiativeUpdatesDirIno(initiativeID string) uint64 {
+	return ino("initiative-updates", initiativeID)
+}
+
+// Team views ---------------------------------------------------------------
+
+func recentDirIno(teamID string) uint64 { return ino("recentdir", teamID) }
+
+// Sidecars -----------------------------------------------------------------
+
+func metaIno(key string) uint64    { return ino("meta", key) }
+func successIno(key string) uint64 { return ino("last", key) }

--- a/internal/fs/ino_test.go
+++ b/internal/fs/ino_test.go
@@ -1,0 +1,69 @@
+package fs
+
+import "testing"
+
+// TestInoStableAndKeyed pins the three properties every inode number relies on:
+// it is stable for a given (kind, id), it varies with the id, and it varies with
+// the kind — so an issue and its comments directory (same id, different kind)
+// never share an inode.
+func TestInoStableAndKeyed(t *testing.T) {
+	t.Parallel()
+	if ino("k", "a") != ino("k", "a") {
+		t.Error("ino not stable for the same (kind, id)")
+	}
+	if ino("k", "a") == ino("k", "b") {
+		t.Error("ino collides across ids")
+	}
+	if ino("k1", "x") == ino("k2", "x") {
+		t.Error("ino collides across kinds for the same id")
+	}
+}
+
+// TestInodeNamespaceDistinct is the namespace guard: every wrapper, given one
+// shared id, must produce a distinct inode. It catches a duplicated or
+// mistyped kind prefix (e.g. the one-character gap between "comment" and
+// "comments"), confirms issueIno's prefix no longer collides with a bare hash,
+// and is the checklist a newly added kind must join. scratchIno is excluded
+// deliberately — its key is parent-scoped, not a kind:id pair.
+func TestInodeNamespaceDistinct(t *testing.T) {
+	t.Parallel()
+	const id = "shared-id"
+	namespace := map[string]uint64{
+		"issueIno":                issueIno(id),
+		"issueDirIno":             issueDirIno(id),
+		"issuesDirIno":            issuesDirIno(id),
+		"childrenDirIno":          childrenDirIno(id),
+		"historyIno":              historyIno(id),
+		"errorIno":                errorIno(id),
+		"commentsDirIno":          commentsDirIno(id),
+		"commentIno":              commentIno(id),
+		"docsDirIno":              docsDirIno(id),
+		"documentIno":             documentIno(id),
+		"attachmentsDirIno":       attachmentsDirIno(id),
+		"embeddedFileIno":         embeddedFileIno(id),
+		"externalAttachmentIno":   externalAttachmentIno(id),
+		"relationsDirIno":         relationsDirIno(id),
+		"relationIno":             relationIno(id),
+		"labelsDirIno":            labelsDirIno(id),
+		"labelIno":                labelIno(id),
+		"projectsDirIno":          projectsDirIno(id),
+		"projectInfoIno":          projectInfoIno(id),
+		"updatesDirIno":           updatesDirIno(id),
+		"milestonesDirIno":        milestonesDirIno(id),
+		"milestoneIno":            milestoneIno(id),
+		"initiativeInfoIno":       initiativeInfoIno(id),
+		"initiativeProjectsIno":   initiativeProjectsIno(id),
+		"initiativeUpdatesDirIno": initiativeUpdatesDirIno(id),
+		"recentDirIno":            recentDirIno(id),
+		"metaIno":                 metaIno(id),
+		"successIno":              successIno(id),
+	}
+
+	seen := make(map[uint64]string, len(namespace))
+	for name, got := range namespace {
+		if other, dup := seen[got]; dup {
+			t.Errorf("inode collision: %s and %s both hash to %d for id %q", name, other, got, id)
+		}
+		seen[got] = name
+	}
+}

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"hash/fnv"
 	"log"
 	"strings"
 	"sync"
@@ -16,48 +15,6 @@ import (
 	"github.com/jra3/linear-fuse/internal/api"
 	"github.com/jra3/linear-fuse/internal/marshal"
 )
-
-// issueIno generates a stable inode number from an issue ID
-func issueIno(issueID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte(issueID))
-	return h.Sum64()
-}
-
-// issuesDirIno generates a stable inode number for a team's issues directory
-func issuesDirIno(teamID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("issues:" + teamID))
-	return h.Sum64()
-}
-
-// issueDirIno generates a stable inode number for an issue directory
-func issueDirIno(issueID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("dir:" + issueID))
-	return h.Sum64()
-}
-
-// childrenDirIno generates a stable inode number for a children directory
-func childrenDirIno(issueID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("children:" + issueID))
-	return h.Sum64()
-}
-
-// historyIno generates a stable inode number for an issue's history.md file
-func historyIno(issueID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("history:" + issueID))
-	return h.Sum64()
-}
-
-// errorIno generates a stable inode number for an issue's .error file
-func errorIno(issueID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("error:" + issueID))
-	return h.Sum64()
-}
 
 // issueWriteResult projects a freshly-created issue into a .last success entry.
 // Path is the issue's identifier — the addressable on-disk directory name.

--- a/internal/fs/labels.go
+++ b/internal/fs/labels.go
@@ -3,7 +3,6 @@ package fs
 import (
 	"context"
 	"fmt"
-	"hash/fnv"
 	"log"
 	"strings"
 	"sync"
@@ -14,20 +13,6 @@ import (
 	"github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/jra3/linear-fuse/internal/api"
 )
-
-// labelsDirIno generates a stable inode number for a labels directory
-func labelsDirIno(teamID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("labels:" + teamID))
-	return h.Sum64()
-}
-
-// labelIno generates a stable inode number for a label
-func labelIno(labelID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("label:" + labelID))
-	return h.Sum64()
-}
 
 // LabelsNode represents the /teams/{KEY}/labels/ directory
 type LabelsNode struct {

--- a/internal/fs/labels_test.go
+++ b/internal/fs/labels_test.go
@@ -480,35 +480,3 @@ key2:value2
 		})
 	}
 }
-
-func TestLabelsDirIno(t *testing.T) {
-	t.Parallel()
-	// Same team ID should produce same inode
-	ino1 := labelsDirIno("team-123")
-	ino2 := labelsDirIno("team-123")
-	if ino1 != ino2 {
-		t.Errorf("labelsDirIno() not stable: got %d and %d for same input", ino1, ino2)
-	}
-
-	// Different team IDs should produce different inodes
-	ino3 := labelsDirIno("team-456")
-	if ino1 == ino3 {
-		t.Errorf("labelsDirIno() collision: got same inode %d for different teams", ino1)
-	}
-}
-
-func TestLabelIno(t *testing.T) {
-	t.Parallel()
-	// Same label ID should produce same inode
-	ino1 := labelIno("label-123")
-	ino2 := labelIno("label-123")
-	if ino1 != ino2 {
-		t.Errorf("labelIno() not stable: got %d and %d for same input", ino1, ino2)
-	}
-
-	// Different label IDs should produce different inodes
-	ino3 := labelIno("label-456")
-	if ino1 == ino3 {
-		t.Errorf("labelIno() collision: got same inode %d for different labels", ino1)
-	}
-}

--- a/internal/fs/metafile.go
+++ b/internal/fs/metafile.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"context"
-	"hash/fnv"
 	"syscall"
 	"time"
 
@@ -28,15 +27,6 @@ import (
 // means the served node always reflects current state. Editors of the sibling
 // editable file call InvalidateUpdated(metaIno(id)) so the kernel drops its
 // cached size/attrs and re-reads.
-
-// metaIno derives the stable inode for an `<entity>.meta` file from a key
-// (typically the entity's Linear ID). The "meta:" prefix keeps it from colliding
-// with error/success/entity inodes.
-func metaIno(key string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("meta:" + key))
-	return h.Sum64()
-}
 
 // metaRender returns the current `.meta` bytes plus the entity's updated/created
 // times, all from a live source. Times are rendered through (not baked at Lookup)

--- a/internal/fs/milestones.go
+++ b/internal/fs/milestones.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"context"
-	"hash/fnv"
 	"log"
 	"strings"
 	"sync"
@@ -14,20 +13,6 @@ import (
 	"github.com/jra3/linear-fuse/internal/api"
 	"github.com/jra3/linear-fuse/internal/marshal"
 )
-
-// milestonesDirIno generates a stable inode for a milestones directory
-func milestonesDirIno(projectID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("milestones:" + projectID))
-	return h.Sum64()
-}
-
-// milestoneIno generates a stable inode for a milestone file
-func milestoneIno(milestoneID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("milestone:" + milestoneID))
-	return h.Sum64()
-}
 
 // MilestonesNode represents a milestones/ directory within a project
 type MilestonesNode struct {

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"hash/fnv"
 	"log"
 	"regexp"
 	"sort"
@@ -18,27 +17,6 @@ import (
 	"github.com/jra3/linear-fuse/internal/api"
 	"github.com/jra3/linear-fuse/internal/marshal"
 )
-
-// projectsDirIno generates a stable inode number for a projects directory
-func projectsDirIno(teamID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("projects:" + teamID))
-	return h.Sum64()
-}
-
-// projectInfoIno generates a stable inode number for a project info file
-func projectInfoIno(projectID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("project-info:" + projectID))
-	return h.Sum64()
-}
-
-// updatesDirIno generates a stable inode number for a project updates directory
-func updatesDirIno(projectID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("updates:" + projectID))
-	return h.Sum64()
-}
 
 // ProjectsNode represents the /teams/{KEY}/projects directory
 type ProjectsNode struct {

--- a/internal/fs/projects_test.go
+++ b/internal/fs/projects_test.go
@@ -9,59 +9,6 @@ import (
 	"github.com/jra3/linear-fuse/internal/api"
 )
 
-func TestProjectsDirIno(t *testing.T) {
-	t.Parallel()
-	// Same team ID should produce same inode
-	ino1 := projectsDirIno("team-123")
-	ino2 := projectsDirIno("team-123")
-	if ino1 != ino2 {
-		t.Errorf("projectsDirIno() not stable: got %d and %d for same input", ino1, ino2)
-	}
-
-	// Different team IDs should produce different inodes
-	ino3 := projectsDirIno("team-456")
-	if ino1 == ino3 {
-		t.Errorf("projectsDirIno() collision: got same inode %d for different teams", ino1)
-	}
-}
-
-func TestProjectInfoIno(t *testing.T) {
-	t.Parallel()
-	// Same project ID should produce same inode
-	ino1 := projectInfoIno("project-123")
-	ino2 := projectInfoIno("project-123")
-	if ino1 != ino2 {
-		t.Errorf("projectInfoIno() not stable: got %d and %d for same input", ino1, ino2)
-	}
-
-	// Different project IDs should produce different inodes
-	ino3 := projectInfoIno("project-456")
-	if ino1 == ino3 {
-		t.Errorf("projectInfoIno() collision: got same inode %d for different projects", ino1)
-	}
-}
-
-func TestUpdatesDirIno(t *testing.T) {
-	t.Parallel()
-	// Same project ID should produce same inode
-	ino1 := updatesDirIno("project-123")
-	ino2 := updatesDirIno("project-123")
-	if ino1 != ino2 {
-		t.Errorf("updatesDirIno() not stable: got %d and %d for same input", ino1, ino2)
-	}
-
-	// Different project IDs should produce different inodes
-	ino3 := updatesDirIno("project-456")
-	if ino1 == ino3 {
-		t.Errorf("updatesDirIno() collision: got same inode %d for different projects", ino1)
-	}
-
-	// Updates inode should differ from project info inode
-	if ino1 == projectInfoIno("project-123") {
-		t.Error("updatesDirIno() should differ from projectInfoIno()")
-	}
-}
-
 func TestProjectDirName(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/fs/recent.go
+++ b/internal/fs/recent.go
@@ -3,7 +3,6 @@ package fs
 import (
 	"context"
 	"fmt"
-	"hash/fnv"
 	"sort"
 	"syscall"
 	"time"
@@ -15,15 +14,6 @@ import (
 
 // recentLimit caps how many issues the recent/ view exposes.
 const recentLimit = 50
-
-// recentDirIno generates the stable inode for a team's recent/ directory, so
-// issue creates can re-coher the view (a fresh issue must appear in recent/
-// immediately, not after the dir cache TTL).
-func recentDirIno(teamID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("recentdir:" + teamID))
-	return h.Sum64()
-}
 
 // RecentNode is teams/{KEY}/recent/: a read-only view listing the team's issues
 // as symlinks, newest-first by updatedAt, capped to recentLimit. It gives an

--- a/internal/fs/relations.go
+++ b/internal/fs/relations.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"hash/fnv"
 	"strings"
 	"syscall"
 	"time"
@@ -14,20 +13,6 @@ import (
 	"github.com/jra3/linear-fuse/internal/api"
 	"github.com/jra3/linear-fuse/internal/db"
 )
-
-// relationsDirIno generates a stable inode for an issue's relations directory
-func relationsDirIno(issueID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("relations:" + issueID))
-	return h.Sum64()
-}
-
-// relationIno generates a stable inode for a relation file
-func relationIno(relationID string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("relation:" + relationID))
-	return h.Sum64()
-}
 
 // RelationsNode represents the /teams/{KEY}/issues/{ID}/relations directory
 type RelationsNode struct {

--- a/internal/fs/successfile.go
+++ b/internal/fs/successfile.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"context"
-	"hash/fnv"
 	"strings"
 	"syscall"
 	"time"
@@ -47,14 +46,6 @@ type writeResultYAML struct {
 	Path       string `yaml:"path"`
 	Title      string `yaml:"title"`
 	Status     string `yaml:"status"`
-}
-
-// successIno derives the stable inode for a `.last` file from its key. The
-// "last:" prefix keeps it from ever colliding with errorIno ("error:"+key).
-func successIno(key string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte("last:" + key))
-	return h.Sum64()
 }
 
 // firstLine returns the first non-empty line of s, trimmed, capped to 80 runes —

--- a/internal/fs/successfile_test.go
+++ b/internal/fs/successfile_test.go
@@ -85,11 +85,3 @@ func TestRenderWriteSuccessYAML(t *testing.T) {
 		}
 	}
 }
-
-// TestSuccessInoDistinctFromErrorIno: a surface's .last and .error never collide.
-func TestSuccessInoDistinctFromErrorIno(t *testing.T) {
-	key := collectionSuccessKey("issues", "team-1")
-	if successIno(key) == errorIno(key) {
-		t.Error("successIno collides with errorIno for the same key")
-	}
-}


### PR DESCRIPTION
**Stacked on #172** — base is `refactor/nodeattr-construction`; review/merge that first, and this diff will retarget to `main`.

## What

Collapses 28 near-identical fnv inode helpers (spread across 13 files) into one `ino(kind, id)` plus named one-line wrappers gathered in `internal/fs/ino.go`. Every virtual inode is now `fnv("kind:"+id)` through a single function — **no bare hashes** — so the kind prefix is a hard invariant and the whole namespace is auditable in one place.

## Why

- **The prefix invariant was unenforced.** `issueIno` hashed the bare id while all 27 siblings used a `"kind:"` prefix — now fixed to `ino("issue", id)` (inode numbers are ephemeral, so the value change is harmless; both call sites recompute consistently, nothing persists or pins it).
- **Typo surface.** `commentIno` uses `"comment:"`, `commentsDirIno` uses `"comments:"` — one character apart. Named wrappers keep each literal written exactly once, so call sites can't mix them up.
- **Auditability.** The wrapper list in one file *is* the namespace.

`scratchIno` stays put — its key mixes the parent directory inode with the name (a different shape than `kind:id`), so it's deliberately not a wrapper.

## Tests

Replaces ~13 scattered per-helper stability/distinctness tests with two focused ones:
- `TestInoStableAndKeyed` — stability + id-keying + kind-keying.
- `TestInodeNamespaceDistinct` — every wrapper with one shared id must produce a distinct inode; catches a duplicated/mistyped prefix and is the checklist a new kind must join.

## LOC

Net **−252 lines** (28 helpers + 13 tests → one function + wrappers + 2 tests). `go test ./...` green; `gofmt`/`vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)