### PR TITLE
refactor(sync): syncCollection — the sync-side reconcile tail

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -294,6 +294,47 @@ is why stamping the syncing team was wrong). The team prune targets
 `team_id = <team>`, so `NULL` workspace labels are outside every team's prune
 scope.
 
+### Sync reconcile tail (`syncCollection`)
+The **deep module** owning the invariant tail of every metadata sync — the
+sync-side sibling of the write-path tails (`commitCreate`/`commitWriteBack`/
+`commitDelete`) and the module that actually **performs the metadata prunes**
+`paginate`'s completeness licenses. Its shape is `convert → upsert-all →
+prune-if-clean`. Six sites reconcile through it: `states` (upsert-only),
+`labels`, `cycles`, `projects` (entity + `project_teams` junction + nested
+milestones), `members` (entity + `team_members` junction), and
+`initiativeProjects` (junction-only). Each restated the same `clean`-flag idiom
+by hand — declare `xClean := true`, loop upserting, `if xClean { Prune }` — so a
+new metadata kind copy-pasted it and a forgotten flag would let a *partial* fetch
+read as removals (silent data loss). `initiativeProjects` even hand-rolled a
+fail-fast variant whose error the caller only logged.
+
+Its interface is closures, no `*db.Store`: `syncCollectionSpec[T]{label, items,
+upsert, prune}`. `upsert(ctx, T)` does whatever the kind needs — convert, entity
+upsert, any junction upsert, nested sub-writes — and `prune(ctx)` runs **once,
+iff every `upsert` returned nil**; a `nil` prune closure means no prune (the
+`states` case). Semantics are uniform **log-and-continue**: a failed `upsert` is
+logged, marks the collection unclean, and does not abort the loop (so
+`initiativeProjects` trades its fail-fast for continue — the observable outcome,
+prune-skipped-on-any-failure, is unchanged and strictly more rows refresh). The
+module returns nothing; sync is best-effort. Pure over closures, so it is
+unit-tested with recording closures asserting *prune runs iff clean* — no real
+store or API.
+
+**"Clean" is completeness-set membership, not "no error anywhere."** An item is
+unclean **iff a write the prune depends on failed** — a write in the prune's
+completeness set. This is grounded in Linear's ontology and the drain contract:
+`Project.teams` is a **peer many-to-many association** (the prunable
+`project_teams` junction, safe to prune because the *projects* connection is
+drained), whereas `ProjectMilestone.project` is **composition** — a milestone is
+wholly owned by one project, its nested `projectMilestones` connection is
+**capped at 50, never drained**, and it has **no prune anywhere**. So a milestone
+upsert failure is a nested best-effort write outside the `project_teams` prune's
+completeness set: the `projects` closure **logs-and-swallows** it (returns nil),
+while a project-entity or `project_teams`-junction failure returns an error and
+correctly suppresses the prune (a stale junction row must never be wrongly
+deleted). The closure author honors the contract by choosing what to return
+versus swallow.
+
 ### ErrorSink
 The minimal seam the WriteBack tail uses to record validation/divergence messages for
 `.error` files: `SetWriteError(key, msg)` / `ClearWriteError(key)`. `*LinearFS`

--- a/internal/sync/synccollection.go
+++ b/internal/sync/synccollection.go
@@ -1,0 +1,59 @@
+package sync
+
+import (
+	"context"
+	"log"
+)
+
+// syncCollectionSpec declares how one metadata collection reconciles into
+// SQLite. See CONTEXT.md "Sync reconcile tail (syncCollection)".
+type syncCollectionSpec[T any] struct {
+	// label names the collection in log lines ("label", "cycle", "project", …).
+	label string
+
+	// items is the complete, drained server-side set to reconcile. Completeness
+	// is what licenses prune — a truncated fetch would read as removals.
+	items []T
+
+	// upsert performs the whole per-item write: convert, entity upsert, any
+	// junction upsert, and any nested sub-writes. It returns an error ONLY for a
+	// write in the prune's completeness set (the rows the prune deletes against).
+	// A nested best-effort sub-write with no prune of its own — e.g. a project's
+	// milestones, which live in a capped, never-pruned connection — logs and
+	// swallows its own failure and returns nil, so it never suppresses the prune.
+	upsert func(context.Context, T) error
+
+	// prune deletes the rows the (complete) fetch no longer returned. It runs
+	// once, after every upsert, and ONLY if all of them succeeded. A nil prune
+	// means the collection is upsert-only (e.g. states, which are
+	// workflow-bounded and fetched single-page, so nothing licenses a prune).
+	prune func(context.Context) error
+}
+
+// syncCollection reconciles one metadata collection: upsert every item, then
+// prune the rows no longer present — but prune ONLY if every upsert succeeded,
+// so a partial fetch never reads as removals. It is the sync-side sibling of the
+// write-path tails (commitCreate/commitWriteBack/commitDelete) and owns the
+// prune-safety invariant that the metadata sites used to restate by hand as a
+// `clean` flag. Sync is best-effort: failures are logged, never returned. Pure
+// over the spec's closures, so it is unit-tested with recording closures — no
+// store or API.
+func syncCollection[T any](ctx context.Context, spec syncCollectionSpec[T]) {
+	clean := true
+	for _, item := range spec.items {
+		if err := spec.upsert(ctx, item); err != nil {
+			log.Printf("[sync] upsert %s failed: %v", spec.label, err)
+			clean = false
+		}
+	}
+	if spec.prune == nil {
+		return // upsert-only collection
+	}
+	if !clean {
+		log.Printf("[sync] skipping %s prune: an upsert failed this pass", spec.label)
+		return
+	}
+	if err := spec.prune(ctx); err != nil {
+		log.Printf("[sync] prune %s failed: %v", spec.label, err)
+	}
+}

--- a/internal/sync/synccollection_test.go
+++ b/internal/sync/synccollection_test.go
@@ -1,0 +1,101 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// syncCollection is pure of the store and API — it drives only the spec's
+// upsert/prune closures. These tests feed it recording fakes and assert the
+// prune-safety invariant: prune runs iff every upsert succeeded, and a nil
+// prune (the states case) is honored.
+
+// recordingCollection records which items were upserted and whether prune fired,
+// and can be told to fail specific items to exercise the clean/unclean gate.
+type recordingCollection struct {
+	upserted []string        // item keys passed to upsert, in order
+	pruned   bool            // set when prune fired
+	failOn   map[string]bool // item keys whose upsert returns an error
+	pruneErr error           // if set, prune returns it
+}
+
+func (r *recordingCollection) spec(items []string) syncCollectionSpec[string] {
+	return syncCollectionSpec[string]{
+		label: "thing",
+		items: items,
+		upsert: func(_ context.Context, item string) error {
+			r.upserted = append(r.upserted, item)
+			if r.failOn[item] {
+				return errors.New("upsert failed: " + item)
+			}
+			return nil
+		},
+		prune: func(_ context.Context) error {
+			r.pruned = true
+			return r.pruneErr
+		},
+	}
+}
+
+func TestSyncCollectionUpsertsAllThenPrunes(t *testing.T) {
+	r := &recordingCollection{}
+	syncCollection(context.Background(), r.spec([]string{"a", "b", "c"}))
+	if len(r.upserted) != 3 {
+		t.Errorf("upserted = %v, want all 3 items", r.upserted)
+	}
+	if !r.pruned {
+		t.Error("prune should fire when every upsert succeeds")
+	}
+}
+
+func TestSyncCollectionUpsertFailureSuppressesPrune(t *testing.T) {
+	r := &recordingCollection{failOn: map[string]bool{"b": true}}
+	syncCollection(context.Background(), r.spec([]string{"a", "b", "c"}))
+	// A failed upsert does not abort the loop — every item is still attempted.
+	if len(r.upserted) != 3 {
+		t.Errorf("upserted = %v, want all 3 attempted (log-and-continue)", r.upserted)
+	}
+	if r.pruned {
+		t.Error("prune must be skipped when any upsert fails — a partial fetch would read as removals")
+	}
+}
+
+func TestSyncCollectionNilPruneSkipsPrune(t *testing.T) {
+	// The states case: upsert-only, no prune closure. Must not panic.
+	var upserted []string
+	syncCollection(context.Background(), syncCollectionSpec[string]{
+		label: "state",
+		items: []string{"todo", "done"},
+		upsert: func(_ context.Context, item string) error {
+			upserted = append(upserted, item)
+			return nil
+		},
+		// prune nil
+	})
+	if len(upserted) != 2 {
+		t.Errorf("upserted = %v, want both states", upserted)
+	}
+}
+
+func TestSyncCollectionEmptyItemsStillPrunes(t *testing.T) {
+	// An empty (but complete) fetch is clean — the prune removes everything
+	// stale, which is exactly right: the collection really is empty now.
+	r := &recordingCollection{}
+	syncCollection(context.Background(), r.spec(nil))
+	if len(r.upserted) != 0 {
+		t.Errorf("upserted = %v, want none", r.upserted)
+	}
+	if !r.pruned {
+		t.Error("prune should fire on an empty-but-complete fetch")
+	}
+}
+
+func TestSyncCollectionPruneErrorDoesNotPanic(t *testing.T) {
+	// A prune failure is logged and swallowed — sync is best-effort.
+	r := &recordingCollection{pruneErr: errors.New("prune boom")}
+	syncCollection(context.Background(), r.spec([]string{"a"}))
+	if !r.pruned {
+		t.Error("prune should have been attempted")
+	}
+}

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -490,10 +490,8 @@ func (w *Worker) syncWorkspace(ctx context.Context) error {
 			continue
 		}
 
-		// Sync initiative-project associations
-		if err := w.syncInitiativeProjects(ctx, initiative, pruneCutoff); err != nil {
-			log.Printf("[sync] sync initiative %s projects failed: %v", initiative.Slug, err)
-		}
+		// Sync initiative-project associations (best-effort; logs internally)
+		w.syncInitiativeProjects(ctx, initiative, pruneCutoff)
 	}
 	log.Printf("[sync] synced %d initiatives", len(data.Initiatives))
 
@@ -508,24 +506,25 @@ func (w *Worker) syncWorkspace(ctx context.Context) error {
 // The prune only runs after every upsert succeeded — a row that merely
 // failed to refresh must not read as a removal — and initiative.Projects
 // is complete by GetWorkspace's contract, which is what makes pruning
-// against it safe.
-func (w *Worker) syncInitiativeProjects(ctx context.Context, initiative api.Initiative, pruneCutoff time.Time) error {
-	for _, project := range initiative.Projects.Nodes {
-		if err := w.store.Queries().UpsertInitiativeProject(ctx, db.UpsertInitiativeProjectParams{
-			InitiativeID: initiative.ID,
-			ProjectID:    project.ID,
-			SyncedAt:     db.Now(),
-		}); err != nil {
-			return fmt.Errorf("upsert initiative-project %s-%s: %w", initiative.ID, project.ID, err)
-		}
-	}
-	if err := w.store.Queries().PruneInitiativeProjects(ctx, db.PruneInitiativeProjectsParams{
-		InitiativeID: initiative.ID,
-		SyncedAt:     pruneCutoff,
-	}); err != nil {
-		return fmt.Errorf("prune initiative-projects %s: %w", initiative.ID, err)
-	}
-	return nil
+// against it safe. Reconciles through the shared syncCollection tail.
+func (w *Worker) syncInitiativeProjects(ctx context.Context, initiative api.Initiative, pruneCutoff time.Time) {
+	syncCollection(ctx, syncCollectionSpec[api.InitiativeProject]{
+		label: "initiative-project",
+		items: initiative.Projects.Nodes,
+		upsert: func(ctx context.Context, project api.InitiativeProject) error {
+			return w.store.Queries().UpsertInitiativeProject(ctx, db.UpsertInitiativeProjectParams{
+				InitiativeID: initiative.ID,
+				ProjectID:    project.ID,
+				SyncedAt:     db.Now(),
+			})
+		},
+		prune: func(ctx context.Context) error {
+			return w.store.Queries().PruneInitiativeProjects(ctx, db.PruneInitiativeProjectsParams{
+				InitiativeID: initiative.ID,
+				SyncedAt:     pruneCutoff,
+			})
+		},
+	})
 }
 
 // =============================================================================
@@ -546,156 +545,138 @@ func (w *Worker) syncTeamMetadata(ctx context.Context, team api.Team) error {
 		return fmt.Errorf("get team metadata: %w", err)
 	}
 
-	// Process states
-	for _, state := range meta.States {
-		params, err := db.APIStateToDBState(state, team.ID)
-		if err != nil {
-			log.Printf("[sync] convert state %s failed: %v", state.Name, err)
-			continue
-		}
-		if err := w.store.Queries().UpsertState(ctx, params); err != nil {
-			log.Printf("[sync] upsert state %s failed: %v", state.Name, err)
-		}
-	}
+	// Each metadata collection reconciles through the same tail — upsert every
+	// item, then prune the rows the (complete) fetch no longer returned, but
+	// only if every upsert succeeded. syncCollection owns that prune-safety
+	// invariant so no site can drop the guard. See CONTEXT.md "Sync reconcile
+	// tail (syncCollection)".
 
-	// Process labels (already deduplicated by GetTeamMetadata)
-	labelsClean := true
-	for _, label := range meta.Labels {
-		// team_id comes from label.Team (fetched via the LabelFields fragment),
-		// not team.ID: team.labels returns workspace labels mixed in, so
-		// stamping team.ID here is what churned workspace labels between teams.
-		params, err := db.APILabelToDBLabel(label)
-		if err != nil {
-			log.Printf("[sync] convert label %s failed: %v", label.Name, err)
-			labelsClean = false
-			continue
-		}
-		if err := w.store.Queries().UpsertLabel(ctx, params); err != nil {
-			log.Printf("[sync] upsert label %s failed: %v", label.Name, err)
-			labelsClean = false
-		}
-	}
-	if labelsClean {
-		if err := w.store.Queries().PruneTeamLabels(ctx, db.PruneTeamLabelsParams{
-			TeamID:   sql.NullString{String: team.ID, Valid: true},
-			SyncedAt: pruneCutoff,
-		}); err != nil {
-			log.Printf("[sync] prune labels %s: %v", team.Key, err)
-		}
-	}
+	// States are workflow-bounded and fetched single-page, so nothing licenses
+	// a prune — upsert-only (nil prune).
+	syncCollection(ctx, syncCollectionSpec[api.State]{
+		label: "state",
+		items: meta.States,
+		upsert: func(ctx context.Context, state api.State) error {
+			params, err := db.APIStateToDBState(state, team.ID)
+			if err != nil {
+				return err
+			}
+			return w.store.Queries().UpsertState(ctx, params)
+		},
+	})
 
-	// Process cycles
-	cyclesClean := true
-	for _, cycle := range meta.Cycles {
-		params, err := db.APICycleToDBCycle(cycle, team.ID)
-		if err != nil {
-			log.Printf("[sync] convert cycle %s failed: %v", cycle.Name, err)
-			cyclesClean = false
-			continue
-		}
-		if err := w.store.Queries().UpsertCycle(ctx, params); err != nil {
-			log.Printf("[sync] upsert cycle %s failed: %v", cycle.Name, err)
-			cyclesClean = false
-		}
-	}
-	if cyclesClean {
-		if err := w.store.Queries().PruneTeamCycles(ctx, db.PruneTeamCyclesParams{
-			TeamID:   team.ID,
-			SyncedAt: pruneCutoff,
-		}); err != nil {
-			log.Printf("[sync] prune cycles %s: %v", team.Key, err)
-		}
-	}
+	// Labels are already deduplicated by GetTeamMetadata. team_id comes from
+	// label.Team (fetched via the LabelFields fragment), not team.ID: team.labels
+	// returns workspace labels mixed in, so stamping team.ID here is what churned
+	// workspace labels between teams.
+	syncCollection(ctx, syncCollectionSpec[api.Label]{
+		label: "label",
+		items: meta.Labels,
+		upsert: func(ctx context.Context, label api.Label) error {
+			params, err := db.APILabelToDBLabel(label)
+			if err != nil {
+				return err
+			}
+			return w.store.Queries().UpsertLabel(ctx, params)
+		},
+		prune: func(ctx context.Context) error {
+			return w.store.Queries().PruneTeamLabels(ctx, db.PruneTeamLabelsParams{
+				TeamID:   sql.NullString{String: team.ID, Valid: true},
+				SyncedAt: pruneCutoff,
+			})
+		},
+	})
 
-	// Process projects (includes milestones)
-	projectsClean := true
-	for _, project := range meta.Projects {
-		params, err := db.APIProjectToDBProject(project)
-		if err != nil {
-			log.Printf("[sync] convert project %s failed: %v", project.Slug, err)
-			projectsClean = false
-			continue
-		}
-		if err := w.store.Queries().UpsertProject(ctx, params); err != nil {
-			log.Printf("[sync] upsert project %s failed: %v", project.Slug, err)
-			projectsClean = false
-			continue
-		}
+	syncCollection(ctx, syncCollectionSpec[api.Cycle]{
+		label: "cycle",
+		items: meta.Cycles,
+		upsert: func(ctx context.Context, cycle api.Cycle) error {
+			params, err := db.APICycleToDBCycle(cycle, team.ID)
+			if err != nil {
+				return err
+			}
+			return w.store.Queries().UpsertCycle(ctx, params)
+		},
+		prune: func(ctx context.Context) error {
+			return w.store.Queries().PruneTeamCycles(ctx, db.PruneTeamCyclesParams{
+				TeamID:   team.ID,
+				SyncedAt: pruneCutoff,
+			})
+		},
+	})
 
-		// Upsert project-team association
-		if err := w.store.Queries().UpsertProjectTeam(ctx, db.UpsertProjectTeamParams{
-			ProjectID: project.ID,
-			TeamID:    team.ID,
-			SyncedAt:  db.Now(),
-		}); err != nil {
-			log.Printf("[sync] upsert project-team %s-%s failed: %v", project.ID, team.ID, err)
-			projectsClean = false
-		}
-
-		// Upsert milestones inline from the metadata query (no extra API calls)
-		if project.Milestones != nil {
-			for _, milestone := range project.Milestones.Nodes {
-				mParams, mErr := db.APIProjectMilestoneToDBMilestone(milestone, project.ID)
-				if mErr != nil {
-					log.Printf("[sync] convert milestone %s failed: %v", milestone.Name, mErr)
-					continue
-				}
-				if err := w.store.Queries().UpsertProjectMilestone(ctx, mParams); err != nil {
-					log.Printf("[sync] upsert milestone %s failed: %v", milestone.Name, err)
+	// Projects prune the project_teams junction (a project that moved off this
+	// team, or was deleted). The upsert closure's completeness set is the project
+	// entity plus the project_teams row: a failure in either suppresses the
+	// prune. Milestones are a nested best-effort sub-write in a capped,
+	// never-pruned connection — outside that set — so a milestone failure is
+	// logged and swallowed, never suppressing the prune.
+	syncCollection(ctx, syncCollectionSpec[api.Project]{
+		label: "project",
+		items: meta.Projects,
+		upsert: func(ctx context.Context, project api.Project) error {
+			params, err := db.APIProjectToDBProject(project)
+			if err != nil {
+				return err
+			}
+			if err := w.store.Queries().UpsertProject(ctx, params); err != nil {
+				return err
+			}
+			// A junction failure marks the item unclean but does not abort the
+			// milestone sub-writes below, so return it after they run.
+			junctionErr := w.store.Queries().UpsertProjectTeam(ctx, db.UpsertProjectTeamParams{
+				ProjectID: project.ID,
+				TeamID:    team.ID,
+				SyncedAt:  db.Now(),
+			})
+			if project.Milestones != nil {
+				for _, milestone := range project.Milestones.Nodes {
+					mParams, mErr := db.APIProjectMilestoneToDBMilestone(milestone, project.ID)
+					if mErr != nil {
+						log.Printf("[sync] convert milestone %s failed: %v", milestone.Name, mErr)
+						continue
+					}
+					if err := w.store.Queries().UpsertProjectMilestone(ctx, mParams); err != nil {
+						log.Printf("[sync] upsert milestone %s failed: %v", milestone.Name, err)
+					}
 				}
 			}
-		}
-	}
+			return junctionErr
+		},
+		prune: func(ctx context.Context) error {
+			return w.store.Queries().PruneProjectTeams(ctx, db.PruneProjectTeamsParams{
+				TeamID:   team.ID,
+				SyncedAt: pruneCutoff,
+			})
+		},
+	})
 
-	// Prune associations the (complete) fetch no longer returned — a project
-	// moved off this team, or deleted in Linear. Skipped when any upsert
-	// above failed: a row that merely failed to refresh must not read as a
-	// removal.
-	if projectsClean {
-		if err := w.store.Queries().PruneProjectTeams(ctx, db.PruneProjectTeamsParams{
-			TeamID:   team.ID,
-			SyncedAt: pruneCutoff,
-		}); err != nil {
-			log.Printf("[sync] prune project-teams %s: %v", team.Key, err)
-		}
-	}
-
-	// Process members
-	membersClean := true
-	for _, member := range meta.Members {
-		// Ensure user exists in users table
-		params, err := db.APIUserToDBUser(member)
-		if err != nil {
-			log.Printf("[sync] convert member %s failed: %v", member.Email, err)
-			membersClean = false
-			continue
-		}
-		if err := w.store.Queries().UpsertUser(ctx, params); err != nil {
-			log.Printf("[sync] upsert member user %s failed: %v", member.Email, err)
-			membersClean = false
-			continue
-		}
-
-		// Upsert team membership
-		if err := w.store.Queries().UpsertTeamMember(ctx, db.UpsertTeamMemberParams{
-			TeamID:   team.ID,
-			UserID:   member.ID,
-			SyncedAt: db.Now(),
-		}); err != nil {
-			log.Printf("[sync] upsert team member %s failed: %v", member.Email, err)
-			membersClean = false
-		}
-	}
-	// Prune departed members from the team_members junction (not the
-	// workspace-wide users table, which other teams share).
-	if membersClean {
-		if err := w.store.Queries().PruneTeamMembers(ctx, db.PruneTeamMembersParams{
-			TeamID:   team.ID,
-			SyncedAt: pruneCutoff,
-		}); err != nil {
-			log.Printf("[sync] prune members %s: %v", team.Key, err)
-		}
-	}
+	// Members prune the team_members junction (a departed member), not the
+	// workspace-wide users table, which other teams share.
+	syncCollection(ctx, syncCollectionSpec[api.User]{
+		label: "member",
+		items: meta.Members,
+		upsert: func(ctx context.Context, member api.User) error {
+			params, err := db.APIUserToDBUser(member)
+			if err != nil {
+				return err
+			}
+			if err := w.store.Queries().UpsertUser(ctx, params); err != nil {
+				return err
+			}
+			return w.store.Queries().UpsertTeamMember(ctx, db.UpsertTeamMemberParams{
+				TeamID:   team.ID,
+				UserID:   member.ID,
+				SyncedAt: db.Now(),
+			})
+		},
+		prune: func(ctx context.Context) error {
+			return w.store.Queries().PruneTeamMembers(ctx, db.PruneTeamMembersParams{
+				TeamID:   team.ID,
+				SyncedAt: pruneCutoff,
+			})
+		},
+	})
 
 	return nil
 }


### PR DESCRIPTION
## What

Extracts `syncCollection[T]` — the sync-side reconcile tail — and routes all six metadata sync sites through it.

The six sites (`states`, `labels`, `cycles`, `projects`, `members` in `syncTeamMetadata`, plus `syncInitiativeProjects`) each restated the same prune-safety idiom by hand:

```go
xClean := true
for _, item := range items {
    if err := convert+upsert(item); err != nil { log; xClean = false; continue }
}
if xClean { Prune() }
```

A seventh kind copy-pastes it, and a forgotten flag lets a **partial fetch read as removals** — silent data loss. `syncInitiativeProjects` even hand-rolled a fail-fast variant whose error the caller only logged.

## The module

`syncCollection` is the sync-side sibling of the write tails (`commitCreate`/`commitWriteBack`/`commitDelete`) and the module that performs the metadata prunes `paginate`'s completeness licenses. Its whole interface is closures:

```go
type syncCollectionSpec[T any] struct {
    label  string
    items  []T
    upsert func(context.Context, T) error
    prune  func(context.Context) error // nil ⇒ upsert-only (states)
}
```

Upsert every item, then prune **iff every upsert succeeded**. Best-effort, void, pure over the closures — unit-tested with recording closures, no store or API.

## "Clean" = completeness-set membership

An item is unclean **iff a write the prune depends on failed** — not "any error anywhere". So a project entity or `project_teams`-junction failure suppresses the `project_teams` prune, while a project's **milestones** (a nested best-effort sub-write in a capped, never-pruned connection, outside that set) **log and swallow** their own failure and never suppress the prune. Grounded in Linear's ontology: `Project.teams` is a peer many-to-many association (prunable because the projects connection is drained), `ProjectMilestone.project` is composition. The projects closure preserves the original ordering exactly (a junction failure still runs the milestone loop, then returns).

## Tests & verification

- New `synccollection_test.go` — 6 recording-closure tests asserting *prune runs iff clean* (upsert-all-then-prune, failure-suppresses-prune-but-still-attempts-all, nil-prune-skips, empty-but-complete-still-prunes, prune-error-swallowed).
- **Behavior-preserving**: the existing `prune_test.go` + `worker_test.go` (which drive the real store's prune behavior) stay green.
- `go build` / `go vet ./...` / gofmt clean; full non-integration suite + integration suite `PASS`.

`worker.go` is −19 net lines; the payoff is locality — the prune-safety rule now lives in one place, and a seventh metadata kind can't drop the guard. `CONTEXT.md` gains the "Sync reconcile tail (`syncCollection`)" concept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)