### PR TITLE
refactor(fs): scalarEdit — the scalar front half of project/initiative edits

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -109,6 +109,32 @@ unit-tested with recording closures (no FUSE mount, SQLite, or API). Persisting 
 junction row inline (rather than the old deferred batch a mid-loop failure skipped)
 keeps SQLite consistent with whatever the API actually accepted on a partial failure.
 
+### Scalar edit (`scalarEdit`)
+The **deep module** owning the *scalar* front half of a project/initiative edit —
+the counterpart to Link reconciliation, which owns the *relational* (list) front
+half of the same two mirror-image handlers. `project.md` and `initiative.md` each
+expose exactly two editable scalars: a **name** (frontmatter) and a
+**description** (body). `scalarEdit` (`internal/fs/scalaredit.go`) is the diff of
+those two — `{name, desc *string, origName, origDesc string}` — and owns the
+change decision (trim both sides of the body so a render/parse trailing-newline
+delta doesn't read as an edit; coerce the name via `marshal.ScalarToString` so a
+numeric/bare-scalar name updates instead of being silently dropped by a direct
+type assertion), the `changed()` predicate, and the read-your-writes
+`divergences(freshName, freshDesc)` classification (one canonical field order,
+`writeBackDivergence` per changed field). It stays **neutral to the entity type**:
+the caller maps `name`/`desc` onto its own typed `api.ProjectUpdateInput` /
+`api.InitiativeUpdateInput` and pulls the fresh values back out — nothing
+Project- or Initiative-shaped crosses the interface, so no generics. This
+collapsed the byte-identical `fieldChanged`-flag diff and the byte-identical
+`commitWriteBack` compare closure that both handlers hand-rolled. The scalar
+mutation failure now routes through the shared `classifyMutationErr` (like the
+reconcile path 20 lines above it), so a rate-limited scalar edit returns
+`EAGAIN` — not the old flat `EIO` — and the server's reason reaches `.error`.
+Pure of the FUSE mount, SQLite, and API: unit-tested directly on a parsed
+`marshal.Document` plus current values. (`marshal.ScalarToString` and
+`marshal.StringSliceFromYAML` — the list coercion the handlers now share for the
+relational front half — were exported from marshal for this.)
+
 ### Create trigger (`createFileNode`)
 The **deep module** owning the write-only `_create` file (and the named-file
 `Create` paths that share its mechanics): buffer written bytes, and on close hand

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -321,20 +321,8 @@ func (i *InitiativeInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall
 		return syscall.EINVAL
 	}
 
-	// Extract projects from frontmatter
-	var newProjectSlugs []string
-	if projectsRaw, ok := doc.Frontmatter["projects"]; ok {
-		switch v := projectsRaw.(type) {
-		case []any:
-			for _, item := range v {
-				if s, ok := item.(string); ok {
-					newProjectSlugs = append(newProjectSlugs, s)
-				}
-			}
-		case []string:
-			newProjectSlugs = v
-		}
-	}
+	// Extract projects from frontmatter (coerced via the shared marshal helper)
+	newProjectSlugs := marshal.StringSliceFromYAML(doc.Frontmatter["projects"])
 
 	// Get current project slugs
 	var currentProjectSlugs []string
@@ -373,22 +361,14 @@ func (i *InitiativeInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall
 
 	// Persist editable scalar fields (name in frontmatter, description in body).
 	// The body maps to the initiative's description, matching generateContent().
-	var initiativeInput api.InitiativeUpdateInput
-	fieldChanged := false
-	if newDesc := strings.TrimSpace(doc.Body); newDesc != strings.TrimSpace(i.initiative.Description) {
-		initiativeInput.Description = &newDesc
-		fieldChanged = true
-	}
-	if name, ok := doc.Frontmatter["name"].(string); ok && name != "" && name != i.initiative.Name {
-		nameCopy := name
-		initiativeInput.Name = &nameCopy
-		fieldChanged = true
-	}
-	if fieldChanged {
+	// scalarEdit owns the diff, name coercion, and the divergence compare below.
+	edit := newScalarEdit(doc, i.initiative.Name, i.initiative.Description)
+	initiativeInput := api.InitiativeUpdateInput{Name: edit.name, Description: edit.desc}
+	if edit.changed() {
 		if err := i.lfs.mutator().UpdateInitiative(ctx, i.initiativeID, initiativeInput); err != nil {
-			log.Printf("Failed to update initiative %s: %v", i.initiative.Name, err)
-			i.lfs.SetWriteError(i.initiativeID, "Field: name/description\nError: failed to update initiative: "+err.Error())
-			return syscall.EIO
+			msg, errno := classifyMutationErr("update initiative", err)
+			i.lfs.SetWriteError(i.initiativeID, msg)
+			return errno
 		}
 		if i.lfs.debug {
 			log.Printf("Updated initiative %s scalar fields", i.initiative.Name)
@@ -407,14 +387,7 @@ func (i *InitiativeInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall
 			return i.lfs.UpsertInitiative(ctx, *fresh)
 		},
 		compare: func(fresh *api.Initiative) []writeBackResult {
-			var results []writeBackResult
-			if initiativeInput.Name != nil {
-				results = append(results, writeBackDivergence("name", *initiativeInput.Name, fresh.Name, i.initiative.Name))
-			}
-			if initiativeInput.Description != nil {
-				results = append(results, writeBackDivergence("description (body)", *initiativeInput.Description, fresh.Description, i.initiative.Description))
-			}
-			return results
+			return edit.divergences(fresh.Name, fresh.Description)
 		},
 	})
 	if fresh != nil {

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -474,20 +474,8 @@ func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Er
 		return syscall.EINVAL
 	}
 
-	// Extract initiatives from frontmatter
-	var newInitiatives []string
-	if initiativesRaw, ok := doc.Frontmatter["initiatives"]; ok {
-		switch v := initiativesRaw.(type) {
-		case []any:
-			for _, item := range v {
-				if s, ok := item.(string); ok {
-					newInitiatives = append(newInitiatives, s)
-				}
-			}
-		case []string:
-			newInitiatives = v
-		}
-	}
+	// Extract initiatives from frontmatter (coerced via the shared marshal helper)
+	newInitiatives := marshal.StringSliceFromYAML(doc.Frontmatter["initiatives"])
 
 	// Get current initiatives
 	var currentInitiatives []string
@@ -528,22 +516,14 @@ func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Er
 
 	// Persist editable scalar fields (name in frontmatter, description in body).
 	// The body maps to the project's description, matching generateContent().
-	var projectInput api.ProjectUpdateInput
-	fieldChanged := false
-	if newDesc := strings.TrimSpace(doc.Body); newDesc != strings.TrimSpace(p.project.Description) {
-		projectInput.Description = &newDesc
-		fieldChanged = true
-	}
-	if name, ok := doc.Frontmatter["name"].(string); ok && name != "" && name != p.project.Name {
-		nameCopy := name
-		projectInput.Name = &nameCopy
-		fieldChanged = true
-	}
-	if fieldChanged {
+	// scalarEdit owns the diff, name coercion, and the divergence compare below.
+	edit := newScalarEdit(doc, p.project.Name, p.project.Description)
+	projectInput := api.ProjectUpdateInput{Name: edit.name, Description: edit.desc}
+	if edit.changed() {
 		if err := p.lfs.mutator().UpdateProject(ctx, p.project.ID, projectInput); err != nil {
-			log.Printf("Failed to update project %s: %v", p.project.Name, err)
-			p.lfs.SetWriteError(p.project.ID, "Field: name/description\nError: failed to update project: "+err.Error())
-			return syscall.EIO
+			msg, errno := classifyMutationErr("update project", err)
+			p.lfs.SetWriteError(p.project.ID, msg)
+			return errno
 		}
 		if p.lfs.debug {
 			log.Printf("Updated project %s scalar fields", p.project.Name)
@@ -560,14 +540,7 @@ func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Er
 			return p.lfs.UpsertProject(ctx, p.team.ID, *fresh)
 		},
 		compare: func(fresh *api.Project) []writeBackResult {
-			var results []writeBackResult
-			if projectInput.Name != nil {
-				results = append(results, writeBackDivergence("name", *projectInput.Name, fresh.Name, p.project.Name))
-			}
-			if projectInput.Description != nil {
-				results = append(results, writeBackDivergence("description (body)", *projectInput.Description, fresh.Description, p.project.Description))
-			}
-			return results
+			return edit.divergences(fresh.Name, fresh.Description)
 		},
 	})
 	if fresh != nil {

--- a/internal/fs/scalaredit.go
+++ b/internal/fs/scalaredit.go
@@ -1,0 +1,58 @@
+package fs
+
+import (
+	"strings"
+
+	"github.com/jra3/linear-fuse/internal/marshal"
+)
+
+// scalarEdit is the diff of the two scalar fields both project.md and
+// initiative.md expose for editing — a name (frontmatter) and a description
+// (body). It owns the change decision (what counts as "changed"), the name
+// coercion, and the read-your-writes divergence classification, so the two
+// handlers no longer each hand-roll a `fieldChanged` flag and a byte-identical
+// commitWriteBack compare closure. See CONTEXT.md "Scalar edit (scalarEdit)".
+//
+// It stays neutral to the entity type: the caller maps name/desc onto its own
+// typed update input (api.ProjectUpdateInput / api.InitiativeUpdateInput) and
+// pulls the fresh values back out for divergences — nothing Project- or
+// Initiative-shaped crosses this interface.
+type scalarEdit struct {
+	name, desc         *string // new value, non-nil iff that field changed
+	origName, origDesc string  // pre-write values, for the divergence "original"
+}
+
+// newScalarEdit diffs a parsed document against the current name/description.
+// The body maps to the description; both sides are trimmed for the change test
+// so a render/parse trailing-newline delta doesn't read as an edit, and the
+// trimmed body is what we send. The frontmatter name is coerced the way the
+// issue handler coerces its scalars (a numeric or bare-scalar name updates
+// rather than being silently dropped); an empty or unchanged name is left alone.
+func newScalarEdit(doc *marshal.Document, curName, curDesc string) scalarEdit {
+	e := scalarEdit{origName: curName, origDesc: curDesc}
+	if newDesc := strings.TrimSpace(doc.Body); newDesc != strings.TrimSpace(curDesc) {
+		e.desc = &newDesc
+	}
+	if name := marshal.ScalarToString(doc.Frontmatter["name"]); name != "" && name != curName {
+		e.name = &name
+	}
+	return e
+}
+
+// changed reports whether either scalar field needs an API update.
+func (e scalarEdit) changed() bool { return e.name != nil || e.desc != nil }
+
+// divergences classifies the read-your-writes result for each field that was
+// sent, comparing what we sent against what persisted (relative to the pre-write
+// value). Only fields that actually changed are checked — an untouched field
+// can't diverge. name is checked before description, one canonical order.
+func (e scalarEdit) divergences(freshName, freshDesc string) []writeBackResult {
+	var results []writeBackResult
+	if e.name != nil {
+		results = append(results, writeBackDivergence("name", *e.name, freshName, e.origName))
+	}
+	if e.desc != nil {
+		results = append(results, writeBackDivergence("description (body)", *e.desc, freshDesc, e.origDesc))
+	}
+	return results
+}

--- a/internal/fs/scalaredit_test.go
+++ b/internal/fs/scalaredit_test.go
@@ -1,0 +1,98 @@
+package fs
+
+import (
+	"testing"
+
+	"github.com/jra3/linear-fuse/internal/marshal"
+)
+
+// scalarEdit is pure — it works on a parsed marshal.Document plus the current
+// name/description, with no FUSE mount, SQLite, or API. These tests pin the
+// change decision, the name coercion (F2), and the divergence classification.
+
+func doc(name string, body string) *marshal.Document {
+	fm := map[string]any{}
+	if name != "" {
+		fm["name"] = name
+	}
+	return &marshal.Document{Frontmatter: fm, Body: body}
+}
+
+func TestScalarEditDetectsBothFields(t *testing.T) {
+	e := newScalarEdit(doc("New Name", "New body"), "Old Name", "Old body")
+	if !e.changed() {
+		t.Fatal("changed() = false, want true")
+	}
+	if e.name == nil || *e.name != "New Name" {
+		t.Errorf("name = %v, want New Name", e.name)
+	}
+	if e.desc == nil || *e.desc != "New body" {
+		t.Errorf("desc = %v, want New body", e.desc)
+	}
+}
+
+func TestScalarEditNoChange(t *testing.T) {
+	e := newScalarEdit(doc("Same", "Same body"), "Same", "Same body")
+	if e.changed() {
+		t.Errorf("changed() = true, want false (name=%v desc=%v)", e.name, e.desc)
+	}
+}
+
+func TestScalarEditTrailingNewlineIsNoOp(t *testing.T) {
+	// The load-bearing trim: a render/parse trailing-newline delta must not read
+	// as an edit, or every no-op save would rewrite the description.
+	e := newScalarEdit(doc("Same", "Body text\n"), "Same", "Body text")
+	if e.desc != nil {
+		t.Errorf("desc = %q, want nil (trailing newline should be a no-op)", *e.desc)
+	}
+}
+
+func TestScalarEditCoercesNumericName(t *testing.T) {
+	// F2: a YAML numeric name coerces and updates, rather than being silently
+	// dropped by a direct string type assertion.
+	e := newScalarEdit(&marshal.Document{Frontmatter: map[string]any{"name": 123}, Body: "b"}, "Old", "b")
+	if e.name == nil || *e.name != "123" {
+		t.Errorf("name = %v, want coerced \"123\"", e.name)
+	}
+}
+
+func TestScalarEditMissingNameLeavesItAlone(t *testing.T) {
+	// No name key in frontmatter: name stays unset, no panic on the nil value.
+	e := newScalarEdit(&marshal.Document{Frontmatter: map[string]any{}, Body: "new body"}, "Keep", "old body")
+	if e.name != nil {
+		t.Errorf("name = %v, want nil when frontmatter has no name", e.name)
+	}
+	if e.desc == nil {
+		t.Error("desc should still update from the body")
+	}
+}
+
+func TestScalarEditClearsDescription(t *testing.T) {
+	// Emptying the body clears the description (sends an empty string).
+	e := newScalarEdit(doc("Same", "   "), "Same", "had content")
+	if e.desc == nil || *e.desc != "" {
+		t.Errorf("desc = %v, want pointer to empty string (cleared)", e.desc)
+	}
+}
+
+func TestScalarEditDivergencesOnlyChangedFields(t *testing.T) {
+	// Only the fields that were sent are checked — an untouched field can't
+	// diverge. Here only the name changed.
+	e := newScalarEdit(doc("Sent Name", "Same body"), "Old Name", "Same body")
+	results := e.divergences("Sent Name", "Same body")
+	if len(results) != 1 {
+		t.Fatalf("divergences = %d results, want 1 (only name changed)", len(results))
+	}
+	if results[0].message != "" || results[0].fatal {
+		t.Errorf("faithful name write should be a clean result, got %+v", results[0])
+	}
+}
+
+func TestScalarEditDivergencesFlagsSilentRevert(t *testing.T) {
+	// Sent a new name, but the fresh value reverted to the original: fatal.
+	e := newScalarEdit(doc("Sent Name", "b"), "Old Name", "b")
+	results := e.divergences("Old Name", "b") // fresh reverted to original
+	if len(results) != 1 || !results[0].fatal {
+		t.Fatalf("expected 1 fatal divergence for a silent revert, got %+v", results)
+	}
+}

--- a/internal/marshal/issue.go
+++ b/internal/marshal/issue.go
@@ -192,7 +192,7 @@ func MarkdownToIssueUpdate(content []byte, original *api.Issue) (map[string]any,
 	update := make(map[string]any)
 	fm := doc.Frontmatter
 
-	// Every editable field is coerced to its scalar form (scalarToString) before
+	// Every editable field is coerced to its scalar form (ScalarToString) before
 	// comparison so a wrong-typed-but-meaningful value — an unquoted `due:` that
 	// parsed as time.Time, a numeric `title:`/`cycle:`, a quoted `estimate: "3"` —
 	// is applied rather than silently ignored (the #148 no-op-write failure mode,
@@ -200,13 +200,13 @@ func MarkdownToIssueUpdate(content []byte, original *api.Issue) (map[string]any,
 	// "not set"; explicit removal is keyed on the field being absent entirely.
 
 	if v, present := fm["title"]; present {
-		if title := scalarToString(v); title != "" && title != original.Title {
+		if title := ScalarToString(v); title != "" && title != original.Title {
 			update["title"] = title
 		}
 	}
 
 	if v, present := fm["status"]; present {
-		if status := scalarToString(v); status != "" {
+		if status := ScalarToString(v); status != "" {
 			origStatus := ""
 			if original.State.ID != "" {
 				origStatus = original.State.Name
@@ -229,7 +229,7 @@ func MarkdownToIssueUpdate(content []byte, original *api.Issue) (map[string]any,
 
 	// Assignee
 	if v, present := fm["assignee"]; present {
-		if assignee := scalarToString(v); assignee != "" {
+		if assignee := ScalarToString(v); assignee != "" {
 			origAssignee := ""
 			if original.Assignee != nil {
 				origAssignee = original.Assignee.Email
@@ -244,7 +244,7 @@ func MarkdownToIssueUpdate(content []byte, original *api.Issue) (map[string]any,
 
 	// Due date
 	if v, present := fm["due"]; present {
-		if due := scalarToString(v); due != "" {
+		if due := ScalarToString(v); due != "" {
 			origDue := ""
 			if original.DueDate != nil {
 				origDue = *original.DueDate
@@ -275,7 +275,7 @@ func MarkdownToIssueUpdate(content []byte, original *api.Issue) (map[string]any,
 
 	// Labels
 	if labelsRaw, present := fm["labels"]; present {
-		newLabels := stringSliceFromYAML(labelsRaw)
+		newLabels := StringSliceFromYAML(labelsRaw)
 
 		origLabels := make([]string, len(original.Labels.Nodes))
 		for i, l := range original.Labels.Nodes {
@@ -292,7 +292,7 @@ func MarkdownToIssueUpdate(content []byte, original *api.Issue) (map[string]any,
 
 	// Parent
 	if v, present := fm["parent"]; present {
-		if parent := scalarToString(v); parent != "" {
+		if parent := ScalarToString(v); parent != "" {
 			origParent := ""
 			if original.Parent != nil {
 				origParent = original.Parent.Identifier
@@ -307,7 +307,7 @@ func MarkdownToIssueUpdate(content []byte, original *api.Issue) (map[string]any,
 
 	// Project
 	if v, present := fm["project"]; present {
-		if project := scalarToString(v); project != "" {
+		if project := ScalarToString(v); project != "" {
 			origProject := ""
 			if original.Project != nil {
 				origProject = original.Project.Name
@@ -322,7 +322,7 @@ func MarkdownToIssueUpdate(content []byte, original *api.Issue) (map[string]any,
 
 	// Milestone
 	if v, present := fm["milestone"]; present {
-		if milestone := scalarToString(v); milestone != "" {
+		if milestone := ScalarToString(v); milestone != "" {
 			origMilestone := ""
 			if original.ProjectMilestone != nil {
 				origMilestone = original.ProjectMilestone.Name
@@ -337,7 +337,7 @@ func MarkdownToIssueUpdate(content []byte, original *api.Issue) (map[string]any,
 
 	// Cycle
 	if v, present := fm["cycle"]; present {
-		if cycle := scalarToString(v); cycle != "" {
+		if cycle := ScalarToString(v); cycle != "" {
 			origCycle := ""
 			if original.Cycle != nil {
 				origCycle = original.Cycle.Name
@@ -379,14 +379,14 @@ func MarkdownToIssueCreate(content []byte) (map[string]any, error) {
 	// `due: 2026-02-01` parses as time.Time, `priority: 2` as int, etc. Silent
 	// field-drops are exactly the #148 failure mode this surface exists to kill.
 	if v, ok := fm["title"]; ok {
-		if s := scalarToString(v); s != "" {
+		if s := ScalarToString(v); s != "" {
 			create["title"] = s
 		}
 	}
-	// Relational fields are coerced to their string name (via scalarToString)
+	// Relational fields are coerced to their string name (via ScalarToString)
 	// rather than bare `.(string)` — a numeric name (`cycle: 42`) or other
 	// non-string scalar must not be silently dropped (#148).
-	if s := scalarToString(fm["status"]); s != "" {
+	if s := ScalarToString(fm["status"]); s != "" {
 		create["stateId"] = s // resolved to state ID
 	}
 	if v, ok := fm["priority"]; ok {
@@ -398,10 +398,10 @@ func MarkdownToIssueCreate(content []byte) (map[string]any, error) {
 			create["priority"] = n
 		}
 	}
-	if s := scalarToString(fm["assignee"]); s != "" {
+	if s := ScalarToString(fm["assignee"]); s != "" {
 		create["assigneeId"] = s // resolved to user ID
 	}
-	if labels := stringSliceFromYAML(fm["labels"]); len(labels) > 0 {
+	if labels := StringSliceFromYAML(fm["labels"]); len(labels) > 0 {
 		create["labelIds"] = labels // resolved to label IDs
 	}
 	if v, ok := fm["due"]; ok {
@@ -414,16 +414,16 @@ func MarkdownToIssueCreate(content []byte) (map[string]any, error) {
 			create["estimate"] = n // Linear estimate is an integer
 		}
 	}
-	if s := scalarToString(fm["project"]); s != "" {
+	if s := ScalarToString(fm["project"]); s != "" {
 		create["projectId"] = s // resolved to project ID
 	}
-	if s := scalarToString(fm["milestone"]); s != "" {
+	if s := ScalarToString(fm["milestone"]); s != "" {
 		create["projectMilestoneId"] = s // resolved to milestone ID
 	}
-	if s := scalarToString(fm["cycle"]); s != "" {
+	if s := ScalarToString(fm["cycle"]); s != "" {
 		create["cycleId"] = s // resolved to cycle ID
 	}
-	if s := scalarToString(fm["parent"]); s != "" {
+	if s := ScalarToString(fm["parent"]); s != "" {
 		create["parentId"] = s // resolved to issue ID
 	}
 	if body := doc.Body; body != "" {
@@ -433,9 +433,9 @@ func MarkdownToIssueCreate(content []byte) (map[string]any, error) {
 	return create, nil
 }
 
-// scalarToString coerces a YAML scalar (string, number, bool) to its string
+// ScalarToString coerces a YAML scalar (string, number, bool) to its string
 // form so a wrong-typed-but-meaningful value isn't silently dropped.
-func scalarToString(v any) string {
+func ScalarToString(v any) string {
 	switch s := v.(type) {
 	case string:
 		return s
@@ -454,14 +454,14 @@ func dueToString(v any) string {
 	if t, ok := v.(time.Time); ok {
 		return t.Format("2006-01-02")
 	}
-	return scalarToString(v)
+	return ScalarToString(v)
 }
 
-// stringSliceFromYAML coerces a YAML value into a []string. It accepts a list
+// StringSliceFromYAML coerces a YAML value into a []string. It accepts a list
 // (`labels: [Bug, Backend]`) or a bare scalar (`labels: Bug`), and coerces each
-// element via scalarToString so a numeric-looking name (`2026`) isn't silently
+// element via ScalarToString so a numeric-looking name (`2026`) isn't silently
 // dropped — silent element-drops are the #148 failure mode this surface kills.
-func stringSliceFromYAML(v any) []string {
+func StringSliceFromYAML(v any) []string {
 	switch s := v.(type) {
 	case nil:
 		return nil
@@ -470,14 +470,14 @@ func stringSliceFromYAML(v any) []string {
 	case []any:
 		out := make([]string, 0, len(s))
 		for _, item := range s {
-			if str := scalarToString(item); str != "" {
+			if str := ScalarToString(item); str != "" {
 				out = append(out, str)
 			}
 		}
 		return out
 	default:
 		// A bare scalar (`labels: Bug`, or a number) — a single-element list.
-		if str := scalarToString(v); str != "" {
+		if str := ScalarToString(v); str != "" {
 			return []string{str}
 		}
 		return nil


### PR DESCRIPTION
## What

`ProjectInfoNode.Flush` and `InitiativeInfoNode.Flush` were mirror images with three byte-identical bookends left over after `reconcileLinks` took the relational middle:

- **(A)** frontmatter list extraction
- **(B)** the `fieldChanged` scalar name/description diff that builds the update input
- **(C)** the `commitWriteBack` compare closure keyed off `input.Name != nil` / `input.Description != nil`

## The module

`scalarEdit` (`internal/fs/scalaredit.go`) owns **B+C** — the scalar counterpart to `reconcileLinks`, which owns the list front half of the same two handlers. `project.md`/`initiative.md` each expose exactly two editable scalars (name in frontmatter, description in body); `scalarEdit` is their diff:

```go
type scalarEdit struct {
    name, desc         *string // new value, non-nil iff that field changed
    origName, origDesc string  // pre-write values, for the divergence "original"
}
func newScalarEdit(doc *marshal.Document, curName, curDesc string) scalarEdit
func (e scalarEdit) changed() bool
func (e scalarEdit) divergences(freshName, freshDesc string) []writeBackResult
```

It stays **neutral to the entity type** — the caller maps `name`/`desc` onto its own typed `api.ProjectUpdateInput`/`api.InitiativeUpdateInput` and pulls the fresh values back out — so no generics, nothing Project/Initiative-shaped crosses the interface. Pure of the mount/SQLite/API; unit-tested directly on a parsed `marshal.Document`.

## Three tidies ride along

All "behave like the issue handler / the reconcile path already do" (agreed during design):

- **F1** — scalar-update failures route through `classifyMutationErr` (like the reconcile path 20 lines above), so a rate-limited scalar edit returns **`EAGAIN`** instead of a flat `EIO`, and the server's reason reaches `.error`. *(latent bug fix)*
- **F2** — the name is coerced via `marshal.ScalarToString`, so a numeric/bare-scalar name updates instead of being silently dropped by a `.(string)` assertion.
- **F3 / (A)** — both handlers reuse `marshal.StringSliceFromYAML` for list extraction (coerces numbers, accepts a bare scalar).

`marshal.ScalarToString` and `marshal.StringSliceFromYAML` were exported for this (rename + internal callers updated).

## Left as-is (deliberately)

- Description trim-on-save (`TrimSpace(body)` is sent) — the trim-both is load-bearing for no-op detection.
- Empty name = silent no-op (can't clear a required field) — correct.

## Verification

- New `scalaredit_test.go` — 8 tests: change detection, trailing-newline no-op, numeric-name coercion (F2), missing-name, clear-description, divergence only-changed-fields, silent-revert-is-fatal.
- `go build` / `go vet` / gofmt clean; full non-integration suite + integration suite `PASS`.

Each handler sheds ~30 net lines. `CONTEXT.md` gains the "Scalar edit (`scalarEdit`)" concept next to Link reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)