### PR TITLE
Fix captured-entity staleness: remote updates now visible after kernel revalidation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -194,6 +194,42 @@ something that doesn't exist -> `ENOENT` at Lookup, never a dangling
 placeholder. Lives in `internal/fs/symlink.go`;
 unit-tested directly, no FUSE mount.
 
+### Node refresh (`nodeRefresher`/`refreshExisting`)
+The **deep module** that closes the captured-entity staleness hole (round 15;
+confirmed live by experiment): go-fuse dedups inodes by StableAttr and keeps
+the FIRST node ever mounted for an ino — `bridge.addNewChild` silently
+discards the freshly-constructed node **after the Lookup handler returns**
+(`NewInode`'s return value is always the fresh struct, so reuse cannot be
+detected from it). Any node that bakes entity state at construction (an
+editBuffer's content, an entity dir's snapshot, a render closure's capture)
+therefore served first-Lookup data for as long as the kernel remembered the
+inode — the sync worker deliberately never notifies the kernel, and the
+timeout-driven re-Lookup that was supposed to bring freshness hit the old
+node. The long-skipped `TestCacheExpiryRefreshesData` ("FUSE inode caching
+prevents immediate refresh") was this bug, filed away.
+
+The seam: construction helpers (`newDirInode`/`newFileInode`/`newRenderInode`/
+`mountRenderFile` and the few raw `NewInode` sites) now take the child's
+**name** and probe `parent.GetChild(name)` *inside* the handler — the inode
+the bridge will keep if it dedups — and push the fresh twin's volatile state
+into it via `refreshFrom(fresh)` (`internal/fs/refresh.go`). A nil child means
+the kernel FORGOT it and the fresh node installs — already fresh. Per-type
+rules: the three entity dir nodes swap their entity under `attrNode.stateMu`
+(which also guards `nodeAttr`, re-stamped by the seam) and expose
+`entity()/setEntity` snapshots; the seven editBuffer file nodes go through
+`editBuffer.refresh` — **a dirty buffer always wins** (a user's in-flight
+edit is never clobbered by background sync) — with Getattr snapshotting
+size+times under one lock; renderFile swaps its closure under `renderMu`
+(embedders with entity fields shadow `refreshFrom` and reuse that lock);
+`EmbeddedFileNode` swaps its file metadata under its own mu. `TeamNode`/
+`UserNode`/cycle dirs are constructed with auto-assigned inos (fresh node per
+Lookup) and don't need the seam — a pre-existing inconsistency with the inode
+namespace that happens to dodge the bug. Guarded end-to-end by
+`TestRemoteUpdateVisibleAfterKernelRevalidation` (remote upsert → pinned
+inode chain so the kernel cannot FORGET → 31s real entry-timeout expiry →
+fresh content and mtime; the pin is what forces the reuse path — without it
+the kernel may forget everything and the test passes vacuously).
+
 ### Attr construction (`nodeAttr`/`attrNode`)
 The **deep module** owning how a directory or file node's attributes are
 constructed — the non-symlink complement to Symlink views (`symlinkNode`), and

--- a/internal/fs/attachments.go
+++ b/internal/fs/attachments.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -82,7 +83,7 @@ func (n *AttachmentsNode) Lookup(ctx context.Context, name string, out *fuse.Ent
 	}
 
 	if entry.external != nil {
-		return n.createExternalAttachmentNode(ctx, *entry.external, out)
+		return n.createExternalAttachmentNode(ctx, name, *entry.external, out)
 	}
 
 	file := *entry.embedded
@@ -103,13 +104,16 @@ func (n *AttachmentsNode) Lookup(ctx context.Context, name string, out *fuse.Ent
 	out.SetAttrTimeout(30 * time.Second)
 	out.SetEntryTimeout(30 * time.Second)
 
+	// The bridge dedups AFTER this handler returns: push the fresh file
+	// metadata into the node it will keep (see refresh.go).
+	refreshExisting(n, name, node)
 	return n.NewInode(ctx, node, fs.StableAttr{
 		Mode: syscall.S_IFREG,
 		Ino:  embeddedFileIno(file.ID),
 	}), 0
 }
 
-func (n *AttachmentsNode) createExternalAttachmentNode(ctx context.Context, att api.Attachment, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+func (n *AttachmentsNode) createExternalAttachmentNode(ctx context.Context, name string, att api.Attachment, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
 	node := &ExternalAttachmentNode{
 		renderFile: renderFile{
 			BaseNode: BaseNode{lfs: n.lfs},
@@ -120,14 +124,31 @@ func (n *AttachmentsNode) createExternalAttachmentNode(ctx context.Context, att 
 		attachment: att,
 		issueID:    n.issueID,
 	}
-	return n.newRenderInode(ctx, out, node, externalAttachmentIno(att.ID), 30*time.Second), 0
+	return n.newRenderInode(ctx, out, name, node, externalAttachmentIno(att.ID), 30*time.Second), 0
 }
 
 // EmbeddedFileNode represents a file in the /attachments/ directory
 // Files are lazily fetched from Linear's CDN on first read
 type EmbeddedFileNode struct {
 	BaseNode
+	mu   sync.Mutex // guards file: swapped by the nodeRefresher seam (refresh.go)
 	file api.EmbeddedFile
+}
+
+// fileSnapshot reads the entity under the lock.
+func (n *EmbeddedFileNode) fileSnapshot() api.EmbeddedFile {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.file
+}
+
+// refreshFrom adopts a fresh twin's file metadata (refresh.go).
+func (n *EmbeddedFileNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*EmbeddedFileNode); ok {
+		n.mu.Lock()
+		n.file = f.file
+		n.mu.Unlock()
+	}
 }
 
 var _ fs.NodeGetattrer = (*EmbeddedFileNode)(nil)
@@ -135,11 +156,12 @@ var _ fs.NodeOpener = (*EmbeddedFileNode)(nil)
 var _ fs.NodeReader = (*EmbeddedFileNode)(nil)
 
 func (n *EmbeddedFileNode) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
+	file := n.fileSnapshot()
 	now := time.Now()
 	out.Mode = 0444 // Read-only
 	n.SetOwner(out)
-	if n.file.FileSize > 0 {
-		out.Size = uint64(n.file.FileSize)
+	if file.FileSize > 0 {
+		out.Size = uint64(file.FileSize)
 	} else {
 		// Report a placeholder size so tools will attempt to read the file.
 		// Lazy-fetch happens during Read(), which will return actual content.
@@ -157,7 +179,7 @@ func (n *EmbeddedFileNode) Open(ctx context.Context, flags uint32) (fs.FileHandl
 
 func (n *EmbeddedFileNode) Read(ctx context.Context, fh fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
 	// Lazy fetch: download file from Linear CDN if not cached
-	content, err := n.lfs.FetchEmbeddedFile(ctx, n.file)
+	content, err := n.lfs.FetchEmbeddedFile(ctx, n.fileSnapshot())
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -185,6 +207,19 @@ type ExternalAttachmentNode struct {
 
 var _ fs.NodeUnlinker = (*ExternalAttachmentNode)(nil)
 
+// refreshFrom adopts a fresh twin's attachment and render closure
+// (refresh.go); renderMu doubles as the entity-field lock.
+func (n *ExternalAttachmentNode) refreshFrom(fresh fs.InodeEmbedder) {
+	f, ok := fresh.(*ExternalAttachmentNode)
+	if !ok {
+		return
+	}
+	n.renderMu.Lock()
+	n.render = f.render
+	n.attachment, n.issueID = f.attachment, f.issueID
+	n.renderMu.Unlock()
+}
+
 // externalAttachmentContent renders a .link file's YAML body.
 func externalAttachmentContent(att api.Attachment) string {
 	var sb strings.Builder
@@ -202,9 +237,15 @@ func externalAttachmentContent(att api.Attachment) string {
 func (n *ExternalAttachmentNode) Unlink(ctx context.Context, name string) syscall.Errno {
 	// The file node already holds its entity, so find just hands it over.
 	return commitDelete(ctx, n.lfs, deleteSpec[api.Attachment]{
-		op:   `delete attachment "` + name + `"`,
-		key:  collectionErrorKey("attachments", n.issueID),
-		find: func(context.Context) (*api.Attachment, error) { return &n.attachment, nil },
+		op:  `delete attachment "` + name + `"`,
+		key: collectionErrorKey("attachments", n.issueID),
+		find: func(context.Context) (*api.Attachment, error) {
+			// Snapshot: a concurrent refresh (refresh.go) may swap the field.
+			n.renderMu.Lock()
+			att := n.attachment
+			n.renderMu.Unlock()
+			return &att, nil
+		},
 		mutate: func(ctx context.Context, a *api.Attachment) error {
 			return n.lfs.mutator().DeleteAttachment(ctx, a.ID)
 		},

--- a/internal/fs/comments.go
+++ b/internal/fs/comments.go
@@ -82,7 +82,7 @@ func (n *CommentsNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 		editBuffer: editBuffer{content: content},
 	}
 	// Shorter timeout for writable files.
-	return n.newFileInode(ctx, out, node, fileAttr(len(content), comment.CreatedAt, comment.UpdatedAt), commentIno(comment.ID), 5*time.Second), 0
+	return n.newFileInode(ctx, out, name, node, fileAttr(len(content), comment.CreatedAt, comment.UpdatedAt), commentIno(comment.ID), 5*time.Second), 0
 }
 
 func (n *CommentsNode) Unlink(ctx context.Context, name string) syscall.Errno {
@@ -152,8 +152,22 @@ var _ fs.NodeFsyncer = (*CommentNode)(nil)
 var _ fs.NodeSetattrer = (*CommentNode)(nil)
 
 func (n *CommentNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	fileAttr(n.size(), n.comment.CreatedAt, n.comment.UpdatedAt).fill(&out.Attr, &n.BaseNode)
+	// One lock for size + times: a concurrent refresh (refresh.go) swaps
+	// content and entity atomically, so the read must snapshot both together.
+	n.mu.Lock()
+	size := len(n.content)
+	created, updated := n.comment.CreatedAt, n.comment.UpdatedAt
+	n.mu.Unlock()
+	fileAttr(size, created, updated).fill(&out.Attr, &n.BaseNode)
 	return 0
+}
+
+// refreshFrom adopts a fresh twin's comment and rendered content unless an
+// edit is in flight — the dirty buffer always wins (refresh.go).
+func (n *CommentNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*CommentNode); ok {
+		n.refresh(f.content, func() { n.comment, n.issueID = f.comment, f.issueID })
+	}
 }
 
 func (n *CommentNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno {

--- a/internal/fs/cycles.go
+++ b/internal/fs/cycles.go
@@ -147,7 +147,7 @@ func (c *CycleDirNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 	// and ctime (preserving the previous sort order), never now().
 	if name == "cycle.md" {
 		team, cycle := c.team, c.cycle
-		return c.lookupRenderFile(ctx, out, func(context.Context) ([]byte, time.Time, time.Time) {
+		return c.lookupRenderFile(ctx, out, "cycle.md", func(context.Context) ([]byte, time.Time, time.Time) {
 			return cycleMarkdown(team, cycle), cycle.StartsAt, cycle.StartsAt
 		}, 0, inheritTimeout), 0
 	}

--- a/internal/fs/documents.go
+++ b/internal/fs/documents.go
@@ -103,7 +103,7 @@ func (n *DocsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 	}
 
 	if doc, ok := n.listing(docs).find(name); ok {
-		return n.newDocumentInode(ctx, doc, out)
+		return n.newDocumentInode(ctx, name, doc, out)
 	}
 
 	return nil, syscall.ENOENT
@@ -199,7 +199,7 @@ func (n *DocsNode) Rename(ctx context.Context, name string, newParent fs.InodeEm
 
 // newDocumentInode builds the read/write DocumentFileNode inode for an existing
 // document, populated with its current content. Shared by Lookup and Create.
-func (n *DocsNode) newDocumentInode(ctx context.Context, doc api.Document, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+func (n *DocsNode) newDocumentInode(ctx context.Context, name string, doc api.Document, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
 	content, err := marshal.DocumentToMarkdown(&doc)
 	if err != nil {
 		log.Printf("Failed to marshal document: %v", err)
@@ -215,7 +215,7 @@ func (n *DocsNode) newDocumentInode(ctx context.Context, doc api.Document, out *
 		editBuffer:   editBuffer{content: content},
 	}
 	// Shorter timeout for writable files.
-	return n.newFileInode(ctx, out, node, fileAttr(len(content), doc.CreatedAt, doc.UpdatedAt), documentIno(doc.ID), 5*time.Second), 0
+	return n.newFileInode(ctx, out, name, node, fileAttr(len(content), doc.CreatedAt, doc.UpdatedAt), documentIno(doc.ID), 5*time.Second), 0
 }
 
 func (n *DocsNode) Create(ctx context.Context, name string, flags uint32, mode uint32, out *fuse.EntryOut) (*fs.Inode, fs.FileHandle, uint32, syscall.Errno) {
@@ -235,7 +235,7 @@ func (n *DocsNode) Create(ctx context.Context, name string, flags uint32, mode u
 	// unwritable (#137).
 	if docs, err := n.getDocuments(ctx); err == nil {
 		if doc, ok := n.listing(docs).find(name); ok {
-			inode, errno := n.newDocumentInode(ctx, doc, out)
+			inode, errno := n.newDocumentInode(ctx, name, doc, out)
 			if errno != 0 {
 				return nil, nil, 0, errno
 			}
@@ -283,8 +283,25 @@ var _ fs.NodeFsyncer = (*DocumentFileNode)(nil)
 var _ fs.NodeSetattrer = (*DocumentFileNode)(nil)
 
 func (n *DocumentFileNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	fileAttr(n.size(), n.document.CreatedAt, n.document.UpdatedAt).fill(&out.Attr, &n.BaseNode)
+	// One lock for size + times: a concurrent refresh (refresh.go) swaps
+	// content and entity atomically, so the read must snapshot both together.
+	n.mu.Lock()
+	size := len(n.content)
+	created, updated := n.document.CreatedAt, n.document.UpdatedAt
+	n.mu.Unlock()
+	fileAttr(size, created, updated).fill(&out.Attr, &n.BaseNode)
 	return 0
+}
+
+// refreshFrom adopts a fresh twin's document and rendered content unless an
+// edit is in flight — the dirty buffer always wins (refresh.go).
+func (n *DocumentFileNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*DocumentFileNode); ok {
+		n.refresh(f.content, func() {
+			n.document = f.document
+			n.issueID, n.teamID, n.projectID, n.initiativeID = f.issueID, f.teamID, f.projectID, f.initiativeID
+		})
+	}
 }
 
 func (n *DocumentFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno {

--- a/internal/fs/editbuffer.go
+++ b/internal/fs/editbuffer.go
@@ -33,6 +33,21 @@ func (b *editBuffer) size() int {
 	return len(b.content)
 }
 
+// refresh adopts freshly-rendered content — the editBuffer half of a node's
+// nodeRefresher implementation (see refresh.go) — UNLESS an edit is in
+// flight: a dirty buffer is the user's, and always wins over background
+// sync. entitySwap runs under the same lock iff the refresh proceeds, so the
+// node's entity fields and its content swap atomically.
+func (b *editBuffer) refresh(freshContent []byte, entitySwap func()) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.dirty {
+		return
+	}
+	b.content = append([]byte(nil), freshContent...)
+	entitySwap()
+}
+
 func (b *editBuffer) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
 	return nil, fuse.FOPEN_KEEP_CACHE, 0
 }

--- a/internal/fs/errorfile.go
+++ b/internal/fs/errorfile.go
@@ -79,5 +79,5 @@ func (lfs *LinearFS) lookupErrorFile(ctx context.Context, parent fs.InodeEmbedde
 		}
 		return nil, time.Time{}, time.Time{}
 	}
-	return lfs.mountRenderFile(ctx, parent, render, errorIno(entityID), 0, out)
+	return lfs.mountRenderFile(ctx, parent, ".error", render, errorIno(entityID), 0, out)
 }

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -57,7 +57,7 @@ func (i *InitiativesNode) Lookup(ctx context.Context, name string, out *fuse.Ent
 	for _, init := range initiatives {
 		if initiativeDirName(init) == name {
 			node := &InitiativeNode{attrNode: attrNode{BaseNode: BaseNode{lfs: i.lfs}}, initiative: init}
-			return i.newDirInode(ctx, out, node, dirAttr(init.CreatedAt, init.UpdatedAt), initiativeDirIno(init.ID), 30*time.Second), 0
+			return i.newDirInode(ctx, out, name, node, dirAttr(init.CreatedAt, init.UpdatedAt), initiativeDirIno(init.ID), 30*time.Second), 0
 		}
 	}
 
@@ -104,8 +104,29 @@ func (i *InitiativeNode) Lookup(ctx context.Context, name string, out *fuse.Entr
 // initiative.md, the read-through initiative.meta, the .error sidecar, and the
 // docs/projects/updates subdirs. Initiative children have no dynamic tail and a
 // 0 timeout.
+// entity/setEntity snapshot and swap the directory's initiative under the
+// node's volatile-state lock: setEntity is written by the Rename write-back
+// and the nodeRefresher seam (refresh.go).
+func (i *InitiativeNode) entity() api.Initiative {
+	i.stateMu.Lock()
+	defer i.stateMu.Unlock()
+	return i.initiative
+}
+
+func (i *InitiativeNode) setEntity(init api.Initiative) {
+	i.stateMu.Lock()
+	i.initiative = init
+	i.stateMu.Unlock()
+}
+
+func (i *InitiativeNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*InitiativeNode); ok {
+		i.setEntity(f.initiative)
+	}
+}
+
 func (i *InitiativeNode) manifest() *dirManifest {
-	initiative := i.initiative // snapshot captured by the build closures
+	initiative := i.entity() // snapshot captured by the build closures
 	lfs := i.lfs
 	m := newDirManifest(&i.BaseNode, initiative.ID, initiative.CreatedAt, initiative.UpdatedAt, 0)
 
@@ -149,7 +170,7 @@ func (i *InitiativeNode) manifest() *dirManifest {
 // with a misleading EROFS on the rw mount (#145).
 func (i *InitiativeNode) Create(ctx context.Context, name string, flags uint32, mode uint32, out *fuse.EntryOut) (*fs.Inode, fs.FileHandle, uint32, syscall.Errno) {
 	if i.lfs.debug {
-		log.Printf("Create scratch file in initiative %s: %s", i.initiative.Name, name)
+		log.Printf("Create scratch file in initiative %s: %s", i.entity().Name, name)
 	}
 	return newScratchInode(ctx, &i.BaseNode, i.EmbeddedInode().StableAttr().Ino, name, out)
 }
@@ -158,8 +179,9 @@ func (i *InitiativeNode) Create(ctx context.Context, name string, flags uint32, 
 // initiative.md is written through initiative.md's normal Flush path.
 // initiative.md is the only writable file here, so other targets are rejected.
 func (i *InitiativeNode) Rename(ctx context.Context, name string, newParent fs.InodeEmbedder, newName string, flags uint32) syscall.Errno {
+	initiative := i.entity()
 	if i.lfs.debug {
-		log.Printf("Rename in initiative %s: %s -> %s", i.initiative.Name, name, newName)
+		log.Printf("Rename in initiative %s: %s -> %s", initiative.Name, name, newName)
 	}
 
 	dirIno := i.EmbeddedInode().StableAttr().Ino
@@ -173,21 +195,21 @@ func (i *InitiativeNode) Rename(ctx context.Context, name string, newParent fs.I
 	}
 
 	if newName != "initiative.md" {
-		i.lfs.SetWriteError(i.initiative.ID, fmt.Sprintf("Operation: rename %s -> %s\nError: only initiative.md is writable in this directory; save your changes onto initiative.md (atomic save-via-rename onto initiative.md is supported).", name, newName))
+		i.lfs.SetWriteError(initiative.ID, fmt.Sprintf("Operation: rename %s -> %s\nError: only initiative.md is writable in this directory; save your changes onto initiative.md (atomic save-via-rename onto initiative.md is supported).", name, newName))
 		return syscall.ENOTSUP
 	}
 
 	fileNode := &InitiativeInfoNode{
 		BaseNode:     BaseNode{lfs: i.lfs},
-		initiative:   i.initiative,
-		initiativeID: i.initiative.ID,
+		initiative:   initiative,
+		initiativeID: initiative.ID,
 		editBuffer:   editBuffer{content: content, dirty: true},
 	}
 	errno := fileNode.Flush(ctx, nil)
 
 	if errno == 0 || errno == syscall.EIO {
-		i.initiative = fileNode.initiative
-		i.lfs.InvalidateRenamed(dirIno, name, newName, initiativeInfoIno(i.initiative.ID))
+		i.setEntity(fileNode.initiative)
+		i.lfs.InvalidateRenamed(dirIno, name, newName, initiativeInfoIno(fileNode.initiative.ID))
 	}
 
 	return errno
@@ -242,8 +264,22 @@ func (i *InitiativeInfoNode) metaContent() []byte {
 }
 
 func (i *InitiativeInfoNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	fileAttr(i.size(), i.initiative.CreatedAt, i.initiative.UpdatedAt).fill(&out.Attr, &i.BaseNode)
+	// One lock for size + times: a concurrent refresh (refresh.go) swaps
+	// content and entity atomically, so the read must snapshot both together.
+	i.mu.Lock()
+	size := len(i.content)
+	created, updated := i.initiative.CreatedAt, i.initiative.UpdatedAt
+	i.mu.Unlock()
+	fileAttr(size, created, updated).fill(&out.Attr, &i.BaseNode)
 	return 0
+}
+
+// refreshFrom adopts a fresh twin's initiative and rendered content unless an
+// edit is in flight — the dirty buffer always wins (refresh.go).
+func (i *InitiativeInfoNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*InitiativeInfoNode); ok {
+		i.refresh(f.content, func() { i.initiative, i.initiativeID = f.initiative, f.initiativeID })
+	}
 }
 
 func (i *InitiativeInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno {
@@ -483,7 +519,7 @@ func (n *InitiativeUpdatesNode) Lookup(ctx context.Context, name string, out *fu
 	if !ok {
 		return nil, syscall.ENOENT
 	}
-	return n.lookupUpdateFile(ctx, out, update.ID, update.Health, update.CreatedAt, update.UpdatedAt,
+	return n.lookupUpdateFile(ctx, out, name, update.ID, update.Health, update.CreatedAt, update.UpdatedAt,
 		update.User, update.Body, initiativeUpdateIno(update.ID)), 0
 }
 

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -136,7 +136,7 @@ func (n *IssuesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut
 	}
 
 	node := &IssueDirectoryNode{attrNode: attrNode{BaseNode: BaseNode{lfs: n.lfs}}, issue: *issue}
-	return n.newDirInode(ctx, out, node, dirAttr(issue.CreatedAt, issue.UpdatedAt), issueDirIno(issue.ID), 30*time.Second), 0
+	return n.newDirInode(ctx, out, issue.Identifier, node, dirAttr(issue.CreatedAt, issue.UpdatedAt), issueDirIno(issue.ID), 30*time.Second), 0
 }
 
 // looksLikeIdentifier checks if a name looks like a Linear issue identifier
@@ -203,7 +203,7 @@ func (n *IssuesNode) Mkdir(ctx context.Context, name string, mode uint32, out *f
 	}
 
 	node := &IssueDirectoryNode{attrNode: attrNode{BaseNode: BaseNode{lfs: n.lfs}}, issue: *issue}
-	return n.newDirInode(ctx, out, node, dirAttr(issue.CreatedAt, issue.UpdatedAt), issueDirIno(issue.ID), 30*time.Second), 0
+	return n.newDirInode(ctx, out, issue.Identifier, node, dirAttr(issue.CreatedAt, issue.UpdatedAt), issueDirIno(issue.ID), 30*time.Second), 0
 }
 
 // createIssue is the issues/_create surface's onFlush: writing a full issue
@@ -302,8 +302,30 @@ func (n *IssueDirectoryNode) Lookup(ctx context.Context, name string, out *fuse.
 // the read-through issue.meta, the generated history.md, the .error/.last
 // sidecars, and the comments/docs/children/attachments/relations subdirs. Issue
 // children have no dynamic tail and a uniform 30s timeout.
+// entity/setEntity snapshot and swap the directory's issue under the node's
+// volatile-state lock: setEntity is written by the Rename write-back and the
+// nodeRefresher seam (refresh.go), which pushes freshly-fetched state into
+// this node when go-fuse dedups a later Lookup onto it.
+func (n *IssueDirectoryNode) entity() api.Issue {
+	n.stateMu.Lock()
+	defer n.stateMu.Unlock()
+	return n.issue
+}
+
+func (n *IssueDirectoryNode) setEntity(issue api.Issue) {
+	n.stateMu.Lock()
+	n.issue = issue
+	n.stateMu.Unlock()
+}
+
+func (n *IssueDirectoryNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*IssueDirectoryNode); ok {
+		n.setEntity(f.issue)
+	}
+}
+
 func (n *IssueDirectoryNode) manifest() *dirManifest {
-	issue := n.issue // snapshot captured by the build closures
+	issue := n.entity() // snapshot captured by the build closures
 	teamID := ""
 	if issue.Team != nil {
 		teamID = issue.Team.ID
@@ -379,10 +401,11 @@ func (n *IssueDirectoryNode) manifest() *dirManifest {
 // write path. Without this, go-fuse rejects the temp-file create with a
 // misleading EROFS even though the mount is rw and issue.md is writable (#145).
 func (n *IssueDirectoryNode) Create(ctx context.Context, name string, flags uint32, mode uint32, out *fuse.EntryOut) (*fs.Inode, fs.FileHandle, uint32, syscall.Errno) {
+	issue := n.entity()
 	if n.lfs.debug {
-		log.Printf("Create scratch file in %s: %s", n.issue.Identifier, name)
+		log.Printf("Create scratch file in %s: %s", issue.Identifier, name)
 	}
-	return newScratchInode(ctx, &n.BaseNode, issueDirIno(n.issue.ID), name, out)
+	return newScratchInode(ctx, &n.BaseNode, issueDirIno(issue.ID), name, out)
 }
 
 // Rename persists an editor's atomic save: when a scratch temp file is renamed
@@ -392,8 +415,9 @@ func (n *IssueDirectoryNode) Create(ctx context.Context, name string, flags uint
 // so renames onto any other target — or of the canonical files themselves — are
 // rejected.
 func (n *IssueDirectoryNode) Rename(ctx context.Context, name string, newParent fs.InodeEmbedder, newName string, flags uint32) syscall.Errno {
+	issue := n.entity()
 	if n.lfs.debug {
-		log.Printf("Rename in %s: %s -> %s", n.issue.Identifier, name, newName)
+		log.Printf("Rename in %s: %s -> %s", issue.Identifier, name, newName)
 	}
 
 	// The atomic-save pattern keeps the temp file a sibling of issue.md.
@@ -411,7 +435,7 @@ func (n *IssueDirectoryNode) Rename(ctx context.Context, name string, newParent 
 	if newName != "issue.md" {
 		// A scratch file only has somewhere to persist when renamed onto issue.md,
 		// the one editable file in this directory.
-		n.lfs.SetIssueError(n.issue.ID, fmt.Sprintf("Operation: rename %s -> %s\nError: only issue.md is writable in this directory; save your changes onto issue.md (atomic save-via-rename onto issue.md is supported).", name, newName))
+		n.lfs.SetIssueError(issue.ID, fmt.Sprintf("Operation: rename %s -> %s\nError: only issue.md is writable in this directory; save your changes onto issue.md (atomic save-via-rename onto issue.md is supported).", name, newName))
 		return syscall.ENOTSUP
 	}
 
@@ -421,7 +445,7 @@ func (n *IssueDirectoryNode) Rename(ctx context.Context, name string, newParent 
 	// Linear in that case).
 	fileNode := &IssueFileNode{
 		BaseNode:   BaseNode{lfs: n.lfs},
-		issue:      n.issue,
+		issue:      issue,
 		editBuffer: editBuffer{content: content, dirty: true},
 	}
 	errno := fileNode.Flush(ctx, nil)
@@ -431,8 +455,8 @@ func (n *IssueDirectoryNode) Rename(ctx context.Context, name string, newParent 
 		// stored content, and drop the kernel caches: go-fuse will MvChild the spent
 		// scratch inode over issue.md, so issue.md must re-Lookup to a fresh
 		// IssueFileNode rather than serve the consumed scratch node.
-		n.issue = fileNode.issue
-		n.lfs.InvalidateRenamed(issueDirIno(n.issue.ID), name, newName, issueIno(n.issue.ID))
+		n.setEntity(fileNode.issue)
+		n.lfs.InvalidateRenamed(issueDirIno(fileNode.issue.ID), name, newName, issueIno(fileNode.issue.ID))
 	}
 
 	return errno
@@ -466,8 +490,22 @@ var _ fs.NodeFsyncer = (*IssueFileNode)(nil)
 var _ fs.NodeSetattrer = (*IssueFileNode)(nil)
 
 func (i *IssueFileNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	fileAttr(i.size(), i.issue.CreatedAt, i.issue.UpdatedAt).fill(&out.Attr, &i.BaseNode)
+	// One lock for size + times: a concurrent refresh (refresh.go) swaps
+	// content and entity atomically, so the read must snapshot both together.
+	i.mu.Lock()
+	size := len(i.content)
+	created, updated := i.issue.CreatedAt, i.issue.UpdatedAt
+	i.mu.Unlock()
+	fileAttr(size, created, updated).fill(&out.Attr, &i.BaseNode)
 	return 0
+}
+
+// refreshFrom adopts a fresh twin's issue and rendered content unless an edit
+// is in flight — the dirty buffer is the user's and always wins (refresh.go).
+func (i *IssueFileNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*IssueFileNode); ok {
+		i.refresh(f.content, func() { i.issue = f.issue })
+	}
 }
 
 func (i *IssueFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno {
@@ -636,5 +674,5 @@ func (n *ChildrenNode) Mkdir(ctx context.Context, name string, mode uint32, out 
 
 	// Return the new issue as a directory node (Mkdir must return a directory)
 	node := &IssueDirectoryNode{attrNode: attrNode{BaseNode: BaseNode{lfs: n.lfs}}, issue: *issue}
-	return n.newDirInode(ctx, out, node, dirAttr(issue.CreatedAt, issue.UpdatedAt), issueDirIno(issue.ID), 30*time.Second), 0
+	return n.newDirInode(ctx, out, issue.Identifier, node, dirAttr(issue.CreatedAt, issue.UpdatedAt), issueDirIno(issue.ID), 30*time.Second), 0
 }

--- a/internal/fs/labels.go
+++ b/internal/fs/labels.go
@@ -60,7 +60,7 @@ func (n *LabelsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut
 	}
 
 	if label, ok := n.listing(labels).find(name); ok {
-		return n.newLabelInode(ctx, label, out)
+		return n.newLabelInode(ctx, name, label, out)
 	}
 
 	return nil, syscall.ENOENT
@@ -68,7 +68,7 @@ func (n *LabelsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut
 
 // newLabelInode builds the read/write LabelFileNode inode for an existing label,
 // populated with its current content. Shared by Lookup and Create.
-func (n *LabelsNode) newLabelInode(ctx context.Context, label api.Label, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+func (n *LabelsNode) newLabelInode(ctx context.Context, name string, label api.Label, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
 	content := labelToMarkdown(&label)
 	node := &LabelFileNode{
 		BaseNode:   BaseNode{lfs: n.lfs},
@@ -84,6 +84,9 @@ func (n *LabelsNode) newLabelInode(ctx context.Context, label api.Label, out *fu
 	out.Attr.SetTimes(&now, &now, &now)
 	out.SetAttrTimeout(5 * time.Second)  // Shorter timeout for writable files
 	out.SetEntryTimeout(5 * time.Second) // Shorter timeout for writable files
+	// The bridge dedups AFTER this handler returns: push the fresh
+	// label/content into the node it will keep (see refresh.go).
+	refreshExisting(n, name, node)
 	return n.NewInode(ctx, node, fs.StableAttr{
 		Mode: syscall.S_IFREG,
 		Ino:  labelIno(label.ID),
@@ -197,7 +200,7 @@ func (n *LabelsNode) Create(ctx context.Context, name string, flags uint32, mode
 	// write-only _create node to the name and corrupting it (#137).
 	if labels, err := n.lfs.GetTeamLabels(ctx, n.teamID); err == nil {
 		if label, ok := n.listing(labels).find(name); ok {
-			inode, errno := n.newLabelInode(ctx, label, out)
+			inode, errno := n.newLabelInode(ctx, name, label, out)
 			if errno != 0 {
 				return nil, nil, 0, errno
 			}
@@ -268,6 +271,14 @@ func (n *LabelFileNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.
 	now := time.Now()
 	fileAttr(n.size(), now, now).fill(&out.Attr, &n.BaseNode)
 	return 0
+}
+
+// refreshFrom adopts a fresh twin's label and rendered content unless an edit
+// is in flight — the dirty buffer always wins (refresh.go).
+func (n *LabelFileNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*LabelFileNode); ok {
+		n.refresh(f.content, func() { n.label, n.teamID = f.label, f.teamID })
+	}
 }
 
 func (n *LabelFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno {

--- a/internal/fs/manifest.go
+++ b/internal/fs/manifest.go
@@ -80,7 +80,7 @@ func (m *dirManifest) subdir(name string, ino uint64, node func() dirChild) {
 	m.children = append(m.children, staticChild{
 		name: name, mode: syscall.S_IFDIR,
 		build: func(ctx context.Context, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-			return m.parent.newDirInode(ctx, out, node(), dirAttr(m.created, m.updated), ino, m.timeout), 0
+			return m.parent.newDirInode(ctx, out, name, node(), dirAttr(m.created, m.updated), ino, m.timeout), 0
 		},
 	})
 }
@@ -98,7 +98,7 @@ func (m *dirManifest) file(name string, ino uint64, build func(ctx context.Conte
 				return nil, errno
 			}
 			na := fileAttr(len(content), m.created, m.updated)
-			return m.parent.newFileInode(ctx, out, node, na, ino, m.timeout), 0
+			return m.parent.newFileInode(ctx, out, name, node, na, ino, m.timeout), 0
 		},
 	})
 }
@@ -111,7 +111,7 @@ func (m *dirManifest) renderFile(name string, ino uint64, render renderFunc) {
 	m.children = append(m.children, staticChild{
 		name: name, mode: syscall.S_IFREG,
 		build: func(ctx context.Context, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-			return m.parent.lookupRenderFile(ctx, out, render, ino, m.timeout), 0
+			return m.parent.lookupRenderFile(ctx, out, name, render, ino, m.timeout), 0
 		},
 	})
 }
@@ -122,7 +122,7 @@ func (m *dirManifest) metaFile(name string, render renderFunc) {
 	m.children = append(m.children, staticChild{
 		name: name, mode: syscall.S_IFREG,
 		build: func(ctx context.Context, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-			return m.parent.lfs.lookupMetaFile(ctx, m.parent, m.id, render, out), 0
+			return m.parent.lfs.lookupMetaFile(ctx, m.parent, name, m.id, render, out), 0
 		},
 	})
 }

--- a/internal/fs/metafile.go
+++ b/internal/fs/metafile.go
@@ -32,6 +32,6 @@ import (
 // closure as a child of parent. render is called on demand (Lookup/Read/Getattr)
 // and must return the current meta bytes and times from a live source. Timeouts
 // are zero (like .error/.last) so the file never serves a stale cached size.
-func (lfs *LinearFS) lookupMetaFile(ctx context.Context, parent fs.InodeEmbedder, key string, render renderFunc, out *fuse.EntryOut) *fs.Inode {
-	return lfs.mountRenderFile(ctx, parent, render, metaIno(key), 0, out)
+func (lfs *LinearFS) lookupMetaFile(ctx context.Context, parent fs.InodeEmbedder, name, key string, render renderFunc, out *fuse.EntryOut) *fs.Inode {
+	return lfs.mountRenderFile(ctx, parent, name, render, metaIno(key), 0, out)
 }

--- a/internal/fs/milestones.go
+++ b/internal/fs/milestones.go
@@ -81,6 +81,9 @@ func (n *MilestonesNode) Lookup(ctx context.Context, name string, out *fuse.Entr
 	out.SetAttrTimeout(5 * time.Second)
 	out.SetEntryTimeout(5 * time.Second)
 	out.Attr.SetTimes(&now, &now, &now)
+	// The bridge dedups AFTER this handler returns: push the fresh
+	// milestone/content into the node it will keep (see refresh.go).
+	refreshExisting(n, name, node)
 	return n.NewInode(ctx, node, fs.StableAttr{
 		Mode: syscall.S_IFREG,
 		Ino:  milestoneIno(m.ID),
@@ -150,6 +153,14 @@ func (n *MilestoneFileNode) Getattr(ctx context.Context, f fs.FileHandle, out *f
 	now := time.Now()
 	fileAttr(n.size(), now, now).fill(&out.Attr, &n.BaseNode)
 	return 0
+}
+
+// refreshFrom adopts a fresh twin's milestone and rendered content unless an
+// edit is in flight — the dirty buffer always wins (refresh.go).
+func (n *MilestoneFileNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*MilestoneFileNode); ok {
+		n.refresh(f.content, func() { n.milestone, n.projectID = f.milestone, f.projectID })
+	}
 }
 
 func (n *MilestoneFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno {

--- a/internal/fs/nodeattr.go
+++ b/internal/fs/nodeattr.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"context"
+	"sync"
 	"syscall"
 	"time"
 
@@ -51,9 +52,18 @@ func fileAttr(size int, created, updated time.Time) nodeAttr {
 // BaseNode. It stores the nodeAttr and provides the default Getattr, so a
 // directory node cannot hand-write a divergent one (the drift that had
 // DocsNode/AttachmentsNode reporting time.Now()).
+//
+// The nodeAttr is mutex-guarded because it is no longer write-once: when
+// go-fuse dedups a Lookup onto an already-known node, newDirInode re-runs
+// setAttr on the OLD node with the freshly-fetched times (the attr half of
+// the nodeRefresher seam — see refresh.go), racing with concurrent Getattrs.
+// stateMu doubles as the volatile-state lock for the embedding entity dir
+// nodes (their entity()/setEntity accessors), so an entity swap and its
+// consumers serialize on one lock.
 type attrNode struct {
 	BaseNode
-	na nodeAttr
+	stateMu sync.Mutex
+	na      nodeAttr
 }
 
 var _ fs.NodeGetattrer = (*attrNode)(nil)
@@ -64,10 +74,20 @@ func (n *attrNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrO
 }
 
 // fillAttr is the one renderer shared by Getattr and newDirInode.
-func (n *attrNode) fillAttr(attr *fuse.Attr) { n.na.fill(attr, &n.BaseNode) }
+func (n *attrNode) fillAttr(attr *fuse.Attr) {
+	n.stateMu.Lock()
+	na := n.na
+	n.stateMu.Unlock()
+	na.fill(attr, &n.BaseNode)
+}
 
-// setAttr stashes the reporting identity; called by newDirInode on the child.
-func (n *attrNode) setAttr(na nodeAttr) { n.na = na }
+// setAttr stashes the reporting identity; called by newDirInode on the child
+// (and re-run on a reused node to refresh its times).
+func (n *attrNode) setAttr(na nodeAttr) {
+	n.stateMu.Lock()
+	n.na = na
+	n.stateMu.Unlock()
+}
 
 // dirChild is a node that embeds attrNode.
 type dirChild interface {
@@ -81,11 +101,20 @@ type dirChild interface {
 // child's own fillAttr — the exact method its Getattr uses — sets the entry
 // timeout, and returns the inode. A Lookup answer and a later stat therefore
 // render identically by construction.
-func (b *BaseNode) newDirInode(ctx context.Context, out *fuse.EntryOut, child dirChild, na nodeAttr, ino uint64, timeout time.Duration) *fs.Inode {
+func (b *BaseNode) newDirInode(ctx context.Context, out *fuse.EntryOut, name string, child dirChild, na nodeAttr, ino uint64, timeout time.Duration) *fs.Inode {
 	child.setAttr(na)
 	child.fillAttr(&out.Attr)
 	out.SetAttrTimeout(timeout)
 	out.SetEntryTimeout(timeout)
+	// The bridge dedups AFTER this handler returns: if it still knows a node
+	// under this name, that one will serve — push the freshly-fetched times
+	// and entity into it (see refresh.go).
+	if existing := b.EmbeddedInode().GetChild(name); existing != nil {
+		if dc, ok := existing.Operations().(dirChild); ok && existing.Operations() != fs.InodeEmbedder(child) {
+			dc.setAttr(na)
+		}
+	}
+	refreshExisting(b, name, child)
 	return b.NewInode(ctx, child, fs.StableAttr{Mode: na.mode & syscall.S_IFMT, Ino: ino})
 }
 
@@ -94,9 +123,12 @@ func (b *BaseNode) newDirInode(ctx context.Context, out *fuse.EntryOut, child di
 // legitimately dynamic edit-buffer value that is meant to diverge from what
 // Lookup first reported — so this installs no inherited Getattr; it only shares
 // the immutable-field construction (mode/uid/gid/times) and the initial size.
-func (b *BaseNode) newFileInode(ctx context.Context, out *fuse.EntryOut, child fs.InodeEmbedder, na nodeAttr, ino uint64, timeout time.Duration) *fs.Inode {
+func (b *BaseNode) newFileInode(ctx context.Context, out *fuse.EntryOut, name string, child fs.InodeEmbedder, na nodeAttr, ino uint64, timeout time.Duration) *fs.Inode {
 	na.fill(&out.Attr, b)
 	out.SetAttrTimeout(timeout)
 	out.SetEntryTimeout(timeout)
+	// The bridge dedups AFTER this handler returns: push fresh content/entity
+	// into the node it will keep (a dirty edit buffer wins — see refresh.go).
+	refreshExisting(b, name, child)
 	return b.NewInode(ctx, child, fs.StableAttr{Mode: na.mode & syscall.S_IFMT, Ino: ino})
 }

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -73,7 +73,7 @@ func (p *ProjectsNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 	for _, project := range projects {
 		if projectDirName(project) == name {
 			node := &ProjectNode{attrNode: attrNode{BaseNode: BaseNode{lfs: p.lfs}}, team: p.team, project: project}
-			return p.newDirInode(ctx, out, node, dirAttr(project.CreatedAt, project.UpdatedAt), projectDirIno(project.ID), 30*time.Second), 0
+			return p.newDirInode(ctx, out, name, node, dirAttr(project.CreatedAt, project.UpdatedAt), projectDirIno(project.ID), 30*time.Second), 0
 		}
 	}
 
@@ -114,7 +114,7 @@ func (p *ProjectsNode) Mkdir(ctx context.Context, name string, mode uint32, out 
 	}
 
 	node := &ProjectNode{attrNode: attrNode{BaseNode: BaseNode{lfs: p.lfs}}, team: p.team, project: *project}
-	return p.newDirInode(ctx, out, node, dirAttr(project.CreatedAt, project.UpdatedAt), projectDirIno(project.ID), 30*time.Second), 0
+	return p.newDirInode(ctx, out, projectDirName(*project), node, dirAttr(project.CreatedAt, project.UpdatedAt), projectDirIno(project.ID), 30*time.Second), 0
 }
 
 // Rmdir archives a project (soft delete)
@@ -182,10 +182,34 @@ var _ fs.NodeCreater = (*ProjectNode)(nil)
 var _ fs.NodeRenamer = (*ProjectNode)(nil)
 var _ fs.NodeUnlinker = (*ProjectNode)(nil)
 
+// entity/setEntity snapshot and swap the directory's project (+team) under
+// the node's volatile-state lock: setEntity is written by the Rename
+// write-back and the nodeRefresher seam (refresh.go).
+func (p *ProjectNode) entity() (api.Team, api.Project) {
+	p.stateMu.Lock()
+	defer p.stateMu.Unlock()
+	return p.team, p.project
+}
+
+func (p *ProjectNode) setEntity(project api.Project) {
+	p.stateMu.Lock()
+	p.project = project
+	p.stateMu.Unlock()
+}
+
+func (p *ProjectNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*ProjectNode); ok {
+		p.stateMu.Lock()
+		p.team, p.project = f.team, f.project
+		p.stateMu.Unlock()
+	}
+}
+
 func (p *ProjectNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
+	_, project := p.entity()
 	entries := p.manifest().entries()
 	// Dynamic tail: issue symlinks.
-	issues, err := p.lfs.GetProjectIssues(ctx, p.project.ID)
+	issues, err := p.lfs.GetProjectIssues(ctx, project.ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -201,7 +225,8 @@ func (p *ProjectNode) Lookup(ctx context.Context, name string, out *fuse.EntryOu
 	}
 
 	// Dynamic tail: an issue symlink, resolved only on a static-child miss.
-	issues, err := p.lfs.GetProjectIssues(ctx, p.project.ID)
+	_, project := p.entity()
+	issues, err := p.lfs.GetProjectIssues(ctx, project.ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -220,8 +245,7 @@ func (p *ProjectNode) Lookup(ctx context.Context, name string, out *fuse.EntryOu
 // docs/updates/milestones subdirs. The dynamic tail (issue symlinks) is appended
 // by Readdir/Lookup, not the manifest. Project children have a 0 timeout.
 func (p *ProjectNode) manifest() *dirManifest {
-	project := p.project // snapshot captured by the build closures
-	team := p.team
+	team, project := p.entity() // snapshot captured by the build closures
 	lfs := p.lfs
 	m := newDirManifest(&p.BaseNode, project.ID, project.CreatedAt, project.UpdatedAt, 0)
 
@@ -265,7 +289,8 @@ func (p *ProjectNode) manifest() *dirManifest {
 // EROFS on the rw mount (#145).
 func (p *ProjectNode) Create(ctx context.Context, name string, flags uint32, mode uint32, out *fuse.EntryOut) (*fs.Inode, fs.FileHandle, uint32, syscall.Errno) {
 	if p.lfs.debug {
-		log.Printf("Create scratch file in project %s: %s", p.project.Name, name)
+		_, project := p.entity()
+		log.Printf("Create scratch file in project %s: %s", project.Name, name)
 	}
 	return newScratchInode(ctx, &p.BaseNode, p.EmbeddedInode().StableAttr().Ino, name, out)
 }
@@ -274,8 +299,9 @@ func (p *ProjectNode) Create(ctx context.Context, name string, flags uint32, mod
 // project.md is written through project.md's normal Flush path. project.md is the
 // only writable file here, so other rename targets are rejected.
 func (p *ProjectNode) Rename(ctx context.Context, name string, newParent fs.InodeEmbedder, newName string, flags uint32) syscall.Errno {
+	team, project := p.entity()
 	if p.lfs.debug {
-		log.Printf("Rename in project %s: %s -> %s", p.project.Name, name, newName)
+		log.Printf("Rename in project %s: %s -> %s", project.Name, name, newName)
 	}
 
 	dirIno := p.EmbeddedInode().StableAttr().Ino
@@ -289,21 +315,21 @@ func (p *ProjectNode) Rename(ctx context.Context, name string, newParent fs.Inod
 	}
 
 	if newName != "project.md" {
-		p.lfs.SetWriteError(p.project.ID, fmt.Sprintf("Operation: rename %s -> %s\nError: only project.md is writable in this directory; save your changes onto project.md (atomic save-via-rename onto project.md is supported).", name, newName))
+		p.lfs.SetWriteError(project.ID, fmt.Sprintf("Operation: rename %s -> %s\nError: only project.md is writable in this directory; save your changes onto project.md (atomic save-via-rename onto project.md is supported).", name, newName))
 		return syscall.ENOTSUP
 	}
 
 	fileNode := &ProjectInfoNode{
 		BaseNode:   BaseNode{lfs: p.lfs},
-		team:       p.team,
-		project:    p.project,
+		team:       team,
+		project:    project,
 		editBuffer: editBuffer{content: content, dirty: true},
 	}
 	errno := fileNode.Flush(ctx, nil)
 
 	if errno == 0 || errno == syscall.EIO {
-		p.project = fileNode.project
-		p.lfs.InvalidateRenamed(dirIno, name, newName, projectInfoIno(p.project.ID))
+		p.setEntity(fileNode.project)
+		p.lfs.InvalidateRenamed(dirIno, name, newName, projectInfoIno(fileNode.project.ID))
 	}
 
 	return errno
@@ -356,8 +382,22 @@ func (p *ProjectInfoNode) metaContent() []byte {
 }
 
 func (p *ProjectInfoNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	fileAttr(p.size(), p.project.CreatedAt, p.project.UpdatedAt).fill(&out.Attr, &p.BaseNode)
+	// One lock for size + times: a concurrent refresh (refresh.go) swaps
+	// content and entity atomically, so the read must snapshot both together.
+	p.mu.Lock()
+	size := len(p.content)
+	created, updated := p.project.CreatedAt, p.project.UpdatedAt
+	p.mu.Unlock()
+	fileAttr(size, created, updated).fill(&out.Attr, &p.BaseNode)
 	return 0
+}
+
+// refreshFrom adopts a fresh twin's project and rendered content unless an
+// edit is in flight — the dirty buffer always wins (refresh.go).
+func (p *ProjectInfoNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*ProjectInfoNode); ok {
+		p.refresh(f.content, func() { p.team, p.project = f.team, f.project })
+	}
 }
 
 func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno {
@@ -519,7 +559,7 @@ func (n *UpdatesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOu
 	if !ok {
 		return nil, syscall.ENOENT
 	}
-	return n.lookupUpdateFile(ctx, out, update.ID, update.Health, update.CreatedAt, update.UpdatedAt,
+	return n.lookupUpdateFile(ctx, out, name, update.ID, update.Health, update.CreatedAt, update.UpdatedAt,
 		update.User, update.Body, projectUpdateIno(update.ID)), 0
 }
 

--- a/internal/fs/refresh.go
+++ b/internal/fs/refresh.go
@@ -1,0 +1,52 @@
+package fs
+
+import (
+	"github.com/hanwen/go-fuse/v2/fs"
+)
+
+// nodeRefresher is the seam that closes the captured-entity staleness hole
+// (round 15): go-fuse deduplicates inodes by StableAttr — bridge.addNewChild
+// keeps the FIRST node ever mounted for an ino and silently discards the
+// freshly-constructed one — so a node that bakes entity state at construction
+// (an editBuffer's content, a directory's entity, a render closure's capture)
+// would serve first-Lookup data for as long as the kernel remembers the
+// inode. The sync worker deliberately never notifies the kernel; freshness
+// arrives via attr/entry timeout expiry forcing a re-Lookup — and that
+// re-Lookup is exactly where this seam acts: the parent has just fetched the
+// entity fresh and built a fresh node; if the bridge still knows an old node
+// under this name, push the fresh state into it.
+//
+// The dedup itself happens in the bridge AFTER a Lookup handler returns
+// (addNewChild — NewInode's return value is always the fresh struct), so the
+// seam cannot detect reuse from NewInode's result. Instead the construction
+// helpers probe parent.GetChild(name): the inode the bridge will keep if it
+// dedups. A nil child (kernel FORGOT it) means the fresh node will be
+// installed — already fresh, nothing to do.
+//
+// Implementations swap their volatile state under their own lock, and an
+// editBuffer node MUST skip the refresh while dirty — a user's in-flight
+// edit always wins over a background sync.
+//
+// TestRemoteUpdateVisibleAfterKernelRevalidation (internal/integration) is
+// the end-to-end guard: remote upsert → kernel revalidation → fresh reads.
+type nodeRefresher interface {
+	refreshFrom(fresh fs.InodeEmbedder)
+}
+
+// refreshExisting runs inside a construction seam, before NewInode: if the
+// parent still links a child by this name, that node is what the bridge will
+// keep — push the fresh twin's volatile state into it. Nodes that don't
+// implement the seam (id-only collection dirs, symlinks) are unaffected.
+func refreshExisting(parent fs.InodeEmbedder, name string, fresh fs.InodeEmbedder) {
+	inode := parent.EmbeddedInode().GetChild(name)
+	if inode == nil {
+		return
+	}
+	ops := inode.Operations()
+	if ops == fresh {
+		return
+	}
+	if r, ok := ops.(nodeRefresher); ok {
+		r.refreshFrom(fresh)
+	}
+}

--- a/internal/fs/relations.go
+++ b/internal/fs/relations.go
@@ -80,7 +80,7 @@ func (n *RelationsNode) Lookup(ctx context.Context, name string, out *fuse.Entry
 		if rel.RelatedIssue != nil && rel.RelatedIssue.Identifier != "" {
 			expectedName := fmt.Sprintf("%s-%s", rel.Type, rel.RelatedIssue.Identifier)
 			if baseName == expectedName {
-				return n.createRelationFileNode(ctx, rel, false, out)
+				return n.createRelationFileNode(ctx, name, rel, false, out)
 			}
 		}
 	}
@@ -92,7 +92,7 @@ func (n *RelationsNode) Lookup(ctx context.Context, name string, out *fuse.Entry
 			inverseName := inverseRelationType(rel.Type)
 			expectedName := fmt.Sprintf("%s-%s", inverseName, rel.Issue.Identifier)
 			if baseName == expectedName {
-				return n.createRelationFileNode(ctx, rel, true, out)
+				return n.createRelationFileNode(ctx, name, rel, true, out)
 			}
 		}
 	}
@@ -100,7 +100,7 @@ func (n *RelationsNode) Lookup(ctx context.Context, name string, out *fuse.Entry
 	return nil, syscall.ENOENT
 }
 
-func (n *RelationsNode) createRelationFileNode(ctx context.Context, rel api.IssueRelation, isInverse bool, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+func (n *RelationsNode) createRelationFileNode(ctx context.Context, name string, rel api.IssueRelation, isInverse bool, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
 	node := &RelationFileNode{
 		renderFile: renderFile{
 			BaseNode: BaseNode{lfs: n.lfs},
@@ -112,7 +112,7 @@ func (n *RelationsNode) createRelationFileNode(ctx context.Context, rel api.Issu
 		isInverse: isInverse,
 		issueID:   n.issueID,
 	}
-	return n.newRenderInode(ctx, out, node, relationIno(rel.ID), 30*time.Second), 0
+	return n.newRenderInode(ctx, out, name, node, relationIno(rel.ID), 30*time.Second), 0
 }
 
 // inverseRelationType returns the inverse relation type name
@@ -142,6 +142,19 @@ type RelationFileNode struct {
 
 var _ fs.NodeUnlinker = (*RelationFileNode)(nil)
 
+// refreshFrom adopts a fresh twin's relation and render closure (refresh.go);
+// renderMu doubles as the entity-field lock.
+func (n *RelationFileNode) refreshFrom(fresh fs.InodeEmbedder) {
+	f, ok := fresh.(*RelationFileNode)
+	if !ok {
+		return
+	}
+	n.renderMu.Lock()
+	n.render = f.render
+	n.relation, n.isInverse, n.issueID = f.relation, f.isInverse, f.issueID
+	n.renderMu.Unlock()
+}
+
 // relationContent renders a relation file's YAML body.
 func relationContent(rel api.IssueRelation, isInverse bool) string {
 	var sb strings.Builder
@@ -170,9 +183,15 @@ func (n *RelationFileNode) Unlink(ctx context.Context, name string) syscall.Errn
 
 	// The file node already holds its entity, so find just hands it over.
 	return commitDelete(ctx, n.lfs, deleteSpec[api.IssueRelation]{
-		op:   `delete relation "` + name + `"`,
-		key:  collectionErrorKey("relations", n.issueID),
-		find: func(context.Context) (*api.IssueRelation, error) { return &n.relation, nil },
+		op:  `delete relation "` + name + `"`,
+		key: collectionErrorKey("relations", n.issueID),
+		find: func(context.Context) (*api.IssueRelation, error) {
+			// Snapshot: a concurrent refresh (refresh.go) may swap the field.
+			n.renderMu.Lock()
+			rel := n.relation
+			n.renderMu.Unlock()
+			return &rel, nil
+		},
 		mutate: func(ctx context.Context, r *api.IssueRelation) error {
 			return n.lfs.mutator().DeleteIssueRelation(ctx, r.ID)
 		},

--- a/internal/fs/renderfile.go
+++ b/internal/fs/renderfile.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"context"
+	"sync"
 	"syscall"
 	"time"
 
@@ -39,7 +40,39 @@ type renderFunc func(ctx context.Context) (content []byte, mtime, ctime time.Tim
 // only its extra methods. See CONTEXT.md "Render file".
 type renderFile struct {
 	BaseNode
-	render renderFunc
+	// renderMu guards render: a reused node's closure is swapped for the
+	// fresh one by the nodeRefresher seam (refresh.go) while concurrent
+	// reads snapshot it.
+	renderMu sync.Mutex
+	render   renderFunc
+}
+
+// renderNow snapshots the closure under the lock and runs it outside it (a
+// render may do I/O; holding the lock across it would serialize readers).
+func (r *renderFile) renderNow(ctx context.Context) ([]byte, time.Time, time.Time) {
+	r.renderMu.Lock()
+	render := r.render
+	r.renderMu.Unlock()
+	return render(ctx)
+}
+
+// refreshRender adopts a fresh twin's closure — the renderFile half of a
+// nodeRefresher implementation (the embedding type swaps its own fields).
+func (r *renderFile) refreshRender(fresh *renderFile) {
+	r.renderMu.Lock()
+	r.render = fresh.render
+	r.renderMu.Unlock()
+}
+
+// refreshFrom makes a bare renderFile adopt a fresh twin's closure — a
+// stable-ino render file whose closure captures entity state (a status
+// update's body, history.md's issue times) would otherwise serve the
+// first-Lookup capture forever (refresh.go). Types embedding renderFile with
+// extra fields shadow this with their own implementation.
+func (r *renderFile) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*renderFile); ok {
+		r.refreshRender(f)
+	}
 }
 
 var _ fs.NodeGetattrer = (*renderFile)(nil)
@@ -51,7 +84,7 @@ var _ renderChild = (*renderFile)(nil)
 // Getattr and a Lookup must agree on. Both go through this one path, so — as
 // with attrNode — the two can never disagree.
 func (r *renderFile) renderAttr(ctx context.Context) nodeAttr {
-	content, mtime, ctime := r.render(ctx)
+	content, mtime, ctime := r.renderNow(ctx)
 	return nodeAttr{mode: 0444 | syscall.S_IFREG, size: uint64(len(content)), created: ctime, updated: mtime}
 }
 
@@ -74,7 +107,7 @@ func (r *renderFile) Open(ctx context.Context, flags uint32) (fs.FileHandle, uin
 }
 
 func (r *renderFile) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	content, _, _ := r.render(ctx)
+	content, _, _ := r.renderNow(ctx)
 	return readWindow(content, dest, off), 0
 }
 
@@ -121,7 +154,10 @@ func fillRenderEntry(ctx context.Context, out *fuse.EntryOut, child renderChild,
 // inode — the render-through file counterpart to newDirInode, called on the
 // parent. Used by the nodes that embed renderFile plus extra methods
 // (RelationFileNode/ExternalAttachmentNode). ino 0 auto-assigns.
-func (b *BaseNode) newRenderInode(ctx context.Context, out *fuse.EntryOut, child renderChild, ino uint64, timeout time.Duration) *fs.Inode {
+func (b *BaseNode) newRenderInode(ctx context.Context, out *fuse.EntryOut, name string, child renderChild, ino uint64, timeout time.Duration) *fs.Inode {
+	// The bridge dedups AFTER this handler returns: push the fresh
+	// closure/entity into the node it will keep (see refresh.go).
+	refreshExisting(b, name, child)
 	fillRenderEntry(ctx, out, child, timeout)
 	return b.NewInode(ctx, child, fs.StableAttr{Mode: syscall.S_IFREG, Ino: ino})
 }
@@ -130,16 +166,19 @@ func (b *BaseNode) newRenderInode(ctx context.Context, out *fuse.EntryOut, child
 // by a render closure as a child of the receiver's node — the one-liner the pure
 // generated-file sites (team.md, states.md, user.md, README.md, …) use in place
 // of a hand-rolled node type.
-func (b *BaseNode) lookupRenderFile(ctx context.Context, out *fuse.EntryOut, render renderFunc, ino uint64, timeout time.Duration) *fs.Inode {
+func (b *BaseNode) lookupRenderFile(ctx context.Context, out *fuse.EntryOut, name string, render renderFunc, ino uint64, timeout time.Duration) *fs.Inode {
 	node := &renderFile{BaseNode: BaseNode{lfs: b.lfs}, render: render}
-	return b.newRenderInode(ctx, out, node, ino, timeout)
+	return b.newRenderInode(ctx, out, name, node, ino, timeout)
 }
 
 // mountRenderFile mounts a bare render file under an arbitrary parent embedder —
 // the variant the .meta/.error/.last helpers use, where the parent is handed in
 // as an fs.InodeEmbedder rather than a *BaseNode.
-func (lfs *LinearFS) mountRenderFile(ctx context.Context, parent fs.InodeEmbedder, render renderFunc, ino uint64, timeout time.Duration, out *fuse.EntryOut) *fs.Inode {
+func (lfs *LinearFS) mountRenderFile(ctx context.Context, parent fs.InodeEmbedder, name string, render renderFunc, ino uint64, timeout time.Duration, out *fuse.EntryOut) *fs.Inode {
 	node := &renderFile{BaseNode: BaseNode{lfs: lfs}, render: render}
+	// The bridge dedups AFTER this handler returns: push the fresh closure
+	// into the node it will keep (see refresh.go).
+	refreshExisting(parent, name, node)
 	fillRenderEntry(ctx, out, node, timeout)
 	return parent.EmbeddedInode().NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFREG, Ino: ino})
 }

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -44,7 +44,7 @@ func (r *RootNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 	case "README.md":
 		// The generated docs have no natural entity time; report zero (unknown).
 		lfs := r.lfs
-		return r.lookupRenderFile(ctx, out, func(context.Context) ([]byte, time.Time, time.Time) {
+		return r.lookupRenderFile(ctx, out, "README.md", func(context.Context) ([]byte, time.Time, time.Time) {
 			return []byte(generateReadme(lfs.MountPoint())), time.Time{}, time.Time{}
 		}, 0, inheritTimeout), 0
 

--- a/internal/fs/successfile.go
+++ b/internal/fs/successfile.go
@@ -160,5 +160,5 @@ func (lfs *LinearFS) lookupSuccessFile(ctx context.Context, parent fs.InodeEmbed
 		}
 		return content, latest, latest
 	}
-	return lfs.mountRenderFile(ctx, parent, render, successIno(key), 0, out)
+	return lfs.mountRenderFile(ctx, parent, ".last", render, successIno(key), 0, out)
 }

--- a/internal/fs/teams.go
+++ b/internal/fs/teams.go
@@ -104,7 +104,7 @@ func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 	switch name {
 	case "team.md":
 		team := t.team
-		return t.lookupRenderFile(ctx, out, func(context.Context) ([]byte, time.Time, time.Time) {
+		return t.lookupRenderFile(ctx, out, "team.md", func(context.Context) ([]byte, time.Time, time.Time) {
 			return teamMarkdown(team), team.UpdatedAt, team.CreatedAt
 		}, 0, inheritTimeout), 0
 
@@ -113,7 +113,7 @@ func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 		// team's times as a stable proxy — never now(). Content is fetched from
 		// SQLite on each read (cheap), so no node-level cache is needed.
 		lfs, team := t.lfs, t.team
-		return t.lookupRenderFile(ctx, out, func(ctx context.Context) ([]byte, time.Time, time.Time) {
+		return t.lookupRenderFile(ctx, out, "states.md", func(ctx context.Context) ([]byte, time.Time, time.Time) {
 			states, err := lfs.GetTeamStates(ctx, team.ID)
 			if err != nil {
 				return []byte("# Error loading states\n"), team.UpdatedAt, team.CreatedAt
@@ -123,7 +123,7 @@ func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 
 	case "labels.md":
 		lfs, team := t.lfs, t.team
-		return t.lookupRenderFile(ctx, out, func(ctx context.Context) ([]byte, time.Time, time.Time) {
+		return t.lookupRenderFile(ctx, out, "labels.md", func(ctx context.Context) ([]byte, time.Time, time.Time) {
 			labels, err := lfs.GetTeamLabels(ctx, team.ID)
 			if err != nil {
 				return []byte("# Error loading labels\n"), team.UpdatedAt, team.CreatedAt
@@ -185,11 +185,11 @@ func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 
 	case "docs":
 		node := &DocsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: t.lfs}}, teamID: t.team.ID}
-		return t.newDirInode(ctx, out, node, dirAttr(t.team.CreatedAt, t.team.UpdatedAt), docsDirIno(t.team.ID), 0), 0
+		return t.newDirInode(ctx, out, "docs", node, dirAttr(t.team.CreatedAt, t.team.UpdatedAt), docsDirIno(t.team.ID), 0), 0
 
 	case "labels":
 		node := &LabelsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: t.lfs}}, teamID: t.team.ID}
-		return t.newDirInode(ctx, out, node, dirAttr(t.team.CreatedAt, t.team.UpdatedAt), labelsDirIno(t.team.ID), 0), 0
+		return t.newDirInode(ctx, out, "labels", node, dirAttr(t.team.CreatedAt, t.team.UpdatedAt), labelsDirIno(t.team.ID), 0), 0
 	}
 
 	return nil, syscall.ENOENT

--- a/internal/fs/updates.go
+++ b/internal/fs/updates.go
@@ -17,11 +17,11 @@ import (
 // carry, so the fields are passed positionally (the two update structs share no
 // interface). Collapses the render-closure + lookupRenderFile pairing the two
 // Lookups hand-rolled identically.
-func (b *BaseNode) lookupUpdateFile(ctx context.Context, out *fuse.EntryOut, id, health string, created, updated time.Time, user *api.User, body string, ino uint64) *fs.Inode {
+func (b *BaseNode) lookupUpdateFile(ctx context.Context, out *fuse.EntryOut, name, id, health string, created, updated time.Time, user *api.User, body string, ino uint64) *fs.Inode {
 	render := func(context.Context) ([]byte, time.Time, time.Time) {
 		return updateMarkdown(id, health, created, updated, user, body), updated, created
 	}
-	return b.lookupRenderFile(ctx, out, render, ino, 30*time.Second)
+	return b.lookupRenderFile(ctx, out, name, render, ino, 30*time.Second)
 }
 
 // updateMarkdown renders a status update (project or initiative) as

--- a/internal/fs/users.go
+++ b/internal/fs/users.go
@@ -123,7 +123,7 @@ func (u *UserNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 	// so the file honestly reports zero (unknown) rather than a fabricated now().
 	if name == "user.md" {
 		user := u.user
-		return u.lookupRenderFile(ctx, out, func(context.Context) ([]byte, time.Time, time.Time) {
+		return u.lookupRenderFile(ctx, out, "user.md", func(context.Context) ([]byte, time.Time, time.Time) {
 			return userMarkdown(user), time.Time{}, time.Time{}
 		}, 0, inheritTimeout), 0
 	}

--- a/internal/integration/cache_test.go
+++ b/internal/integration/cache_test.go
@@ -33,12 +33,11 @@ func TestCacheHitOnReread(t *testing.T) {
 	}
 }
 
-func TestCacheExpiryRefreshesData(t *testing.T) {
-	// This test verifies that external API changes eventually become visible
-	// Note: Due to FUSE inode caching, this may require the inode to be evicted
-	// which happens after the entry timeout (30s by default)
-	t.Skip("Skipped: FUSE inode caching prevents immediate refresh - see filesystem implementation")
-}
+// External-change visibility is guarded by
+// TestRemoteUpdateVisibleAfterKernelRevalidation (staleness_test.go): the old
+// skipped TestCacheExpiryRefreshesData lived here — its skip message ("FUSE
+// inode caching prevents immediate refresh") was the captured-entity staleness
+// bug the nodeRefresher seam (internal/fs/refresh.go) now fixes.
 
 func TestIssueEditInvalidatesTeamCache(t *testing.T) {
 	skipIfNoWriteTests(t)

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -21,6 +21,7 @@ var (
 	mountPoint  string
 	server      *fuse.Server
 	lfs         *fs.LinearFS
+	testStore   *db.Store // fixture mode: the store behind the mount, for tests simulating sync-side writes
 	apiClient   *api.Client
 	testTeamID  string
 	testTeamKey string
@@ -138,6 +139,8 @@ func setupSQLiteFixtures() error {
 		os.RemoveAll(mountPoint)
 		return fmt.Errorf("create linearfs: %w", err)
 	}
+
+	testStore = store
 
 	// Inject the store and create repository (no API client for fetching)
 	if err := lfs.InjectTestStore(store); err != nil {

--- a/internal/integration/staleness_test.go
+++ b/internal/integration/staleness_test.go
@@ -1,0 +1,117 @@
+package integration
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jra3/linear-fuse/internal/db"
+	"github.com/jra3/linear-fuse/internal/testutil/fixtures"
+)
+
+// TestRemoteUpdateVisibleAfterKernelRevalidation is the decisive experiment
+// for the captured-entity staleness question (round-15 review, candidate 1):
+// when a REMOTE change lands in SQLite (the sync worker's job — it never
+// notifies the kernel), freshness relies on the kernel re-asking userspace
+// via Lookup after its caches drop. go-fuse then reuses the already-known
+// node for a stable ino (bridge.addNewChild: "child is ignored"), so if the
+// serving nodes bake the entity at first Lookup, the re-Lookup serves the
+// OLD data anyway — stale for as long as the kernel remembers the inode.
+//
+// The test simulates the full revalidation cycle deterministically: read
+// (populate nodes) → upsert a changed row (simulate sync) → drop the kernel
+// dentries/attrs explicitly (what timeout expiry does, without waiting 30s)
+// → re-read. Fresh content passing means the reuse hazard is compensated;
+// stale content is the latent bug, confirmed end-to-end.
+func TestRemoteUpdateVisibleAfterKernelRevalidation(t *testing.T) {
+	ctx := context.Background()
+	path := mountPoint + "/teams/TST/issues/TST-1/issue.md"
+
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("first read: %v", err)
+	}
+	if !strings.Contains(string(before), "Test Issue 1") {
+		t.Fatalf("fixture issue not served, got:\n%s", before)
+	}
+
+	// Pin the inode chain: an open descriptor keeps the kernel from
+	// FORGETting the file inode and its ancestor dentries during the wait,
+	// so the post-expiry re-Lookups hit the ALREADY-KNOWN nodes — the
+	// go-fuse reuse path this test exists to guard (without the pin, the
+	// kernel may forget everything and build fresh nodes, which was fresh
+	// even before the nodeRefresher seam existed).
+	pin, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("pin open: %v", err)
+	}
+	defer pin.Close()
+
+	// Simulate the sync worker landing a remote edit: same issue, new title,
+	// newer updatedAt — written straight to the store, no kernel notification
+	// (faithful to production sync).
+	team := fixtures.FixtureAPITeam()
+	renamed := fixtures.FixtureAPIIssue(
+		fixtures.WithIssueID("issue-1", "TST-1"),
+		fixtures.WithTitle("Renamed By Remote Sync"),
+		fixtures.WithTeam(&team),
+	)
+	renamed.UpdatedAt = time.Now()
+	row, err := db.APIIssueToDBIssue(renamed)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if testStore == nil {
+		t.Skip("store-backed staleness simulation requires fixture mode")
+	}
+	if err := testStore.Queries().UpsertIssue(ctx, row.ToUpsertParams()); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	// Let the kernel's caches expire for real — the production freshness
+	// mechanism. The sync worker never notifies the kernel; entry timeouts
+	// (30s) make the next path walk re-Lookup every component, and each
+	// re-Lookup runs the nodeRefresher seam. (Targeted EntryNotify calls
+	// can't stand in for this: several ancestor dirs use auto-assigned inos,
+	// so their kernel ids aren't derivable from the ino namespace.)
+	if testing.Short() {
+		t.Skip("waits out the 30s kernel entry timeout; skipped with -short")
+	}
+	time.Sleep(31 * time.Second)
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if !strings.Contains(string(after), "Renamed By Remote Sync") {
+		t.Errorf("STALE: issue.md still serves first-Lookup content after remote update + full kernel revalidation.\ngot:\n%s", after)
+	}
+
+	// The reported mtime should likewise follow the remote update.
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if age := time.Since(st.ModTime()); age > time.Hour {
+		t.Errorf("STALE ATTRS: issue.md mtime %v predates the remote update (age %v)", st.ModTime(), age)
+	}
+
+	// Layer isolation: issue.meta's render closure RE-FETCHES by identifier on
+	// every read (the freshestByID pattern) instead of trusting the captured
+	// entity. If .meta is fresh while issue.md is stale, the mechanism is
+	// pinned: go-fuse node reuse + entity captured at first Lookup.
+	meta, err := os.ReadFile(mountPoint + "/teams/TST/issues/TST-1/issue.meta")
+	if err != nil {
+		t.Fatalf("read issue.meta: %v", err)
+	}
+	if !strings.Contains(string(meta), "Renamed By Remote Sync") {
+		// .meta doesn't render the title — check the updated timestamp instead.
+		if !strings.Contains(string(meta), time.Now().Format("2006-01-02")) {
+			t.Logf("NOTE: issue.meta also stale (updated stamp not today):\n%s", meta)
+		} else {
+			t.Logf("CONTRAST: issue.meta reflects the remote update (re-fetching closure) while issue.md does not:\n%s", meta)
+		}
+	}
+}


### PR DESCRIPTION
Round-15 review candidate 1, dug to ground and confirmed by experiment before fixing.

## The bug
go-fuse dedups inodes by StableAttr and keeps the **first node ever mounted** for an ino — `bridge.addNewChild` silently discards the freshly-constructed node *after* the Lookup handler returns. Every node baking entity state at construction (the 7 editBuffer content files, the 3 entity dir nodes, entity-capturing render closures) served first-Lookup data for as long as the kernel remembered the inode. The sync worker never notifies the kernel (by design); the timeout-driven re-Lookup that should restore freshness hit the old node. Net effect: **a teammate's edit never appeared in `issue.md` on re-read** — stale content *and* stale mtime, indefinitely. The long-skipped `TestCacheExpiryRefreshesData` ("FUSE inode caching prevents immediate refresh") was this bug filed away as a skip.

Diagnosis milestones: reproduced end-to-end in a mounted test (stale content + Jan-2024 mtime after remote upsert + full revalidation); isolated the mechanism via a built-in contrast (`issue.meta` re-fetches in its closure and stayed fresh while `issue.md` didn't); discovered `NewInode`'s return value can't detect reuse (dedup happens post-handler), which killed the first fix attempt and led to the `GetChild` probe.

## The fix — `nodeRefresher` seam (internal/fs/refresh.go)
Construction helpers take the child's name and probe `parent.GetChild(name)` inside the handler — the node the bridge will keep — and push the fresh twin's volatile state into it:
- entity dirs swap under `attrNode.stateMu` (also re-stamps times) with `entity()/setEntity` snapshots
- editBuffer files via `editBuffer.refresh` — **a dirty buffer always wins**; a user's in-flight edit is never clobbered by background sync
- `renderFile` swaps its closure under `renderMu`; `EmbeddedFileNode` its metadata under its own mutex
- all entity reads that now race a refresh moved behind the same locks; `go test -race ./internal/fs` clean

## The guard
`TestRemoteUpdateVisibleAfterKernelRevalidation`: remote upsert straight to SQLite, an **open fd pinning the inode chain** so the kernel can't FORGET (this forces the reuse path — without the pin the kernel may drop everything and the test passes vacuously), a real 31s entry-timeout expiry, then fresh content and mtime asserted. Full suite + vet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)