### PR TITLE
fix(sync): route issue-details sync through syncCollection, closing a silent-prune bug

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -361,6 +361,21 @@ correctly suppresses the prune (a stale junction row must never be wrongly
 deleted). The closure author honors the contract by choosing what to return
 versus swallow.
 
+The **per-issue detail sync** (`syncIssueDetailsBatch` — an issue's comments,
+documents, attachments) reconciles through the same tail, three calls per issue.
+Here completeness is *page*-shaped rather than *drain*-shaped: a full page
+(`len == IssueDetailsPageSize`) may be truncated, so the caller composes a
+`pruneWhenComplete(complete, fn)` policy that passes the real prune only on a
+short (provably complete) page and `nil` otherwise — the module then adds its
+clean guard, so a detail prune fires **iff clean AND complete**. This closed a
+silent-prune bug the hand-rolled version carried: it gated the prune on page
+completeness alone, so a failed comment/doc/attachment upsert (its `synced_at`
+left un-stamped) was deleted as stale on the next complete page. Embedded-file
+extraction from a comment body is the nested best-effort here (its own
+never-pruned `embedded_files` table), analogous to milestones — it runs inside
+the comment `upsert` closure regardless of the upsert result and cannot affect
+cleanliness.
+
 ### ErrorSink
 The minimal seam the WriteBack tail uses to record validation/divergence messages for
 `.error` files: `SetWriteError(key, msg)` / `ClearWriteError(key)`. `*LinearFS`

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -811,77 +811,81 @@ func (w *Worker) syncIssueDetailsBatch(ctx context.Context, issues []struct {
 		return
 	}
 
-	// Store results
+	// Store each issue's comments/documents/attachments through the shared
+	// syncCollection tail. The module contributes the CLEAN guard (a failed
+	// convert/upsert marks the collection unclean and suppresses its prune —
+	// the fix for the old silent-prune bug, where a failed upsert left a row's
+	// synced_at un-stamped yet the prune still deleted it); the caller
+	// contributes COMPLETENESS via prune-or-nil below. A prune therefore fires
+	// only when the fetch was clean AND complete.
+	//
+	// The prunes must run before the Touch* pass below, which re-stamps ALL of
+	// an issue's rows and would exempt phantoms from the cutoff. Completeness
+	// still relies on the API client's all-or-nothing batch semantics — c.query
+	// fails the WHOLE batch on any GraphQL error, so a partially-failed response
+	// never reaches this loop as a short-but-"complete" details struct.
+	pruneWhenComplete := func(complete bool, fn func(context.Context) error) func(context.Context) error {
+		if !complete {
+			return nil // a full page may be truncated — pruning against it would delete real rows
+		}
+		return fn
+	}
+
 	for issueID, details := range detailsMap {
 		if details == nil {
 			continue
 		}
 
-		// Store comments
-		for _, comment := range details.Comments {
-			params, err := db.APICommentToDBComment(comment, issueID)
-			if err != nil {
-				continue
-			}
-			if err := w.store.Queries().UpsertComment(ctx, params); err != nil {
-				log.Printf("[sync] upsert comment %s failed: %v", comment.ID, err)
-			}
+		syncCollection(ctx, syncCollectionSpec[api.Comment]{
+			label: "comment " + issueID,
+			items: details.Comments,
+			upsert: func(ctx context.Context, comment api.Comment) error {
+				params, err := db.APICommentToDBComment(comment, issueID)
+				if err != nil {
+					return err
+				}
+				upsertErr := w.store.Queries().UpsertComment(ctx, params)
+				// Embedded files are a nested best-effort sub-write to a
+				// separate, never-pruned table — outside this prune's
+				// completeness set — so extraction runs regardless of the
+				// upsert result and cannot affect cleanliness.
+				w.extractAndStoreEmbeddedFiles(ctx, issueID, comment.Body, "comment:"+comment.ID)
+				return upsertErr
+			},
+			prune: pruneWhenComplete(len(details.Comments) < api.IssueDetailsPageSize, func(ctx context.Context) error {
+				return w.store.Queries().PruneIssueComments(ctx, db.PruneIssueCommentsParams{IssueID: issueID, SyncedAt: pruneCutoff})
+			}),
+		})
 
-			// Extract embedded files from comment body
-			w.extractAndStoreEmbeddedFiles(ctx, issueID, comment.Body, "comment:"+comment.ID)
-		}
+		syncCollection(ctx, syncCollectionSpec[api.Document]{
+			label: "document " + issueID,
+			items: details.Documents,
+			upsert: func(ctx context.Context, doc api.Document) error {
+				params, err := db.APIDocumentToDBDocument(doc)
+				if err != nil {
+					return err
+				}
+				return w.store.Queries().UpsertDocument(ctx, params)
+			},
+			prune: pruneWhenComplete(len(details.Documents) < api.IssueDetailsPageSize, func(ctx context.Context) error {
+				return w.store.Queries().PruneIssueDocuments(ctx, db.PruneIssueDocumentsParams{IssueID: sql.NullString{String: issueID, Valid: true}, SyncedAt: pruneCutoff})
+			}),
+		})
 
-		// Store documents
-		for _, doc := range details.Documents {
-			params, err := db.APIDocumentToDBDocument(doc)
-			if err != nil {
-				continue
-			}
-			if err := w.store.Queries().UpsertDocument(ctx, params); err != nil {
-				log.Printf("[sync] upsert document %s failed: %v", doc.ID, err)
-			}
-		}
-
-		// Store attachments
-		for _, attachment := range details.Attachments {
-			params, err := db.APIAttachmentToDBAttachment(attachment, issueID)
-			if err != nil {
-				continue
-			}
-			if err := w.store.Queries().UpsertAttachment(ctx, params); err != nil {
-				log.Printf("[sync] upsert attachment %s failed: %v", attachment.ID, err)
-			}
-		}
-
-		// Prune rows the fetch no longer returned — a comment/doc/attachment
-		// deleted in Linear, or a phantom left by a delete whose SQLite forget
-		// failed. The upserts above re-stamped every fetched row's synced_at,
-		// so anything still older than the pre-fetch cutoff is stale. Only a
-		// provably complete set may prune: a full page (IssueDetailsPageSize)
-		// may be truncated, and pruning against it would delete real rows.
-		// This must run before the Touch* pass below, which re-stamps ALL of
-		// an issue's rows and would exempt phantoms from the cutoff.
-		//
-		// SAFETY: pruning against an empty-but-wrong set relies on the API
-		// client's all-or-nothing batch semantics — c.query fails the WHOLE
-		// batch on any GraphQL error, so a partially-failed response can never
-		// reach this loop as an empty details struct. If that ever relaxes to
-		// "return the data we got", this prune becomes silent data loss.
-		if len(details.Comments) < api.IssueDetailsPageSize {
-			if err := w.store.Queries().PruneIssueComments(ctx, db.PruneIssueCommentsParams{IssueID: issueID, SyncedAt: pruneCutoff}); err != nil {
-				log.Printf("[sync] prune comments %s: %v", issueID, err)
-			}
-		}
-		if len(details.Documents) < api.IssueDetailsPageSize {
-			if err := w.store.Queries().PruneIssueDocuments(ctx, db.PruneIssueDocumentsParams{IssueID: sql.NullString{String: issueID, Valid: true}, SyncedAt: pruneCutoff}); err != nil {
-				log.Printf("[sync] prune documents %s: %v", issueID, err)
-			}
-		}
-		if len(details.Attachments) < api.IssueDetailsPageSize {
-			if err := w.store.Queries().PruneIssueAttachments(ctx, db.PruneIssueAttachmentsParams{IssueID: issueID, SyncedAt: pruneCutoff}); err != nil {
-				log.Printf("[sync] prune attachments %s: %v", issueID, err)
-			}
-		}
+		syncCollection(ctx, syncCollectionSpec[api.Attachment]{
+			label: "attachment " + issueID,
+			items: details.Attachments,
+			upsert: func(ctx context.Context, attachment api.Attachment) error {
+				params, err := db.APIAttachmentToDBAttachment(attachment, issueID)
+				if err != nil {
+					return err
+				}
+				return w.store.Queries().UpsertAttachment(ctx, params)
+			},
+			prune: pruneWhenComplete(len(details.Attachments) < api.IssueDetailsPageSize, func(ctx context.Context) error {
+				return w.store.Queries().PruneIssueAttachments(ctx, db.PruneIssueAttachmentsParams{IssueID: issueID, SyncedAt: pruneCutoff})
+			}),
+		})
 	}
 
 	// Touch synced_at for all fetched issues so the FS layer doesn't immediately

--- a/internal/sync/worker_test.go
+++ b/internal/sync/worker_test.go
@@ -967,6 +967,85 @@ func TestDetailsSyncFullPageSkipsPrune(t *testing.T) {
 	}
 }
 
+// TestDetailsSyncPrunesStaleDocsAndAttachments guards the document/attachment
+// wiring of the three near-identical syncCollection specs the details sync now
+// uses: a mis-wired items slice or issueID (e.g. handing details.Comments to the
+// document spec, or the wrong id to a prune) would leave a stale row un-pruned or
+// a live one deleted. Comments have their own prune test above; this covers the
+// other two collections end-to-end.
+func TestDetailsSyncPrunesStaleDocsAndAttachments(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	old := time.Now().Add(-time.Minute)
+	issueRef := &api.Issue{ID: "issue-1"} // documents key their issue_id off document.Issue.ID
+
+	liveDoc := api.Document{ID: "doc-live", SlugID: "slug-live", Title: "Live", Issue: issueRef, CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	staleDoc := api.Document{ID: "doc-stale", SlugID: "slug-stale", Title: "Stale", Issue: issueRef, CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	for _, d := range []api.Document{liveDoc, staleDoc} {
+		params, err := db.APIDocumentToDBDocument(d)
+		if err != nil {
+			t.Fatalf("convert document: %v", err)
+		}
+		params.SyncedAt = old
+		if err := store.Queries().UpsertDocument(ctx, params); err != nil {
+			t.Fatalf("seed document: %v", err)
+		}
+	}
+
+	liveAtt := api.Attachment{ID: "att-live", Title: "Live", URL: "https://x/live", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	staleAtt := api.Attachment{ID: "att-stale", Title: "Stale", URL: "https://x/stale", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	for _, a := range []api.Attachment{liveAtt, staleAtt} {
+		params, err := db.APIAttachmentToDBAttachment(a, "issue-1")
+		if err != nil {
+			t.Fatalf("convert attachment: %v", err)
+		}
+		params.SyncedAt = old
+		if err := store.Queries().UpsertAttachment(ctx, params); err != nil {
+			t.Fatalf("seed attachment: %v", err)
+		}
+	}
+
+	// The fetch returns only the live row for each collection.
+	mock := newMockAPIClient()
+	mock.detailsByIssue["issue-1"] = &api.IssueDetails{
+		Documents:   []api.Document{liveDoc},
+		Attachments: []api.Attachment{liveAtt},
+	}
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	worker.syncIssueDetailsBatch(ctx, []struct {
+		ID         string
+		Identifier string
+	}{{ID: "issue-1", Identifier: "TST-1"}})
+
+	docs, err := store.Queries().ListIssueDocuments(ctx, sql.NullString{String: "issue-1", Valid: true})
+	if err != nil {
+		t.Fatalf("list documents: %v", err)
+	}
+	if len(docs) != 1 || docs[0].ID != "doc-live" {
+		got := []string{}
+		for _, d := range docs {
+			got = append(got, d.ID)
+		}
+		t.Errorf("documents = %v, want [doc-live] (stale pruned, live retained)", got)
+	}
+
+	atts, err := store.Queries().ListIssueAttachments(ctx, "issue-1")
+	if err != nil {
+		t.Fatalf("list attachments: %v", err)
+	}
+	if len(atts) != 1 || atts[0].ID != "att-live" {
+		got := []string{}
+		for _, a := range atts {
+			got = append(got, a.ID)
+		}
+		t.Errorf("attachments = %v, want [att-live] (stale pruned, live retained)", got)
+	}
+}
+
 // TestSetRateLimitedAdaptiveBackoff verifies M-3: when the API client reports a non-zero
 // RateLimitResetAt(), setRateLimited() uses that time (+ 5s buffer) instead of the 15-min default.
 func TestSetRateLimitedAdaptiveBackoff(t *testing.T) {


### PR DESCRIPTION
## The bug

`syncIssueDetailsBatch` reconciled each issue's comments/documents/attachments by hand, gating the prune **only** on page-completeness (`len(details.Comments) < IssueDetailsPageSize`). But a failed per-item upsert was logged and skipped — its `synced_at` never re-stamped — while the prune still fired:

```go
for _, comment := range details.Comments {
    ...
    if err := w.store.Queries().UpsertComment(ctx, params); err != nil {
        log.Printf("[sync] upsert comment %s failed: %v", comment.ID, err)
        // continues — prune below still runs
    }
}
if len(details.Comments) < api.IssueDetailsPageSize {
    w.store.Queries().PruneIssueComments(...) // deletes the un-re-stamped row
}
```

A complete page + one failed upsert ⇒ the live row is deleted as stale. **Silent data loss.** The (thorough) safety comment reasoned about batch-level completeness and the API's all-or-nothing semantics, but missed *per-item* cleanliness — exactly the invariant `syncCollection` owns.

## The fix

Route the three collections through the existing `syncCollection` module — three calls per issue. Two conditions compose:

- **`syncCollection` contributes the clean guard** — a failed convert/upsert marks the collection unclean and suppresses its prune. That's the fix, falling out of the module.
- **The caller contributes completeness** — a local `pruneWhenComplete(complete, fn)` policy passes the real prune only on a short (provably complete) page and `nil` on a full (possibly truncated) one.

A detail prune now fires **iff clean AND complete**. `syncCollection` is unchanged: completeness is a property of *this* fetch, owned at the call site, not baked into the tail as a one-consumer field.

## Embedded-file extraction

Moves inside the comment `upsert` closure as a nested best-effort (its own never-pruned `embedded_files` table, like project milestones): it runs regardless of the upsert result and returns nothing, so it can't affect cleanliness. Behavior preserved — extraction still fires even when the comment upsert fails.

## Tests

- Existing detail-prune tests stay green: stale-pruned, mid-fetch-create spared, full-page skipped.
- The failed-upsert-suppresses-prune guarantee is covered at the module level (`synccollection_test.go`).
- **New** `TestDetailsSyncPrunesStaleDocsAndAttachments` guards the document/attachment wiring of the three near-identical specs (a mis-wired items slice or `issueID` would strand a stale row) — comments already had theirs.
- `go build` / `go vet` / gofmt clean; full non-integration suite + integration suite `PASS`.

`CONTEXT.md`'s `syncCollection` entry gains the per-issue-detail / `pruneWhenComplete` note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)