### PR TITLE
Interactive budget promotion: thread ctx to render closures, promote the two synchronous API reads

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -277,9 +277,13 @@ truncate-grow/shrink, read-clamps-at-EOF), no FUSE mount.
 The **deep module** owning every read-only *generated* file — the render-through
 file complement to `attrNode` (the directory mixin) and the read-side twin of
 `editBuffer` (the editable-file buffer). `renderFile` (`internal/fs/renderfile.go`)
-is `{BaseNode, render func() (content []byte, mtime, ctime time.Time)}` and
+is `{BaseNode, render func(ctx) (content []byte, mtime, ctime time.Time)}` and
 provides the three FUSE ops such a file needs — `Open`/`Read`/`Getattr`, promoted
-into whatever embeds it. Its whole interface is the one render closure. It
+into whatever embeds it. Its whole interface is the one render closure, which
+receives the FUSE handler's ctx on every path (Read, Getattr, and the
+Lookup-time render — `TestRenderFileThreadsContext` pins it): a closure whose
+source is a synchronous API call promotes it via `api.WithInteractive` at the
+call; SQLite-backed closures pass it through for cancellation. It
 replaced **nine** hand-copied node types (`TeamInfoNode`, `StatesInfoNode`,
 `LabelsInfoNode`, `UserInfoNode`, `CycleFileNode`, `ReadmeNode`, `MetaFileNode`,
 `ErrorFileNode`, `SuccessFileNode`) and reduced two more (`RelationFileNode`,
@@ -673,7 +677,11 @@ reserve`); **optimistic refill** past `resetAt`; and a defensive
 `RATELIMITED` snap-to-zero honoring the error's reset (bounded fallback when
 headerless). Base tier comes from a static `opName → tier` intent map in the
 module; `WithInteractive(ctx)` is the promotion mechanism for on-demand FS
-reads (mechanism only in PR1 — call sites not yet threaded). It collapsed
+reads — threaded at the **only two** synchronous user-blocking API calls
+(`GetTeamDocuments`; the attachment-create re-check); every other FS read is
+SQLite-first with background refresh, which must stay at base tier. The rule
+at `WithInteractive`: promote at the moment of the call, never store a
+promoted ctx or hand it to a goroutine. It collapsed
 `checkRateLimitHeaders`, the inline `Tokens() < 2` write-reserve gate, the
 `linearHourlyLimit` constant, and the token-count `LowBudget`;
 `Client.LowBudget`/`RateLimitResetAt` now delegate to it (paginate's

--- a/internal/api/ratebudget.go
+++ b/internal/api/ratebudget.go
@@ -156,10 +156,15 @@ type interactiveCtxKey struct{}
 // mutation. Background sync must NOT use this.
 //
 // ADOPTION NOTE (PR1): this is the mechanism only. On-demand FS read call
-// sites do not pass it yet — every read currently runs at its base tier,
-// which is the old behavior or better. Threading WithInteractive through
-// the FS-triggered read paths (repo staleness refreshes etc.) is a
-// follow-up.
+// The FS layer threads it at its synchronous, user-blocking API call sites
+// (GetTeamDocuments; the attachment-create authoritative re-check) — most
+// read paths never need it because they are SQLite-first with *background*
+// refresh, and background work must stay at base tier.
+//
+// RULE: apply WithInteractive at the moment of the synchronous call, never
+// store a promoted ctx or hand it to a goroutine that outlives the FUSE
+// request — a leaked promotion would let background work drain the
+// interactive reserve the promotion exists to protect.
 func WithInteractive(ctx context.Context) context.Context {
 	return context.WithValue(ctx, interactiveCtxKey{}, true)
 }

--- a/internal/fs/attachments.go
+++ b/internal/fs/attachments.go
@@ -113,7 +113,7 @@ func (n *AttachmentsNode) createExternalAttachmentNode(ctx context.Context, att 
 	node := &ExternalAttachmentNode{
 		renderFile: renderFile{
 			BaseNode: BaseNode{lfs: n.lfs},
-			render: func() ([]byte, time.Time, time.Time) {
+			render: func(context.Context) ([]byte, time.Time, time.Time) {
 				return []byte(externalAttachmentContent(att)), att.UpdatedAt, att.CreatedAt
 			},
 		},
@@ -265,7 +265,9 @@ func (n *AttachmentsNode) createAttachment(ctx context.Context, raw []byte) sysc
 			// duplicate. On failure, re-check authoritatively against the API:
 			// if the URL is in fact already attached, treat it as the idempotent
 			// success it is rather than surfacing the raw GraphQL rejection.
-			if live, lerr := n.lfs.client.GetIssueAttachments(ctx, n.issueID); lerr == nil {
+			// Synchronous API read inside a user-blocking flush: promote it so
+			// a tight detail budget can't stall the user's write verdict.
+			if live, lerr := n.lfs.client.GetIssueAttachments(api.WithInteractive(ctx), n.issueID); lerr == nil {
 				for _, ex := range live {
 					if attachmentURLsEqual(ex.URL, url) {
 						return &ex, nil

--- a/internal/fs/cycles.go
+++ b/internal/fs/cycles.go
@@ -147,7 +147,7 @@ func (c *CycleDirNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 	// and ctime (preserving the previous sort order), never now().
 	if name == "cycle.md" {
 		team, cycle := c.team, c.cycle
-		return c.lookupRenderFile(ctx, out, func() ([]byte, time.Time, time.Time) {
+		return c.lookupRenderFile(ctx, out, func(context.Context) ([]byte, time.Time, time.Time) {
 			return cycleMarkdown(team, cycle), cycle.StartsAt, cycle.StartsAt
 		}, 0, inheritTimeout), 0
 	}

--- a/internal/fs/errorfile.go
+++ b/internal/fs/errorfile.go
@@ -73,7 +73,7 @@ func collectionErrorKey(kind, parentID string) string {
 // with zero timeouts, so it always reflects the most recent write rather than a
 // stale cached (often empty) value; the reported time is when the error was set.
 func (lfs *LinearFS) lookupErrorFile(ctx context.Context, parent fs.InodeEmbedder, entityID string, out *fuse.EntryOut) *fs.Inode {
-	render := func() ([]byte, time.Time, time.Time) {
+	render := func(context.Context) ([]byte, time.Time, time.Time) {
 		if e := lfs.GetWriteError(entityID); e != nil {
 			return []byte(e.Message + "\n"), e.Timestamp, e.Timestamp
 		}

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -119,9 +119,9 @@ func (i *InitiativeNode) manifest() *dirManifest {
 
 	// initiative.meta: read-through from the freshest initiative so an edit to
 	// initiative.md is reflected here.
-	m.metaFile("initiative.meta", func() ([]byte, time.Time, time.Time) {
+	m.metaFile("initiative.meta", func(ctx context.Context) ([]byte, time.Time, time.Time) {
 		init := initiative
-		if inits, err := lfs.GetInitiatives(context.Background()); err == nil {
+		if inits, err := lfs.GetInitiatives(ctx); err == nil {
 			init = freshestByID(inits, initiative.ID, func(i api.Initiative) string { return i.ID }, initiative)
 		}
 		node := &InitiativeInfoNode{BaseNode: BaseNode{lfs: lfs}, initiative: init, initiativeID: init.ID}

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -327,12 +327,12 @@ func (n *IssueDirectoryNode) manifest() *dirManifest {
 	// freshest issue so an edit to issue.md is reflected here.
 	lfs := n.lfs
 	ident := issue.Identifier
-	m.metaFile("issue.meta", func() ([]byte, time.Time, time.Time) {
+	m.metaFile("issue.meta", func(ctx context.Context) ([]byte, time.Time, time.Time) {
 		iss := &issue
-		if fresh, err := lfs.FetchIssueByIdentifier(context.Background(), ident); err == nil && fresh != nil {
+		if fresh, err := lfs.FetchIssueByIdentifier(ctx, ident); err == nil && fresh != nil {
 			iss = fresh
 		}
-		att, _ := lfs.GetIssueAttachments(context.Background(), iss.ID)
+		att, _ := lfs.GetIssueAttachments(ctx, iss.ID)
 		b, err := marshal.IssueMetaToMarkdown(iss, att...)
 		if err != nil {
 			return nil, iss.UpdatedAt, iss.CreatedAt
@@ -343,8 +343,8 @@ func (n *IssueDirectoryNode) manifest() *dirManifest {
 	// history.md: a read-only generated file, rendered fresh from the issue's
 	// activity history on each read. It reports the issue's own times; a transient
 	// fetch failure renders an empty file rather than making the entry vanish.
-	m.renderFile("history.md", historyIno(issue.ID), func() ([]byte, time.Time, time.Time) {
-		entries, err := lfs.GetIssueHistory(context.Background(), issue.ID)
+	m.renderFile("history.md", historyIno(issue.ID), func(ctx context.Context) ([]byte, time.Time, time.Time) {
+		entries, err := lfs.GetIssueHistory(ctx, issue.ID)
 		if err != nil {
 			log.Printf("Failed to fetch history for %s: %v", issue.Identifier, err)
 			return nil, issue.UpdatedAt, issue.CreatedAt

--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -555,9 +555,11 @@ func (lfs *LinearFS) GetIssueDocuments(ctx context.Context, issueID string) ([]a
 	return lfs.repo.GetIssueDocuments(ctx, issueID)
 }
 
-// GetTeamDocuments returns documents for a team (currently via API as not synced)
+// GetTeamDocuments returns documents for a team (currently via API as not
+// synced). This is a synchronous API call on a live FUSE path — the caller's
+// user is blocked on it — so it promotes to the interactive budget tier.
 func (lfs *LinearFS) GetTeamDocuments(ctx context.Context, teamID string) ([]api.Document, error) {
-	return lfs.client.GetTeamDocuments(ctx, teamID)
+	return lfs.client.GetTeamDocuments(api.WithInteractive(ctx), teamID)
 }
 
 func (lfs *LinearFS) GetProjectDocuments(ctx context.Context, projectID string) ([]api.Document, error) {

--- a/internal/fs/metafile_test.go
+++ b/internal/fs/metafile_test.go
@@ -16,7 +16,7 @@ import (
 func TestMetaFileNodeReadThrough(t *testing.T) {
 	current := "id: X\nupdated: T1\n"
 	mtime := time.Unix(1000, 0)
-	node := &renderFile{render: func() ([]byte, time.Time, time.Time) {
+	node := &renderFile{render: func(context.Context) ([]byte, time.Time, time.Time) {
 		return []byte(current), mtime, time.Unix(500, 0)
 	}}
 

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -235,9 +235,9 @@ func (p *ProjectNode) manifest() *dirManifest {
 
 	// project.meta: read-through from the freshest project so an edit to
 	// project.md is reflected here.
-	m.metaFile("project.meta", func() ([]byte, time.Time, time.Time) {
+	m.metaFile("project.meta", func(ctx context.Context) ([]byte, time.Time, time.Time) {
 		proj := project
-		if projs, err := lfs.GetTeamProjects(context.Background(), team.ID); err == nil {
+		if projs, err := lfs.GetTeamProjects(ctx, team.ID); err == nil {
 			proj = freshestByID(projs, project.ID, func(p api.Project) string { return p.ID }, project)
 		}
 		node := &ProjectInfoNode{BaseNode: BaseNode{lfs: lfs}, team: team, project: proj}

--- a/internal/fs/relations.go
+++ b/internal/fs/relations.go
@@ -104,7 +104,7 @@ func (n *RelationsNode) createRelationFileNode(ctx context.Context, rel api.Issu
 	node := &RelationFileNode{
 		renderFile: renderFile{
 			BaseNode: BaseNode{lfs: n.lfs},
-			render: func() ([]byte, time.Time, time.Time) {
+			render: func(context.Context) ([]byte, time.Time, time.Time) {
 				return []byte(relationContent(rel, isInverse)), rel.UpdatedAt, rel.CreatedAt
 			},
 		},

--- a/internal/fs/renderfile.go
+++ b/internal/fs/renderfile.go
@@ -13,7 +13,12 @@ import (
 // it should report (mtime=updated, ctime=created), from a live source. A zero
 // time reports "unknown" (nonZeroTime renders it as an unset attr), never a
 // fabricated now() — that fabrication was the drift this module exists to kill.
-type renderFunc func() (content []byte, mtime, ctime time.Time)
+//
+// The ctx is the FUSE handler's: a closure whose source is a synchronous
+// Linear API call (a live user is blocked on it) wraps it with
+// api.WithInteractive(ctx) at the call so the request spends from the
+// interactive budget reserve. SQLite-only closures ignore it.
+type renderFunc func(ctx context.Context) (content []byte, mtime, ctime time.Time)
 
 // renderFile is the mixin every read-only generated file embeds — the
 // render-through file complement to attrNode (the directory mixin) and the
@@ -45,15 +50,15 @@ var _ renderChild = (*renderFile)(nil)
 // renderAttr renders the current content and returns the reporting identity a
 // Getattr and a Lookup must agree on. Both go through this one path, so — as
 // with attrNode — the two can never disagree.
-func (r *renderFile) renderAttr() nodeAttr {
-	content, mtime, ctime := r.render()
+func (r *renderFile) renderAttr(ctx context.Context) nodeAttr {
+	content, mtime, ctime := r.render(ctx)
 	return nodeAttr{mode: 0444 | syscall.S_IFREG, size: uint64(len(content)), created: ctime, updated: mtime}
 }
 
 func (r *renderFile) baseNode() *BaseNode { return &r.BaseNode }
 
 func (r *renderFile) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	r.renderAttr().fill(&out.Attr, &r.BaseNode)
+	r.renderAttr(ctx).fill(&out.Attr, &r.BaseNode)
 	return 0
 }
 
@@ -69,7 +74,7 @@ func (r *renderFile) Open(ctx context.Context, flags uint32) (fs.FileHandle, uin
 }
 
 func (r *renderFile) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	content, _, _ := r.render()
+	content, _, _ := r.render(ctx)
 	return readWindow(content, dest, off), 0
 }
 
@@ -91,7 +96,7 @@ func readWindow(content, dest []byte, off int64) fuse.ReadResult {
 // embedding one plus extra methods (Unlink). newRenderInode builds any of them.
 type renderChild interface {
 	fs.InodeEmbedder
-	renderAttr() nodeAttr
+	renderAttr(ctx context.Context) nodeAttr
 	baseNode() *BaseNode
 }
 
@@ -104,8 +109,8 @@ const inheritTimeout = time.Duration(-1)
 // same renderAttr() path its Getattr uses, so the two can never disagree — and
 // applies the timeout (< 0 inherits the mount default). Shared by both mount
 // paths below.
-func fillRenderEntry(out *fuse.EntryOut, child renderChild, timeout time.Duration) {
-	child.renderAttr().fill(&out.Attr, child.baseNode())
+func fillRenderEntry(ctx context.Context, out *fuse.EntryOut, child renderChild, timeout time.Duration) {
+	child.renderAttr(ctx).fill(&out.Attr, child.baseNode())
 	if timeout >= 0 {
 		out.SetAttrTimeout(timeout)
 		out.SetEntryTimeout(timeout)
@@ -117,7 +122,7 @@ func fillRenderEntry(out *fuse.EntryOut, child renderChild, timeout time.Duratio
 // parent. Used by the nodes that embed renderFile plus extra methods
 // (RelationFileNode/ExternalAttachmentNode). ino 0 auto-assigns.
 func (b *BaseNode) newRenderInode(ctx context.Context, out *fuse.EntryOut, child renderChild, ino uint64, timeout time.Duration) *fs.Inode {
-	fillRenderEntry(out, child, timeout)
+	fillRenderEntry(ctx, out, child, timeout)
 	return b.NewInode(ctx, child, fs.StableAttr{Mode: syscall.S_IFREG, Ino: ino})
 }
 
@@ -135,6 +140,6 @@ func (b *BaseNode) lookupRenderFile(ctx context.Context, out *fuse.EntryOut, ren
 // as an fs.InodeEmbedder rather than a *BaseNode.
 func (lfs *LinearFS) mountRenderFile(ctx context.Context, parent fs.InodeEmbedder, render renderFunc, ino uint64, timeout time.Duration, out *fuse.EntryOut) *fs.Inode {
 	node := &renderFile{BaseNode: BaseNode{lfs: lfs}, render: render}
-	fillRenderEntry(out, node, timeout)
+	fillRenderEntry(ctx, out, node, timeout)
 	return parent.EmbeddedInode().NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG, Ino: ino})
 }

--- a/internal/fs/renderfile_test.go
+++ b/internal/fs/renderfile_test.go
@@ -39,7 +39,7 @@ func TestReadWindowClampsAtEOF(t *testing.T) {
 }
 
 func TestRenderFileOpenRejectsWrites(t *testing.T) {
-	r := &renderFile{render: func() ([]byte, time.Time, time.Time) {
+	r := &renderFile{render: func(context.Context) ([]byte, time.Time, time.Time) {
 		return []byte("x"), time.Time{}, time.Time{}
 	}}
 	if _, _, errno := r.Open(context.Background(), syscall.O_RDONLY); errno != 0 {
@@ -56,7 +56,7 @@ func TestRenderFileGetattrReportsRenderedSizeAndTimes(t *testing.T) {
 	mtime := time.Unix(2000, 0)
 	ctime := time.Unix(1000, 0)
 	body := []byte("id: X\n")
-	r := &renderFile{render: func() ([]byte, time.Time, time.Time) {
+	r := &renderFile{render: func(context.Context) ([]byte, time.Time, time.Time) {
 		return body, mtime, ctime
 	}}
 
@@ -81,7 +81,7 @@ func TestRenderFileGetattrReportsRenderedSizeAndTimes(t *testing.T) {
 // A zero time reports as an unset attr (nonZeroTime), never a fabricated now()
 // or a wrapped garbage timestamp — the drift this module exists to kill.
 func TestRenderFileZeroTimeReportsUnset(t *testing.T) {
-	r := &renderFile{render: func() ([]byte, time.Time, time.Time) {
+	r := &renderFile{render: func(context.Context) ([]byte, time.Time, time.Time) {
 		return []byte("no times"), time.Time{}, time.Time{}
 	}}
 	var out fuse.AttrOut
@@ -90,5 +90,39 @@ func TestRenderFileZeroTimeReportsUnset(t *testing.T) {
 	}
 	if out.Mtime != 0 || out.Ctime != 0 {
 		t.Errorf("zero times reported as mtime=%d ctime=%d, want 0/0", out.Mtime, out.Ctime)
+	}
+}
+
+// TestRenderFileThreadsContext pins the ctx contract: the FUSE handler's ctx
+// reaches the render closure on every path (Read, Getattr, and the Lookup-time
+// renderAttr), so a closure that promotes it with api.WithInteractive actually
+// affects the request — a context.Background() substitution anywhere in the
+// chain would silently strip the promotion (the pre-fix behavior).
+func TestRenderFileThreadsContext(t *testing.T) {
+	type ctxKey struct{}
+	want := context.WithValue(context.Background(), ctxKey{}, "marker")
+
+	var got []any
+	r := &renderFile{render: func(ctx context.Context) ([]byte, time.Time, time.Time) {
+		got = append(got, ctx.Value(ctxKey{}))
+		return []byte("x"), time.Time{}, time.Time{}
+	}}
+
+	if _, errno := r.Read(want, nil, make([]byte, 8), 0); errno != 0 {
+		t.Fatalf("Read errno=%v", errno)
+	}
+	var out fuse.AttrOut
+	if errno := r.Getattr(want, nil, &out); errno != 0 {
+		t.Fatalf("Getattr errno=%v", errno)
+	}
+	r.renderAttr(want)
+
+	if len(got) != 3 {
+		t.Fatalf("render called %d times, want 3", len(got))
+	}
+	for i, v := range got {
+		if v != "marker" {
+			t.Errorf("call %d: render did not receive the handler ctx (got %v)", i, v)
+		}
 	}
 }

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -44,7 +44,7 @@ func (r *RootNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 	case "README.md":
 		// The generated docs have no natural entity time; report zero (unknown).
 		lfs := r.lfs
-		return r.lookupRenderFile(ctx, out, func() ([]byte, time.Time, time.Time) {
+		return r.lookupRenderFile(ctx, out, func(context.Context) ([]byte, time.Time, time.Time) {
 			return []byte(generateReadme(lfs.MountPoint())), time.Time{}, time.Time{}
 		}, 0, inheritTimeout), 0
 

--- a/internal/fs/successfile.go
+++ b/internal/fs/successfile.go
@@ -147,7 +147,7 @@ func (lfs *LinearFS) renderWriteSuccess(key string) []byte {
 // is a plain renderFile with zero timeouts, so it always reflects the most recent
 // create; the reported time is the newest recorded create's timestamp.
 func (lfs *LinearFS) lookupSuccessFile(ctx context.Context, parent fs.InodeEmbedder, key string, out *fuse.EntryOut) *fs.Inode {
-	render := func() ([]byte, time.Time, time.Time) {
+	render := func(context.Context) ([]byte, time.Time, time.Time) {
 		content := lfs.renderWriteSuccess(key)
 		if content == nil {
 			return nil, time.Time{}, time.Time{}

--- a/internal/fs/teams.go
+++ b/internal/fs/teams.go
@@ -104,7 +104,7 @@ func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 	switch name {
 	case "team.md":
 		team := t.team
-		return t.lookupRenderFile(ctx, out, func() ([]byte, time.Time, time.Time) {
+		return t.lookupRenderFile(ctx, out, func(context.Context) ([]byte, time.Time, time.Time) {
 			return teamMarkdown(team), team.UpdatedAt, team.CreatedAt
 		}, 0, inheritTimeout), 0
 
@@ -113,8 +113,8 @@ func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 		// team's times as a stable proxy — never now(). Content is fetched from
 		// SQLite on each read (cheap), so no node-level cache is needed.
 		lfs, team := t.lfs, t.team
-		return t.lookupRenderFile(ctx, out, func() ([]byte, time.Time, time.Time) {
-			states, err := lfs.GetTeamStates(context.Background(), team.ID)
+		return t.lookupRenderFile(ctx, out, func(ctx context.Context) ([]byte, time.Time, time.Time) {
+			states, err := lfs.GetTeamStates(ctx, team.ID)
 			if err != nil {
 				return []byte("# Error loading states\n"), team.UpdatedAt, team.CreatedAt
 			}
@@ -123,8 +123,8 @@ func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 
 	case "labels.md":
 		lfs, team := t.lfs, t.team
-		return t.lookupRenderFile(ctx, out, func() ([]byte, time.Time, time.Time) {
-			labels, err := lfs.GetTeamLabels(context.Background(), team.ID)
+		return t.lookupRenderFile(ctx, out, func(ctx context.Context) ([]byte, time.Time, time.Time) {
+			labels, err := lfs.GetTeamLabels(ctx, team.ID)
 			if err != nil {
 				return []byte("# Error loading labels\n"), team.UpdatedAt, team.CreatedAt
 			}

--- a/internal/fs/updates.go
+++ b/internal/fs/updates.go
@@ -18,7 +18,7 @@ import (
 // interface). Collapses the render-closure + lookupRenderFile pairing the two
 // Lookups hand-rolled identically.
 func (b *BaseNode) lookupUpdateFile(ctx context.Context, out *fuse.EntryOut, id, health string, created, updated time.Time, user *api.User, body string, ino uint64) *fs.Inode {
-	render := func() ([]byte, time.Time, time.Time) {
+	render := func(context.Context) ([]byte, time.Time, time.Time) {
 		return updateMarkdown(id, health, created, updated, user, body), updated, created
 	}
 	return b.lookupRenderFile(ctx, out, render, ino, 30*time.Second)

--- a/internal/fs/users.go
+++ b/internal/fs/users.go
@@ -123,7 +123,7 @@ func (u *UserNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 	// so the file honestly reports zero (unknown) rather than a fabricated now().
 	if name == "user.md" {
 		user := u.user
-		return u.lookupRenderFile(ctx, out, func() ([]byte, time.Time, time.Time) {
+		return u.lookupRenderFile(ctx, out, func(context.Context) ([]byte, time.Time, time.Time) {
 			return userMarkdown(user), time.Time{}, time.Time{}
 		}, 0, inheritTimeout), 0
 	}


### PR DESCRIPTION
Rate-budget PR2 (spec: docs/plans/2026-07-07-interactive-promotion-threading.md, untracked). The `WithInteractive` mechanism shipped in PR1 with zero call sites — this threads it, with a corrected inventory:

- **The spec's 7 render-closure "API sites" turned out to be SQLite-first with background refresh** — no synchronous API call to promote. But they were discarding the FUSE handler's ctx (`context.Background()` at 8 sites), so `renderFunc` now takes the handler's ctx: cancellation and any future promotion actually reach the read. `TestRenderFileThreadsContext` pins propagation through Read, Getattr, and the Lookup-time render.
- **The only two genuinely synchronous user-blocking API calls now promote**: `GetTeamDocuments` (team docs listing — the one read that's API-only) and the attachment-create authoritative re-check inside a flush.
- The never-store rule is documented at `WithInteractive`: promote at the moment of the synchronous call; a promoted ctx must never reach a goroutine that outlives the request, or background work drains the interactive reserve.

Budget-tier promotion behavior was already unit-tested (ratebudget_test.go TestInteractivePromotion); CONTEXT.md updated (renderFile signature, rateBudget threading status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)