### PR TITLE
refactor(fs): one indexedListing module for index-named collections

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -207,6 +207,27 @@ is deliberately **not** a wrapper: its key mixes the parent directory inode with
 the name (so concurrent temp files in different dirs don't collide), a different
 shape than `kind:id`.
 
+### Indexed listing (`indexedListing`)
+The **deep module** owning the index-derived filenames of a collection whose
+entries are named `<NNNN>-<date>…md` by creation order — comments and the
+project/initiative status updates. The sibling of `collectionTrio` (which owns
+the same collection's `_create`/`.error`/`.last`): the trio owns the *virtual*
+files, this owns the *item* files. `indexedListing[T]{items, lessKey, nameOf}`
+(`internal/fs/indexedlisting.go`) **owns the sort** and the name derivation, and
+exposes `entries()` (the Readdir projection) and `find(name)` (the Lookup/Unlink
+projection). Because all three surfaces derive names through the one module over
+one canonical order, they cannot disagree — a file you can `ls` you can also
+open and `rm`. Before this, each surface re-sorted and re-`Sprintf`'d
+independently (seven copies across three files), so a timestamp-format tweak or
+an off-by-one in one surface would silently strand a file: listed but
+un-openable. Each collection declares its listing via a `listing(items)` method
+(mirroring `trio()`); the two update collections share the `updateEntryName`
+formatter (their `<NNNN>-<date>-<health>.md` convention is identical), while
+comments own a per-minute timestamp format with no health. `TestIndexedListing-
+RoundTrip` guards the invariant: every name `entries()` emits resolves back
+through `find`, and same-second items still get distinct names via the 1-based
+index.
+
 ### Connection drain (`paginate`)
 The **deep module** owning cursor pagination of Linear GraphQL connections —
 the read-side counterpart to `execMutation`. Linear silently caps a

--- a/internal/fs/comments.go
+++ b/internal/fs/comments.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -41,28 +40,25 @@ func (n *CommentsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno
 		return fs.NewListDirStream(n.trio().entries()), 0
 	}
 
-	entries := n.trio().entries()
-
-	// Sort comments by creation time
-	sort.Slice(comments, func(i, j int) bool {
-		return comments[i].CreatedAt.Before(comments[j].CreatedAt)
-	})
-
-	for i, comment := range comments {
-		// Format: 001-2025-01-10T14:30.md
-		timestamp := comment.CreatedAt.Format("2006-01-02T15-04")
-		entries = append(entries, fuse.DirEntry{
-			Name: fmt.Sprintf("%04d-%s.md", i+1, timestamp),
-			Mode: syscall.S_IFREG,
-		})
-	}
-
+	entries := append(n.trio().entries(), n.listing(comments).entries()...)
 	return fs.NewListDirStream(entries), 0
 }
 
 // trio declares the comments collection's writable surfaces.
 func (n *CommentsNode) trio() collectionTrio {
 	return collectionTrio{kind: "comments", parentID: n.issueID, onFlush: n.createComment}
+}
+
+// listing declares how comment files are named — <NNNN>-<date-time>.md by
+// creation order — so Readdir, Lookup, and Unlink derive identical names.
+func (n *CommentsNode) listing(comments []api.Comment) indexedListing[api.Comment] {
+	return indexedListing[api.Comment]{
+		items:   comments,
+		lessKey: func(c api.Comment) time.Time { return c.CreatedAt },
+		nameOf: func(i int, c api.Comment) string {
+			return fmt.Sprintf("%04d-%s.md", i+1, c.CreatedAt.Format("2006-01-02T15-04"))
+		},
+	}
 }
 
 func (n *CommentsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
@@ -75,30 +71,20 @@ func (n *CommentsNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 		return nil, syscall.EIO
 	}
 
-	// Sort comments by creation time
-	sort.Slice(comments, func(i, j int) bool {
-		return comments[i].CreatedAt.Before(comments[j].CreatedAt)
-	})
-
-	// Match by filename pattern
-	for i, comment := range comments {
-		timestamp := comment.CreatedAt.Format("2006-01-02T15-04")
-		expectedName := fmt.Sprintf("%04d-%s.md", i+1, timestamp)
-		if expectedName == name {
-			content := commentToMarkdown(&comment)
-			node := &CommentNode{
-				BaseNode:     BaseNode{lfs: n.lfs},
-				issueID:      n.issueID,
-				comment:      comment,
-				content:      content,
-				contentReady: true,
-			}
-			// Shorter timeout for writable files.
-			return n.newFileInode(ctx, out, node, fileAttr(len(content), comment.CreatedAt, comment.UpdatedAt), commentIno(comment.ID), 5*time.Second), 0
-		}
+	comment, ok := n.listing(comments).find(name)
+	if !ok {
+		return nil, syscall.ENOENT
 	}
-
-	return nil, syscall.ENOENT
+	content := commentToMarkdown(&comment)
+	node := &CommentNode{
+		BaseNode:     BaseNode{lfs: n.lfs},
+		issueID:      n.issueID,
+		comment:      comment,
+		content:      content,
+		contentReady: true,
+	}
+	// Shorter timeout for writable files.
+	return n.newFileInode(ctx, out, node, fileAttr(len(content), comment.CreatedAt, comment.UpdatedAt), commentIno(comment.ID), 5*time.Second), 0
 }
 
 func (n *CommentsNode) Unlink(ctx context.Context, name string) syscall.Errno {
@@ -119,15 +105,8 @@ func (n *CommentsNode) Unlink(ctx context.Context, name string) syscall.Errno {
 			if err != nil {
 				return nil, err
 			}
-			// Filenames are index-derived from creation order.
-			sort.Slice(comments, func(i, j int) bool {
-				return comments[i].CreatedAt.Before(comments[j].CreatedAt)
-			})
-			for i, comment := range comments {
-				timestamp := comment.CreatedAt.Format("2006-01-02T15-04")
-				if fmt.Sprintf("%04d-%s.md", i+1, timestamp) == name {
-					return &comment, nil
-				}
+			if c, ok := n.listing(comments).find(name); ok {
+				return &c, nil
 			}
 			return nil, nil
 		},

--- a/internal/fs/indexedlisting.go
+++ b/internal/fs/indexedlisting.go
@@ -1,0 +1,68 @@
+package fs
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/hanwen/go-fuse/v2/fuse"
+)
+
+// indexedListing owns the index-derived filenames of a collection whose entries
+// are named <NNNN>-<date>…md by creation order (comments, project and
+// initiative updates). Fixing the sort and the name derivation in one place is
+// what lets a collection's Readdir, Lookup, and Unlink agree on every name — a
+// file you can `ls` you can also open and `rm`. Before this, each surface
+// re-sorted and re-formatted independently, so a change to one (a timestamp
+// format, an off-by-one) could silently strand a file. Sibling of
+// collectionTrio, which owns the same collection's _create/.error/.last. See
+// CONTEXT.md "Indexed listing".
+type indexedListing[T any] struct {
+	items   []T
+	lessKey func(T) time.Time          // sort ascending; the index follows this order
+	nameOf  func(i int, item T) string // 0-based position -> filename
+}
+
+// sorted returns the items in the canonical order the index numbers follow. The
+// order is the one source of truth every surface shares.
+func (l indexedListing[T]) sorted() []T {
+	out := make([]T, len(l.items))
+	copy(out, l.items)
+	sort.SliceStable(out, func(i, j int) bool {
+		return l.lessKey(out[i]).Before(l.lessKey(out[j]))
+	})
+	return out
+}
+
+// entries is the Readdir projection: one S_IFREG DirEntry per item, named by
+// nameOf over the canonical order.
+func (l indexedListing[T]) entries() []fuse.DirEntry {
+	items := l.sorted()
+	entries := make([]fuse.DirEntry, len(items))
+	for i, it := range items {
+		entries[i] = fuse.DirEntry{Name: l.nameOf(i, it), Mode: syscall.S_IFREG}
+	}
+	return entries
+}
+
+// find is the Lookup/Unlink projection: locate the item whose derived name
+// matches, over the same canonical order entries() used.
+func (l indexedListing[T]) find(name string) (T, bool) {
+	for i, it := range l.sorted() {
+		if l.nameOf(i, it) == name {
+			return it, true
+		}
+	}
+	var zero T
+	return zero, false
+}
+
+// updateEntryName is the filename for a project or initiative status update:
+// <NNNN>-<date>-<health>.md by creation order. Shared by both update
+// collections (their convention is identical); comments own a different format
+// (a per-minute timestamp, no health).
+func updateEntryName(i int, createdAt time.Time, health string) string {
+	return fmt.Sprintf("%04d-%s-%s.md", i+1, createdAt.Format("2006-01-02"), strings.ToLower(health))
+}

--- a/internal/fs/indexedlisting_test.go
+++ b/internal/fs/indexedlisting_test.go
@@ -1,0 +1,81 @@
+package fs
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestIndexedListingRoundTrip is the anti-drift guarantee in executable form:
+// for every name entries() produces, find(name) must return the matching item,
+// over the same canonical order — so a collection's Readdir, Lookup, and Unlink
+// can never disagree. It feeds unsorted items (including two sharing a second)
+// to prove the sort is owned by the module and that same-second items still get
+// distinct names via the 1-based index.
+func TestIndexedListingRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	type item struct {
+		id string
+		at time.Time
+	}
+	base := time.Unix(1_700_000_000, 0)
+	items := []item{
+		{"c", base.Add(2 * time.Hour)},
+		{"a", base},
+		{"b-same-second", base}, // duplicate timestamp — index must still disambiguate
+		{"d", base.Add(3 * time.Hour)},
+	}
+
+	l := indexedListing[item]{
+		items:   items,
+		lessKey: func(it item) time.Time { return it.at },
+		nameOf: func(i int, it item) string {
+			return fmt.Sprintf("%04d-%s.md", i+1, it.at.Format("2006-01-02T15-04"))
+		},
+	}
+
+	entries := l.entries()
+	if len(entries) != len(items) {
+		t.Fatalf("entries() len = %d, want %d", len(entries), len(items))
+	}
+
+	// Every listed name resolves back to exactly one item, and names are unique.
+	seen := map[string]bool{}
+	for _, e := range entries {
+		if seen[e.Name] {
+			t.Errorf("duplicate entry name %q — index failed to disambiguate", e.Name)
+		}
+		seen[e.Name] = true
+		if _, ok := l.find(e.Name); !ok {
+			t.Errorf("entries() produced %q but find() could not locate it", e.Name)
+		}
+	}
+
+	// find is ordered by lessKey, not input order: the earliest two items (same
+	// second) occupy slots 1 and 2, stably in input order.
+	if got, _ := l.find("0001-" + base.Format("2006-01-02T15-04") + ".md"); got.id != "a" {
+		t.Errorf("slot 1 = %q, want a (earliest, stable)", got.id)
+	}
+	if got, _ := l.find("0002-" + base.Format("2006-01-02T15-04") + ".md"); got.id != "b-same-second" {
+		t.Errorf("slot 2 = %q, want b-same-second", got.id)
+	}
+
+	if _, ok := l.find("9999-nonexistent.md"); ok {
+		t.Error("find() matched a name no entry produced")
+	}
+}
+
+// TestUpdateEntryName pins the shared status-update filename format used by both
+// the project and initiative update collections.
+func TestUpdateEntryName(t *testing.T) {
+	t.Parallel()
+	at := time.Date(2026, 1, 15, 9, 30, 0, 0, time.UTC)
+	if got := updateEntryName(0, at, "onTrack"); got != "0001-2026-01-15-ontrack.md" {
+		t.Errorf("updateEntryName = %q, want 0001-2026-01-15-ontrack.md", got)
+	}
+	// Health is lower-cased; index is 1-based and zero-padded to four digits.
+	if got := updateEntryName(11, at, "AtRisk"); got != "0012-2026-01-15-atrisk.md" {
+		t.Errorf("updateEntryName = %q, want 0012-2026-01-15-atrisk.md", got)
+	}
+}

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -627,29 +626,23 @@ func (n *InitiativeUpdatesNode) Readdir(ctx context.Context) (fs.DirStream, sysc
 		return nil, syscall.EIO
 	}
 
-	entries := n.trio().entries()
-
-	// Sort updates by creation time
-	sort.Slice(updates, func(i, j int) bool {
-		return updates[i].CreatedAt.Before(updates[j].CreatedAt)
-	})
-
-	for i, update := range updates {
-		// Format: 001-2025-01-15-ontrack.md
-		timestamp := update.CreatedAt.Format("2006-01-02")
-		healthSuffix := strings.ToLower(update.Health)
-		entries = append(entries, fuse.DirEntry{
-			Name: fmt.Sprintf("%04d-%s-%s.md", i+1, timestamp, healthSuffix),
-			Mode: syscall.S_IFREG,
-		})
-	}
-
+	entries := append(n.trio().entries(), n.listing(updates).entries()...)
 	return fs.NewListDirStream(entries), 0
 }
 
 // trio declares the initiative-updates collection's writable surfaces.
 func (n *InitiativeUpdatesNode) trio() collectionTrio {
 	return collectionTrio{kind: "updates", parentID: n.initiativeID, onFlush: n.createUpdate}
+}
+
+// listing declares how update files are named — <NNNN>-<date>-<health>.md by
+// creation order — so Readdir and Lookup derive identical names.
+func (n *InitiativeUpdatesNode) listing(updates []api.InitiativeUpdate) indexedListing[api.InitiativeUpdate] {
+	return indexedListing[api.InitiativeUpdate]{
+		items:   updates,
+		lessKey: func(u api.InitiativeUpdate) time.Time { return u.CreatedAt },
+		nameOf:  func(i int, u api.InitiativeUpdate) string { return updateEntryName(i, u.CreatedAt, u.Health) },
+	}
 }
 
 func (n *InitiativeUpdatesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
@@ -662,32 +655,22 @@ func (n *InitiativeUpdatesNode) Lookup(ctx context.Context, name string, out *fu
 		return nil, syscall.EIO
 	}
 
-	// Sort updates by creation time
-	sort.Slice(updates, func(i, j int) bool {
-		return updates[i].CreatedAt.Before(updates[j].CreatedAt)
-	})
-
-	// Match by filename pattern
-	for i, update := range updates {
-		timestamp := update.CreatedAt.Format("2006-01-02")
-		healthSuffix := strings.ToLower(update.Health)
-		expectedName := fmt.Sprintf("%04d-%s-%s.md", i+1, timestamp, healthSuffix)
-		if expectedName == name {
-			content := initiativeUpdateToMarkdown(&update)
-			node := &InitiativeUpdateNode{
-				BaseNode: BaseNode{lfs: n.lfs},
-				update:   update,
-				content:  content,
-			}
-			out.Attr.Mode = 0444 | syscall.S_IFREG // Read-only
-			out.Attr.Uid = n.lfs.uid
-			out.Attr.Gid = n.lfs.gid
-			out.Attr.Size = uint64(len(content))
-			out.SetAttrTimeout(30 * time.Second)
-			out.SetEntryTimeout(30 * time.Second)
-			out.Attr.SetTimes(&update.UpdatedAt, &update.UpdatedAt, &update.CreatedAt)
-			return n.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG}), 0
+	update, ok := n.listing(updates).find(name)
+	if ok {
+		content := initiativeUpdateToMarkdown(&update)
+		node := &InitiativeUpdateNode{
+			BaseNode: BaseNode{lfs: n.lfs},
+			update:   update,
+			content:  content,
 		}
+		out.Attr.Mode = 0444 | syscall.S_IFREG // Read-only
+		out.Attr.Uid = n.lfs.uid
+		out.Attr.Gid = n.lfs.gid
+		out.Attr.Size = uint64(len(content))
+		out.SetAttrTimeout(30 * time.Second)
+		out.SetEntryTimeout(30 * time.Second)
+		out.Attr.SetTimes(&update.UpdatedAt, &update.UpdatedAt, &update.CreatedAt)
+		return n.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG}), 0
 	}
 
 	return nil, syscall.ENOENT

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -702,29 +701,23 @@ func (n *UpdatesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno)
 		return nil, syscall.EIO
 	}
 
-	entries := n.trio().entries()
-
-	// Sort updates by creation time
-	sort.Slice(updates, func(i, j int) bool {
-		return updates[i].CreatedAt.Before(updates[j].CreatedAt)
-	})
-
-	for i, update := range updates {
-		// Format: 001-2025-01-15-ontrack.md
-		timestamp := update.CreatedAt.Format("2006-01-02")
-		healthSuffix := strings.ToLower(update.Health)
-		entries = append(entries, fuse.DirEntry{
-			Name: fmt.Sprintf("%04d-%s-%s.md", i+1, timestamp, healthSuffix),
-			Mode: syscall.S_IFREG,
-		})
-	}
-
+	entries := append(n.trio().entries(), n.listing(updates).entries()...)
 	return fs.NewListDirStream(entries), 0
 }
 
 // trio declares the project-updates collection's writable surfaces.
 func (n *UpdatesNode) trio() collectionTrio {
 	return collectionTrio{kind: "updates", parentID: n.projectID, onFlush: n.createUpdate}
+}
+
+// listing declares how update files are named — <NNNN>-<date>-<health>.md by
+// creation order — so Readdir and Lookup derive identical names.
+func (n *UpdatesNode) listing(updates []api.ProjectUpdate) indexedListing[api.ProjectUpdate] {
+	return indexedListing[api.ProjectUpdate]{
+		items:   updates,
+		lessKey: func(u api.ProjectUpdate) time.Time { return u.CreatedAt },
+		nameOf:  func(i int, u api.ProjectUpdate) string { return updateEntryName(i, u.CreatedAt, u.Health) },
+	}
 }
 
 func (n *UpdatesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
@@ -737,32 +730,21 @@ func (n *UpdatesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOu
 		return nil, syscall.EIO
 	}
 
-	// Sort updates by creation time
-	sort.Slice(updates, func(i, j int) bool {
-		return updates[i].CreatedAt.Before(updates[j].CreatedAt)
-	})
-
-	// Match by filename pattern
-	for i, update := range updates {
-		timestamp := update.CreatedAt.Format("2006-01-02")
-		healthSuffix := strings.ToLower(update.Health)
-		expectedName := fmt.Sprintf("%04d-%s-%s.md", i+1, timestamp, healthSuffix)
-		if expectedName == name {
-			content := updateToMarkdown(&update)
-			node := &UpdateNode{
-				update:  update,
-				content: content,
-			}
-			out.Attr.Mode = 0444 | syscall.S_IFREG // Read-only
-			out.Attr.Size = uint64(len(content))
-			out.SetAttrTimeout(30 * time.Second)
-			out.SetEntryTimeout(30 * time.Second)
-			out.Attr.SetTimes(&update.UpdatedAt, &update.UpdatedAt, &update.CreatedAt)
-			return n.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG}), 0
-		}
+	update, ok := n.listing(updates).find(name)
+	if !ok {
+		return nil, syscall.ENOENT
 	}
-
-	return nil, syscall.ENOENT
+	content := updateToMarkdown(&update)
+	node := &UpdateNode{
+		update:  update,
+		content: content,
+	}
+	out.Attr.Mode = 0444 | syscall.S_IFREG // Read-only
+	out.Attr.Size = uint64(len(content))
+	out.SetAttrTimeout(30 * time.Second)
+	out.SetEntryTimeout(30 * time.Second)
+	out.Attr.SetTimes(&update.UpdatedAt, &update.UpdatedAt, &update.CreatedAt)
+	return n.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG}), 0
 }
 
 func (n *UpdatesNode) Create(ctx context.Context, name string, flags uint32, mode uint32, out *fuse.EntryOut) (*fs.Inode, fs.FileHandle, uint32, syscall.Errno) {


### PR DESCRIPTION
**Stacked on #173 → #172.** Base is `refactor/inode-namespace`; merge #172 then #173 first, and this retargets to `main`.

## What

Comments and the project/initiative status updates name their files `<NNNN>-<date>…md` by creation order. Readdir, Lookup, and each collection's Unlink each **independently re-sorted and re-`Sprintf`'d** that name — 7 copies across 3 files. `indexedListing[T]{items, lessKey, nameOf}` owns the sort + name derivation once, exposing `entries()` (Readdir) and `find(name)` (Lookup/Unlink).

## Why

Nothing forced the three surfaces to agree. A timestamp-format tweak or an off-by-one in one of them would silently strand a file — **listed by `ls` but un-openable and un-`rm`-able**. Routing all three through one module over one canonical order makes that drift structurally impossible.

- Each collection declares its listing via a `listing(items)` method, mirroring `trio()`.
- The two update collections share `updateEntryName` (identical `<NNNN>-<date>-<health>.md` convention); comments keep their per-minute timestamp format.
- Sibling of `collectionTrio` (which owns the same collection's `_create`/`.error`/`.last`).

## Tests

- `TestIndexedListingRoundTrip` — every name `entries()` emits resolves back through `find`; **same-second items still get distinct names** via the 1-based index (the reason the index exists).
- `TestUpdateEntryName` — pins the shared update-filename format.

`go test ./...` green (incl. integration, which exercises the comments listing); `gofmt`/`vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)