### PR TITLE
refactor(api): project mutation responses through fragments, fixing attachment drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,10 +217,19 @@ query TeamIssues($teamId: String!) {
 ```
 
 Available fragments:
-- `IssueFields` - All issue fields (used by 11 queries)
+- `IssueFields` / `IssueFieldsLite` - Issue fields; the Lite variant (no relations) also backs the create mutation
 - `CommentFields` - Comment fields (query, create, update)
 - `DocumentFields` - Document fields (issue docs, project docs, create)
 - `LabelFields` - Label fields (query, create, update)
+- `AttachmentFields` - Attachment fields (detail query, create, link)
+- `ProjectMilestoneFields` - Milestone fields (nested in project queries, milestone query, create, update)
+- `ProjectUpdateFields` / `InitiativeUpdateFields` - Status-update fields (query + create)
+
+**Every mutation that returns an entity must project it through the entity's
+fragment, not an inlined field list** — an inlined copy silently drifts when the
+fragment gains a field (a real instance: the attachment create/link mutations
+had drifted, omitting `metadata` and `creator`). A fragment canonicalizes to one
+field set, so a created entity carries the same fields a fetched one does.
 
 When adding new fields to an entity, update the corresponding fragment.
 

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -158,6 +158,45 @@ fragment AttachmentFields on Attachment {
 }
 `
 
+// ProjectMilestoneFields is the shared projection for a project milestone,
+// used by the nested selections in queryTeamProjects/queryProject, the
+// standalone queryProjectMilestones, and the create/update mutations.
+const projectMilestoneFieldsFragment = `
+fragment ProjectMilestoneFields on ProjectMilestone {
+  id
+  name
+  description
+  targetDate
+  sortOrder
+}
+`
+
+// ProjectUpdateFields / InitiativeUpdateFields are the shared projections for
+// status updates. The create mutations previously omitted updatedAt; the
+// fragment canonicalizes to the query's fuller set so a created update carries
+// the same fields a fetched one does.
+const projectUpdateFieldsFragment = `
+fragment ProjectUpdateFields on ProjectUpdate {
+  id
+  body
+  health
+  createdAt
+  updatedAt
+  user { id name email }
+}
+`
+
+const initiativeUpdateFieldsFragment = `
+fragment InitiativeUpdateFields on InitiativeUpdate {
+  id
+  body
+  health
+  createdAt
+  updatedAt
+  user { id name email }
+}
+`
+
 // queryTeamMetadata fetches team metadata in a single query: states,
 // labels, cycles, members, and workspace labels. Projects deliberately live
 // in their own paginated query (queryTeamProjects): their nested selections
@@ -319,7 +358,7 @@ query TeamCycles($teamId: String!) {
 // selections cost ~187 complexity points per project node, so 50 is the
 // largest page that fits Linear's 10k complexity budget (measured live:
 // first:100 scores 18751).
-const queryTeamProjects = `
+var queryTeamProjects = `
 query TeamProjects($teamId: String!, $after: String) {
   team(id: $teamId) {
     projects(first: 50, after: $after) {
@@ -351,21 +390,15 @@ query TeamProjects($teamId: String!, $after: String) {
           }
         }
         projectMilestones {
-          nodes {
-            id
-            name
-            description
-            targetDate
-            sortOrder
-          }
+          nodes { ...ProjectMilestoneFields }
         }
       }
     }
   }
 }
-`
+` + projectMilestoneFieldsFragment
 
-const queryProject = `
+var queryProject = `
 query Project($id: String!) {
   project(id: $id) {
     id
@@ -394,33 +427,21 @@ query Project($id: String!) {
       }
     }
     projectMilestones {
-      nodes {
-        id
-        name
-        description
-        targetDate
-        sortOrder
-      }
+      nodes { ...ProjectMilestoneFields }
     }
   }
 }
-`
+` + projectMilestoneFieldsFragment
 
-const queryProjectMilestones = `
+var queryProjectMilestones = `
 query ProjectMilestones($projectId: String!) {
   project(id: $projectId) {
     projectMilestones {
-      nodes {
-        id
-        name
-        description
-        targetDate
-        sortOrder
-      }
+      nodes { ...ProjectMilestoneFields }
     }
   }
 }
-`
+` + projectMilestoneFieldsFragment
 
 // =============================================================================
 // Project Milestones Mutations
@@ -442,35 +463,23 @@ mutation UpdateInitiative($id: String!, $input: InitiativeUpdateInput!) {
 }
 `
 
-const mutationCreateProjectMilestone = `
+var mutationCreateProjectMilestone = `
 mutation CreateProjectMilestone($projectId: String!, $name: String!, $description: String) {
   projectMilestoneCreate(input: { projectId: $projectId, name: $name, description: $description }) {
     success
-    projectMilestone {
-      id
-      name
-      description
-      targetDate
-      sortOrder
-    }
+    projectMilestone { ...ProjectMilestoneFields }
   }
 }
-`
+` + projectMilestoneFieldsFragment
 
-const mutationUpdateProjectMilestone = `
+var mutationUpdateProjectMilestone = `
 mutation UpdateProjectMilestone($id: String!, $input: ProjectMilestoneUpdateInput!) {
   projectMilestoneUpdate(id: $id, input: $input) {
     success
-    projectMilestone {
-      id
-      name
-      description
-      targetDate
-      sortOrder
-    }
+    projectMilestone { ...ProjectMilestoneFields }
   }
 }
-`
+` + projectMilestoneFieldsFragment
 
 const mutationDeleteProjectMilestone = `
 mutation DeleteProjectMilestone($id: String!) {
@@ -480,85 +489,43 @@ mutation DeleteProjectMilestone($id: String!) {
 }
 `
 
-const queryProjectUpdates = `
+var queryProjectUpdates = `
 query ProjectUpdates($projectId: String!) {
   project(id: $projectId) {
     projectUpdates {
-      nodes {
-        id
-        body
-        health
-        createdAt
-        updatedAt
-        user {
-          id
-          name
-          email
-        }
-      }
+      nodes { ...ProjectUpdateFields }
     }
   }
 }
-`
+` + projectUpdateFieldsFragment
 
-const mutationCreateProjectUpdate = `
+var mutationCreateProjectUpdate = `
 mutation CreateProjectUpdate($projectId: String!, $body: String!, $health: ProjectUpdateHealthType) {
   projectUpdateCreate(input: {projectId: $projectId, body: $body, health: $health}) {
     success
-    projectUpdate {
-      id
-      body
-      health
-      createdAt
-      user {
-        id
-        name
-        email
-      }
-    }
+    projectUpdate { ...ProjectUpdateFields }
   }
 }
-`
+` + projectUpdateFieldsFragment
 
-const queryInitiativeUpdates = `
+var queryInitiativeUpdates = `
 query InitiativeUpdates($initiativeId: String!) {
   initiative(id: $initiativeId) {
     initiativeUpdates {
-      nodes {
-        id
-        body
-        health
-        createdAt
-        updatedAt
-        user {
-          id
-          name
-          email
-        }
-      }
+      nodes { ...InitiativeUpdateFields }
     }
   }
 }
-`
+` + initiativeUpdateFieldsFragment
 
-const mutationCreateInitiativeUpdate = `
+var mutationCreateInitiativeUpdate = `
 mutation CreateInitiativeUpdate($initiativeId: String!, $body: String!, $health: InitiativeUpdateHealthType) {
   initiativeUpdateCreate(input: {initiativeId: $initiativeId, body: $body, health: $health}) {
     success
-    initiativeUpdate {
-      id
-      body
-      health
-      createdAt
-      user {
-        id
-        name
-        email
-      }
-    }
+    initiativeUpdate { ...InitiativeUpdateFields }
   }
 }
-`
+` + initiativeUpdateFieldsFragment
 
 const mutationCreateProject = `
 mutation CreateProject($input: ProjectCreateInput!) {
@@ -770,46 +737,14 @@ mutation UpdateIssue($id: String!, $input: IssueUpdateInput!) {
 }
 `
 
-const mutationCreateIssue = `
+var mutationCreateIssue = `
 mutation CreateIssue($input: IssueCreateInput!) {
   issueCreate(input: $input) {
     success
-    issue {
-      id
-      identifier
-      title
-      description
-      state {
-        id
-        name
-        type
-      }
-      assignee {
-        id
-        name
-        email
-      }
-      priority
-      labels {
-        nodes {
-          id
-          name
-          color
-          description
-        }
-      }
-      createdAt
-      updatedAt
-      url
-      team {
-        id
-        key
-        name
-      }
-    }
+    issue { ...IssueFieldsLite }
   }
 }
-`
+` + issueFieldsFragmentLite
 
 const mutationArchiveIssue = `
 mutation ArchiveIssue($id: String!) {
@@ -1063,39 +998,23 @@ mutation DeleteIssueRelation($id: String!) {
 // Attachments Create/Link
 // =============================================================================
 
-const mutationCreateAttachment = `
+var mutationCreateAttachment = `
 mutation CreateAttachment($issueId: String!, $title: String!, $url: String!, $subtitle: String) {
   attachmentCreate(input: { issueId: $issueId, title: $title, url: $url, subtitle: $subtitle }) {
     success
-    attachment {
-      id
-      title
-      subtitle
-      url
-      sourceType
-      createdAt
-      updatedAt
-    }
+    attachment { ...AttachmentFields }
   }
 }
-`
+` + AttachmentFieldsFragment
 
-const mutationLinkURL = `
+var mutationLinkURL = `
 mutation AttachmentLinkURL($issueId: String!, $url: String!, $title: String) {
   attachmentLinkURL(issueId: $issueId, url: $url, title: $title) {
     success
-    attachment {
-      id
-      title
-      subtitle
-      url
-      sourceType
-      createdAt
-      updatedAt
-    }
+    attachment { ...AttachmentFields }
   }
 }
-`
+` + AttachmentFieldsFragment
 
 const mutationDeleteAttachment = `
 mutation DeleteAttachment($id: String!) {


### PR DESCRIPTION
## What

Create/link mutations hand-copied their GraphQL response projection instead of using the entity fragment — a drift trap, since a schema change updates the fragment and silently skips the inlined copy. **One had already drifted:** `mutationCreateAttachment` and `mutationLinkURL` inline a 7-field subset that omits `metadata` and `creator`, both of which `AttachmentFields` carries. So a freshly created/linked attachment came back missing them until the next sync re-fetched it via the fragment.

## Change

Point every inlined mutation/query at a shared fragment, **canonicalizing to the fuller field set** — a created entity now carries the same fields a fetched one does:

- **Attachment** create/link → `...AttachmentFields` (restores `metadata` + `creator` — the drift fix).
- **Issue** create → `...IssueFieldsLite` (existing fragment; create now returns a complete issue for the SQLite upsert instead of a 12-field subset).
- **New fragments**:
  - `ProjectMilestoneFields` — 5 sites (nested in `queryTeamProjects`/`queryProject`, `queryProjectMilestones`, create, update)
  - `ProjectUpdateFields` / `InitiativeUpdateFields` — query + create each; the create mutations gain `updatedAt`, matching the query.

Each new fragment has **2–5 real consumers** (query + mutation(s)), so the seam is justified, and every field is copied verbatim from a selection that already runs live.

## Safety

- **Use/append parity verified**: every `...Fragment` reference has its definition appended to that query (a missing append is a runtime GraphQL error the compiler can't catch) — checked by count for all five fragments.
- **Complexity budget unaffected**: the milestone fragment fetches the identical 5 fields inside the budgeted `queryTeamProjects`; create mutations are infrequent.
- Net **−72 lines** in `queries.go`.

## Verification

- `go build` / `go vet` / gofmt clean; `internal/api` tests + full non-integration suite + integration suite `PASS`.
- ⚠️ The default suites (mock + SQLite fixtures) **do not validate query text against the live schema**. Confidence rests on the established fragment pattern (Comment/Doc/Label already do this), verbatim field provenance, and use/append parity. `LINEARFS_LIVE_API=1` would exercise the assembled queries against the real API.

`CLAUDE.md`'s fragment list is updated with the new fragments and the "mutations must project through a fragment" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)