### PR TITLE
feat(api): rateBudget — complexity-aware, server-anchored rate limiting

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -376,6 +376,60 @@ never-pruned `embedded_files` table), analogous to milestones — it runs inside
 the comment `upsert` closure regardless of the upsert result and cannot affect
 cleanliness.
 
+### Rate budget (`rateBudget`)
+The **deep module** governing Linear's hourly rate limits
+(`internal/api/ratebudget.go`). Linear meters every key on TWO axes —
+requests AND complexity points — and reports both on every response
+(`X-RateLimit-{Requests,Complexity}-{Limit,Remaining,Reset}` plus
+`X-Complexity`, this query's actual cost). The old client governed only
+request count, at a hardcoded 1500/hr that matched neither the docs (5000)
+nor the live limit (2500), and parsed the reset from a header Linear doesn't
+send, as seconds — Linear sends per-axis epoch **milliseconds** — so the
+complexity axis (the one that actually gets exhausted; it wedged the account
+into `RATELIMITED` on 2026-07-06) was never governed and adaptive backoff was
+dead. `Client.query` makes exactly two calls: `admit(op, priority)` before
+sending, and on the returned admission `observe(headers)` /
+`rateLimited(headers)` / `release()` after (idempotent; a deferred `release`
+is the catch-all for early returns).
+
+Inside: two windowed budgets `{limit, remaining, resetAt}` — **all read from
+response headers, never hardcoded** — reconciled to server truth on every
+round-trip (a restart self-heals on the first response); a per-op cost
+predictor (last-seen `X-Complexity`, conservative 10k default for unmeasured
+ops); a **priority-reserve ladder** (write > interactive > skeleton > list >
+detail, each with a reserve floor as a fraction of the limit) so detail
+fetches stop first and cold-start gentleness is emergent, not a mode —
+blocked reads defer to the existing retry queues, blocked mutations wait
+briefly for the window; a reserve-on-admit/release-on-settle **in-flight
+semaphore** on both axes (concurrent admits see `remaining − inFlight −
+reserve`); **optimistic refill** past `resetAt`; and a defensive
+`RATELIMITED` snap-to-zero honoring the error's reset (bounded fallback when
+headerless). Base tier comes from a static `opName → tier` intent map in the
+module; `WithInteractive(ctx)` is the promotion mechanism for on-demand FS
+reads (mechanism only in PR1 — call sites not yet threaded). It collapsed
+`checkRateLimitHeaders`, the inline `Tokens() < 2` write-reserve gate, the
+`linearHourlyLimit` constant, and the token-count `LowBudget`;
+`Client.LowBudget`/`RateLimitResetAt` now delegate to it (paginate's
+`ErrBudget` gate and the worker's backoff consult real budget state), and the
+micro-burst `rate.Limiter` survives only as a spike smoother re-sized from
+the observed request limit. The injected clock (`now func() time.Time`) is
+the test seam: `ratebudget_test.go` drives the ladder, reconcile, semaphore,
+rollover, and RATELIMITED paths with a fake clock and synthetic headers — no
+HTTP, no live API.
+
+An unseen axis doesn't gate, so a fresh process would burst un-gated before
+the first response lands. The **cold-start probe** closes that hole:
+`Worker.probeBudget` (`internal/sync/worker.go`) fires one cheap
+`GetViewer` (now on the worker's `APIClient` interface) synchronously at the
+top of `run()`, so the probe's headers seed the budget strictly before the
+first `syncAllTeams` issues expensive work. A `RATELIMITED` probe (account
+already exhausted) marks the worker rate-limited — the backoff honors the
+budget's reset, seeded by that very response — and sleeps until expiry
+before starting sync (interruptible by ctx/Stop); any other probe failure
+logs and proceeds. Probe sequencing and the delay path are unit-tested in
+`worker_test.go` (`TestProbe*`); the client-level seed-then-defer wiring in
+`client_test.go` (`TestViewerProbeSeedsBudget`).
+
 ### ErrorSink
 The minimal seam the WriteBack tail uses to record validation/divergence messages for
 `.error` files: `SetWriteError(key, msg)` / `ClearWriteError(key)`. `*LinearFS`

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 	gosync "sync"
 	"sync/atomic"
@@ -30,16 +29,31 @@ const (
 	circuitBreakerCooldown  = 30 * time.Second // how long to stay open
 )
 
+// maxWriteWait caps how long a blocked mutation waits for the budget window
+// to reset before it is returned as a deferral error instead. Mutations are
+// user-facing (a FUSE flush blocks on them), so waiting past the HTTP
+// timeout is absurd; reads never wait — a blocked read defers immediately
+// and the sync worker's queues retry it.
+const maxWriteWait = 30 * time.Second
+
 type Client struct {
 	apiKey     string
 	apiURL     string
 	httpClient *http.Client
-	limiter    *rate.Limiter
 	stats      *APIStats
 
-	// M-3: server-reported rate limit reset time (from X-RateLimit-Reset header)
-	rateLimitMu      gosync.RWMutex
-	rateLimitResetAt time.Time
+	// budget is the hourly rate-limit governor (see ratebudget.go): query
+	// admits every request through its priority-reserve ladder and observes
+	// every response's headers back into it.
+	budget *rateBudget
+
+	// limiter is a thin micro-burst smoother only — the budget prevents
+	// hourly overshoot, the limiter prevents instantaneous spikes. It is
+	// re-sized from the server-reported request limit on first observation
+	// (see syncLimiterSize); the construction-time rate is just a seed.
+	limiter         *rate.Limiter
+	limiterMu       gosync.Mutex
+	limiterSizedFor float64 // last request limit applied to limiter/stats
 
 	// Circuit breaker: stop burning rate limiter tokens during connectivity loss
 	consecutiveErrors atomic.Int32
@@ -56,19 +70,19 @@ func NewClient(apiKey string) *Client {
 }
 
 func NewClientWithOptions(apiKey string, opts ClientOptions) *Client {
-	// Linear allows 1,500 requests/hour (0.417/sec sustained).
-	// The burst absorbs one sync cycle's spike; sustained rate stays within
-	// budget regardless of burst size. Sizing: a cycle is workspace (1) +
-	// per-team metadata (2: combined query + paginated projects) + issues
-	// (1+) for every team, and the write-reserve gate defers reads below 2
-	// tokens — at burst 10 a 4-team cycle spent exactly ~10 before the last
-	// team, which therefore never synced (its reads deferred every cycle).
-	limiter := rate.NewLimiter(rate.Limit(1500.0/3600.0), 16)
+	// The limiter is a micro-burst smoother, not the budget: hourly
+	// governance lives in rateBudget (both axes, limits read from response
+	// headers). The seed rate here is replaced by the observed request
+	// limit on the first response (syncLimiterSize). The burst absorbs one
+	// sync cycle's spike; sustained rate stays within budget regardless of
+	// burst size.
+	limiter := rate.NewLimiter(rate.Limit(float64(seedHourlyRequestLimit)/3600.0), 16)
 
 	return &Client{
 		apiKey:     apiKey,
 		apiURL:     defaultAPIURL,
 		httpClient: &http.Client{Timeout: 30 * time.Second},
+		budget:     newRateBudget(time.Now),
 		limiter:    limiter,
 		stats:      NewAPIStats(opts.APIStatsEnabled),
 	}
@@ -120,13 +134,35 @@ func (c *Client) query(ctx context.Context, query string, variables map[string]a
 		c.circuitOpenUntil.Store(0)
 	}
 
-	// Mutation priority: reserve the last 2 burst tokens for user-facing writes.
-	// Non-mutation queries are rejected when tokens are critically low, so writes
-	// don't get stuck behind a queue of background reads.
+	// Budget gate: the priority-reserve ladder (ratebudget.go). Reads that
+	// trip their tier's reserve defer immediately (the sync worker's queues
+	// retry them); a blocked mutation waits for the window when the wait is
+	// short, because writes are user-facing and must not be silently dropped.
 	isMutation := strings.HasPrefix(strings.TrimSpace(query), "mutation")
-	if !isMutation && c.limiter.Tokens() < 2 {
-		return fmt.Errorf("rate limit: query %s deferred (reserving capacity for writes)", opName)
+	tier := tierFor(ctx, opName, isMutation)
+	adm, dec := c.budget.admit(opName, tier)
+	if adm == nil && tier == pWrite && dec.retryAfter > 0 && dec.retryAfter <= maxWriteWait {
+		log.Printf("[ratelimit] mutation %s waiting %s for budget window reset", opName, dec.retryAfter.Round(time.Second))
+		timer := time.NewTimer(dec.retryAfter)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("rate limit wait cancelled: %w", ctx.Err())
+		case <-timer.C:
+		}
+		adm, dec = c.budget.admit(opName, tier)
 	}
+	if adm == nil {
+		return fmt.Errorf("rate limit: query %s deferred (%s)", opName, dec.reason)
+	}
+	// The admission must be settled exactly once. The success and
+	// rate-limited paths settle explicitly below (observe/rateLimited);
+	// this deferred release is the idempotent catch-all for every early
+	// return (marshal error, transport error, cancellation).
+	defer adm.release()
+	// After the response has been observed, re-size the micro-burst
+	// limiter to the server-reported request limit.
+	defer c.syncLimiterSize()
 
 	// Log token bucket exhaustion before blocking
 	if tokens := c.limiter.Tokens(); tokens <= 0 {
@@ -153,10 +189,9 @@ func (c *Client) query(ctx context.Context, query string, variables map[string]a
 	}
 	// Always log noisy rate limit waits (no env var required)
 	if rateLimitWait > 100*time.Millisecond {
-		hourly := c.stats.HourlyCount()
-		pct := float64(hourly) / float64(linearHourlyLimit) * 100
-		log.Printf("[ratelimit] %s waited %s (budget: %d/%d this hour, %.0f%% used)",
-			opName, rateLimitWait.Round(time.Millisecond), hourly, linearHourlyLimit, pct)
+		hourly, pct := c.stats.BudgetSnapshot()
+		log.Printf("[ratelimit] %s waited %s (budget: %d requests this hour, %.0f%% of limit)",
+			opName, rateLimitWait.Round(time.Millisecond), hourly, pct)
 	}
 
 	// Track request duration for stats
@@ -201,28 +236,39 @@ func (c *Client) query(ctx context.Context, query string, variables map[string]a
 	// Request succeeded at the network level — reset circuit breaker
 	c.consecutiveErrors.Store(0)
 
-	// Check server-side rate limit headers
-	c.checkRateLimitHeaders(resp, opName)
-
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
+		// Headers arrived even though the body didn't: still observe them.
+		adm.observe(resp.Header)
 		queryErr = fmt.Errorf("failed to read response: %w", err)
 		return queryErr
 	}
 
 	if resp.StatusCode == http.StatusTooManyRequests {
+		adm.rateLimited(resp.Header)
 		queryErr = fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
 		log.Printf("[ratelimit] ERROR: %s rate limited by Linear API (HTTP 429): %s", opName, string(respBody))
 		return queryErr
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		// Linear reports budget exhaustion as HTTP 400 with a RATELIMITED
+		// error code in the body. Non-200 bodies are Linear's own error
+		// envelope (never user data), so a substring check cannot false-
+		// positive on issue content.
+		if strings.Contains(string(respBody), "RATELIMITED") {
+			adm.rateLimited(resp.Header)
+			log.Printf("[ratelimit] ERROR: %s rate limited by Linear API (HTTP %d): %s", opName, resp.StatusCode, string(respBody))
+		} else {
+			adm.observe(resp.Header)
+		}
 		queryErr = fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
 		return queryErr
 	}
 
 	var gqlResp graphQLResponse
 	if err := json.Unmarshal(respBody, &gqlResp); err != nil {
+		adm.observe(resp.Header)
 		queryErr = fmt.Errorf("failed to parse response: %w", err)
 		return queryErr
 	}
@@ -231,10 +277,17 @@ func (c *Client) query(ctx context.Context, query string, variables map[string]a
 		errMsg := gqlResp.Errors[0].Message
 		queryErr = fmt.Errorf("GraphQL error: %s", errMsg)
 		if strings.Contains(errMsg, "RATELIMITED") || strings.Contains(strings.ToLower(errMsg), "rate limit") {
+			adm.rateLimited(resp.Header)
 			log.Printf("[ratelimit] ERROR: %s rate limited by Linear API: %s", opName, errMsg)
+		} else {
+			adm.observe(resp.Header)
 		}
 		return queryErr
 	}
+
+	// Success: settle the reservation and reconcile the budget to the
+	// server-reported headers (both axes + this op's actual X-Complexity).
+	adm.observe(resp.Header)
 
 	if err := json.Unmarshal(gqlResp.Data, result); err != nil {
 		queryErr = fmt.Errorf("failed to parse data: %w", err)
@@ -244,50 +297,32 @@ func (c *Client) query(ctx context.Context, query string, variables map[string]a
 	return nil
 }
 
-// checkRateLimitHeaders logs warnings when Linear's rate limit headers indicate low remaining budget
-// and records the reset time for adaptive backoff.
-func (c *Client) checkRateLimitHeaders(resp *http.Response, opName string) {
-	// M-3: Parse X-RateLimit-Reset for adaptive backoff in sync worker
-	if resetStr := resp.Header.Get("X-RateLimit-Reset"); resetStr != "" {
-		if resetUnix, err := strconv.ParseInt(resetStr, 10, 64); err == nil {
-			resetTime := time.Unix(resetUnix, 0)
-			c.rateLimitMu.Lock()
-			c.rateLimitResetAt = resetTime
-			c.rateLimitMu.Unlock()
-		}
-	}
-
-	remaining := resp.Header.Get("X-RateLimit-Requests-Remaining")
-	limit := resp.Header.Get("X-RateLimit-Requests-Limit")
-
-	if remaining == "" {
+// syncLimiterSize re-sizes the micro-burst limiter (and the stats
+// denominator) to the server-reported hourly request limit once the budget
+// has observed it. No-op until the first response and after that only on
+// change; the construction-time seed is never trusted past first contact.
+func (c *Client) syncLimiterSize() {
+	lim := c.budget.requestsLimit()
+	if lim <= 0 {
 		return
 	}
-
-	rem, err := strconv.Atoi(remaining)
-	if err != nil {
+	c.limiterMu.Lock()
+	defer c.limiterMu.Unlock()
+	if lim == c.limiterSizedFor {
 		return
 	}
-
-	lim := linearHourlyLimit
-	if limit != "" {
-		if parsed, err := strconv.Atoi(limit); err == nil {
-			lim = parsed
-		}
-	}
-
-	// Warn when below 20% of limit
-	if lim > 0 && float64(rem)/float64(lim) < 0.20 {
-		log.Printf("[ratelimit] Linear API: %d/%d requests remaining this hour (after %s)", rem, lim, opName)
-	}
+	c.limiterSizedFor = lim
+	c.limiter.SetLimit(rate.Limit(lim / 3600.0))
+	c.stats.SetHourlyLimit(int(lim))
+	log.Printf("[ratelimit] observed request limit %.0f/hr; limiter re-sized", lim)
 }
 
-// RateLimitResetAt returns the server-reported time when the rate limit window resets.
-// Returns zero time if no X-RateLimit-Reset header has been seen yet.
+// RateLimitResetAt returns the server-reported time when the rate limit
+// window resets (the later of the two axes' resets, parsed from the
+// per-axis millisecond headers). Zero until a response has been observed.
+// The sync worker's backoff consults this instead of guessing.
 func (c *Client) RateLimitResetAt() time.Time {
-	c.rateLimitMu.RLock()
-	defer c.rateLimitMu.RUnlock()
-	return c.rateLimitResetAt
+	return c.budget.resetAt()
 }
 
 // Stats returns the client's API stats tracker for external inspection.
@@ -1191,12 +1226,12 @@ func (c *Client) DeleteAttachment(ctx context.Context, attachmentID string) erro
 	return execMutationOK(ctx, c, mutationDeleteAttachment, map[string]any{"id": attachmentID}, "attachmentDelete")
 }
 
-// LowBudget reports whether the rate limiter has fewer than 5 tokens left.
-// The reconciliation pass uses this to defer the next per-team page when
-// budget is tight, leaving headroom for user-facing writes and ongoing sync.
+// LowBudget reports whether a conservatively-priced list-tier request would
+// currently be refused by the rate budget. The paginate module refuses to
+// start a new drain on it, and the reconciliation pass defers its per-team
+// sweeps — leaving headroom for user-facing writes and ongoing sync.
 func (c *Client) LowBudget() bool {
-	// 5 = write-reserve (2, see c.query) + sync headroom (~3 pages).
-	return c.limiter.Tokens() < 5
+	return c.budget.low(pList)
 }
 
 // GetTeamIssueIDs returns the IDs of every issue in the team, draining the

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -929,15 +930,17 @@ func TestGetTeamMembers(t *testing.T) {
 	}
 }
 
-// TestRateLimitResetHeaderParsed verifies M-3: the X-RateLimit-Reset response header
-// is parsed and stored so the sync worker can use it for adaptive backoff.
+// TestRateLimitResetHeaderParsed verifies the per-axis reset headers are
+// parsed as epoch MILLISECONDS (Linear's actual unit) and surfaced through
+// RateLimitResetAt so the sync worker can use them for adaptive backoff.
 func TestRateLimitResetHeaderParsed(t *testing.T) {
 	t.Parallel()
 
-	resetUnix := time.Now().Add(60 * time.Second).Unix()
+	resetMs := time.Now().Add(60 * time.Second).UnixMilli()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetUnix, 10))
+		w.Header().Set("X-RateLimit-Complexity-Reset", strconv.FormatInt(resetMs, 10))
+		w.Header().Set("X-RateLimit-Requests-Reset", strconv.FormatInt(resetMs, 10))
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"data": {"teams": {"nodes": []}}}`)
 	}))
@@ -954,14 +957,73 @@ func TestRateLimitResetHeaderParsed(t *testing.T) {
 	_, _ = client.GetTeams(context.Background())
 
 	got := client.RateLimitResetAt()
-	expected := time.Unix(resetUnix, 0)
+	expected := time.UnixMilli(resetMs)
 	if !got.Equal(expected) {
 		t.Errorf("RateLimitResetAt() = %v, want %v", got, expected)
 	}
 }
 
-// TestRateLimitResetHeaderMissing verifies M-3: when no X-RateLimit-Reset header is sent,
-// RateLimitResetAt() remains zero.
+// TestViewerProbeSeedsBudget verifies the cold-start probe contract end to
+// end at the client level: before any response the budget is unseen (nothing
+// gates), and one cheap GetViewer whose headers report a nearly-exhausted
+// complexity window seeds the budget so the NEXT expensive query is deferred
+// without ever reaching the server. This is the hole the sync worker's probe
+// closes: without a first observed response, a cold start's burst would all
+// admit un-gated.
+func TestViewerProbeSeedsBudget(t *testing.T) {
+	t.Parallel()
+
+	resetMs := time.Now().Add(30 * time.Minute).UnixMilli()
+	var requests atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("X-Complexity", "1")
+		w.Header().Set("X-RateLimit-Complexity-Limit", "3000000")
+		w.Header().Set("X-RateLimit-Complexity-Remaining", "1000") // nearly exhausted
+		w.Header().Set("X-RateLimit-Complexity-Reset", strconv.FormatInt(resetMs, 10))
+		w.Header().Set("X-RateLimit-Requests-Limit", "2500")
+		w.Header().Set("X-RateLimit-Requests-Remaining", "2400")
+		w.Header().Set("X-RateLimit-Requests-Reset", strconv.FormatInt(resetMs, 10))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"data": {"viewer": {"id": "user-1", "name": "Probe", "email": "p@example.com"}}}`)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-api-key")
+	client.SetAPIURL(server.URL)
+
+	// Unseen budget: nothing gates yet.
+	if client.LowBudget() {
+		t.Fatal("LowBudget() = true before any response; an unseen budget must not gate")
+	}
+
+	viewer, err := client.GetViewer(context.Background())
+	if err != nil {
+		t.Fatalf("GetViewer failed: %v", err)
+	}
+	if viewer.ID != "user-1" {
+		t.Errorf("viewer.ID = %q, want user-1", viewer.ID)
+	}
+
+	// The probe's headers seeded the budget: 1000 complexity remaining is
+	// under every read tier's reserve, so expensive work now defers.
+	if !client.LowBudget() {
+		t.Error("LowBudget() = false after probe reported 1000/3000000 complexity remaining")
+	}
+	if _, err := client.GetTeams(context.Background()); err == nil || !strings.Contains(err.Error(), "deferred") {
+		t.Errorf("GetTeams after exhausted probe: err = %v, want budget deferral", err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Errorf("server saw %d requests, want 1 (the deferred query must not reach the server)", got)
+	}
+	if got, want := client.RateLimitResetAt(), time.UnixMilli(resetMs); !got.Equal(want) {
+		t.Errorf("RateLimitResetAt() = %v, want %v (seeded by the probe)", got, want)
+	}
+}
+
+// TestRateLimitResetHeaderMissing verifies that when no reset headers are
+// sent, RateLimitResetAt() remains zero.
 func TestRateLimitResetHeaderMissing(t *testing.T) {
 	t.Parallel()
 
@@ -1071,7 +1133,10 @@ func TestCircuitBreakerCooldownAllowsProbe(t *testing.T) {
 // Mutation Priority Tests
 // =============================================================================
 
-func TestMutationPriorityReservesTokensForWrites(t *testing.T) {
+// TestMutationPriorityReservesBudgetForWrites verifies the reserve ladder
+// in Client.query: under a drained complexity budget a background read
+// defers, while a mutation (reserve 0) still flows.
+func TestMutationPriorityReservesBudgetForWrites(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1083,42 +1148,48 @@ func TestMutationPriorityReservesTokensForWrites(t *testing.T) {
 	client := NewClient("test-api-key")
 	client.SetAPIURL(server.URL)
 
-	// Drain the token bucket to near-empty (below the 2-token write
-	// reserve), whatever the burst size.
-	for client.limiter.Tokens() >= 2 {
-		client.limiter.Allow()
+	// Drain the budget: 20k complexity left of 3M — under every read
+	// tier's reserve floor, but enough for a write (reserve 0).
+	client.budget.mu.Lock()
+	client.budget.complexity = window{
+		name: "complexity", limit: 3000000, remaining: 20000,
+		resetAt: time.Now().Add(time.Hour), seen: true,
 	}
+	client.budget.mu.Unlock()
 
-	// Non-mutation query should be rejected when tokens < 2
+	// Non-mutation query should defer under the reserve floor
 	var result struct {
 		Teams struct {
 			Nodes []struct{} `json:"nodes"`
 		} `json:"teams"`
 	}
 	err := client.query(context.Background(), "query Teams { teams { nodes { id } } }", nil, &result)
-	if err == nil || !strings.Contains(err.Error(), "reserving capacity for writes") {
-		t.Errorf("expected query to be rejected for write reservation, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "deferred") {
+		t.Errorf("expected read to be deferred under drained budget, got: %v", err)
 	}
 
 	// Mutation should still be allowed through
 	err = client.query(context.Background(), "mutation UpdateIssue($id: String!) { issueUpdate(id: $id) { success } }", nil, &result)
-	if err != nil && strings.Contains(err.Error(), "reserving capacity") {
-		t.Errorf("mutation should bypass write reservation, got: %v", err)
+	if err != nil && strings.Contains(err.Error(), "deferred") {
+		t.Errorf("mutation should bypass the read reserves, got: %v", err)
 	}
 }
 
 func TestClient_LowBudget(t *testing.T) {
 	c := NewClient("test-key")
-	// Fresh limiter has a full burst. Should not be low.
+	// A fresh budget has observed nothing — unseen axes never gate.
 	if c.LowBudget() {
-		t.Error("LowBudget true with full burst")
+		t.Error("LowBudget true before any response observed")
 	}
-	// Drain the burst to just under the threshold, whatever its size.
-	for c.limiter.Tokens() >= 5 {
-		c.limiter.Reserve()
+	// Drain the complexity window below the list-tier reserve.
+	c.budget.mu.Lock()
+	c.budget.complexity = window{
+		name: "complexity", limit: 3000000, remaining: 100000,
+		resetAt: time.Now().Add(time.Hour), seen: true,
 	}
+	c.budget.mu.Unlock()
 	if !c.LowBudget() {
-		t.Error("LowBudget false with <5 tokens remaining")
+		t.Error("LowBudget false with remaining under the list reserve")
 	}
 }
 

--- a/internal/api/paginate.go
+++ b/internal/api/paginate.go
@@ -31,8 +31,8 @@ import (
 // has started runs to completion instead: aborting between pages would
 // discard pages already paid for, and observed live it burned one token
 // per cycle on a page-1 fetch it then threw away, forever. The transport's
-// own write-reserve gate (reads deferred under 2 tokens) remains the hard
-// floor under a running drain. Exported so schedulers (the reconcile pass
+// own gate (the rateBudget priority-reserve ladder in Client.query) remains
+// the hard floor under a running drain. Exported so schedulers (the reconcile pass
 // in internal/repo) can distinguish "retry later" from "broken" with
 // errors.Is; treating it as an ordinary error is always safe.
 var ErrBudget = errors.New("pagination deferred: rate-limit budget low")

--- a/internal/api/paginate_test.go
+++ b/internal/api/paginate_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jra3/linear-fuse/internal/testutil"
 )
@@ -115,11 +116,20 @@ func TestDrainFromAllOrNothing(t *testing.T) {
 	}
 }
 
+// drainClientBudget puts the client's rate budget under the list-tier
+// reserve so LowBudget() reports true (the way a busy hour would).
+func drainClientBudget(c *Client) {
+	c.budget.mu.Lock()
+	c.budget.complexity = window{
+		name: "complexity", limit: 3000000, remaining: 100000,
+		resetAt: time.Now().Add(time.Hour), seen: true,
+	}
+	c.budget.mu.Unlock()
+}
+
 func TestDrainFromBudgetRefusesToStart(t *testing.T) {
 	c := NewClient("test")
-	for !c.LowBudget() {
-		c.limiter.Reserve() // drain burst below the LowBudget threshold
-	}
+	drainClientBudget(c)
 	calls := 0
 	fetch := func(_ context.Context, _ string) (conn[int], error) {
 		calls++
@@ -143,9 +153,7 @@ func TestDrainFromStartedDrainIgnoresBudget(t *testing.T) {
 	c := NewClient("test")
 	fetch := func(_ context.Context, after string) (conn[int], error) {
 		if after == "" {
-			for !c.LowBudget() {
-				c.limiter.Reserve() // budget collapses after page 1
-			}
+			drainClientBudget(c) // budget collapses after page 1
 			return conn[int]{PageInfo: pi(true, "c1"), Nodes: []int{1}}, nil
 		}
 		return conn[int]{PageInfo: pi(false, ""), Nodes: []int{2}}, nil

--- a/internal/api/ratebudget.go
+++ b/internal/api/ratebudget.go
@@ -1,0 +1,489 @@
+package api
+
+// The rate-budget core.
+//
+// Linear meters every API key on TWO hourly axes — requests and complexity
+// points — and reports both on every response (X-RateLimit-{Requests,
+// Complexity}-{Limit,Remaining,Reset}, plus X-Complexity: this query's
+// cost). The old client shaped only request count, at a hardcoded rate that
+// matched neither the docs nor the live limit, and parsed the reset from a
+// header Linear doesn't send (as seconds; Linear sends per-axis epoch
+// MILLISECONDS) — so the axis that actually gets exhausted (complexity) was
+// never governed and adaptive backoff was dead. rateBudget owns everything
+// the old code scattered: both windowed budgets, a per-operation cost
+// predictor, the priority-reserve ladder, the in-flight reservation
+// semaphore, and header reconciliation. Client.query makes exactly two
+// calls: admit before sending, observe (or rateLimited/release) after.
+//
+// Control model: hybrid, server-anchored. admit gates on a local predictive
+// budget; observe snaps remaining/limit/reset for both axes to the response
+// headers, so estimate drift is erased every round-trip and a restart
+// self-heals on the first response. Limits are NEVER hardcoded — the live
+// request limit (2500/hr) matches neither Linear's docs (5000) nor the old
+// constant (1500).
+//
+// The clock is injected (now func() time.Time) and every method is
+// mutex-guarded; unit tests drive window resets and reservations with a
+// fake clock and synthetic headers, no HTTP.
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// priority ranks a request's claim on the remaining budget. Higher
+// priorities spend deeper into the window: each priority has a reserve
+// floor (a fraction of the axis limit, reserveFrac) that admit refuses to
+// dip into. Details stop first, then lists, then skeleton reads; writes
+// flow until the tank is essentially empty. This ladder is what makes
+// cold-start gentleness emergent — from a constrained budget the skeleton
+// syncs first and detail fetches defer to pending_detail_sync — without a
+// special cold-start mode.
+type priority int
+
+const (
+	pDetail      priority = iota // issue details: comments/docs/attachments/updates
+	pList                        // issue lists, reconcile ID sweeps
+	pSkeleton                    // teams/states/labels/users/projects — the FS shape
+	pInteractive                 // a read promoted because a live FS caller waits on it
+	pWrite                       // mutations: user-facing, never silently dropped
+)
+
+func (p priority) String() string {
+	switch p {
+	case pDetail:
+		return "detail"
+	case pList:
+		return "list"
+	case pSkeleton:
+		return "skeleton"
+	case pInteractive:
+		return "interactive"
+	case pWrite:
+		return "write"
+	}
+	return fmt.Sprintf("priority(%d)", int(p))
+}
+
+// reserveFrac is the fraction of an axis's limit held back from each
+// priority. admit allows a request only if, on both axes,
+// predictedCost <= remaining − inFlight − reserveFrac[p]·limit.
+var reserveFrac = map[priority]float64{
+	pWrite:       0,    // flow unless the window is essentially empty
+	pInteractive: 0.02, // a user is waiting; spend nearly to the floor
+	pSkeleton:    0.05,
+	pList:        0.15,
+	pDetail:      0.40, // the biggest spender runs only with ample headroom
+}
+
+// defaultPredictedCost prices an operation that has never been measured:
+// the single-query complexity maximum, so unknowns are treated as expensive
+// until the first response teaches us their real cost.
+const defaultPredictedCost = 10000
+
+// seedHourlyRequestLimit seeds the micro-burst rate.Limiter and the stats
+// denominator before the first response has reported the real request
+// limit. It is a smoothing seed only — admit never gates on it; both
+// budgets read their limits exclusively from response headers.
+const seedHourlyRequestLimit = 2500
+
+// rateLimitedFallbackBackoff bounds the lockout after a RATELIMITED
+// response that carried no usable reset header — liveness insurance, not a
+// guess we prefer (a header reset always wins).
+const rateLimitedFallbackBackoff = 15 * time.Minute
+
+// opBaseTier classifies each operation's INTENT — what breaks if it is
+// deferred — which is stable in a way per-op cost is not. Ops absent from
+// the map default to pList (mid-ladder); mutations are pWrite regardless
+// (see tierFor).
+var opBaseTier = map[string]priority{
+	// Skeleton: identity and metadata the filesystem's shape depends on.
+	"Viewer":                   pSkeleton,
+	"Teams":                    pSkeleton,
+	"TeamMetadata":             pSkeleton,
+	"TeamStates":               pSkeleton,
+	"TeamLabels":               pSkeleton,
+	"TeamLabelsPage":           pSkeleton,
+	"TeamCycles":               pSkeleton,
+	"TeamCyclesPage":           pSkeleton,
+	"TeamMembers":              pSkeleton,
+	"TeamMembersPage":          pSkeleton,
+	"TeamProjects":             pSkeleton,
+	"Workspace":                pSkeleton,
+	"WorkspaceLabelsPage":      pSkeleton,
+	"WorkspaceUsersPage":       pSkeleton,
+	"WorkspaceInitiativesPage": pSkeleton,
+	"InitiativeProjectsPage":   pSkeleton,
+	"Users":                    pSkeleton,
+	"Initiatives":              pSkeleton,
+	"Initiative":               pSkeleton,
+	"Project":                  pSkeleton,
+
+	// Lists: issue pages and the reconcile ID sweeps.
+	"TeamIssuesByUpdatedAt":  pList,
+	"TeamIssueIDs":           pList,
+	"WorkspaceProjectIDs":    pList,
+	"WorkspaceInitiativeIDs": pList,
+	"Issue":                  pList,
+
+	// Details: the per-issue/project/initiative deep fetches — the largest
+	// complexity spenders, and the first to defer.
+	"IssueDetailsBatch":   pDetail,
+	"IssueDetails":        pDetail,
+	"IssueComments":       pDetail,
+	"IssueDocuments":      pDetail,
+	"IssueAttachments":    pDetail,
+	"IssueHistory":        pDetail,
+	"ProjectDocuments":    pDetail,
+	"InitiativeDocuments": pDetail,
+	"ProjectUpdates":      pDetail,
+	"InitiativeUpdates":   pDetail,
+	"ProjectMilestones":   pDetail,
+}
+
+// interactiveCtxKey marks a context as carrying a live caller (a user
+// blocked on a FUSE read), promoting the request above its base tier.
+type interactiveCtxKey struct{}
+
+// WithInteractive marks every API call made under ctx as user-facing: its
+// base tier is promoted to pInteractive, so it spends nearly as deep as a
+// mutation. Background sync must NOT use this.
+//
+// ADOPTION NOTE (PR1): this is the mechanism only. On-demand FS read call
+// sites do not pass it yet — every read currently runs at its base tier,
+// which is the old behavior or better. Threading WithInteractive through
+// the FS-triggered read paths (repo staleness refreshes etc.) is a
+// follow-up.
+func WithInteractive(ctx context.Context) context.Context {
+	return context.WithValue(ctx, interactiveCtxKey{}, true)
+}
+
+func isInteractive(ctx context.Context) bool {
+	v, _ := ctx.Value(interactiveCtxKey{}).(bool)
+	return v
+}
+
+// tierFor resolves the effective priority for one request: mutations are
+// always pWrite; reads take their base tier from opBaseTier (default
+// pList), promoted to pInteractive when the context says a caller waits.
+func tierFor(ctx context.Context, opName string, isMutation bool) priority {
+	if isMutation {
+		return pWrite
+	}
+	tier, ok := opBaseTier[opName]
+	if !ok {
+		tier = pList
+	}
+	if isInteractive(ctx) && tier < pInteractive {
+		tier = pInteractive
+	}
+	return tier
+}
+
+// decision is admit's verdict. When allow is false, retryAfter is how long
+// until the binding axis resets (0 = unknown; retry next cycle) and reason
+// says which axis refused and why (for the deferral error message).
+type decision struct {
+	allow      bool
+	retryAfter time.Duration
+	reason     string
+}
+
+// window is one budget axis: {limit, remaining, resetAt}, all read from
+// response headers, never hardcoded. seen is false until the first header
+// reconcile — an unseen axis does not gate (the first response seeds it).
+type window struct {
+	name      string // "complexity" / "requests", for messages
+	limit     float64
+	remaining float64
+	resetAt   time.Time
+	seen      bool
+}
+
+// effectiveRemaining applies optimistic refill: past resetAt the axis is
+// treated as full (the clock is believed over a stale exhausted remaining,
+// so a new window never waits an extra hour) until the next observe reports
+// fresh numbers. An unseen axis is unlimited.
+func (w *window) effectiveRemaining(now time.Time) float64 {
+	if !w.seen {
+		return math.Inf(1)
+	}
+	if !w.resetAt.IsZero() && !now.Before(w.resetAt) {
+		if w.limit > 0 {
+			return w.limit
+		}
+		return math.Inf(1)
+	}
+	return w.remaining
+}
+
+// rateBudget owns the two windowed budgets, the per-op cost predictor, the
+// reserve ladder, and the in-flight reservation semaphore. All fields are
+// guarded by mu; the clock is injected for tests.
+type rateBudget struct {
+	mu           sync.Mutex
+	now          func() time.Time
+	complexity   window
+	requests     window
+	inFlightCost float64            // complexity points reserved by unsettled admissions
+	inFlightReqs float64            // request count reserved by unsettled admissions
+	cost         map[string]float64 // opName -> last-seen X-Complexity
+}
+
+func newRateBudget(now func() time.Time) *rateBudget {
+	return &rateBudget{
+		now:        now,
+		complexity: window{name: "complexity"},
+		requests:   window{name: "requests"},
+		cost:       make(map[string]float64),
+	}
+}
+
+// admission is one allowed request's reservation. Exactly one of observe /
+// rateLimited / release MUST eventually be called; all three are idempotent
+// (the first settles, the rest no-op), so a deferred release is a safe
+// catch-all under an explicit observe on the success path.
+type admission struct {
+	b       *rateBudget
+	op      string
+	cost    float64
+	settled bool // guarded by b.mu
+}
+
+// admit gates one request at the given priority. On allow it reserves the
+// predicted cost against both axes (the in-flight semaphore: concurrent
+// admits see remaining − inFlight − reserve and start deferring before any
+// response lands) and returns the reservation. On deny, admission is nil
+// and the decision says how long to defer.
+func (b *rateBudget) admit(op string, p priority) (*admission, decision) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	now := b.now()
+	cost := b.predictLocked(op)
+	if d, ok := admitAxis(&b.complexity, cost, b.inFlightCost, p, now); !ok {
+		return nil, d
+	}
+	if d, ok := admitAxis(&b.requests, 1, b.inFlightReqs, p, now); !ok {
+		return nil, d
+	}
+	b.inFlightCost += cost
+	b.inFlightReqs++
+	return &admission{b: b, op: op, cost: cost}, decision{allow: true}
+}
+
+// admitAxis is the per-axis gate: cost <= remaining − inFlight − reserve.
+func admitAxis(w *window, cost, inFlight float64, p priority, now time.Time) (decision, bool) {
+	rem := w.effectiveRemaining(now)
+	if math.IsInf(rem, 1) {
+		return decision{allow: true}, true
+	}
+	reserve := reserveFrac[p] * w.limit
+	if cost <= rem-inFlight-reserve {
+		return decision{allow: true}, true
+	}
+	var retry time.Duration
+	if w.resetAt.After(now) {
+		retry = w.resetAt.Sub(now)
+	}
+	return decision{
+		retryAfter: retry,
+		reason: fmt.Sprintf("%s budget: need %.0f, remaining %.0f, in-flight %.0f, %s-tier reserve %.0f",
+			w.name, cost, rem, inFlight, p, reserve),
+	}, false
+}
+
+// predictLocked prices op: last-seen X-Complexity, or the conservative
+// default for an op never measured.
+func (b *rateBudget) predictLocked(op string) float64 {
+	if c, ok := b.cost[op]; ok {
+		return c
+	}
+	return defaultPredictedCost
+}
+
+// observe settles the admission from a normal response: releases the
+// in-flight reservation, records the actual X-Complexity for the op, and
+// snaps both axes' remaining/limit/reset to the headers (server truth).
+func (a *admission) observe(h http.Header) {
+	a.b.mu.Lock()
+	defer a.b.mu.Unlock()
+	if a.settled {
+		return
+	}
+	a.settled = true
+	a.b.releaseLocked(a.cost)
+	a.b.reconcileLocked(a.op, h)
+}
+
+// rateLimited settles the admission from a 400/RATELIMITED (or 429)
+// response: reconciles whatever the headers still report, then defensively
+// snaps the exhausted axis's remaining to 0 so admit defers everything
+// until its reset. If the headers identify no exhausted axis, both are
+// snapped; if no reset is known, a bounded fallback keeps the budget live.
+func (a *admission) rateLimited(h http.Header) {
+	a.b.mu.Lock()
+	defer a.b.mu.Unlock()
+	if a.settled {
+		return
+	}
+	a.settled = true
+	a.b.releaseLocked(a.cost)
+	a.b.reconcileLocked(a.op, h)
+	a.b.snapExhaustedLocked()
+}
+
+// release settles the admission for a request that never produced a
+// response (transport error, marshal failure, ctx cancellation): the
+// reservation is returned, the windows are left alone.
+func (a *admission) release() {
+	a.b.mu.Lock()
+	defer a.b.mu.Unlock()
+	if a.settled {
+		return
+	}
+	a.settled = true
+	a.b.releaseLocked(a.cost)
+}
+
+func (b *rateBudget) releaseLocked(cost float64) {
+	b.inFlightCost -= cost
+	if b.inFlightCost < 0 {
+		b.inFlightCost = 0
+	}
+	b.inFlightReqs--
+	if b.inFlightReqs < 0 {
+		b.inFlightReqs = 0
+	}
+}
+
+// reconcileLocked snaps both axes to the response headers and records the
+// op's actual cost. Missing headers leave the corresponding fields alone.
+// The reset headers are epoch MILLISECONDS, per-axis (the old code read a
+// header Linear doesn't send, as seconds — dead backoff).
+func (b *rateBudget) reconcileLocked(op string, h http.Header) {
+	if v, ok := headerFloat(h, "X-Complexity"); ok {
+		b.cost[op] = v
+	}
+	reconcileAxis(&b.complexity, h, "X-RateLimit-Complexity")
+	reconcileAxis(&b.requests, h, "X-RateLimit-Requests")
+
+	// Preserve the old low-budget warning, now on real server numbers.
+	for _, w := range []*window{&b.complexity, &b.requests} {
+		if w.seen && w.limit > 0 && w.remaining/w.limit < 0.20 {
+			log.Printf("[ratelimit] Linear API: %.0f/%.0f %s remaining this hour (after %s)",
+				w.remaining, w.limit, w.name, op)
+		}
+	}
+}
+
+func reconcileAxis(w *window, h http.Header, prefix string) {
+	if v, ok := headerFloat(h, prefix+"-Limit"); ok {
+		w.limit = v
+		w.seen = true
+	}
+	if v, ok := headerFloat(h, prefix+"-Remaining"); ok {
+		w.remaining = v
+		w.seen = true
+	}
+	if ms, ok := headerInt(h, prefix+"-Reset"); ok {
+		w.resetAt = time.UnixMilli(ms)
+	}
+}
+
+// snapExhaustedLocked implements the defensive RATELIMITED snap: any axis
+// the headers show as (near-)exhausted goes to remaining 0; if none
+// qualifies (headers absent or contradicting the 400), both do — the 400 is
+// believed over stale numbers. Every snapped axis gets a future resetAt
+// (header reset if usable, else the bounded fallback) so optimistic refill
+// cannot immediately undo the snap and the budget always self-recovers.
+func (b *rateBudget) snapExhaustedLocked() {
+	now := b.now()
+	axes := []*window{&b.complexity, &b.requests}
+	var snapped []*window
+	for _, w := range axes {
+		if w.seen && w.limit > 0 && w.remaining <= 0.01*w.limit {
+			snapped = append(snapped, w)
+		}
+	}
+	if len(snapped) == 0 {
+		snapped = axes
+	}
+	for _, w := range snapped {
+		w.seen = true
+		w.remaining = 0
+		if !w.resetAt.After(now) {
+			w.resetAt = now.Add(rateLimitedFallbackBackoff)
+		}
+	}
+}
+
+// resetAt reports when the budget expects to be whole again: the later of
+// the two axes' server-reported resets (zero if none seen yet). Client.
+// RateLimitResetAt delegates here; the sync worker's backoff consults it.
+func (b *rateBudget) resetAt() time.Time {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	r := b.complexity.resetAt
+	if b.requests.resetAt.After(r) {
+		r = b.requests.resetAt
+	}
+	return r
+}
+
+// low reports whether a conservatively-priced (never-measured) request at
+// priority p would currently be refused — the successor to the old
+// token-count LowBudget, reusing the exact admit arithmetic.
+func (b *rateBudget) low(p priority) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	now := b.now()
+	if _, ok := admitAxis(&b.complexity, defaultPredictedCost, b.inFlightCost, p, now); !ok {
+		return true
+	}
+	if _, ok := admitAxis(&b.requests, 1, b.inFlightReqs, p, now); !ok {
+		return true
+	}
+	return false
+}
+
+// requestsLimit returns the server-reported hourly request limit, 0 until
+// the first response has been observed. Client uses it to size the
+// micro-burst limiter and the stats denominator.
+func (b *rateBudget) requestsLimit() float64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.requests.seen {
+		return 0
+	}
+	return b.requests.limit
+}
+
+func headerFloat(h http.Header, key string) (float64, bool) {
+	s := h.Get(key)
+	if s == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+func headerInt(h http.Header, key string) (int64, bool) {
+	s := h.Get(key)
+	if s == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}

--- a/internal/api/ratebudget_test.go
+++ b/internal/api/ratebudget_test.go
@@ -1,0 +1,426 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// fakeClock drives rateBudget's injected now() in tests.
+type fakeClock struct{ t time.Time }
+
+func (f *fakeClock) now() time.Time          { return f.t }
+func (f *fakeClock) advance(d time.Duration) { f.t = f.t.Add(d) }
+func newFakeClock() *fakeClock               { return &fakeClock{t: time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)} }
+func testBudget(c *fakeClock) *rateBudget    { return newRateBudget(c.now) }
+func hdr(kv map[string]string) http.Header {
+	h := http.Header{}
+	for k, v := range kv {
+		h.Set(k, v)
+	}
+	return h
+}
+
+// fullHeaders builds a complete synthetic Linear rate-limit header set.
+func fullHeaders(cost, cLimit, cRemaining, rLimit, rRemaining float64, reset time.Time) http.Header {
+	return hdr(map[string]string{
+		"X-Complexity":                     strconv.FormatFloat(cost, 'f', -1, 64),
+		"X-RateLimit-Complexity-Limit":     strconv.FormatFloat(cLimit, 'f', -1, 64),
+		"X-RateLimit-Complexity-Remaining": strconv.FormatFloat(cRemaining, 'f', -1, 64),
+		"X-RateLimit-Complexity-Reset":     strconv.FormatInt(reset.UnixMilli(), 10),
+		"X-RateLimit-Requests-Limit":       strconv.FormatFloat(rLimit, 'f', -1, 64),
+		"X-RateLimit-Requests-Remaining":   strconv.FormatFloat(rRemaining, 'f', -1, 64),
+		"X-RateLimit-Requests-Reset":       strconv.FormatInt(reset.UnixMilli(), 10),
+	})
+}
+
+// seedWindows installs known window state directly (white-box), the way an
+// earlier observe would have.
+func seedWindows(b *rateBudget, complexity, requests window) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	complexity.name = "complexity"
+	requests.name = "requests"
+	b.complexity = complexity
+	b.requests = requests
+}
+
+// TestRateBudget_ReserveLadder: under a drained complexity budget
+// (120k of 1M remaining), low tiers defer while skeleton/interactive/write
+// still pass; an unmeasured op costs defaultPredictedCost (10k).
+func TestRateBudget_ReserveLadder(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		p         priority
+		wantAllow bool
+	}{
+		{pDetail, false},     // reserve 400k > 120k remaining
+		{pList, false},       // reserve 150k > 120k remaining
+		{pSkeleton, true},    // reserve 50k: 120k-50k=70k >= 10k
+		{pInteractive, true}, // reserve 20k
+		{pWrite, true},       // reserve 0
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.p.String(), func(t *testing.T) {
+			clock := newFakeClock()
+			b := testBudget(clock)
+			seedWindows(b,
+				window{limit: 1000000, remaining: 120000, resetAt: clock.t.Add(time.Hour), seen: true},
+				window{limit: 2500, remaining: 2400, resetAt: clock.t.Add(time.Hour), seen: true},
+			)
+			adm, dec := b.admit("SomeOp", tt.p)
+			if got := adm != nil; got != tt.wantAllow {
+				t.Fatalf("admit at %s: allow=%v (reason %q), want %v", tt.p, got, dec.reason, tt.wantAllow)
+			}
+			if !tt.wantAllow && dec.retryAfter != time.Hour {
+				t.Errorf("retryAfter = %v, want %v (time to reset)", dec.retryAfter, time.Hour)
+			}
+			if adm != nil {
+				adm.release()
+			}
+		})
+	}
+}
+
+// TestRateBudget_ReserveLadderRequestsAxis: the ladder gates the requests
+// axis independently — a drained request count defers details even with a
+// full complexity tank.
+func TestRateBudget_ReserveLadderRequestsAxis(t *testing.T) {
+	t.Parallel()
+
+	clock := newFakeClock()
+	b := testBudget(clock)
+	seedWindows(b,
+		window{limit: 3000000, remaining: 3000000, resetAt: clock.t.Add(time.Hour), seen: true},
+		window{limit: 2500, remaining: 300, resetAt: clock.t.Add(time.Hour), seen: true},
+	)
+
+	if adm, dec := b.admit("Op", pDetail); adm != nil {
+		t.Errorf("detail admit should defer on drained requests axis, got allow (reason %q)", dec.reason)
+	}
+	adm, dec := b.admit("Op", pWrite)
+	if adm == nil {
+		t.Fatalf("write admit should pass with 300 requests remaining: %q", dec.reason)
+	}
+	adm.release()
+}
+
+// TestRateBudget_ObserveReconciles: observe snaps limit/remaining/resetAt
+// for BOTH axes from the headers (reset parsed as epoch milliseconds) and
+// records the op's actual X-Complexity. Header keys are matched
+// case-insensitively (canonicalized).
+func TestRateBudget_ObserveReconciles(t *testing.T) {
+	t.Parallel()
+
+	clock := newFakeClock()
+	b := testBudget(clock)
+	reset := clock.t.Add(37 * time.Minute).Truncate(time.Millisecond)
+
+	adm, _ := b.admit("TeamMetadata", pSkeleton) // unseen axes: admits freely
+	if adm == nil {
+		t.Fatal("fresh budget must admit before any observation")
+	}
+
+	// Deliberately weird casing: http.Header canonicalizes on Set/Get.
+	h := hdr(map[string]string{
+		"x-complexity":                     "1234",
+		"x-ratelimit-complexity-limit":     "3000000",
+		"x-ratelimit-complexity-remaining": "2716000",
+		"x-ratelimit-complexity-reset":     strconv.FormatInt(reset.UnixMilli(), 10),
+		"x-ratelimit-requests-limit":       "2500",
+		"x-ratelimit-requests-remaining":   "2371",
+		"x-ratelimit-requests-reset":       strconv.FormatInt(reset.UnixMilli(), 10),
+	})
+	adm.observe(h)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.complexity.limit != 3000000 || b.complexity.remaining != 2716000 || !b.complexity.seen {
+		t.Errorf("complexity window = %+v, want limit 3000000 remaining 2716000 seen", b.complexity)
+	}
+	if !b.complexity.resetAt.Equal(reset) {
+		t.Errorf("complexity resetAt = %v, want %v (UnixMilli parse)", b.complexity.resetAt, reset)
+	}
+	if b.requests.limit != 2500 || b.requests.remaining != 2371 || !b.requests.resetAt.Equal(reset) {
+		t.Errorf("requests window = %+v, want limit 2500 remaining 2371 reset %v", b.requests, reset)
+	}
+	if got := b.cost["TeamMetadata"]; got != 1234 {
+		t.Errorf("recorded cost = %v, want 1234 (X-Complexity)", got)
+	}
+	if b.inFlightCost != 0 || b.inFlightReqs != 0 {
+		t.Errorf("in-flight not released: cost=%v reqs=%v", b.inFlightCost, b.inFlightReqs)
+	}
+}
+
+// TestRateBudget_CostPredictor: an unmeasured op is priced at the
+// conservative default (10k, the single-query max); once observed, the
+// last-seen X-Complexity is used instead.
+func TestRateBudget_CostPredictor(t *testing.T) {
+	t.Parallel()
+
+	clock := newFakeClock()
+	b := testBudget(clock)
+
+	// Teach the budget: MeasuredOp costs 200; the same response reports
+	// only 9999 complexity remaining.
+	adm, _ := b.admit("MeasuredOp", pWrite)
+	adm.observe(fullHeaders(200, 3000000, 9999, 2500, 2400, clock.t.Add(time.Hour)))
+
+	// Unmeasured op: predicted 10000 > 9999 remaining, even at write tier.
+	if adm, dec := b.admit("NeverSeenOp", pWrite); adm != nil {
+		t.Errorf("unmeasured op should be priced at %d and defer, got allow (reason %q)", defaultPredictedCost, dec.reason)
+	}
+	// Measured op: predicted 200 <= 9999.
+	adm, dec := b.admit("MeasuredOp", pWrite)
+	if adm == nil {
+		t.Fatalf("measured op (cost 200) should pass: %q", dec.reason)
+	}
+	adm.release()
+}
+
+// TestRateBudget_InFlightSemaphore: concurrent admissions reserve their
+// predicted cost before any response lands, so admits start deferring once
+// inFlight+reserve exceeds remaining; observe/release return the
+// reservation.
+func TestRateBudget_InFlightSemaphore(t *testing.T) {
+	t.Parallel()
+
+	clock := newFakeClock()
+	b := testBudget(clock)
+	seedWindows(b,
+		window{limit: 3000000, remaining: 35000, resetAt: clock.t.Add(time.Hour), seen: true},
+		window{limit: 2500, remaining: 2400, resetAt: clock.t.Add(time.Hour), seen: true},
+	)
+
+	// Three unmeasured writes (10k each) fit in 35k; the fourth does not.
+	var adms []*admission
+	for i := 0; i < 3; i++ {
+		adm, dec := b.admit(fmt.Sprintf("Op%d", i), pWrite)
+		if adm == nil {
+			t.Fatalf("admit %d should pass: %q", i, dec.reason)
+		}
+		adms = append(adms, adm)
+	}
+	if adm, dec := b.admit("Op3", pWrite); adm != nil {
+		t.Fatal("4th concurrent admit should defer: inFlight 30k + cost 10k > 35k remaining")
+	} else if dec.reason == "" {
+		t.Error("deny decision should carry a reason")
+	}
+
+	// Observing one in-flight response releases its reservation.
+	adms[0].observe(fullHeaders(10000, 3000000, 35000, 2500, 2400, clock.t.Add(time.Hour)))
+	adm, dec := b.admit("Op3", pWrite)
+	if adm == nil {
+		t.Fatalf("admit after release should pass: %q", dec.reason)
+	}
+
+	// Settling is idempotent: double-release must not free extra budget.
+	adms[1].release()
+	adms[1].release()
+	adms[1].observe(fullHeaders(1, 3000000, 35000, 2500, 2400, clock.t.Add(time.Hour)))
+	b.mu.Lock()
+	if b.inFlightCost != 20000 || b.inFlightReqs != 2 {
+		t.Errorf("in-flight after settles = cost %v reqs %v, want 20000/2", b.inFlightCost, b.inFlightReqs)
+	}
+	b.mu.Unlock()
+}
+
+// TestRateBudget_InFlightSemaphoreRequestsAxis: the request-count axis is a
+// semaphore too — one request each.
+func TestRateBudget_InFlightSemaphoreRequestsAxis(t *testing.T) {
+	t.Parallel()
+
+	clock := newFakeClock()
+	b := testBudget(clock)
+	seedWindows(b,
+		window{limit: 3000000, remaining: 3000000, resetAt: clock.t.Add(time.Hour), seen: true},
+		window{limit: 2500, remaining: 2, resetAt: clock.t.Add(time.Hour), seen: true},
+	)
+
+	a1, _ := b.admit("Op", pWrite)
+	a2, _ := b.admit("Op", pWrite)
+	if a1 == nil || a2 == nil {
+		t.Fatal("two writes should fit in 2 remaining requests")
+	}
+	if adm, _ := b.admit("Op", pWrite); adm != nil {
+		t.Fatal("3rd admit should defer: 2 in-flight requests exhaust remaining 2")
+	}
+	a1.release()
+	if adm, _ := b.admit("Op", pWrite); adm == nil {
+		t.Fatal("admit should pass after a release")
+	}
+}
+
+// TestRateBudget_ResetRollover: past an axis's resetAt the window is
+// optimistically treated as refilled to its full limit until the next
+// observe — the clock is believed over a stale exhausted remaining.
+func TestRateBudget_ResetRollover(t *testing.T) {
+	t.Parallel()
+
+	clock := newFakeClock()
+	b := testBudget(clock)
+	resetAt := clock.t.Add(time.Hour)
+	seedWindows(b,
+		window{limit: 3000000, remaining: 0, resetAt: resetAt, seen: true},
+		window{limit: 2500, remaining: 0, resetAt: resetAt, seen: true},
+	)
+
+	adm, dec := b.admit("IssueDetailsBatch", pDetail)
+	if adm != nil {
+		t.Fatal("exhausted window must defer before reset")
+	}
+	if dec.retryAfter != time.Hour {
+		t.Errorf("retryAfter = %v, want %v", dec.retryAfter, time.Hour)
+	}
+
+	clock.advance(time.Hour + time.Second)
+	adm, dec = b.admit("IssueDetailsBatch", pDetail)
+	if adm == nil {
+		t.Fatalf("past resetAt the axis should read as full: %q", dec.reason)
+	}
+	adm.release()
+}
+
+// TestRateBudget_RateLimited: a RATELIMITED response snaps the exhausted
+// axis's remaining to 0 and honors the header reset; everything defers
+// until the window rolls over.
+func TestRateBudget_RateLimited(t *testing.T) {
+	t.Parallel()
+
+	clock := newFakeClock()
+	b := testBudget(clock)
+	reset := clock.t.Add(30 * time.Minute)
+	seedWindows(b,
+		window{limit: 3000000, remaining: 500000, resetAt: clock.t.Add(time.Hour), seen: true},
+		window{limit: 2500, remaining: 2000, resetAt: clock.t.Add(time.Hour), seen: true},
+	)
+
+	adm, _ := b.admit("IssueDetailsBatch", pSkeleton)
+	if adm == nil {
+		t.Fatal("setup admit should pass")
+	}
+	// Server says: complexity effectively gone (12 <= 1% of limit),
+	// requests fine, window resets in 30min.
+	adm.rateLimited(fullHeaders(0, 3000000, 12, 2500, 1990, reset))
+
+	b.mu.Lock()
+	if b.complexity.remaining != 0 {
+		t.Errorf("complexity remaining = %v, want 0 (snapped)", b.complexity.remaining)
+	}
+	if b.requests.remaining != 1990 {
+		t.Errorf("requests remaining = %v, want 1990 (healthy axis untouched)", b.requests.remaining)
+	}
+	if !b.complexity.resetAt.Equal(reset.Truncate(time.Millisecond)) {
+		t.Errorf("complexity resetAt = %v, want %v (the error's reset)", b.complexity.resetAt, reset)
+	}
+	b.mu.Unlock()
+
+	// All read tiers — and even writes (cost > remaining 0) — defer until reset.
+	for _, p := range []priority{pDetail, pList, pSkeleton, pInteractive, pWrite} {
+		if adm, dec := b.admit("AnyOp", p); adm != nil {
+			t.Errorf("%s admit should defer after RATELIMITED", p)
+		} else if dec.retryAfter != 30*time.Minute {
+			t.Errorf("%s retryAfter = %v, want 30m", p, dec.retryAfter)
+		}
+	}
+
+	// Past the reset, optimistic refill recovers without a response.
+	clock.advance(31 * time.Minute)
+	adm, dec := b.admit("AnyOp", pList)
+	if adm == nil {
+		t.Fatalf("admit after reset should pass: %q", dec.reason)
+	}
+	adm.release()
+}
+
+// TestRateBudget_RateLimitedNoHeaders: a RATELIMITED response with no
+// usable headers snaps both axes and installs the bounded fallback reset,
+// so the budget stays live instead of wedging open or shut.
+func TestRateBudget_RateLimitedNoHeaders(t *testing.T) {
+	t.Parallel()
+
+	clock := newFakeClock()
+	b := testBudget(clock)
+
+	adm, _ := b.admit("Teams", pSkeleton)
+	if adm == nil {
+		t.Fatal("fresh budget must admit")
+	}
+	adm.rateLimited(http.Header{})
+
+	adm2, dec := b.admit("Teams", pSkeleton)
+	if adm2 != nil {
+		t.Fatal("admit should defer after headerless RATELIMITED")
+	}
+	if dec.retryAfter != rateLimitedFallbackBackoff {
+		t.Errorf("retryAfter = %v, want fallback %v", dec.retryAfter, rateLimitedFallbackBackoff)
+	}
+
+	// After the fallback window the budget recovers (unseen-limit axes
+	// stop gating rather than refilling to a limit of 0).
+	clock.advance(rateLimitedFallbackBackoff + time.Second)
+	adm3, dec := b.admit("Teams", pSkeleton)
+	if adm3 == nil {
+		t.Fatalf("admit should recover after fallback backoff: %q", dec.reason)
+	}
+	adm3.release()
+}
+
+// TestRateBudget_ResetAt: RateLimitResetAt's source — the later of the two
+// axes' server-reported resets, zero before any observation.
+func TestRateBudget_ResetAt(t *testing.T) {
+	t.Parallel()
+
+	clock := newFakeClock()
+	b := testBudget(clock)
+	if !b.resetAt().IsZero() {
+		t.Error("resetAt should be zero before any observation")
+	}
+	later := clock.t.Add(45 * time.Minute)
+	seedWindows(b,
+		window{limit: 1, remaining: 1, resetAt: clock.t.Add(10 * time.Minute), seen: true},
+		window{limit: 1, remaining: 1, resetAt: later, seen: true},
+	)
+	if got := b.resetAt(); !got.Equal(later) {
+		t.Errorf("resetAt = %v, want the later axis reset %v", got, later)
+	}
+}
+
+// TestTierFor: base tiers classify intent; mutations are always writes; the
+// interactive context promotes reads (and only reads) above their base tier.
+func TestTierFor(t *testing.T) {
+	t.Parallel()
+
+	bg := context.Background()
+	ia := WithInteractive(context.Background())
+
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		op         string
+		isMutation bool
+		want       priority
+	}{
+		{"mutation is write", bg, "UpdateIssue", true, pWrite},
+		{"metadata is skeleton", bg, "TeamMetadata", false, pSkeleton},
+		{"workspace is skeleton", bg, "Workspace", false, pSkeleton},
+		{"issue list is list", bg, "TeamIssuesByUpdatedAt", false, pList},
+		{"details batch is detail", bg, "IssueDetailsBatch", false, pDetail},
+		{"unknown op defaults to list", bg, "SomeNewOp", false, pList},
+		{"interactive promotes detail", ia, "IssueDetailsBatch", false, pInteractive},
+		{"interactive promotes list", ia, "TeamIssuesByUpdatedAt", false, pInteractive},
+		{"interactive does not demote write", ia, "UpdateIssue", true, pWrite},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tierFor(tt.ctx, tt.op, tt.isMutation); got != tt.want {
+				t.Errorf("tierFor(%q, mutation=%v) = %s, want %s", tt.op, tt.isMutation, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/api/stats.go
+++ b/internal/api/stats.go
@@ -11,9 +11,6 @@ import (
 )
 
 const (
-	// Linear's rate limit
-	linearHourlyLimit = 1500
-
 	// How often to log stats (when enabled)
 	statsLogInterval = 5 * time.Minute
 
@@ -32,8 +29,9 @@ type OperationStats struct {
 type APIStats struct {
 	mu              sync.RWMutex
 	operations      map[string]*OperationStats
-	recentCalls     []time.Time // timestamps for rolling hourly window
-	rateLimitWaitNs int64       // total time waiting for rate limiter (atomic)
+	recentCalls     []time.Time  // timestamps for rolling hourly window
+	rateLimitWaitNs int64        // total time waiting for rate limiter (atomic)
+	hourlyLimit     atomic.Int64 // requests/hr denominator; seeded, then set from response headers
 	startTime       time.Time
 	stopCh          chan struct{}
 	wg              sync.WaitGroup
@@ -49,6 +47,9 @@ func NewAPIStats(logEnabled bool) *APIStats {
 		startTime:   time.Now(),
 		stopCh:      make(chan struct{}),
 	}
+	// Seed only: the Client replaces this with the server-reported request
+	// limit on the first observed response (SetHourlyLimit).
+	s.hourlyLimit.Store(seedHourlyRequestLimit)
 
 	// Always run periodic logger — the 5-minute interval is not noisy
 	// and provides essential observability for rate limit issues.
@@ -118,9 +119,17 @@ func (s *APIStats) HourlyCount() int {
 	return count
 }
 
-// HourlyRate returns the percentage of Linear's hourly limit used.
+// SetHourlyLimit updates the requests/hr denominator to the server-reported
+// limit. Called by the Client when the rate budget observes it.
+func (s *APIStats) SetHourlyLimit(limit int) {
+	if limit > 0 {
+		s.hourlyLimit.Store(int64(limit))
+	}
+}
+
+// HourlyRate returns the percentage of Linear's hourly request limit used.
 func (s *APIStats) HourlyRate() float64 {
-	return float64(s.HourlyCount()) / float64(linearHourlyLimit) * 100
+	return float64(s.HourlyCount()) / float64(s.hourlyLimit.Load()) * 100
 }
 
 // RateLimitWaitTotal returns the total time spent waiting for the rate limiter.
@@ -131,7 +140,7 @@ func (s *APIStats) RateLimitWaitTotal() time.Duration {
 // BudgetSnapshot returns the current hourly call count and percentage used.
 func (s *APIStats) BudgetSnapshot() (count int, pct float64) {
 	count = s.HourlyCount()
-	pct = float64(count) / float64(linearHourlyLimit) * 100
+	pct = float64(count) / float64(s.hourlyLimit.Load()) * 100
 	return
 }
 
@@ -158,7 +167,7 @@ func (s *APIStats) Summary() string {
 		}
 	}
 
-	hourlyRate := float64(hourlyCount) / float64(linearHourlyLimit) * 100
+	hourlyRate := float64(hourlyCount) / float64(s.hourlyLimit.Load()) * 100
 	rateLimitWait := time.Duration(atomic.LoadInt64(&s.rateLimitWaitNs))
 
 	var sb strings.Builder

--- a/internal/api/stats_test.go
+++ b/internal/api/stats_test.go
@@ -66,8 +66,11 @@ func TestAPIStats_HourlyRate(t *testing.T) {
 	stats := NewAPIStats(false)
 	defer stats.Close()
 
-	// Record 150 calls (10% of 1500 limit)
-	for i := 0; i < 150; i++ {
+	// The denominator follows the server-reported request limit.
+	stats.SetHourlyLimit(2000)
+
+	// Record 200 calls (10% of the 2000 limit)
+	for i := 0; i < 200; i++ {
 		stats.Record("TestOp", 10*time.Millisecond, nil)
 	}
 

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -46,7 +46,15 @@ type APIClient interface {
 	// Auth
 	AuthHeader() string
 
-	// M-3: server-reported rate limit window reset time (zero if not yet seen)
+	// Viewer (the authenticated user). The worker fires this once as the
+	// cold-start budget probe (see probeBudget): the cheapest possible
+	// query whose response headers seed the client's rate budget before
+	// any expensive work is issued.
+	GetViewer(ctx context.Context) (*api.User, error)
+
+	// Server-reported rate limit window reset time, per the client's rate
+	// budget (parsed from the per-axis millisecond reset headers; zero if
+	// no response has been observed yet).
 	RateLimitResetAt() time.Time
 }
 
@@ -182,6 +190,12 @@ func (w *Worker) run(ctx context.Context) {
 		w.mu.Unlock()
 		close(w.doneCh)
 	}()
+
+	// Cold-start probe: seed the rate budget from one cheap query BEFORE
+	// the first (expensive) sync cycle. Aborts only on shutdown.
+	if !w.probeBudget(ctx) {
+		return
+	}
 
 	// Initial sync
 	if err := w.syncAllTeams(ctx); err != nil {
@@ -713,15 +727,17 @@ func (w *Worker) isRateLimited() bool {
 	return time.Now().Before(w.rateLimitExpiry)
 }
 
-// setRateLimited marks that we've hit a rate limit.
-// M-3: Uses the server-provided X-RateLimit-Reset time when available for accurate backoff;
-// falls back to a 15-minute fixed backoff.
+// setRateLimited marks that we've hit a rate limit. The backoff consults
+// the client's rate budget: RateLimitResetAt is the server-reported window
+// reset (parsed from the per-axis millisecond headers), so the pause ends
+// when the budget actually refills; the fixed 15-minute backoff is only the
+// fallback for a reset the server never told us about.
 func (w *Worker) setRateLimited() {
 	w.rateLimitMu.Lock()
 	defer w.rateLimitMu.Unlock()
 	w.rateLimitedAt = time.Now()
 
-	// Use server-provided reset time if it's in the future (M-3)
+	// Use the budget's server-provided reset time if it's in the future
 	backoff := 15 * time.Minute
 	if resetAt := w.client.RateLimitResetAt(); !resetAt.IsZero() && resetAt.After(time.Now()) {
 		backoff = time.Until(resetAt) + 5*time.Second // 5s buffer past the reset
@@ -730,11 +746,63 @@ func (w *Worker) setRateLimited() {
 
 	if w.budget != nil {
 		count, pct := w.budget.BudgetSnapshot()
-		log.Printf("[sync] rate limited, pausing issue details sync until %s (backoff=%s, budget: %d/1500 used this hour, %.0f%%)",
+		log.Printf("[sync] rate limited, pausing issue details sync until %s (backoff=%s, budget: %d requests this hour, %.0f%%)",
 			w.rateLimitExpiry.Format(time.RFC3339), backoff.Round(time.Second), count, pct)
 	} else {
 		log.Printf("[sync] rate limited, pausing issue details sync until %s (backoff=%s)",
 			w.rateLimitExpiry.Format(time.RFC3339), backoff.Round(time.Second))
+	}
+}
+
+// probeBudget is the cold-start probe: before the worker's first sync cycle
+// it fires one cheap viewer query so the client's rate budget is seeded from
+// real response headers BEFORE any expensive team-metadata/issue/detail
+// query is admitted. Without it a fresh process's budget has seen neither
+// axis (unseen axes don't gate), so the initial burst could all admit
+// un-gated before any response lands — the exact cold-start thundering herd
+// the budget exists to prevent. The viewer is the cheapest query we have
+// (~1-2 complexity points) and dual-purpose: /my needs it anyway.
+//
+// If the probe itself reports RATELIMITED, the account is already exhausted:
+// mark the worker rate-limited (the backoff honors the budget's
+// server-reported reset, which this very response's headers just seeded) and
+// sleep until the backoff expires instead of bursting into the wall. Any
+// other probe failure (network down, auth) is logged and sync proceeds —
+// those failures repeat identically in syncAllTeams and are handled there,
+// and the budget stays conservative once the first response does land.
+//
+// Returns false only when shutdown (ctx cancellation / Stop) interrupts the
+// delay, so run can exit without firing a post-stop sync cycle.
+func (w *Worker) probeBudget(ctx context.Context) bool {
+	_, err := w.client.GetViewer(ctx)
+	if err == nil {
+		return true
+	}
+	if !isRateLimitError(err) {
+		log.Printf("[sync] budget probe failed (continuing): %v", err)
+		return true
+	}
+
+	w.setRateLimited()
+	w.rateLimitMu.RLock()
+	expiry := w.rateLimitExpiry
+	w.rateLimitMu.RUnlock()
+
+	wait := time.Until(expiry)
+	log.Printf("[sync] budget probe RATELIMITED; delaying sync start %s (until %s)",
+		wait.Round(time.Second), expiry.Format(time.RFC3339))
+	if wait <= 0 {
+		return true
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-w.stopCh:
+		return false
+	case <-timer.C:
+		return true
 	}
 }
 

--- a/internal/sync/worker_test.go
+++ b/internal/sync/worker_test.go
@@ -3,8 +3,10 @@ package sync
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"path/filepath"
+	gosync "sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -43,6 +45,24 @@ type mockAPIClient struct {
 	onDetailsBatch   func()                       // if set, runs inside GetIssueDetailsBatch (simulates writes racing the fetch)
 	onTeamMetadata   func()                       // if set, runs inside GetTeamMetadata (simulates writes racing the fetch)
 	onWorkspace      func()                       // if set, runs inside GetWorkspace (simulates writes racing the fetch)
+	viewerErr        error                        // if set, GetViewer (the cold-start budget probe) fails with this
+	getViewerCalls   int32
+	opMu             gosync.Mutex
+	opOrder          []string // call order across GetViewer/GetWorkspace/GetTeams (probe-sequencing tests)
+}
+
+// recordOp appends op to the observed call order.
+func (m *mockAPIClient) recordOp(op string) {
+	m.opMu.Lock()
+	m.opOrder = append(m.opOrder, op)
+	m.opMu.Unlock()
+}
+
+// callOrder returns a snapshot of the observed call order.
+func (m *mockAPIClient) callOrder() []string {
+	m.opMu.Lock()
+	defer m.opMu.Unlock()
+	return append([]string(nil), m.opOrder...)
 }
 
 func newMockAPIClient() *mockAPIClient {
@@ -60,6 +80,7 @@ func newMockAPIClient() *mockAPIClient {
 }
 
 func (m *mockAPIClient) GetTeams(ctx context.Context) ([]api.Team, error) {
+	m.recordOp("GetTeams")
 	atomic.AddInt32(&m.getTeamsCalls, 1)
 	if m.simulateError != nil {
 		return nil, m.simulateError
@@ -131,6 +152,7 @@ func (m *mockAPIClient) GetTeamMetadata(ctx context.Context, teamID string) (*ap
 }
 
 func (m *mockAPIClient) GetWorkspace(ctx context.Context) (*api.WorkspaceData, error) {
+	m.recordOp("GetWorkspace")
 	if m.simulateError != nil {
 		return nil, m.simulateError
 	}
@@ -199,6 +221,15 @@ func (m *mockAPIClient) GetIssueAttachments(ctx context.Context, issueID string)
 
 func (m *mockAPIClient) AuthHeader() string {
 	return "Bearer test-token"
+}
+
+func (m *mockAPIClient) GetViewer(ctx context.Context) (*api.User, error) {
+	m.recordOp("GetViewer")
+	atomic.AddInt32(&m.getViewerCalls, 1)
+	if m.viewerErr != nil {
+		return nil, m.viewerErr
+	}
+	return &api.User{ID: "viewer-1", Name: "Test Viewer", Email: "viewer@example.com"}, nil
 }
 
 func (m *mockAPIClient) RateLimitResetAt() time.Time {
@@ -1099,6 +1130,118 @@ func TestSetRateLimitedFallback(t *testing.T) {
 	}
 	if diff > 2*time.Second {
 		t.Errorf("rateLimitExpiry = %v, want ~%v (diff %v)", got, expected, diff)
+	}
+}
+
+// =============================================================================
+// Cold-Start Budget Probe Tests
+// =============================================================================
+
+// TestProbeSeedsBudgetBeforeFirstSync verifies the ordering guarantee of the
+// cold-start probe: the cheap viewer query completes (seeding the client's
+// rate budget from its response headers) BEFORE the worker issues any
+// expensive work (workspace, teams, metadata, issues).
+func TestProbeSeedsBudgetBeforeFirstSync(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+
+	mock := newMockAPIClient()
+	mock.teams = []api.Team{{ID: "team-1", Key: "TST", Name: "Test"}}
+
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	worker.Start(ctx)
+	defer worker.Stop()
+
+	// Wait for the initial sync cycle to reach GetTeams.
+	deadline := time.Now().Add(5 * time.Second)
+	for atomic.LoadInt32(&mock.getTeamsCalls) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("initial sync never called GetTeams")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	order := mock.callOrder()
+	if len(order) == 0 || order[0] != "GetViewer" {
+		t.Fatalf("call order = %v, want GetViewer (the budget probe) strictly first", order)
+	}
+	if atomic.LoadInt32(&mock.getViewerCalls) != 1 {
+		t.Errorf("GetViewer calls = %d, want exactly 1 probe", atomic.LoadInt32(&mock.getViewerCalls))
+	}
+}
+
+// TestProbeRateLimitedDelaysSyncStart verifies the exhausted-account path:
+// when the probe itself reports RATELIMITED, the worker marks itself
+// rate-limited (honoring the budget's server-reported reset) and delays the
+// entire sync start instead of bursting into the wall — and shutdown during
+// that delay exits cleanly without firing a post-stop sync cycle.
+func TestProbeRateLimitedDelaysSyncStart(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+
+	mock := newMockAPIClient()
+	mock.teams = []api.Team{{ID: "team-1", Key: "TST", Name: "Test"}}
+	mock.viewerErr = errors.New("GraphQL error: RATELIMITED: rate limit exceeded")
+	// The budget's server-reported reset (seeded by the probe response's
+	// headers in production) is an hour out.
+	mock.rateLimitResetAt = time.Now().Add(time.Hour)
+
+	worker := NewWorker(mock, store, Config{Interval: 10 * time.Millisecond})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	worker.Start(ctx)
+
+	// Give the worker ample time to (incorrectly) start syncing.
+	time.Sleep(200 * time.Millisecond)
+
+	if got := atomic.LoadInt32(&mock.getTeamsCalls); got != 0 {
+		t.Errorf("GetTeams calls during rate-limited probe delay = %d, want 0", got)
+	}
+	if !worker.isRateLimited() {
+		t.Error("worker should report rate-limited after a RATELIMITED probe")
+	}
+
+	// Stop must interrupt the delay; no sync cycle may fire on the way out.
+	worker.Stop()
+	if order := mock.callOrder(); len(order) != 1 || order[0] != "GetViewer" {
+		t.Errorf("call order after stop = %v, want just the probe [GetViewer]", order)
+	}
+}
+
+// TestProbeFailureProceeds verifies that a non-rate-limit probe failure
+// (network down, bad auth) does not block sync: those failures repeat in
+// syncAllTeams and are handled there.
+func TestProbeFailureProceeds(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+
+	mock := newMockAPIClient()
+	mock.teams = []api.Team{{ID: "team-1", Key: "TST", Name: "Test"}}
+	mock.viewerErr = errors.New("connection refused")
+
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	worker.Start(ctx)
+	defer worker.Stop()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for atomic.LoadInt32(&mock.getTeamsCalls) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("sync never proceeded past a non-rate-limit probe failure")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if worker.isRateLimited() {
+		t.Error("a non-rate-limit probe failure must not mark the worker rate-limited")
 	}
 }
 


### PR DESCRIPTION
## Why

The client throttled the **wrong meter**. Linear bills two hourly axes — **requests** and **complexity points** — and the binding constraint at cold-start is complexity. The old client:

- shaped only **request count**, hardcoded at `1500/hr` (the real limit is **2,500**),
- **ignored complexity entirely** — the axis that actually gets exhausted,
- parsed the reset from `X-RateLimit-Reset` (a header Linear doesn't send) as **seconds**, but Linear returns per-axis `-Reset` in **epoch milliseconds** — so adaptive backoff was dead.

A fresh mount's full sync could blow the **3,000,000-complexity/hr** budget into a `RATELIMITED` wall (observed live on 2026-07-06).

## What

A new deep module **`internal/api/ratebudget.go`** owns everything the old code scattered: two windowed budgets (**limits read from headers, never hardcoded**), a per-op cost predictor learned from `X-Complexity`, a priority-reserve ladder, an in-flight reservation semaphore, and header reconciliation.

**Control model — hybrid, server-anchored.** `admit(op, priority)` gates on a local predictive budget before sending; `observe` snaps both axes' remaining/limit/reset to the response headers — drift is erased every round-trip and a restart self-heals on the first response. Settlement is via an idempotent `admission` handle (`observe` / `rateLimited` / `release`), with `defer release()` as the catch-all.

**Emergent cold-start gentleness.** The reserve ladder (write 0, interactive 2%, skeleton 5%, list 15%, **detail 40%**) means under a constrained budget the skeleton syncs first and detail fetches defer into the existing `pending_detail_sync` queue — no special mode. `admit` allows only if `cost ≤ remaining − inFlight − reserve(priority)` on **both** axes.

**Cold-start probe.** `Worker.probeBudget` fires one cheap `GetViewer` that is `observe`d **before** the first expensive sync cycle, seeding the budget so the initial burst is gated. A `RATELIMITED` probe honors the reset and delays the sync start.

**Fixes along the way:** per-axis `time.UnixMilli` reset parsing (revives backoff), optimistic refill past the window, `RATELIMITED` snap-to-zero-until-reset, right-sized micro-burst limiter + stats denominator from the header limit. `checkRateLimitHeaders` folds into `observe`; `LowBudget`/`RateLimitResetAt` delegate to the budget; the worker's backoff now uses the real server reset.

Priority is a static `opName→tier` intent map, promotable via `api.WithInteractive(ctx)` — **mechanism only in PR1**; threading it through on-demand FS reads is a documented follow-up.

## Testing

Unit-tested behind the seam with a **fake clock + synthetic headers** (no live API): reserve ladder defers the right tiers, header reconcile incl. UnixMilli, in-flight semaphore under concurrent admits, reset rollover, `RATELIMITED` snap-to-zero, cost predictor, and probe ordering + RATELIMITED-delays-start — **passing under `-race`**. `go build` / `vet` / gofmt clean; full non-integration suite + integration suite `PASS`.

**Foundation validated by one live header probe** (viewer, cost 1pt): confirmed `X-Complexity` and `X-RateLimit-{Complexity,Requests}-*` exist, reset is epoch ms, and the request limit is **2,500** (matching neither docs nor the old constant) — hence the read-from-header rule.

## Follow-ups (not in this PR)
- Thread `WithInteractive` through on-demand FS read paths (mechanism exists; zero adopters yet).
- PR2 — explicit cold-start sequencing polish, only if the emergent behavior proves insufficient in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)