### PR TITLE
refactor(fs): renderFile — collapse read-only generated-file nodes (+ real .rel times)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -260,6 +260,66 @@ carry no `CreatedAt`/`UpdatedAt`, so `Getattr` reports `now()` — see
 [[attr-construction]]). Unit-tested directly (write-expands, in-place,
 truncate-grow/shrink, read-clamps-at-EOF), no FUSE mount.
 
+### Render file (`renderFile`)
+The **deep module** owning every read-only *generated* file — the render-through
+file complement to `attrNode` (the directory mixin) and the read-side twin of
+`editBuffer` (the editable-file buffer). `renderFile` (`internal/fs/renderfile.go`)
+is `{BaseNode, render func() (content []byte, mtime, ctime time.Time)}` and
+provides the three FUSE ops such a file needs — `Open`/`Read`/`Getattr`, promoted
+into whatever embeds it. Its whole interface is the one render closure. It
+replaced **nine** hand-copied node types (`TeamInfoNode`, `StatesInfoNode`,
+`LabelsInfoNode`, `UserInfoNode`, `CycleFileNode`, `ReadmeNode`, `MetaFileNode`,
+`ErrorFileNode`, `SuccessFileNode`) and reduced two more (`RelationFileNode`,
+`ExternalAttachmentNode`, which embed it and keep only their `Unlink`) — net
+−490-odd lines. The byte-window offset-clamp that all of them hand-rolled (a dozen
+verbatim copies) lives once in `readWindow`.
+
+**It renders on every read (`FOPEN_DIRECT_IO`), uniformly.** go-fuse dedups
+inodes by `StableAttr.Ino` and reuses the first node for a given ino, so baking
+bytes *or times* at Lookup serves stale values for the life of the mount — the
+reasoning the `.meta`/`.error`/`.last` nodes already used. Collapsing the old
+`KEEP_CACHE` nodes onto DIRECT_IO also fixed a latent bug: `states.md`/`labels.md`
+carried a 10-min TTL content cache that was **dead under `KEEP_CACHE`** (the
+kernel served the first read forever); the TTL/`cachedContent` fields are gone —
+each read now fetches from SQLite (cheap) and re-renders. These files are tiny and
+read interactively, so the per-read FUSE round-trip is imperceptible. The attr
+timeout stays a per-construction param (`inheritTimeout` = leave the mount default
+60s/30s, preserving the nodes that set none; `.meta`/`.error`/`.last` keep 0;
+relation/attachment keep 30s).
+
+**The closure returns real times, never `now()`** — the drift this module kills
+(`ls -lt` used to reshuffle those files every call). A zero time reports as an
+unset attr (`nonZeroTime`), i.e. honest "unknown". Sources: `team.md` uses the
+team's times; `cycle.md` uses `StartsAt` (a cycle has no `updatedAt`; its
+former decorative `atime=EndsAt` is dropped); attachment `.link` uses the
+attachment's times; `.error` uses `WriteError.Timestamp`; `.last` uses the newest
+`WriteResult.Timestamp`; `.rel` uses the relation's own times (see below);
+`states.md`/`labels.md` use the **team's** times as a stable proxy (a collection
+has no single mtime); `user.md`/README report **zero** (`api.User` has no time
+fields; README is a generated doc). Construction goes through
+`newRenderInode`/`lookupRenderFile` (parent is a `*BaseNode`) or `mountRenderFile`
+(parent handed in as an `fs.InodeEmbedder`, for the `.meta`/`.error`/`.last`
+helpers), all filling the Lookup `EntryOut` from the same `renderAttr()` the
+`Getattr` uses — so a Lookup answer and a later stat can't disagree, the `attrNode`
+guarantee extended to dynamic-size files. Unit-tested directly on the struct with
+a stub closure (window clamp, write-open→`EACCES`, size/time reporting, zero-time),
+no FUSE mount.
+
+**Precursor — real `.rel` times (`IssueRelation` created/updated).** `.rel` files
+used to fabricate `now()`; making them report real times required carrying the
+relation's `createdAt`/`updatedAt` end-to-end, which nothing did. The
+`issue_relations` table already had the columns and `UpsertIssueRelation` already
+took them — the gap was above the DB: `api.IssueRelation` gained the two fields,
+the `CreateIssueRelation` mutation (and the issue fragment) now select
+`createdAt`/`updatedAt`, the create-persist writes the server's times (not
+`now()`), and `GetIssueRelations`/`GetIssueInverseRelations`/`GetIssueRelationByID`
+map them back onto the struct. (Orthogonal pre-existing gap, left alone:
+relations are populated **only** by the local create handler — the sync worker and
+`refreshIssueDetails` don't persist them — so relations made in Linear's own UI
+never appear as `.rel` files.) `EmbeddedFileNode` (the actual `*.png`/`*.pdf`
+bytes) stays out of `renderFile`: it is a lazy CDN byte-streamer, not a
+render-closure file, and `api.EmbeddedFile` has no times either.
+
 ### Indexed listing (`indexedListing`)
 The **deep module** owning the index-derived filenames of a collection whose
 entries are named `<NNNN>-<date>…md` by creation order — comments and the

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -96,8 +96,8 @@ fragment IssueFields on Issue {
   parent { id identifier title }
   children { nodes { id identifier title createdAt updatedAt } }
   cycle { id name number }
-  relations { nodes { id type relatedIssue { id identifier title } } }
-  inverseRelations { nodes { id type issue { id identifier title } } }
+  relations { nodes { id type relatedIssue { id identifier title } createdAt updatedAt } }
+  inverseRelations { nodes { id type issue { id identifier title } createdAt updatedAt } }
 }
 `
 
@@ -981,6 +981,8 @@ mutation CreateIssueRelation($issueId: String!, $relatedIssueId: String!, $type:
       type
       issue { id identifier title }
       relatedIssue { id identifier title }
+      createdAt
+      updatedAt
     }
   }
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -55,6 +55,8 @@ type IssueRelation struct {
 	Type         string       `json:"type"` // blocks, duplicate, related, similar
 	RelatedIssue *ParentIssue `json:"relatedIssue,omitempty"`
 	Issue        *ParentIssue `json:"issue,omitempty"` // For inverse relations
+	CreatedAt    time.Time    `json:"createdAt"`
+	UpdatedAt    time.Time    `json:"updatedAt"`
 }
 
 // IssueCycle is a minimal cycle representation for issue references

--- a/internal/fs/attachments.go
+++ b/internal/fs/attachments.go
@@ -129,23 +129,16 @@ func (n *AttachmentsNode) Lookup(ctx context.Context, name string, out *fuse.Ent
 
 func (n *AttachmentsNode) createExternalAttachmentNode(ctx context.Context, att api.Attachment, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
 	node := &ExternalAttachmentNode{
-		BaseNode:   BaseNode{lfs: n.lfs},
+		renderFile: renderFile{
+			BaseNode: BaseNode{lfs: n.lfs},
+			render: func() ([]byte, time.Time, time.Time) {
+				return []byte(externalAttachmentContent(att)), att.UpdatedAt, att.CreatedAt
+			},
+		},
 		attachment: att,
 		issueID:    n.issueID,
 	}
-	content := node.generateContent()
-	now := time.Now()
-	out.Attr.Mode = 0444 | syscall.S_IFREG // Read-only
-	out.Attr.Uid = n.lfs.uid
-	out.Attr.Gid = n.lfs.gid
-	out.Attr.Size = uint64(len(content))
-	out.SetAttrTimeout(30 * time.Second)
-	out.SetEntryTimeout(30 * time.Second)
-	out.Attr.SetTimes(&now, &now, &now)
-	return n.NewInode(ctx, node, fs.StableAttr{
-		Mode: syscall.S_IFREG,
-		Ino:  externalAttachmentIno(att.ID),
-	}), 0
+	return n.newRenderInode(ctx, out, node, externalAttachmentIno(att.ID), 30*time.Second), 0
 }
 
 // EmbeddedFileNode represents a file in the /attachments/ directory
@@ -232,55 +225,29 @@ func sanitizeFilename(s string) string {
 	return s
 }
 
-// ExternalAttachmentNode represents a .link file for an external attachment (GitHub PR, URL, etc.)
+// ExternalAttachmentNode represents a .link file for an external attachment
+// (GitHub PR, URL, etc.). It embeds renderFile for Open/Read/Getattr and keeps
+// only its Unlink.
 type ExternalAttachmentNode struct {
-	BaseNode
+	renderFile
 	attachment api.Attachment
 	issueID    string
 }
 
-var _ fs.NodeGetattrer = (*ExternalAttachmentNode)(nil)
-var _ fs.NodeOpener = (*ExternalAttachmentNode)(nil)
-var _ fs.NodeReader = (*ExternalAttachmentNode)(nil)
 var _ fs.NodeUnlinker = (*ExternalAttachmentNode)(nil)
 
-func (n *ExternalAttachmentNode) generateContent() string {
+// externalAttachmentContent renders a .link file's YAML body.
+func externalAttachmentContent(att api.Attachment) string {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("title: %s\n", n.attachment.Title))
-	sb.WriteString(fmt.Sprintf("url: %s\n", n.attachment.URL))
-	if n.attachment.Subtitle != "" {
-		sb.WriteString(fmt.Sprintf("subtitle: %s\n", n.attachment.Subtitle))
+	sb.WriteString(fmt.Sprintf("title: %s\n", att.Title))
+	sb.WriteString(fmt.Sprintf("url: %s\n", att.URL))
+	if att.Subtitle != "" {
+		sb.WriteString(fmt.Sprintf("subtitle: %s\n", att.Subtitle))
 	}
-	if n.attachment.SourceType != "" {
-		sb.WriteString(fmt.Sprintf("source: %s\n", n.attachment.SourceType))
+	if att.SourceType != "" {
+		sb.WriteString(fmt.Sprintf("source: %s\n", att.SourceType))
 	}
 	return sb.String()
-}
-
-func (n *ExternalAttachmentNode) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	content := n.generateContent()
-	now := time.Now()
-	out.Mode = 0444 // Read-only
-	n.SetOwner(out)
-	out.Size = uint64(len(content))
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
-
-func (n *ExternalAttachmentNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	return nil, fuse.FOPEN_KEEP_CACHE, 0
-}
-
-func (n *ExternalAttachmentNode) Read(ctx context.Context, fh fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	content := []byte(n.generateContent())
-	if off >= int64(len(content)) {
-		return fuse.ReadResultData(nil), 0
-	}
-	end := off + int64(len(dest))
-	if end > int64(len(content)) {
-		end = int64(len(content))
-	}
-	return fuse.ReadResultData(content[off:end]), 0
 }
 
 func (n *ExternalAttachmentNode) Unlink(ctx context.Context, name string) syscall.Errno {

--- a/internal/fs/cycles.go
+++ b/internal/fs/cycles.go
@@ -143,16 +143,13 @@ func (c *CycleDirNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno
 }
 
 func (c *CycleDirNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	// Handle cycle.md
+	// Handle cycle.md. A cycle has no updatedAt; report StartsAt as both mtime
+	// and ctime (preserving the previous sort order), never now().
 	if name == "cycle.md" {
-		node := &CycleFileNode{BaseNode: BaseNode{lfs: c.lfs}, team: c.team, cycle: c.cycle}
-		content := node.generateContent()
-		out.Attr.Mode = 0444 | syscall.S_IFREG
-		out.Attr.Uid = c.lfs.uid
-		out.Attr.Gid = c.lfs.gid
-		out.Attr.Size = uint64(len(content))
-		out.Attr.SetTimes(&c.cycle.EndsAt, &c.cycle.StartsAt, &c.cycle.StartsAt)
-		return c.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG}), 0
+		team, cycle := c.team, c.cycle
+		return c.lookupRenderFile(ctx, out, func() ([]byte, time.Time, time.Time) {
+			return cycleMarkdown(team, cycle), cycle.StartsAt, cycle.StartsAt
+		}, 0, inheritTimeout), 0
 	}
 
 	// Handle issue symlinks (e.g., "ENG-123")
@@ -172,28 +169,19 @@ func (c *CycleDirNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 	return nil, syscall.ENOENT
 }
 
-// CycleFileNode represents the cycle.md file inside a cycle directory
-type CycleFileNode struct {
-	BaseNode
-	team  api.Team
-	cycle api.Cycle
-}
-
-var _ fs.NodeGetattrer = (*CycleFileNode)(nil)
-var _ fs.NodeOpener = (*CycleFileNode)(nil)
-var _ fs.NodeReader = (*CycleFileNode)(nil)
-
-func (c *CycleFileNode) generateContent() []byte {
+// cycleMarkdown renders the cycle.md content for a cycle. Status/progress are
+// computed at render time, so a read reflects the cycle's live state.
+func cycleMarkdown(team api.Team, cycle api.Cycle) []byte {
 	now := time.Now()
-	isCurrent := now.After(c.cycle.StartsAt) && now.Before(c.cycle.EndsAt)
+	isCurrent := now.After(cycle.StartsAt) && now.Before(cycle.EndsAt)
 
 	// Calculate progress from history arrays
 	var completed, total int
-	if len(c.cycle.CompletedIssueCountHistory) > 0 {
-		completed = c.cycle.CompletedIssueCountHistory[len(c.cycle.CompletedIssueCountHistory)-1]
+	if len(cycle.CompletedIssueCountHistory) > 0 {
+		completed = cycle.CompletedIssueCountHistory[len(cycle.CompletedIssueCountHistory)-1]
 	}
-	if len(c.cycle.IssueCountHistory) > 0 {
-		total = c.cycle.IssueCountHistory[len(c.cycle.IssueCountHistory)-1]
+	if len(cycle.IssueCountHistory) > 0 {
+		total = cycle.IssueCountHistory[len(cycle.IssueCountHistory)-1]
 	}
 
 	var percentage float64
@@ -204,16 +192,16 @@ func (c *CycleFileNode) generateContent() []byte {
 	status := "upcoming"
 	if isCurrent {
 		status = "current"
-	} else if now.After(c.cycle.EndsAt) {
+	} else if now.After(cycle.EndsAt) {
 		status = "completed"
 	}
 
-	cycleName := c.cycle.Name
+	cycleName := cycle.Name
 	if cycleName == "" {
-		cycleName = fmt.Sprintf("Cycle %d", c.cycle.Number)
+		cycleName = fmt.Sprintf("Cycle %d", cycle.Number)
 	}
 
-	content := fmt.Sprintf(`---
+	return []byte(fmt.Sprintf(`---
 id: %s
 number: %d
 name: %s
@@ -233,50 +221,24 @@ progress:
 - **Progress:** %d/%d issues (%.1f%%)
 - **Status:** %s
 `,
-		c.cycle.ID,
-		c.cycle.Number,
+		cycle.ID,
+		cycle.Number,
 		cycleName,
-		c.team.Key,
-		c.cycle.StartsAt.Format(time.RFC3339),
-		c.cycle.EndsAt.Format(time.RFC3339),
+		team.Key,
+		cycle.StartsAt.Format(time.RFC3339),
+		cycle.EndsAt.Format(time.RFC3339),
 		status,
 		completed,
 		total,
 		percentage,
 		cycleName,
-		c.cycle.StartsAt.Format("Jan 2, 2006"),
-		c.cycle.EndsAt.Format("Jan 2, 2006"),
+		cycle.StartsAt.Format("Jan 2, 2006"),
+		cycle.EndsAt.Format("Jan 2, 2006"),
 		completed,
 		total,
 		percentage,
 		status,
-	)
-	return []byte(content)
-}
-
-func (c *CycleFileNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	content := c.generateContent()
-	out.Mode = 0444 | syscall.S_IFREG
-	c.SetOwner(out)
-	out.Size = uint64(len(content))
-	out.Attr.SetTimes(&c.cycle.EndsAt, &c.cycle.StartsAt, &c.cycle.StartsAt)
-	return 0
-}
-
-func (c *CycleFileNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	return nil, fuse.FOPEN_KEEP_CACHE, 0
-}
-
-func (c *CycleFileNode) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	content := c.generateContent()
-	if off >= int64(len(content)) {
-		return fuse.ReadResultData(nil), 0
-	}
-	end := off + int64(len(dest))
-	if end > int64(len(content)) {
-		end = int64(len(content))
-	}
-	return fuse.ReadResultData(content[off:end]), 0
+	))
 }
 
 // isCurrent checks if a cycle is the current active cycle

--- a/internal/fs/cycles_test.go
+++ b/internal/fs/cycles_test.go
@@ -125,20 +125,18 @@ func TestCycleFileNode_GenerateContent(t *testing.T) {
 	startsAt := now.Add(-24 * time.Hour)
 	endsAt := now.Add(24 * time.Hour)
 
-	node := &CycleFileNode{
-		team: api.Team{Key: "ENG"},
-		cycle: api.Cycle{
-			ID:                         "cycle-123",
-			Number:                     5,
-			Name:                       "Sprint 5",
-			StartsAt:                   startsAt,
-			EndsAt:                     endsAt,
-			IssueCountHistory:          []int{10},
-			CompletedIssueCountHistory: []int{3},
-		},
+	team := api.Team{Key: "ENG"}
+	cycle := api.Cycle{
+		ID:                         "cycle-123",
+		Number:                     5,
+		Name:                       "Sprint 5",
+		StartsAt:                   startsAt,
+		EndsAt:                     endsAt,
+		IssueCountHistory:          []int{10},
+		CompletedIssueCountHistory: []int{3},
 	}
 
-	content := node.generateContent()
+	content := cycleMarkdown(team, cycle)
 
 	// Check that content includes expected fields
 	contentStr := string(content)
@@ -165,20 +163,18 @@ func TestCycleFileNode_GenerateContent_EmptyHistory(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
 
-	node := &CycleFileNode{
-		team: api.Team{Key: "ENG"},
-		cycle: api.Cycle{
-			ID:       "cycle-456",
-			Number:   1,
-			StartsAt: now.Add(24 * time.Hour),
-			EndsAt:   now.Add(48 * time.Hour),
-			// Empty history arrays
-			IssueCountHistory:          []int{},
-			CompletedIssueCountHistory: []int{},
-		},
+	team := api.Team{Key: "ENG"}
+	cycle := api.Cycle{
+		ID:       "cycle-456",
+		Number:   1,
+		StartsAt: now.Add(24 * time.Hour),
+		EndsAt:   now.Add(48 * time.Hour),
+		// Empty history arrays
+		IssueCountHistory:          []int{},
+		CompletedIssueCountHistory: []int{},
 	}
 
-	content := node.generateContent()
+	content := cycleMarkdown(team, cycle)
 	contentStr := string(content)
 
 	// Should have zero values for progress

--- a/internal/fs/errorfile.go
+++ b/internal/fs/errorfile.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"context"
-	"syscall"
 	"time"
 
 	"github.com/hanwen/go-fuse/v2/fs"
@@ -68,85 +67,17 @@ func collectionErrorKey(kind, parentID string) string {
 	return kind + ":" + parentID
 }
 
-// lookupErrorFile mounts the `.error` virtual file for an entity as a child of
-// parent and fills out the lookup attrs. entityID is the key used with
-// SetWriteError. Entry/attr timeouts are short so the file reflects the result
-// of the most recent write rather than a stale cached value.
+// lookupErrorFile mounts the read-only `.error` virtual file for an entity as a
+// child of parent. Reading it returns the last failed-write message (empty if
+// the most recent write succeeded), keyed by entityID. It is a plain renderFile
+// with zero timeouts, so it always reflects the most recent write rather than a
+// stale cached (often empty) value; the reported time is when the error was set.
 func (lfs *LinearFS) lookupErrorFile(ctx context.Context, parent fs.InodeEmbedder, entityID string, out *fuse.EntryOut) *fs.Inode {
-	node := &ErrorFileNode{BaseNode: BaseNode{lfs: lfs}, entityID: entityID}
-
-	size := uint64(0)
-	if e := lfs.GetWriteError(entityID); e != nil {
-		size = uint64(len(e.Message) + 1) // +1 for trailing newline
+	render := func() ([]byte, time.Time, time.Time) {
+		if e := lfs.GetWriteError(entityID); e != nil {
+			return []byte(e.Message + "\n"), e.Timestamp, e.Timestamp
+		}
+		return nil, time.Time{}, time.Time{}
 	}
-
-	now := time.Now()
-	out.Attr.Mode = 0444 | syscall.S_IFREG // Read-only
-	out.Attr.Uid = lfs.uid
-	out.Attr.Gid = lfs.gid
-	out.Attr.Size = size
-	// Do not cache: a feedback file must always reflect the most recent write.
-	// Any nonzero timeout lets the kernel serve a stale (often empty) size and
-	// short-circuit the read.
-	out.SetAttrTimeout(0)
-	out.SetEntryTimeout(0)
-	out.Attr.SetTimes(&now, &now, &now)
-
-	return parent.EmbeddedInode().NewInode(ctx, node, fs.StableAttr{
-		Mode: syscall.S_IFREG,
-		Ino:  errorIno(entityID),
-	})
-}
-
-// ErrorFileNode is the read-only `.error` virtual file shown alongside any
-// writable entity. Reading it returns the last failed-write message (empty if
-// the most recent write succeeded). It is keyed by the entity's Linear ID.
-type ErrorFileNode struct {
-	BaseNode
-	entityID string
-}
-
-var _ fs.NodeGetattrer = (*ErrorFileNode)(nil)
-var _ fs.NodeOpener = (*ErrorFileNode)(nil)
-var _ fs.NodeReader = (*ErrorFileNode)(nil)
-
-func (e *ErrorFileNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	out.Mode = 0444 // Read-only
-	e.SetOwner(out)
-
-	if writeErr := e.lfs.GetWriteError(e.entityID); writeErr != nil {
-		out.Size = uint64(len(writeErr.Message) + 1) // +1 for newline
-	} else {
-		out.Size = 0
-	}
-
-	return 0
-}
-
-func (e *ErrorFileNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	// FOPEN_DIRECT_IO: .error content is volatile (it changes on every write to
-	// the entity). Direct I/O makes the kernel issue a real READ on every open
-	// instead of trusting a cached size — which could be a stale 0 from an
-	// earlier read, causing the kernel to short-circuit and return empty.
-	return nil, fuse.FOPEN_DIRECT_IO, 0
-}
-
-func (e *ErrorFileNode) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	writeErr := e.lfs.GetWriteError(e.entityID)
-	if writeErr == nil {
-		return fuse.ReadResultData(nil), 0
-	}
-
-	content := []byte(writeErr.Message + "\n")
-
-	if off >= int64(len(content)) {
-		return fuse.ReadResultData(nil), 0
-	}
-
-	end := off + int64(len(dest))
-	if end > int64(len(content)) {
-		end = int64(len(content))
-	}
-
-	return fuse.ReadResultData(content[off:end]), 0
+	return lfs.mountRenderFile(ctx, parent, render, errorIno(entityID), 0, out)
 }

--- a/internal/fs/metafile.go
+++ b/internal/fs/metafile.go
@@ -2,8 +2,6 @@ package fs
 
 import (
 	"context"
-	"syscall"
-	"time"
 
 	"github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
@@ -18,85 +16,22 @@ import (
 // successful write to the editable file never rewrites the bytes the writer
 // wrote — the staleness/"modified since read" churn goes away.
 //
-// MetaFileNode is READ-THROUGH: it holds a render closure (not baked bytes) and
-// renders current content inside Read/Getattr, exactly like ErrorFileNode and
-// SuccessFileNode. This is load-bearing: go-fuse dedups inodes by StableAttr.Ino,
-// so a second Lookup for the same entity returns the *original* node and discards
-// any freshly-constructed one — baking bytes at Lookup would serve stale content
-// for the life of the mount. Rendering on demand from a live source (the repo)
-// means the served node always reflects current state. Editors of the sibling
-// editable file call InvalidateUpdated(metaIno(id)) so the kernel drops its
-// cached size/attrs and re-reads.
-
-// metaRender returns the current `.meta` bytes plus the entity's updated/created
-// times, all from a live source. Times are rendered through (not baked at Lookup)
-// for the same reason the bytes are: go-fuse reuses the first node for a given
-// ino, so a baked mtime would freeze at first-Lookup forever — breaking the
-// `mtime=updatedAt` contract for the very file that exposes `updated:`.
-type metaRender func() (content []byte, mtime, ctime time.Time)
+// `.meta` is a plain renderFile: it holds a render closure (not baked bytes) and
+// renders current content on demand. This is load-bearing: go-fuse dedups inodes
+// by StableAttr.Ino, so a second Lookup for the same entity returns the
+// *original* node and discards any freshly-constructed one — baking bytes or
+// times at Lookup would serve stale content for the life of the mount. Rendering
+// on demand from a live source (the repo) means the served node always reflects
+// current state. Editors of the sibling editable file call
+// InvalidateUpdated(metaIno(id)) so the kernel drops its cached size/attrs and
+// re-reads. Times are rendered through for the same reason the bytes are: a baked
+// mtime would freeze at first-Lookup forever — breaking the `mtime=updatedAt`
+// contract for the very file that exposes `updated:`.
 
 // lookupMetaFile mounts a read-only `.meta` virtual file backed by a render
 // closure as a child of parent. render is called on demand (Lookup/Read/Getattr)
-// and must return the current meta bytes and times from a live source.
-func (lfs *LinearFS) lookupMetaFile(ctx context.Context, parent fs.InodeEmbedder, key string, render metaRender, out *fuse.EntryOut) *fs.Inode {
-	node := &MetaFileNode{BaseNode: BaseNode{lfs: lfs}, render: render}
-
-	content, mtime, ctime := render()
-	out.Attr.Mode = 0444 | syscall.S_IFREG // Read-only
-	out.Attr.Uid = lfs.uid
-	out.Attr.Gid = lfs.gid
-	out.Attr.Size = uint64(len(content))
-	// Feedback-file caching model: don't trust a cached size. Editors of the
-	// sibling editable file InvalidateUpdated(metaIno) to force a refresh.
-	out.SetAttrTimeout(0)
-	out.SetEntryTimeout(0)
-	out.Attr.SetTimes(&mtime, &mtime, &ctime)
-
-	return parent.EmbeddedInode().NewInode(ctx, node, fs.StableAttr{
-		Mode: syscall.S_IFREG,
-		Ino:  metaIno(key),
-	})
-}
-
-// MetaFileNode is a read-only virtual file that renders `.meta` content and times
-// on demand from a live source (never baked — see the package comment on go-fuse
-// inode dedup).
-type MetaFileNode struct {
-	BaseNode
-	render metaRender
-}
-
-var _ fs.NodeGetattrer = (*MetaFileNode)(nil)
-var _ fs.NodeOpener = (*MetaFileNode)(nil)
-var _ fs.NodeReader = (*MetaFileNode)(nil)
-
-func (m *MetaFileNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	content, mtime, ctime := m.render()
-	out.Mode = 0444 // Read-only
-	m.SetOwner(out)
-	out.Size = uint64(len(content))
-	out.SetTimes(&mtime, &mtime, &ctime)
-	return 0
-}
-
-func (m *MetaFileNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	// Reject writes explicitly (read-only sidecar).
-	if flags&(syscall.O_WRONLY|syscall.O_RDWR) != 0 {
-		return nil, 0, syscall.EACCES
-	}
-	// DIRECT_IO: content is volatile; force a real READ (through render) on each
-	// open instead of trusting a cached page.
-	return nil, fuse.FOPEN_DIRECT_IO, 0
-}
-
-func (m *MetaFileNode) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	content, _, _ := m.render()
-	if off >= int64(len(content)) {
-		return fuse.ReadResultData(nil), 0
-	}
-	end := off + int64(len(dest))
-	if end > int64(len(content)) {
-		end = int64(len(content))
-	}
-	return fuse.ReadResultData(content[off:end]), 0
+// and must return the current meta bytes and times from a live source. Timeouts
+// are zero (like .error/.last) so the file never serves a stale cached size.
+func (lfs *LinearFS) lookupMetaFile(ctx context.Context, parent fs.InodeEmbedder, key string, render renderFunc, out *fuse.EntryOut) *fs.Inode {
+	return lfs.mountRenderFile(ctx, parent, render, metaIno(key), 0, out)
 }

--- a/internal/fs/metafile_test.go
+++ b/internal/fs/metafile_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 // TestMetaFileNodeReadThrough guards the blocker the naive review caught: a
-// MetaFileNode must render current content on every Read, not serve bytes baked
-// at construction time. go-fuse dedups inodes by StableAttr.Ino, so a stale
+// `.meta` renderFile must render current content on every Read, not serve bytes
+// baked at construction time. go-fuse dedups inodes by StableAttr.Ino, so a stale
 // baked-bytes node would be served for the life of the mount after the first
-// lookup. This test fails if MetaFileNode ever regresses to holding fixed bytes.
+// lookup. This test fails if the render-through property ever regresses.
 func TestMetaFileNodeReadThrough(t *testing.T) {
 	current := "id: X\nupdated: T1\n"
 	mtime := time.Unix(1000, 0)
-	node := &MetaFileNode{render: func() ([]byte, time.Time, time.Time) {
+	node := &renderFile{render: func() ([]byte, time.Time, time.Time) {
 		return []byte(current), mtime, time.Unix(500, 0)
 	}}
 

--- a/internal/fs/relations.go
+++ b/internal/fs/relations.go
@@ -102,24 +102,17 @@ func (n *RelationsNode) Lookup(ctx context.Context, name string, out *fuse.Entry
 
 func (n *RelationsNode) createRelationFileNode(ctx context.Context, rel api.IssueRelation, isInverse bool, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
 	node := &RelationFileNode{
-		BaseNode:  BaseNode{lfs: n.lfs},
+		renderFile: renderFile{
+			BaseNode: BaseNode{lfs: n.lfs},
+			render: func() ([]byte, time.Time, time.Time) {
+				return []byte(relationContent(rel, isInverse)), rel.UpdatedAt, rel.CreatedAt
+			},
+		},
 		relation:  rel,
 		isInverse: isInverse,
 		issueID:   n.issueID,
 	}
-	now := time.Now()
-	content := node.generateContent()
-	out.Attr.Mode = 0444 | syscall.S_IFREG // Read-only
-	out.Attr.Uid = n.lfs.uid
-	out.Attr.Gid = n.lfs.gid
-	out.Attr.Size = uint64(len(content))
-	out.SetAttrTimeout(30 * time.Second)
-	out.SetEntryTimeout(30 * time.Second)
-	out.Attr.SetTimes(&now, &now, &now)
-	return n.NewInode(ctx, node, fs.StableAttr{
-		Mode: syscall.S_IFREG,
-		Ino:  relationIno(rel.ID),
-	}), 0
+	return n.newRenderInode(ctx, out, node, relationIno(rel.ID), 30*time.Second), 0
 }
 
 // inverseRelationType returns the inverse relation type name
@@ -138,62 +131,35 @@ func inverseRelationType(relType string) string {
 	}
 }
 
-// RelationFileNode represents a relation file (read-only info)
+// RelationFileNode represents a relation file (read-only info + rm-to-delete).
+// It embeds renderFile for Open/Read/Getattr and keeps only its Unlink.
 type RelationFileNode struct {
-	BaseNode
+	renderFile
 	relation  api.IssueRelation
 	isInverse bool
 	issueID   string // parent issue (for the relations/ .error key)
 }
 
-var _ fs.NodeGetattrer = (*RelationFileNode)(nil)
-var _ fs.NodeOpener = (*RelationFileNode)(nil)
-var _ fs.NodeReader = (*RelationFileNode)(nil)
 var _ fs.NodeUnlinker = (*RelationFileNode)(nil)
 
-func (n *RelationFileNode) generateContent() string {
+// relationContent renders a relation file's YAML body.
+func relationContent(rel api.IssueRelation, isInverse bool) string {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("type: %s\n", n.relation.Type))
+	sb.WriteString(fmt.Sprintf("type: %s\n", rel.Type))
 
-	if n.isInverse && n.relation.Issue != nil {
-		sb.WriteString(fmt.Sprintf("from: %s\n", n.relation.Issue.Identifier))
-		if n.relation.Issue.Title != "" {
-			sb.WriteString(fmt.Sprintf("title: %s\n", n.relation.Issue.Title))
+	if isInverse && rel.Issue != nil {
+		sb.WriteString(fmt.Sprintf("from: %s\n", rel.Issue.Identifier))
+		if rel.Issue.Title != "" {
+			sb.WriteString(fmt.Sprintf("title: %s\n", rel.Issue.Title))
 		}
-	} else if n.relation.RelatedIssue != nil {
-		sb.WriteString(fmt.Sprintf("to: %s\n", n.relation.RelatedIssue.Identifier))
-		if n.relation.RelatedIssue.Title != "" {
-			sb.WriteString(fmt.Sprintf("title: %s\n", n.relation.RelatedIssue.Title))
+	} else if rel.RelatedIssue != nil {
+		sb.WriteString(fmt.Sprintf("to: %s\n", rel.RelatedIssue.Identifier))
+		if rel.RelatedIssue.Title != "" {
+			sb.WriteString(fmt.Sprintf("title: %s\n", rel.RelatedIssue.Title))
 		}
 	}
 
 	return sb.String()
-}
-
-func (n *RelationFileNode) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	content := n.generateContent()
-	now := time.Now()
-	out.Mode = 0444 // Read-only
-	n.SetOwner(out)
-	out.Size = uint64(len(content))
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
-
-func (n *RelationFileNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	return nil, fuse.FOPEN_KEEP_CACHE, 0
-}
-
-func (n *RelationFileNode) Read(ctx context.Context, fh fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	content := []byte(n.generateContent())
-	if off >= int64(len(content)) {
-		return fuse.ReadResultData(nil), 0
-	}
-	end := off + int64(len(dest))
-	if end > int64(len(content)) {
-		end = int64(len(content))
-	}
-	return fuse.ReadResultData(content[off:end]), 0
 }
 
 func (n *RelationFileNode) Unlink(ctx context.Context, name string) syscall.Errno {
@@ -267,13 +233,23 @@ func (n *RelationsNode) createRelation(ctx context.Context, raw []byte) syscall.
 		},
 		persist: func(ctx context.Context, rel *api.IssueRelation) error {
 			now := time.Now()
+			// Prefer the server's authoritative relation times; fall back to now()
+			// if the mutation echoed a zero time.
+			created := rel.CreatedAt
+			if created.IsZero() {
+				created = now
+			}
+			updated := rel.UpdatedAt
+			if updated.IsZero() {
+				updated = now
+			}
 			return n.lfs.store.Queries().UpsertIssueRelation(ctx, db.UpsertIssueRelationParams{
 				ID:             rel.ID,
 				IssueID:        n.issueID,
 				RelatedIssueID: relatedID,
 				Type:           relationType,
-				CreatedAt:      sql.NullTime{Time: now, Valid: true},
-				UpdatedAt:      sql.NullTime{Time: now, Valid: true},
+				CreatedAt:      sql.NullTime{Time: created, Valid: true},
+				UpdatedAt:      sql.NullTime{Time: updated, Valid: true},
 				SyncedAt:       now,
 			})
 		},

--- a/internal/fs/renderfile.go
+++ b/internal/fs/renderfile.go
@@ -1,0 +1,140 @@
+package fs
+
+import (
+	"context"
+	"syscall"
+	"time"
+
+	"github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
+)
+
+// renderFunc produces a read-only generated file's current bytes plus the times
+// it should report (mtime=updated, ctime=created), from a live source. A zero
+// time reports "unknown" (nonZeroTime renders it as an unset attr), never a
+// fabricated now() — that fabrication was the drift this module exists to kill.
+type renderFunc func() (content []byte, mtime, ctime time.Time)
+
+// renderFile is the mixin every read-only generated file embeds — the
+// render-through file complement to attrNode (the directory mixin) and the
+// read-side twin of editBuffer. It owns the three FUSE operations a generated
+// file needs (Open/Read/Getattr, promoted into whatever embeds it) and holds a
+// single render closure.
+//
+// It renders on every read (FOPEN_DIRECT_IO), so content and times can never
+// freeze at first Lookup — go-fuse dedups inodes by StableAttr.Ino and reuses
+// the first node for a given ino, so baking bytes or times would serve stale
+// values for the life of the mount (the reasoning that already made the
+// .meta/.error/.last nodes DIRECT_IO). These files are tiny and read
+// interactively, so the per-read FUSE round-trip is imperceptible.
+//
+// A node that is purely a generated file *is* a renderFile (constructed via
+// lookupRenderFile). A node that needs more — RelationFileNode and
+// ExternalAttachmentNode add Unlink (rm-to-delete) — embeds renderFile and keeps
+// only its extra methods. See CONTEXT.md "Render file".
+type renderFile struct {
+	BaseNode
+	render renderFunc
+}
+
+var _ fs.NodeGetattrer = (*renderFile)(nil)
+var _ fs.NodeOpener = (*renderFile)(nil)
+var _ fs.NodeReader = (*renderFile)(nil)
+var _ renderChild = (*renderFile)(nil)
+
+// renderAttr renders the current content and returns the reporting identity a
+// Getattr and a Lookup must agree on. Both go through this one path, so — as
+// with attrNode — the two can never disagree.
+func (r *renderFile) renderAttr() nodeAttr {
+	content, mtime, ctime := r.render()
+	return nodeAttr{mode: 0444 | syscall.S_IFREG, size: uint64(len(content)), created: ctime, updated: mtime}
+}
+
+func (r *renderFile) baseNode() *BaseNode { return &r.BaseNode }
+
+func (r *renderFile) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
+	r.renderAttr().fill(&out.Attr, &r.BaseNode)
+	return 0
+}
+
+func (r *renderFile) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
+	// Read-only: reject any write-open explicitly (the 0444 mode already blocks
+	// it at the kernel, but this matches the .meta node's belt-and-suspenders).
+	if flags&(syscall.O_WRONLY|syscall.O_RDWR) != 0 {
+		return nil, 0, syscall.EACCES
+	}
+	// DIRECT_IO: content is volatile; force a real READ (through render) on each
+	// open instead of trusting a cached page.
+	return nil, fuse.FOPEN_DIRECT_IO, 0
+}
+
+func (r *renderFile) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
+	content, _, _ := r.render()
+	return readWindow(content, dest, off), 0
+}
+
+// readWindow slices the [off, off+len(dest)) byte window from content — the one
+// copy of the offset-clamp that every read-only file node used to hand-roll (it
+// appeared verbatim a dozen times across the package).
+func readWindow(content, dest []byte, off int64) fuse.ReadResult {
+	if off >= int64(len(content)) {
+		return fuse.ReadResultData(nil)
+	}
+	end := off + int64(len(dest))
+	if end > int64(len(content)) {
+		end = int64(len(content))
+	}
+	return fuse.ReadResultData(content[off:end])
+}
+
+// renderChild is a node that embeds renderFile: a bare renderFile, or a type
+// embedding one plus extra methods (Unlink). newRenderInode builds any of them.
+type renderChild interface {
+	fs.InodeEmbedder
+	renderAttr() nodeAttr
+	baseNode() *BaseNode
+}
+
+// inheritTimeout, passed as the timeout to newRenderInode/lookupRenderFile, means
+// "leave the mount's default attr/entry timeout" — for the nodes that never set a
+// per-file timeout. Any value >= 0 is applied to both attr and entry.
+const inheritTimeout = time.Duration(-1)
+
+// fillRenderEntry fills a Lookup EntryOut from the child's first render — the
+// same renderAttr() path its Getattr uses, so the two can never disagree — and
+// applies the timeout (< 0 inherits the mount default). Shared by both mount
+// paths below.
+func fillRenderEntry(out *fuse.EntryOut, child renderChild, timeout time.Duration) {
+	child.renderAttr().fill(&out.Attr, child.baseNode())
+	if timeout >= 0 {
+		out.SetAttrTimeout(timeout)
+		out.SetEntryTimeout(timeout)
+	}
+}
+
+// newRenderInode fills a read-only render file's Lookup EntryOut and returns its
+// inode — the render-through file counterpart to newDirInode, called on the
+// parent. Used by the nodes that embed renderFile plus extra methods
+// (RelationFileNode/ExternalAttachmentNode). ino 0 auto-assigns.
+func (b *BaseNode) newRenderInode(ctx context.Context, out *fuse.EntryOut, child renderChild, ino uint64, timeout time.Duration) *fs.Inode {
+	fillRenderEntry(out, child, timeout)
+	return b.NewInode(ctx, child, fs.StableAttr{Mode: syscall.S_IFREG, Ino: ino})
+}
+
+// lookupRenderFile mounts a bare read-only render file (no extra methods) backed
+// by a render closure as a child of the receiver's node — the one-liner the pure
+// generated-file sites (team.md, states.md, user.md, README.md, …) use in place
+// of a hand-rolled node type.
+func (b *BaseNode) lookupRenderFile(ctx context.Context, out *fuse.EntryOut, render renderFunc, ino uint64, timeout time.Duration) *fs.Inode {
+	node := &renderFile{BaseNode: BaseNode{lfs: b.lfs}, render: render}
+	return b.newRenderInode(ctx, out, node, ino, timeout)
+}
+
+// mountRenderFile mounts a bare render file under an arbitrary parent embedder —
+// the variant the .meta/.error/.last helpers use, where the parent is handed in
+// as an fs.InodeEmbedder rather than a *BaseNode.
+func (lfs *LinearFS) mountRenderFile(ctx context.Context, parent fs.InodeEmbedder, render renderFunc, ino uint64, timeout time.Duration, out *fuse.EntryOut) *fs.Inode {
+	node := &renderFile{BaseNode: BaseNode{lfs: lfs}, render: render}
+	fillRenderEntry(out, node, timeout)
+	return parent.EmbeddedInode().NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG, Ino: ino})
+}

--- a/internal/fs/renderfile_test.go
+++ b/internal/fs/renderfile_test.go
@@ -1,0 +1,94 @@
+package fs
+
+import (
+	"context"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/hanwen/go-fuse/v2/fuse"
+)
+
+// renderFile's interface is its test surface: a render closure. These exercise
+// the byte-window slice, the write-open rejection, and the size/time reporting
+// directly on the struct — no FUSE mount, SQLite, or API.
+
+func TestReadWindowClampsAtEOF(t *testing.T) {
+	content := []byte("hello world")
+	cases := []struct {
+		off  int64
+		size int
+		want string
+	}{
+		{0, 5, "hello"},
+		{6, 100, "world"},       // dest larger than remaining -> clamps to EOF
+		{0, 100, "hello world"}, // whole thing
+		{11, 10, ""},            // off == len -> empty
+		{50, 10, ""},            // off past len -> empty
+	}
+	for _, c := range cases {
+		res := readWindow(content, make([]byte, c.size), c.off)
+		got, status := res.Bytes(make([]byte, c.size))
+		if !status.Ok() {
+			t.Fatalf("off=%d size=%d: status=%v", c.off, c.size, status)
+		}
+		if string(got) != c.want {
+			t.Errorf("off=%d size=%d: got %q, want %q", c.off, c.size, string(got), c.want)
+		}
+	}
+}
+
+func TestRenderFileOpenRejectsWrites(t *testing.T) {
+	r := &renderFile{render: func() ([]byte, time.Time, time.Time) {
+		return []byte("x"), time.Time{}, time.Time{}
+	}}
+	if _, _, errno := r.Open(context.Background(), syscall.O_RDONLY); errno != 0 {
+		t.Errorf("read-open errno = %v, want 0", errno)
+	}
+	for _, flag := range []uint32{syscall.O_WRONLY, syscall.O_RDWR} {
+		if _, _, errno := r.Open(context.Background(), flag); errno != syscall.EACCES {
+			t.Errorf("write-open(%d) errno = %v, want EACCES", flag, errno)
+		}
+	}
+}
+
+func TestRenderFileGetattrReportsRenderedSizeAndTimes(t *testing.T) {
+	mtime := time.Unix(2000, 0)
+	ctime := time.Unix(1000, 0)
+	body := []byte("id: X\n")
+	r := &renderFile{render: func() ([]byte, time.Time, time.Time) {
+		return body, mtime, ctime
+	}}
+
+	var out fuse.AttrOut
+	if errno := r.Getattr(context.Background(), nil, &out); errno != 0 {
+		t.Fatalf("Getattr errno=%v", errno)
+	}
+	if out.Size != uint64(len(body)) {
+		t.Errorf("size = %d, want %d", out.Size, len(body))
+	}
+	if out.Mtime != uint64(mtime.Unix()) {
+		t.Errorf("mtime = %d, want %d", out.Mtime, mtime.Unix())
+	}
+	if out.Ctime != uint64(ctime.Unix()) {
+		t.Errorf("ctime = %d, want %d", out.Ctime, ctime.Unix())
+	}
+	if out.Mode&0o777 != 0o444 {
+		t.Errorf("mode = %o, want read-only 0444", out.Mode&0o777)
+	}
+}
+
+// A zero time reports as an unset attr (nonZeroTime), never a fabricated now()
+// or a wrapped garbage timestamp — the drift this module exists to kill.
+func TestRenderFileZeroTimeReportsUnset(t *testing.T) {
+	r := &renderFile{render: func() ([]byte, time.Time, time.Time) {
+		return []byte("no times"), time.Time{}, time.Time{}
+	}}
+	var out fuse.AttrOut
+	if errno := r.Getattr(context.Background(), nil, &out); errno != 0 {
+		t.Fatalf("Getattr errno=%v", errno)
+	}
+	if out.Mtime != 0 || out.Ctime != 0 {
+		t.Errorf("zero times reported as mtime=%d ctime=%d, want 0/0", out.Mtime, out.Ctime)
+	}
+}

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -42,14 +42,11 @@ func (r *RootNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 	now := time.Now()
 	switch name {
 	case "README.md":
-		node := &ReadmeNode{BaseNode: BaseNode{lfs: r.lfs}}
-		content := node.generateContent()
-		out.Attr.Mode = 0444 | syscall.S_IFREG
-		out.Attr.Size = uint64(len(content))
-		out.Attr.Uid = r.lfs.uid
-		out.Attr.Gid = r.lfs.gid
-		out.Attr.SetTimes(&now, &now, &now)
-		return r.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG}), 0
+		// The generated docs have no natural entity time; report zero (unknown).
+		lfs := r.lfs
+		return r.lookupRenderFile(ctx, out, func() ([]byte, time.Time, time.Time) {
+			return []byte(generateReadme(lfs.MountPoint())), time.Time{}, time.Time{}
+		}, 0, inheritTimeout), 0
 
 	case "teams":
 		node := &TeamsNode{BaseNode: BaseNode{lfs: r.lfs}}
@@ -86,46 +83,6 @@ func (r *RootNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 	default:
 		return nil, syscall.ENOENT
 	}
-}
-
-// ReadmeNode is a virtual file containing filesystem documentation
-type ReadmeNode struct {
-	BaseNode
-}
-
-var _ fs.NodeGetattrer = (*ReadmeNode)(nil)
-var _ fs.NodeOpener = (*ReadmeNode)(nil)
-var _ fs.NodeReader = (*ReadmeNode)(nil)
-
-func (r *ReadmeNode) generateContent() []byte {
-	mp := r.lfs.MountPoint()
-	return []byte(generateReadme(mp))
-}
-
-func (r *ReadmeNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	content := r.generateContent()
-	out.Mode = 0444 | syscall.S_IFREG
-	out.Size = uint64(len(content))
-	r.SetOwner(out)
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
-
-func (r *ReadmeNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	return nil, fuse.FOPEN_KEEP_CACHE, 0
-}
-
-func (r *ReadmeNode) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	content := r.generateContent()
-	if off >= int64(len(content)) {
-		return fuse.ReadResultData(nil), 0
-	}
-	end := off + int64(len(dest))
-	if end > int64(len(content)) {
-		end = int64(len(content))
-	}
-	return fuse.ReadResultData(content[off:end]), 0
 }
 
 func generateReadme(mountPoint string) string {

--- a/internal/fs/successfile.go
+++ b/internal/fs/successfile.go
@@ -3,7 +3,6 @@ package fs
 import (
 	"context"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/hanwen/go-fuse/v2/fs"
@@ -142,62 +141,24 @@ func (lfs *LinearFS) renderWriteSuccess(key string) []byte {
 	return out
 }
 
-// lookupSuccessFile mounts the `.last` virtual file for a collection as a child
-// of parent. key is the collectionSuccessKey used with AppendWriteSuccess.
-// Timeouts are zero so the file always reflects the most recent create.
+// lookupSuccessFile mounts the read-only `.last` virtual file for a collection as
+// a child of parent. Reading it returns the YAML list of recent creates (empty if
+// none yet), keyed by the collectionSuccessKey used with AppendWriteSuccess. It
+// is a plain renderFile with zero timeouts, so it always reflects the most recent
+// create; the reported time is the newest recorded create's timestamp.
 func (lfs *LinearFS) lookupSuccessFile(ctx context.Context, parent fs.InodeEmbedder, key string, out *fuse.EntryOut) *fs.Inode {
-	node := &SuccessFileNode{BaseNode: BaseNode{lfs: lfs}, key: key}
-
-	size := uint64(len(lfs.renderWriteSuccess(key)))
-
-	now := time.Now()
-	out.Attr.Mode = 0444 | syscall.S_IFREG // Read-only
-	out.Attr.Uid = lfs.uid
-	out.Attr.Gid = lfs.gid
-	out.Attr.Size = size
-	out.SetAttrTimeout(0)
-	out.SetEntryTimeout(0)
-	out.Attr.SetTimes(&now, &now, &now)
-
-	return parent.EmbeddedInode().NewInode(ctx, node, fs.StableAttr{
-		Mode: syscall.S_IFREG,
-		Ino:  successIno(key),
-	})
-}
-
-// SuccessFileNode is the read-only `.last` virtual file shown alongside any
-// writable collection. Reading it returns the YAML list of recent creates (empty
-// if none yet). Keyed by the collection's success key.
-type SuccessFileNode struct {
-	BaseNode
-	key string
-}
-
-var _ fs.NodeGetattrer = (*SuccessFileNode)(nil)
-var _ fs.NodeOpener = (*SuccessFileNode)(nil)
-var _ fs.NodeReader = (*SuccessFileNode)(nil)
-
-func (s *SuccessFileNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	out.Mode = 0444 // Read-only
-	s.SetOwner(out)
-	out.Size = uint64(len(s.lfs.renderWriteSuccess(s.key)))
-	return 0
-}
-
-func (s *SuccessFileNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	// FOPEN_DIRECT_IO: `.last` changes on every create; direct I/O forces a real
-	// READ on each open instead of trusting a possibly-stale cached size.
-	return nil, fuse.FOPEN_DIRECT_IO, 0
-}
-
-func (s *SuccessFileNode) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	content := s.lfs.renderWriteSuccess(s.key)
-	if off >= int64(len(content)) {
-		return fuse.ReadResultData(nil), 0
+	render := func() ([]byte, time.Time, time.Time) {
+		content := lfs.renderWriteSuccess(key)
+		if content == nil {
+			return nil, time.Time{}, time.Time{}
+		}
+		var latest time.Time
+		for _, r := range lfs.GetWriteSuccess(key) {
+			if r.Timestamp.After(latest) {
+				latest = r.Timestamp
+			}
+		}
+		return content, latest, latest
 	}
-	end := off + int64(len(dest))
-	if end > int64(len(content)) {
-		end = int64(len(content))
-	}
-	return fuse.ReadResultData(content[off:end]), 0
+	return lfs.mountRenderFile(ctx, parent, render, successIno(key), 0, out)
 }

--- a/internal/fs/teams.go
+++ b/internal/fs/teams.go
@@ -103,34 +103,33 @@ func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 	now := time.Now()
 	switch name {
 	case "team.md":
-		node := &TeamInfoNode{BaseNode: BaseNode{lfs: t.lfs}, team: t.team}
-		content := node.generateContent()
-		out.Attr.Mode = 0444 | syscall.S_IFREG
-		out.Attr.Uid = t.lfs.uid
-		out.Attr.Gid = t.lfs.gid
-		out.Attr.Size = uint64(len(content))
-		out.Attr.SetTimes(&t.team.UpdatedAt, &t.team.UpdatedAt, &t.team.CreatedAt)
-		return t.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG}), 0
+		team := t.team
+		return t.lookupRenderFile(ctx, out, func() ([]byte, time.Time, time.Time) {
+			return teamMarkdown(team), team.UpdatedAt, team.CreatedAt
+		}, 0, inheritTimeout), 0
 
 	case "states.md":
-		node := &StatesInfoNode{BaseNode: BaseNode{lfs: t.lfs}, team: t.team}
-		content := node.getContent(ctx)
-		out.Attr.Mode = 0444 | syscall.S_IFREG
-		out.Attr.Uid = t.lfs.uid
-		out.Attr.Gid = t.lfs.gid
-		out.Attr.Size = uint64(len(content))
-		out.Attr.SetTimes(&now, &now, &now)
-		return t.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG}), 0
+		// states.md has no single mtime (it lists a collection); report the
+		// team's times as a stable proxy — never now(). Content is fetched from
+		// SQLite on each read (cheap), so no node-level cache is needed.
+		lfs, team := t.lfs, t.team
+		return t.lookupRenderFile(ctx, out, func() ([]byte, time.Time, time.Time) {
+			states, err := lfs.GetTeamStates(context.Background(), team.ID)
+			if err != nil {
+				return []byte("# Error loading states\n"), team.UpdatedAt, team.CreatedAt
+			}
+			return statesMarkdown(team, states), team.UpdatedAt, team.CreatedAt
+		}, 0, inheritTimeout), 0
 
 	case "labels.md":
-		node := &LabelsInfoNode{BaseNode: BaseNode{lfs: t.lfs}, team: t.team}
-		content := node.getContent(ctx)
-		out.Attr.Mode = 0444 | syscall.S_IFREG
-		out.Attr.Uid = t.lfs.uid
-		out.Attr.Gid = t.lfs.gid
-		out.Attr.Size = uint64(len(content))
-		out.Attr.SetTimes(&now, &now, &now)
-		return t.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG}), 0
+		lfs, team := t.lfs, t.team
+		return t.lookupRenderFile(ctx, out, func() ([]byte, time.Time, time.Time) {
+			labels, err := lfs.GetTeamLabels(context.Background(), team.ID)
+			if err != nil {
+				return []byte("# Error loading labels\n"), team.UpdatedAt, team.CreatedAt
+			}
+			return labelsMarkdown(team, labels), team.UpdatedAt, team.CreatedAt
+		}, 0, inheritTimeout), 0
 
 	case "by":
 		out.Attr.Mode = 0755 | syscall.S_IFDIR
@@ -196,18 +195,9 @@ func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 	return nil, syscall.ENOENT
 }
 
-// TeamInfoNode is a virtual file containing team metadata
-type TeamInfoNode struct {
-	BaseNode
-	team api.Team
-}
-
-var _ fs.NodeGetattrer = (*TeamInfoNode)(nil)
-var _ fs.NodeOpener = (*TeamInfoNode)(nil)
-var _ fs.NodeReader = (*TeamInfoNode)(nil)
-
-func (t *TeamInfoNode) generateContent() []byte {
-	content := fmt.Sprintf(`---
+// teamMarkdown renders the team.md content for a team.
+func teamMarkdown(team api.Team) []byte {
+	return []byte(fmt.Sprintf(`---
 id: %s
 key: %s
 name: %q
@@ -221,83 +211,32 @@ updated: %q
 - **Key:** %s
 - **ID:** %s
 `,
-		t.team.ID,
-		t.team.Key,
-		t.team.Name,
-		t.team.Icon,
-		t.team.CreatedAt.Format(time.RFC3339),
-		t.team.UpdatedAt.Format(time.RFC3339),
-		t.team.Name,
-		t.team.Key,
-		t.team.ID,
-	)
-	return []byte(content)
+		team.ID,
+		team.Key,
+		team.Name,
+		team.Icon,
+		team.CreatedAt.Format(time.RFC3339),
+		team.UpdatedAt.Format(time.RFC3339),
+		team.Name,
+		team.Key,
+		team.ID,
+	))
 }
 
-func (t *TeamInfoNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	content := t.generateContent()
-	out.Mode = 0444 | syscall.S_IFREG
-	t.SetOwner(out)
-	out.Size = uint64(len(content))
-	out.Attr.SetTimes(&t.team.UpdatedAt, &t.team.UpdatedAt, &t.team.CreatedAt)
-	return 0
-}
-
-func (t *TeamInfoNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	return nil, fuse.FOPEN_KEEP_CACHE, 0
-}
-
-func (t *TeamInfoNode) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	content := t.generateContent()
-	if off >= int64(len(content)) {
-		return fuse.ReadResultData(nil), 0
-	}
-	end := off + int64(len(dest))
-	if end > int64(len(content)) {
-		end = int64(len(content))
-	}
-	return fuse.ReadResultData(content[off:end]), 0
-}
-
-// StatesInfoNode is a virtual file containing workflow states metadata
-type StatesInfoNode struct {
-	BaseNode
-	team          api.Team
-	cachedContent []byte
-	cachedAt      time.Time
-}
-
-var _ fs.NodeGetattrer = (*StatesInfoNode)(nil)
-var _ fs.NodeOpener = (*StatesInfoNode)(nil)
-var _ fs.NodeReader = (*StatesInfoNode)(nil)
-
-const metadataCacheTTL = 10 * time.Minute // Match state/label cache TTL
-
-func (s *StatesInfoNode) getContent(ctx context.Context) []byte {
-	// Return cached content if still valid
-	if s.cachedContent != nil && time.Since(s.cachedAt) < metadataCacheTTL {
-		return s.cachedContent
-	}
-
-	states, err := s.lfs.GetTeamStates(ctx, s.team.ID)
-	if err != nil {
-		return []byte("# Error loading states\n")
-	}
-
-	// Build YAML frontmatter
+// statesMarkdown renders the states.md content for a team's workflow states.
+func statesMarkdown(team api.Team, states []api.State) []byte {
 	var statesYAML string
 	for _, state := range states {
 		statesYAML += fmt.Sprintf("  - id: %s\n    name: %s\n    type: %s\n",
 			state.ID, state.Name, state.Type)
 	}
 
-	// Build markdown table
 	var table string
 	for _, state := range states {
 		table += fmt.Sprintf("| %s | %s | %s |\n", state.Name, state.Type, state.ID)
 	}
 
-	content := []byte(fmt.Sprintf(`---
+	return []byte(fmt.Sprintf(`---
 team: %s
 states:
 %s---
@@ -307,67 +246,15 @@ states:
 | Name | Type | ID |
 |------|------|-----|
 %s`,
-		s.team.Key,
+		team.Key,
 		statesYAML,
-		s.team.Key,
+		team.Key,
 		table,
 	))
-
-	s.cachedContent = content
-	s.cachedAt = time.Now()
-	return content
 }
 
-func (s *StatesInfoNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	content := s.getContent(ctx)
-	out.Mode = 0444 | syscall.S_IFREG
-	s.SetOwner(out)
-	out.Size = uint64(len(content))
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
-
-func (s *StatesInfoNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	return nil, fuse.FOPEN_KEEP_CACHE, 0
-}
-
-func (s *StatesInfoNode) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	content := s.getContent(ctx)
-	if off >= int64(len(content)) {
-		return fuse.ReadResultData(nil), 0
-	}
-	end := off + int64(len(dest))
-	if end > int64(len(content)) {
-		end = int64(len(content))
-	}
-	return fuse.ReadResultData(content[off:end]), 0
-}
-
-// LabelsInfoNode is a virtual file containing labels metadata
-type LabelsInfoNode struct {
-	BaseNode
-	team          api.Team
-	cachedContent []byte
-	cachedAt      time.Time
-}
-
-var _ fs.NodeGetattrer = (*LabelsInfoNode)(nil)
-var _ fs.NodeOpener = (*LabelsInfoNode)(nil)
-var _ fs.NodeReader = (*LabelsInfoNode)(nil)
-
-func (l *LabelsInfoNode) getContent(ctx context.Context) []byte {
-	// Return cached content if still valid
-	if l.cachedContent != nil && time.Since(l.cachedAt) < metadataCacheTTL {
-		return l.cachedContent
-	}
-
-	labels, err := l.lfs.GetTeamLabels(ctx, l.team.ID)
-	if err != nil {
-		return []byte("# Error loading labels\n")
-	}
-
-	// Build YAML frontmatter
+// labelsMarkdown renders the labels.md content for a team's labels.
+func labelsMarkdown(team api.Team, labels []api.Label) []byte {
 	var labelsYAML string
 	for _, label := range labels {
 		labelsYAML += fmt.Sprintf("  - id: %s\n    name: %s\n    color: %q\n",
@@ -377,13 +264,12 @@ func (l *LabelsInfoNode) getContent(ctx context.Context) []byte {
 		}
 	}
 
-	// Build markdown table
 	var table string
 	for _, label := range labels {
 		table += fmt.Sprintf("| %s | %s | %s |\n", label.Name, label.Color, label.ID)
 	}
 
-	content := []byte(fmt.Sprintf(`---
+	return []byte(fmt.Sprintf(`---
 team: %s
 labels:
 %s---
@@ -393,39 +279,9 @@ labels:
 | Name | Color | ID |
 |------|-------|-----|
 %s`,
-		l.team.Key,
+		team.Key,
 		labelsYAML,
-		l.team.Key,
+		team.Key,
 		table,
 	))
-
-	l.cachedContent = content
-	l.cachedAt = time.Now()
-	return content
-}
-
-func (l *LabelsInfoNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	content := l.getContent(ctx)
-	out.Mode = 0444 | syscall.S_IFREG
-	l.SetOwner(out)
-	out.Size = uint64(len(content))
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
-
-func (l *LabelsInfoNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	return nil, fuse.FOPEN_KEEP_CACHE, 0
-}
-
-func (l *LabelsInfoNode) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	content := l.getContent(ctx)
-	if off >= int64(len(content)) {
-		return fuse.ReadResultData(nil), 0
-	}
-	end := off + int64(len(dest))
-	if end > int64(len(content)) {
-		end = int64(len(content))
-	}
-	return fuse.ReadResultData(content[off:end]), 0
 }

--- a/internal/fs/users.go
+++ b/internal/fs/users.go
@@ -119,15 +119,13 @@ func (u *UserNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 }
 
 func (u *UserNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	// Handle user.md metadata file
+	// Handle user.md metadata file. api.User carries no created/updated times,
+	// so the file honestly reports zero (unknown) rather than a fabricated now().
 	if name == "user.md" {
-		node := &UserInfoNode{BaseNode: BaseNode{lfs: u.lfs}, user: u.user}
-		content := node.generateContent()
-		out.Attr.Mode = 0444 | syscall.S_IFREG
-		out.Attr.Uid = u.lfs.uid
-		out.Attr.Gid = u.lfs.gid
-		out.Attr.Size = uint64(len(content))
-		return u.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG}), 0
+		user := u.user
+		return u.lookupRenderFile(ctx, out, func() ([]byte, time.Time, time.Time) {
+			return userMarkdown(user), time.Time{}, time.Time{}
+		}, 0, inheritTimeout), 0
 	}
 
 	issues, err := u.lfs.GetUserIssues(ctx, u.user.ID)
@@ -148,23 +146,14 @@ func (u *UserNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 	return nil, syscall.ENOENT
 }
 
-// UserInfoNode is a virtual file containing user metadata
-type UserInfoNode struct {
-	BaseNode
-	user api.User
-}
-
-var _ fs.NodeGetattrer = (*UserInfoNode)(nil)
-var _ fs.NodeOpener = (*UserInfoNode)(nil)
-var _ fs.NodeReader = (*UserInfoNode)(nil)
-
-func (u *UserInfoNode) generateContent() []byte {
+// userMarkdown renders the user.md content for a user.
+func userMarkdown(user api.User) []byte {
 	status := "active"
-	if !u.user.Active {
+	if !user.Active {
 		status = "inactive"
 	}
 
-	content := fmt.Sprintf(`---
+	return []byte(fmt.Sprintf(`---
 id: %s
 name: %s
 email: %s
@@ -178,39 +167,14 @@ status: %s
 - **ID:** %s
 - **Status:** %s
 `,
-		u.user.ID,
-		u.user.Name,
-		u.user.Email,
-		u.user.DisplayName,
+		user.ID,
+		user.Name,
+		user.Email,
+		user.DisplayName,
 		status,
-		u.user.Name,
-		u.user.Email,
-		u.user.ID,
+		user.Name,
+		user.Email,
+		user.ID,
 		status,
-	)
-	return []byte(content)
-}
-
-func (u *UserInfoNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	content := u.generateContent()
-	out.Mode = 0444 | syscall.S_IFREG
-	u.SetOwner(out)
-	out.Size = uint64(len(content))
-	return 0
-}
-
-func (u *UserInfoNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	return nil, fuse.FOPEN_KEEP_CACHE, 0
-}
-
-func (u *UserInfoNode) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	content := u.generateContent()
-	if off >= int64(len(content)) {
-		return fuse.ReadResultData(nil), 0
-	}
-	end := off + int64(len(dest))
-	if end > int64(len(content)) {
-		end = int64(len(content))
-	}
-	return fuse.ReadResultData(content[off:end]), 0
+	))
 }

--- a/internal/fs/users_test.go
+++ b/internal/fs/users_test.go
@@ -68,17 +68,13 @@ func TestUserDirName(t *testing.T) {
 
 func TestUserInfoNode_GenerateContent(t *testing.T) {
 	t.Parallel()
-	node := &UserInfoNode{
-		user: api.User{
-			ID:          "user-123",
-			Name:        "John Smith",
-			Email:       "john@example.com",
-			DisplayName: "jsmith",
-			Active:      true,
-		},
-	}
-
-	content := node.generateContent()
+	content := userMarkdown(api.User{
+		ID:          "user-123",
+		Name:        "John Smith",
+		Email:       "john@example.com",
+		DisplayName: "jsmith",
+		Active:      true,
+	})
 	contentStr := string(content)
 
 	checks := []string{
@@ -99,16 +95,12 @@ func TestUserInfoNode_GenerateContent(t *testing.T) {
 
 func TestUserInfoNode_GenerateContent_Inactive(t *testing.T) {
 	t.Parallel()
-	node := &UserInfoNode{
-		user: api.User{
-			ID:     "user-456",
-			Name:   "Jane Doe",
-			Email:  "jane@example.com",
-			Active: false,
-		},
-	}
-
-	content := node.generateContent()
+	content := userMarkdown(api.User{
+		ID:     "user-456",
+		Name:   "Jane Doe",
+		Email:  "jane@example.com",
+		Active: false,
+	})
 	contentStr := string(content)
 
 	if !strings.Contains(contentStr, "status: inactive") {

--- a/internal/repo/sqlite.go
+++ b/internal/repo/sqlite.go
@@ -1497,6 +1497,8 @@ func (r *SQLiteRepository) GetIssueRelations(ctx context.Context, issueID string
 			RelatedIssue: &api.ParentIssue{
 				ID: rel.RelatedIssueID,
 			},
+			CreatedAt: rel.CreatedAt.Time,
+			UpdatedAt: rel.UpdatedAt.Time,
 		}
 		// Try to get the related issue details
 		if issue, err := r.GetIssueByID(ctx, rel.RelatedIssueID); err == nil && issue != nil {
@@ -1523,6 +1525,8 @@ func (r *SQLiteRepository) GetIssueInverseRelations(ctx context.Context, issueID
 			Issue: &api.ParentIssue{
 				ID: rel.IssueID,
 			},
+			CreatedAt: rel.CreatedAt.Time,
+			UpdatedAt: rel.UpdatedAt.Time,
 		}
 		// Try to get the source issue details
 		if issue, err := r.GetIssueByID(ctx, rel.IssueID); err == nil && issue != nil {
@@ -1549,6 +1553,8 @@ func (r *SQLiteRepository) GetIssueRelationByID(ctx context.Context, id string) 
 		RelatedIssue: &api.ParentIssue{
 			ID: rel.RelatedIssueID,
 		},
+		CreatedAt: rel.CreatedAt.Time,
+		UpdatedAt: rel.UpdatedAt.Time,
 	}
 	// Try to get the related issue details
 	if issue, err := r.GetIssueByID(ctx, rel.RelatedIssueID); err == nil && issue != nil {


### PR DESCRIPTION
Round 12 of the architecture review. Extracts **`renderFile`**, the read-through file complement to `attrNode` and the read-side twin of `editBuffer`, collapsing every read-only *generated* file node into one mixin.

## Commits

**`feat(api)` — precursor: carry `IssueRelation` created/updated through API→repo**
`.rel` files fabricated `now()` because `api.IssueRelation` had no time fields — even though the `issue_relations` table already stores `created_at`/`updated_at` and `UpsertIssueRelation` already takes them. Wires the gap above the DB: struct fields, mutation/fragment selection, and the three repo read-mappings. No schema change, no sqlc regen.

**`refactor(fs)` — renderFile — collapse 9 read-only generated-file node types**
- Collapses 9 node types (Team/States/Labels/User/Cycle/Readme/Meta/Error/Success) into one; `RelationFileNode`/`ExternalAttachmentNode` embed it and keep only their `Unlink`. The offset-clamp that appeared verbatim a dozen times lives once in `readWindow`.
- **Uniform `FOPEN_DIRECT_IO`**, which fixes a latent bug: states.md/labels.md carried a 10-min TTL content cache that was *dead* under `KEEP_CACHE` (the kernel served the first read for the mount's lifetime). Attr timeout stays a per-construction param (`inheritTimeout` sentinel preserves the mount-default / 0 / 30s classes).
- **Times come from the closure, never `now()`** (kills the `ls -lt` reshuffle drift): real where available (team, cycle `StartsAt`, attachment, `.error`/`.last` stored timestamps, `.rel` relation times), team-proxy for states/labels, zero for user.md/README (no time source). Lookup and Getattr both fill from `renderAttr()`, so they can't disagree — `attrNode`'s guarantee extended to dynamic-size files.

Net **−490-odd lines**. `EmbeddedFileNode` (lazy CDN byte-streamer) stays out of scope. `CONTEXT.md` gains a "Render file" entry.

## Testing
- New `renderfile_test.go` exercises the module directly on the struct (window clamp, write-open→`EACCES`, size/time reporting, zero-time) — no FUSE mount.
- Full `fs`/`api`/`repo`/`sync`/`db`/`marshal` unit suites green.
- Render-surface integration tests pass individually (batch runs fail spuriously — the known parallel-mount artifact).

Pure refactor + drift fixes, so no reinstall required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)