### PR TITLE
refactor(fs): namedListing — collapse 13 entity-named listing sites

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -279,7 +279,64 @@ formatter (their `<NNNN>-<date>-<health>.md` convention is identical), while
 comments own a per-minute timestamp format with no health. `TestIndexedListing-
 RoundTrip` guards the invariant: every name `entries()` emits resolves back
 through `find`, and same-second items still get distinct names via the 1-based
-index.
+index. Its un-indexed twin is [[named-listing]].
+
+### Named listing (`namedListing`)
+The **deep module** owning the *entity-derived* filenames of a collection — the
+un-indexed sibling of [[indexed-listing]]. Where that module derives a name from
+an item's **position** in a sorted order, this one derives it from the item's
+**identity**, so there is no `lessKey` and no sort. `namedListing[T]{items,
+nameOf}` (`internal/fs/namedlisting.go`) exposes `entries()` (Readdir) and
+`find(name)` (Lookup/Unlink/Rename/Create-overwrite), and each of the three
+collections declares its listing via a `listing(items)` method (mirroring
+`trio()`) that reuses the existing `documentFilename`/`labelFilename`/
+`milestoneFilename` by value. It absorbed **13 hand-copied name-matching sites**
+across `documents.go`/`labels.go`/`milestones.go` (5+5+3): every surface that
+mapped a name to an entity re-derived and re-matched independently, so a
+`sanitizeFilename` tweak in one could strand a file (listed but un-openable). The
+caller fetches and passes the slice; the module is pure of the repo, so it is
+unit-tested on literal slices, no mount.
+
+**Ordering is the repo's job, never this module's.** The SQLite list queries
+carry the `ORDER BY` (labels by name, documents by title, milestones by
+`sort_order` — a *meaningful manual order*), so `namedListing` preserves the
+`items` slice as given. A filename sort here would clobber milestones'
+`sort_order` into alphabetical — a regression — so the module stays neutral to
+order and owns only name derivation and matching.
+
+**Collisions are first-match, emit-once — deliberately NOT dedup (the
+load-bearing decision, settled on live evidence; a future review must not
+re-suggest disambiguation).** `find` returns the first match and `entries()`
+emits each derived name once (first wins), yielding a well-formed readdir
+consistent with `find` by construction — and fixing the pre-existing sloppiness
+where the hand-rolled loops emitted a *duplicate dirent* and leaned on the kernel
+to collapse it. Why not disambiguate the second (`Bug (2).md`)? Because the mount
+is a name-addressed projection of a source that *permits* duplicate names, and
+the whole name→entity stack is already assume-first:
+
+- **Documents** can't collide: `slug_id` is `UNIQUE NOT NULL` and
+  `documentFilename` uses the slug first — the slug is their index.
+- **Milestones** can't collide on name: Linear *enforces* per-project milestone-
+  name uniqueness (verified in the product UI). The only residual is
+  `sanitizeFilename` mangling an exotic name — narrow.
+- **Labels** *can* collide: a workspace label (`team_id IS NULL`) and a team
+  label share a directory (`WHERE team_id = ? OR team_id IS NULL`) and can share
+  a name — but they **shadow each other in Linear's own product too**, so
+  first-match faithfully mirrors the source (verified: two `testy-one` labels →
+  one file in the mount).
+
+A disambiguated `Bug (2).md` would be strictly worse than a shadow: it resolves
+**nowhere**, because `ResolveMilestoneID` and `GetLabelByName` match the raw
+entity `Name`, not the filename — an addressable file you can't assign to (a
+decoy), not completeness. `indexedListing` escapes this only because
+comments/updates are name-resolved *nowhere else*, so it can disambiguate freely;
+milestones/labels are resolution keys, pinning the filename to the resolution
+name. True per-file addressability would mean reworking name resolution end-to-
+end — a separate change, not a listing collapse. Attachments are the excluded
+case (two heterogeneous item types in one dir + stateful `deduplicateFilename`),
+the way `EmbeddedFileNode` is excluded from [[render-file]].
+`TestNamedListing*` guards the round-trip, the collision first-wins contract
+(the shadow as a *tested* invariant), order preservation, and totality.
 
 ### Connection drain (`paginate`)
 The **deep module** owning cursor pagination of Linear GraphQL connections —

--- a/internal/fs/documents.go
+++ b/internal/fs/documents.go
@@ -75,15 +75,7 @@ func (n *DocsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 		return fs.NewListDirStream(n.trio().entries()), 0
 	}
 
-	entries := n.trio().entries()
-
-	for _, doc := range docs {
-		entries = append(entries, fuse.DirEntry{
-			Name: documentFilename(doc),
-			Mode: syscall.S_IFREG,
-		})
-	}
-
+	entries := append(n.trio().entries(), n.listing(docs).entries()...)
 	return fs.NewListDirStream(entries), 0
 }
 
@@ -91,6 +83,13 @@ func (n *DocsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 // has no user-chosen filename, so the title must come from the content.
 func (n *DocsNode) trio() collectionTrio {
 	return collectionTrio{kind: "docs", parentID: n.parentID(), onFlush: n.createDocument("")}
+}
+
+// listing declares the docs collection's item files: one per document, named by
+// documentFilename. Backs Readdir/Lookup/Unlink/Rename/Create-overwrite so they
+// derive and match names through one place. See namedListing.
+func (n *DocsNode) listing(docs []api.Document) namedListing[api.Document] {
+	return namedListing[api.Document]{items: docs, nameOf: documentFilename}
 }
 
 func (n *DocsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
@@ -103,11 +102,8 @@ func (n *DocsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 		return nil, syscall.EIO
 	}
 
-	// Match by filename
-	for _, doc := range docs {
-		if documentFilename(doc) == name {
-			return n.newDocumentInode(ctx, doc, out)
-		}
+	if doc, ok := n.listing(docs).find(name); ok {
+		return n.newDocumentInode(ctx, doc, out)
 	}
 
 	return nil, syscall.ENOENT
@@ -131,10 +127,8 @@ func (n *DocsNode) Unlink(ctx context.Context, name string) syscall.Errno {
 			if err != nil {
 				return nil, err
 			}
-			for _, doc := range docs {
-				if documentFilename(doc) == name {
-					return &doc, nil
-				}
+			if doc, ok := n.listing(docs).find(name); ok {
+				return &doc, nil
 			}
 			return nil, nil
 		},
@@ -179,30 +173,28 @@ func (n *DocsNode) Rename(ctx context.Context, name string, newParent fs.InodeEm
 		return syscall.EIO
 	}
 
-	// Find the document by old filename
-	for _, doc := range docs {
-		if documentFilename(doc) == name {
-			// Update document title
-			updatedDoc, err := n.lfs.UpdateDocument(ctx, doc.ID, map[string]any{"title": newTitle}, n.issueID, n.teamID, n.projectID)
-			if err != nil {
-				log.Printf("Failed to rename document: %v", err)
-				n.lfs.SetWriteError(collectionErrorKey("docs", n.parentID()), "Operation: rename document "+name+" -> "+newName+"\nError: "+err.Error())
-				return syscall.EIO
-			}
-			// Upsert to SQLite so it's immediately visible
-			if err := n.lfs.UpsertDocument(ctx, *updatedDoc); err != nil {
-				log.Printf("Warning: failed to upsert document to SQLite: %v", err)
-			}
-			if n.lfs.debug {
-				log.Printf("Document renamed successfully: %s -> %s", doc.Title, newTitle)
-			}
-			// Invalidate kernel cache for old and new names
-			n.lfs.InvalidateRenamed(docsDirIno(n.parentID()), name, newName, 0)
-			return 0
-		}
+	doc, ok := n.listing(docs).find(name)
+	if !ok {
+		return syscall.ENOENT
 	}
 
-	return syscall.ENOENT
+	// Update document title
+	updatedDoc, err := n.lfs.UpdateDocument(ctx, doc.ID, map[string]any{"title": newTitle}, n.issueID, n.teamID, n.projectID)
+	if err != nil {
+		log.Printf("Failed to rename document: %v", err)
+		n.lfs.SetWriteError(collectionErrorKey("docs", n.parentID()), "Operation: rename document "+name+" -> "+newName+"\nError: "+err.Error())
+		return syscall.EIO
+	}
+	// Upsert to SQLite so it's immediately visible
+	if err := n.lfs.UpsertDocument(ctx, *updatedDoc); err != nil {
+		log.Printf("Warning: failed to upsert document to SQLite: %v", err)
+	}
+	if n.lfs.debug {
+		log.Printf("Document renamed successfully: %s -> %s", doc.Title, newTitle)
+	}
+	// Invalidate kernel cache for old and new names
+	n.lfs.InvalidateRenamed(docsDirIno(n.parentID()), name, newName, 0)
+	return 0
 }
 
 // newDocumentInode builds the read/write DocumentFileNode inode for an existing
@@ -242,14 +234,12 @@ func (n *DocsNode) Create(ctx context.Context, name string, flags uint32, mode u
 	// write-only _create node to the name, leaving the file unreadable and
 	// unwritable (#137).
 	if docs, err := n.getDocuments(ctx); err == nil {
-		for _, doc := range docs {
-			if documentFilename(doc) == name {
-				inode, errno := n.newDocumentInode(ctx, doc, out)
-				if errno != 0 {
-					return nil, nil, 0, errno
-				}
-				return inode, nil, 0, 0
+		if doc, ok := n.listing(docs).find(name); ok {
+			inode, errno := n.newDocumentInode(ctx, doc, out)
+			if errno != 0 {
+				return nil, nil, 0, errno
 			}
+			return inode, nil, 0, 0
 		}
 	}
 

--- a/internal/fs/labels.go
+++ b/internal/fs/labels.go
@@ -33,20 +33,20 @@ func (n *LabelsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) 
 		return nil, syscall.EIO
 	}
 
-	entries := n.trio().entries()
-	for _, label := range labels {
-		entries = append(entries, fuse.DirEntry{
-			Name: labelFilename(label),
-			Mode: syscall.S_IFREG,
-		})
-	}
-
+	entries := append(n.trio().entries(), n.listing(labels).entries()...)
 	return fs.NewListDirStream(entries), 0
 }
 
 // trio declares the labels collection's writable surfaces.
 func (n *LabelsNode) trio() collectionTrio {
 	return collectionTrio{kind: "labels", parentID: n.teamID, onFlush: n.createLabel}
+}
+
+// listing declares the labels collection's item files: one per label, named by
+// labelFilename. Backs Readdir/Lookup/Unlink/Rename/Create-overwrite so they
+// derive and match names through one place. See namedListing.
+func (n *LabelsNode) listing(labels []api.Label) namedListing[api.Label] {
+	return namedListing[api.Label]{items: labels, nameOf: labelFilename}
 }
 
 func (n *LabelsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
@@ -59,11 +59,8 @@ func (n *LabelsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut
 		return nil, syscall.EIO
 	}
 
-	// Match by filename
-	for _, label := range labels {
-		if labelFilename(label) == name {
-			return n.newLabelInode(ctx, label, out)
-		}
+	if label, ok := n.listing(labels).find(name); ok {
+		return n.newLabelInode(ctx, label, out)
 	}
 
 	return nil, syscall.ENOENT
@@ -111,10 +108,8 @@ func (n *LabelsNode) Unlink(ctx context.Context, name string) syscall.Errno {
 			if err != nil {
 				return nil, err
 			}
-			for _, label := range labels {
-				if labelFilename(label) == name {
-					return &label, nil
-				}
+			if label, ok := n.listing(labels).find(name); ok {
+				return &label, nil
 			}
 			return nil, nil
 		},
@@ -163,30 +158,28 @@ func (n *LabelsNode) Rename(ctx context.Context, name string, newParent fs.Inode
 		return syscall.EIO
 	}
 
-	// Find the label by old filename
-	for _, label := range labels {
-		if labelFilename(label) == name {
-			// Update label name
-			updatedLabel, err := n.lfs.UpdateLabel(ctx, label.ID, map[string]any{"name": newLabelName}, n.teamID)
-			if err != nil {
-				log.Printf("Failed to rename label: %v", err)
-				n.lfs.SetWriteError(collectionErrorKey("labels", n.teamID), "Operation: rename label "+name+" -> "+newName+"\nError: "+err.Error())
-				return syscall.EIO
-			}
-			// Upsert to SQLite so it's immediately visible
-			if err := n.lfs.UpsertLabel(ctx, n.teamID, *updatedLabel); err != nil {
-				log.Printf("Warning: failed to upsert label to SQLite: %v", err)
-			}
-			if n.lfs.debug {
-				log.Printf("Label renamed successfully: %s -> %s", label.Name, newLabelName)
-			}
-			// Invalidate kernel cache for old and new names
-			n.lfs.InvalidateRenamed(labelsDirIno(n.teamID), name, newName, 0)
-			return 0
-		}
+	label, ok := n.listing(labels).find(name)
+	if !ok {
+		return syscall.ENOENT
 	}
 
-	return syscall.ENOENT
+	// Update label name
+	updatedLabel, err := n.lfs.UpdateLabel(ctx, label.ID, map[string]any{"name": newLabelName}, n.teamID)
+	if err != nil {
+		log.Printf("Failed to rename label: %v", err)
+		n.lfs.SetWriteError(collectionErrorKey("labels", n.teamID), "Operation: rename label "+name+" -> "+newName+"\nError: "+err.Error())
+		return syscall.EIO
+	}
+	// Upsert to SQLite so it's immediately visible
+	if err := n.lfs.UpsertLabel(ctx, n.teamID, *updatedLabel); err != nil {
+		log.Printf("Warning: failed to upsert label to SQLite: %v", err)
+	}
+	if n.lfs.debug {
+		log.Printf("Label renamed successfully: %s -> %s", label.Name, newLabelName)
+	}
+	// Invalidate kernel cache for old and new names
+	n.lfs.InvalidateRenamed(labelsDirIno(n.teamID), name, newName, 0)
+	return 0
 }
 
 func (n *LabelsNode) Create(ctx context.Context, name string, flags uint32, mode uint32, out *fuse.EntryOut) (*fs.Inode, fs.FileHandle, uint32, syscall.Errno) {
@@ -203,14 +196,12 @@ func (n *LabelsNode) Create(ctx context.Context, name string, flags uint32, mode
 	// overwrite (mv/cp/editor save-over) updates it in place instead of binding a
 	// write-only _create node to the name and corrupting it (#137).
 	if labels, err := n.lfs.GetTeamLabels(ctx, n.teamID); err == nil {
-		for _, label := range labels {
-			if labelFilename(label) == name {
-				inode, errno := n.newLabelInode(ctx, label, out)
-				if errno != 0 {
-					return nil, nil, 0, errno
-				}
-				return inode, nil, 0, 0
+		if label, ok := n.listing(labels).find(name); ok {
+			inode, errno := n.newLabelInode(ctx, label, out)
+			if errno != 0 {
+				return nil, nil, 0, errno
 			}
+			return inode, nil, 0, 0
 		}
 	}
 

--- a/internal/fs/milestones.go
+++ b/internal/fs/milestones.go
@@ -31,20 +31,20 @@ func (n *MilestonesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Err
 		return fs.NewListDirStream(n.trio().entries()), 0
 	}
 
-	entries := n.trio().entries()
-	for _, m := range milestones {
-		entries = append(entries, fuse.DirEntry{
-			Name: milestoneFilename(m),
-			Mode: syscall.S_IFREG,
-		})
-	}
-
+	entries := append(n.trio().entries(), n.listing(milestones).entries()...)
 	return fs.NewListDirStream(entries), 0
 }
 
 // trio declares the milestones collection's writable surfaces.
 func (n *MilestonesNode) trio() collectionTrio {
 	return collectionTrio{kind: "milestones", parentID: n.projectID, onFlush: n.createMilestone}
+}
+
+// listing declares the milestones collection's item files: one per milestone,
+// named by milestoneFilename. Backs Readdir/Lookup/Unlink so they derive and
+// match names through one place. See namedListing.
+func (n *MilestonesNode) listing(ms []api.ProjectMilestone) namedListing[api.ProjectMilestone] {
+	return namedListing[api.ProjectMilestone]{items: ms, nameOf: milestoneFilename}
 }
 
 func (n *MilestonesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
@@ -57,36 +57,34 @@ func (n *MilestonesNode) Lookup(ctx context.Context, name string, out *fuse.Entr
 		return nil, syscall.EIO
 	}
 
-	// Match by filename
-	for _, m := range milestones {
-		if milestoneFilename(m) == name {
-			content, err := marshal.MilestoneToMarkdown(&m)
-			if err != nil {
-				log.Printf("Failed to marshal milestone: %v", err)
-				return nil, syscall.EIO
-			}
-			node := &MilestoneFileNode{
-				BaseNode:   BaseNode{lfs: n.lfs},
-				milestone:  m,
-				projectID:  n.projectID,
-				editBuffer: editBuffer{content: content},
-			}
-			now := time.Now()
-			out.Attr.Mode = 0644 | syscall.S_IFREG
-			out.Attr.Uid = n.lfs.uid
-			out.Attr.Gid = n.lfs.gid
-			out.Attr.Size = uint64(len(content))
-			out.SetAttrTimeout(5 * time.Second)
-			out.SetEntryTimeout(5 * time.Second)
-			out.Attr.SetTimes(&now, &now, &now)
-			return n.NewInode(ctx, node, fs.StableAttr{
-				Mode: syscall.S_IFREG,
-				Ino:  milestoneIno(m.ID),
-			}), 0
-		}
+	m, ok := n.listing(milestones).find(name)
+	if !ok {
+		return nil, syscall.ENOENT
 	}
 
-	return nil, syscall.ENOENT
+	content, err := marshal.MilestoneToMarkdown(&m)
+	if err != nil {
+		log.Printf("Failed to marshal milestone: %v", err)
+		return nil, syscall.EIO
+	}
+	node := &MilestoneFileNode{
+		BaseNode:   BaseNode{lfs: n.lfs},
+		milestone:  m,
+		projectID:  n.projectID,
+		editBuffer: editBuffer{content: content},
+	}
+	now := time.Now()
+	out.Attr.Mode = 0644 | syscall.S_IFREG
+	out.Attr.Uid = n.lfs.uid
+	out.Attr.Gid = n.lfs.gid
+	out.Attr.Size = uint64(len(content))
+	out.SetAttrTimeout(5 * time.Second)
+	out.SetEntryTimeout(5 * time.Second)
+	out.Attr.SetTimes(&now, &now, &now)
+	return n.NewInode(ctx, node, fs.StableAttr{
+		Mode: syscall.S_IFREG,
+		Ino:  milestoneIno(m.ID),
+	}), 0
 }
 
 func (n *MilestonesNode) Unlink(ctx context.Context, name string) syscall.Errno {
@@ -107,10 +105,8 @@ func (n *MilestonesNode) Unlink(ctx context.Context, name string) syscall.Errno 
 			if err != nil {
 				return nil, err
 			}
-			for _, m := range milestones {
-				if milestoneFilename(m) == name {
-					return &m, nil
-				}
+			if m, ok := n.listing(milestones).find(name); ok {
+				return &m, nil
 			}
 			return nil, nil
 		},

--- a/internal/fs/namedlisting.go
+++ b/internal/fs/namedlisting.go
@@ -1,0 +1,66 @@
+package fs
+
+import (
+	"syscall"
+
+	"github.com/hanwen/go-fuse/v2/fuse"
+)
+
+// namedListing owns the entity-derived filenames of a collection whose entries
+// are named directly from an entity field — documents (slug/title), labels
+// (name), and project milestones (name). It is the un-indexed sibling of
+// indexedListing: where that module derives a name from an item's *position* in
+// a sorted order, this one derives it from the item's *identity*, so there is no
+// sort and no index. Deriving the name in one place is what lets a collection's
+// Readdir, Lookup, Unlink, Rename, and Create-overwrite agree on every name — a
+// file you can `ls` you can also open, `rm`, and `mv`. Before this, each of
+// those surfaces re-derived and re-matched independently (13 sites across three
+// nodes), so a change to one could silently strand a file.
+//
+// Ordering is the repo's job, not this module's: the SQLite list queries carry
+// the ORDER BY (labels by name, documents by title, milestones by sort_order — a
+// meaningful manual order that a filename sort would clobber), so namedListing
+// preserves the items slice as given and never sorts.
+//
+// Collisions are first-match, emit-once. Two entities can derive the same
+// filename (two cross-scope labels named "Bug"; a sanitized-name clash), and the
+// mount is a name-addressed projection of a source that permits such duplicates —
+// Linear itself shadows them in its own product. So find returns the first match
+// and entries emits each derived name once (first wins), a well-formed readdir
+// consistent with find by construction. This is deliberately not a dedup
+// *policy*: a disambiguated name like "Bug (2).md" would resolve nowhere, since
+// ResolveMilestoneID and GetLabelByName match the raw entity name — the whole
+// name->entity stack is already assume-first. See CONTEXT.md "Named listing".
+type namedListing[T any] struct {
+	items  []T
+	nameOf func(T) string
+}
+
+// entries is the Readdir projection: one S_IFREG DirEntry per distinct derived
+// name, in items order. A name colliding with an earlier item's is dropped
+// (first wins), so the listing never emits a duplicate dirent.
+func (l namedListing[T]) entries() []fuse.DirEntry {
+	entries := make([]fuse.DirEntry, 0, len(l.items))
+	seen := make(map[string]struct{}, len(l.items))
+	for _, it := range l.items {
+		name := l.nameOf(it)
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		entries = append(entries, fuse.DirEntry{Name: name, Mode: syscall.S_IFREG})
+	}
+	return entries
+}
+
+// find is the Lookup/Unlink/Rename/Create-overwrite projection: locate the first
+// item whose derived name matches, over the same items order entries() used.
+func (l namedListing[T]) find(name string) (T, bool) {
+	for _, it := range l.items {
+		if l.nameOf(it) == name {
+			return it, true
+		}
+	}
+	var zero T
+	return zero, false
+}

--- a/internal/fs/namedlisting_test.go
+++ b/internal/fs/namedlisting_test.go
@@ -1,0 +1,92 @@
+package fs
+
+import (
+	"testing"
+)
+
+// nameBySelf is a nameOf that treats each string item as its own filename.
+func nameBySelf(s string) string { return s }
+
+// TestNamedListingRoundTrip is the core invariant: every name entries() emits
+// resolves back through find(). Same contract TestIndexedListingRoundTrip guards
+// for the indexed sibling.
+func TestNamedListingRoundTrip(t *testing.T) {
+	l := namedListing[string]{
+		items:  []string{"alpha.md", "beta.md", "gamma.md"},
+		nameOf: nameBySelf,
+	}
+	for _, e := range l.entries() {
+		if _, ok := l.find(e.Name); !ok {
+			t.Errorf("entries() emitted %q but find() could not resolve it", e.Name)
+		}
+	}
+}
+
+// TestNamedListingCollisionFirstWins guards the collision contract settled on
+// evidence: two items deriving the same name emit that name exactly once, and
+// find returns the FIRST item in items order. The second item is shadowed — a
+// tested contract, not an accident, mirroring how Linear itself shadows
+// same-named cross-scope entities.
+func TestNamedListingCollisionFirstWins(t *testing.T) {
+	type label struct{ id, name string }
+	l := namedListing[label]{
+		items: []label{
+			{id: "workspace", name: "Bug.md"},
+			{id: "team", name: "Bug.md"},
+			{id: "other", name: "Chore.md"},
+		},
+		nameOf: func(x label) string { return x.name },
+	}
+
+	// entries() emits each name once.
+	got := l.entries()
+	if len(got) != 2 {
+		t.Fatalf("entries() = %d entries, want 2 (collision collapsed): %+v", len(got), got)
+	}
+	seen := map[string]int{}
+	for _, e := range got {
+		seen[e.Name]++
+	}
+	if seen["Bug.md"] != 1 {
+		t.Errorf("entries() emitted Bug.md %d times, want 1 (no duplicate dirent)", seen["Bug.md"])
+	}
+
+	// find() returns the first item in items order.
+	if hit, ok := l.find("Bug.md"); !ok || hit.id != "workspace" {
+		t.Errorf("find(Bug.md) = (%+v, %v), want the first item (id=workspace)", hit, ok)
+	}
+}
+
+// TestNamedListingPreservesOrder: distinct names are emitted in items order, not
+// sorted — determinism is the repo's ORDER BY, never this module's.
+func TestNamedListingPreservesOrder(t *testing.T) {
+	items := []string{"gamma.md", "alpha.md", "beta.md"} // deliberately unsorted
+	l := namedListing[string]{items: items, nameOf: nameBySelf}
+
+	got := l.entries()
+	if len(got) != len(items) {
+		t.Fatalf("entries() = %d, want %d", len(got), len(items))
+	}
+	for i, e := range got {
+		if e.Name != items[i] {
+			t.Errorf("entries()[%d] = %q, want %q (items order preserved)", i, e.Name, items[i])
+		}
+	}
+}
+
+// TestNamedListingTotality: find of an absent name is a clean miss, and an empty
+// listing yields no entries.
+func TestNamedListingTotality(t *testing.T) {
+	l := namedListing[string]{items: []string{"only.md"}, nameOf: nameBySelf}
+	if _, ok := l.find("missing.md"); ok {
+		t.Error("find(missing.md) = true, want false")
+	}
+
+	empty := namedListing[string]{items: nil, nameOf: nameBySelf}
+	if got := empty.entries(); len(got) != 0 {
+		t.Errorf("empty.entries() = %d entries, want 0", len(got))
+	}
+	if _, ok := empty.find("anything"); ok {
+		t.Error("empty.find() = true, want false")
+	}
+}


### PR DESCRIPTION
The un-indexed sibling of `indexedListing`: where that derives a filename from an item's **position** in a sorted order, `namedListing` derives it from the item's **identity**. `namedListing[T]{items, nameOf}` exposes `entries()` (Readdir) and `find()` (Lookup/Unlink/Rename/Create-overwrite); each of docs/labels/milestones declares a `listing(items)` method reusing the existing `documentFilename`/`labelFilename`/`milestoneFilename` by value.

## What it collapses
**13 hand-copied name-matching sites** (documents 5, labels 5, milestones 3) that each re-derived and re-matched independently — so a `sanitizeFilename` tweak in one surface could strand a file (listed but un-openable). Net −23 lines across the three nodes even after adding the `listing()` methods.

## Decisions (grilled, evidence-backed)
- **No sort** — ordering is the repo's job (SQLite `ORDER BY`); a filename sort would clobber milestones' meaningful `sort_order`.
- **Collisions: first-match, emit-once, deliberately NOT dedup.** The mount is a name-addressed projection of a source that permits duplicate names (Linear shadows them itself), and the name→entity stack (`ResolveMilestoneID`/`GetLabelByName`) is already assume-first, so a disambiguated `Bug (2).md` would resolve nowhere. Documents can't collide (`slug_id UNIQUE`); milestones can't collide on name (Linear-enforced, verified in-product); labels can, cross-scope, and mirror Linear's own shadowing (verified: two `testy-one` → one file).
- **Kept separate from `indexedListing`** — the unified `listing[T]` was designed and rejected as shallower (dead positional param, `nil` order sentinel, a dead dedup branch).
- **Attachments excluded** (two item types + stateful dedup), like `EmbeddedFileNode` is excluded from `renderFileNode`.

## Tests
`namedlisting_test.go` — round-trip, collision first-wins (the shadow as a guarded contract), order preservation, totality. Pure, no mount. Full `internal/fs` suite green; build/gofmt/vet clean.

CONTEXT.md gains a `### Named listing` entry with the why-not-dedup rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)