### PR TITLE
chore: round-14 follow-up cleanups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,21 +327,13 @@ SQLite serves as the persistent cache layer. See `internal/db/schema.sql` for ta
 
 The SQLite driver is configured with `_time_format=sqlite` which returns space-separated timestamps instead of RFC3339's `T` separator. This causes `time.Parse(time.RFC3339, s)` to fail silently.
 
-**Solution**: Use the `parseTime()` helper in `internal/repo/sqlite.go` or `parseSQLiteTime()` in `internal/sync/worker.go`:
-
-```go
-var sqliteTimeFormats = []string{
-    time.RFC3339,
-    time.RFC3339Nano,
-    "2006-01-02 15:04:05.999999999-07:00", // SQLite with timezone
-    "2006-01-02 15:04:05.999999999Z07:00",
-    "2006-01-02 15:04:05-07:00",
-    "2006-01-02 15:04:05Z07:00",
-    "2006-01-02 15:04:05",                 // SQLite without timezone
-}
-```
-
-When parsing times from SQLite queries (especially `MAX()`, `MIN()` aggregates which return `interface{}`), always use these helpers rather than `time.Parse(time.RFC3339, s)` directly.
+**Solution**: Use the canonical helpers in `internal/db/timeparse.go` —
+`db.ParseSQLiteTime(string)` and `db.ParseSQLiteTimeAny(interface{})` (the
+latter for `MAX()`/`MIN()` aggregates, which return `interface{}`). They try
+every layout a timestamp can arrive in (RFC3339 variants plus the
+space-separated SQLite forms). `internal/repo/sqlite.go`'s `parseTime` is a
+thin wrapper over `ParseSQLiteTimeAny`. Never call
+`time.Parse(time.RFC3339, s)` directly on a value read from SQLite.
 
 ### Adding New Tables
 

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -874,9 +874,6 @@ DELETE FROM issue_relations WHERE issue_id = ?;
 -- owned by other issues and must never license their deletion.
 DELETE FROM issue_relations WHERE issue_id = ? AND synced_at < ?;
 
--- name: GetIssueRelationsSyncedAt :one
-SELECT MAX(synced_at) FROM issue_relations WHERE issue_id = ?;
-
 -- =============================================================================
 -- Issue History Cache
 -- =============================================================================

--- a/internal/db/queries.sql.go
+++ b/internal/db/queries.sql.go
@@ -913,17 +913,6 @@ func (q *Queries) GetIssueRelation(ctx context.Context, id string) (IssueRelatio
 	return i, err
 }
 
-const getIssueRelationsSyncedAt = `-- name: GetIssueRelationsSyncedAt :one
-SELECT MAX(synced_at) FROM issue_relations WHERE issue_id = ?
-`
-
-func (q *Queries) GetIssueRelationsSyncedAt(ctx context.Context, issueID string) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, getIssueRelationsSyncedAt, issueID)
-	var max interface{}
-	err := row.Scan(&max)
-	return max, err
-}
-
 const getIssueUpdatedAt = `-- name: GetIssueUpdatedAt :one
 
 


### PR DESCRIPTION
Two small cleanups flagged during the round-14 review:

- **CLAUDE.md stale claim**: the Time Handling section still said the parse helpers were duplicated across `repo/sqlite.go` and `sync/worker.go`; they've lived in `internal/db/timeparse.go` since the consolidation. The doc now points at `ParseSQLiteTime`/`ParseSQLiteTimeAny`.
- **Dead query**: `GetIssueRelationsSyncedAt` had zero callers (nothing consults relations staleness — the relations prune uses the pre-fetch cutoff, not MAX(synced_at)). Removed and sqlc regenerated.

Also deleted the stale `refactor/render-file-node` branch (round-12 leftover; its work landed on main via PR #183).

🤖 Generated with [Claude Code](https://claude.com/claude-code)