### PR TITLE
Round-15 smalls: embedded-file times, columns-win guards, relation fragments, Touch note

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -948,12 +948,14 @@ func (c *Client) GetIssueDetailsBatch(ctx context.Context, issueIDs []string) (m
 		varDecls = append(varDecls, fmt.Sprintf("$id%d: String!", i))
 	}
 
-	query := fmt.Sprintf(`query IssueDetailsBatch(%s) { %s } %s %s %s`,
+	query := fmt.Sprintf(`query IssueDetailsBatch(%s) { %s } %s %s %s %s %s`,
 		strings.Join(varDecls, ", "),
 		strings.Join(queryParts, " "),
 		CommentFieldsFragment,
 		DocumentFieldsFragment,
 		AttachmentFieldsFragment,
+		issueRelationFieldsFragment,
+		issueInverseRelationFieldsFragment,
 	)
 
 	// Result will be a map of alias -> issue data

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -33,7 +33,7 @@ var queryIssue = `
 query Issue($id: String!) {
   issue(id: $id) { ...IssueFields }
 }
-` + issueFieldsFragment
+` + issueFieldsFragment + issueRelationFieldsFragment + issueInverseRelationFieldsFragment
 
 // issueFieldsFragmentLite is a lighter fragment for bulk queries (no relations).
 // Use this for fetching many issues at once to avoid GraphQL complexity limits.
@@ -67,6 +67,19 @@ fragment IssueFieldsLite on Issue {
 }
 `
 
+// issueRelationFieldsFragment / issueInverseRelationFieldsFragment project a
+// relation node's fields exactly once — referenced by both the IssueFields
+// fragment and IssueDetailsSelection, so the two selections can never drift
+// (the fragment rule: an inlined copy silently diverges when one gains a
+// field). A query that references them must append them.
+const issueRelationFieldsFragment = `
+fragment IssueRelationFields on IssueRelation { id type relatedIssue { id identifier title } createdAt updatedAt }
+`
+
+const issueInverseRelationFieldsFragment = `
+fragment IssueInverseRelationFields on IssueRelation { id type issue { id identifier title } createdAt updatedAt }
+`
+
 // issueFieldsFragment is a GraphQL fragment containing all fields fetched for an issue.
 // Includes relations - use only for single-issue queries to avoid complexity limits.
 const issueFieldsFragment = `
@@ -96,8 +109,8 @@ fragment IssueFields on Issue {
   parent { id identifier title }
   children { nodes { id identifier title createdAt updatedAt } }
   cycle { id name number }
-  relations { nodes { id type relatedIssue { id identifier title } createdAt updatedAt } }
-  inverseRelations { nodes { id type issue { id identifier title } createdAt updatedAt } }
+  relations { nodes { ...IssueRelationFields } }
+  inverseRelations { nodes { ...IssueInverseRelationFields } }
 }
 `
 
@@ -774,8 +787,8 @@ const IssueRelationsPageSize = 50
 var IssueDetailsSelection = fmt.Sprintf(`comments(first: %d) { nodes { ...CommentFields } }
     documents(first: %d) { nodes { ...DocumentFields } }
     attachments(first: %d) { nodes { ...AttachmentFields } }
-    relations(first: %d) { nodes { id type relatedIssue { id identifier title } createdAt updatedAt } }
-    inverseRelations(first: %d) { nodes { id type issue { id identifier title } createdAt updatedAt } }`,
+    relations(first: %d) { nodes { ...IssueRelationFields } }
+    inverseRelations(first: %d) { nodes { ...IssueInverseRelationFields } }`,
 	IssueDetailsPageSize, IssueDetailsPageSize, IssueDetailsPageSize, IssueRelationsPageSize, IssueRelationsPageSize)
 
 // queryIssueDetails fetches comments, documents, attachments, and relations
@@ -787,7 +800,8 @@ query IssueDetails($issueId: String!) {
   }
 }
 `, IssueDetailsSelection) +
-	CommentFieldsFragment + DocumentFieldsFragment + AttachmentFieldsFragment
+	CommentFieldsFragment + DocumentFieldsFragment + AttachmentFieldsFragment +
+	issueRelationFieldsFragment + issueInverseRelationFieldsFragment
 
 // queryIssueAttachments fetches only attachments for an issue
 var queryIssueAttachments = `

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -353,7 +353,8 @@ type EmbeddedFile struct {
 	FileSize  int64     // File size in bytes (0 if unknown)
 	CachePath string    // Local cache path (empty if not cached)
 	Source    string    // Where found: "description" or "comment:{id}"
-	SyncedAt  time.Time // When metadata was synced
+	CreatedAt time.Time // When the row was first extracted (the file's ctime)
+	SyncedAt  time.Time // When metadata was synced (the file's mtime)
 }
 
 // TeamMetadata contains all metadata for a team fetched in a single query.

--- a/internal/db/convert.go
+++ b/internal/db/convert.go
@@ -857,6 +857,7 @@ func DBEmbeddedFileToAPIFile(file EmbeddedFile) api.EmbeddedFile {
 		FileSize:  file.FileSize.Int64,
 		CachePath: NullStringValue(file.CachePath),
 		Source:    file.Source,
+		CreatedAt: file.CreatedAt,
 		SyncedAt:  file.SyncedAt,
 	}
 }

--- a/internal/db/convert_test.go
+++ b/internal/db/convert_test.go
@@ -1385,3 +1385,102 @@ func TestDBEmbeddedFilesToAPIFilesEmpty(t *testing.T) {
 		t.Errorf("Expected empty slice, got %d files", len(apiFiles))
 	}
 }
+
+// TestOverlayColumnsWin pins the other half of the reverse-conversion
+// contract: the columns are AUTHORITATIVE, so when the data blob disagrees
+// with a column (which cannot happen through the normal write path, but is
+// exactly what a column added to the sqlc model and FORGOTTEN in the overlay
+// would look like), every column-backed field must read the column's value —
+// never the blob's stale copy. A new column without an overlay assignment and
+// a matching assertion here should fail loudly in review.
+func TestOverlayColumnsWin(t *testing.T) {
+	t.Parallel()
+
+	t.Run("state", func(t *testing.T) {
+		t.Parallel()
+		blob := mustMarshal(api.State{ID: "blob-id", Name: "blob-name", Type: "blob-type"})
+		got := DBStateToAPIState(State{ID: "col-id", Name: "col-name", Type: "col-type", Data: blob})
+		want := api.State{ID: "col-id", Name: "col-name", Type: "col-type"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("blob won over columns:\n got=%+v\nwant=%+v", got, want)
+		}
+	})
+
+	t.Run("label", func(t *testing.T) {
+		t.Parallel()
+		blob := mustMarshal(api.Label{ID: "blob-id", Name: "blob-name", Color: "blob-color", Description: "blob-desc", Team: &api.Team{ID: "blob-team"}})
+		got := DBLabelToAPILabel(Label{
+			ID:          "col-id",
+			Name:        "col-name",
+			Color:       sql.NullString{String: "col-color", Valid: true},
+			Description: sql.NullString{String: "col-desc", Valid: true},
+			TeamID:      sql.NullString{String: "col-team", Valid: true},
+			Data:        blob,
+		})
+		want := api.Label{ID: "col-id", Name: "col-name", Color: "col-color", Description: "col-desc", Team: &api.Team{ID: "col-team"}}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("blob won over columns:\n got=%+v\nwant=%+v", got, want)
+		}
+	})
+
+	t.Run("user", func(t *testing.T) {
+		t.Parallel()
+		blob := mustMarshal(api.User{ID: "blob-id", Name: "blob-name", Email: "blob@x", DisplayName: "blob-dn", Active: false})
+		got := DBUserToAPIUser(User{
+			ID:          "col-id",
+			Name:        "col-name",
+			Email:       "col@x",
+			DisplayName: sql.NullString{String: "col-dn", Valid: true},
+			Active:      1,
+			Data:        blob,
+		})
+		want := api.User{ID: "col-id", Name: "col-name", Email: "col@x", DisplayName: "col-dn", Active: true}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("blob won over columns:\n got=%+v\nwant=%+v", got, want)
+		}
+	})
+
+	t.Run("cycle", func(t *testing.T) {
+		t.Parallel()
+		colStart := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+		colEnd := time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC)
+		blob := mustMarshal(api.Cycle{
+			ID: "blob-id", Number: 1, Name: "blob-name",
+			StartsAt: colStart.AddDate(0, 0, -7), EndsAt: colEnd.AddDate(0, 0, -7),
+			IssueCountHistory: []int{1, 2, 3}, // blob-only field: must survive
+		})
+		got := DBCycleToAPICycle(Cycle{
+			ID:       "col-id",
+			Number:   42,
+			Name:     sql.NullString{String: "col-name", Valid: true},
+			StartsAt: sql.NullTime{Time: colStart, Valid: true},
+			EndsAt:   sql.NullTime{Time: colEnd, Valid: true},
+			Data:     blob,
+		})
+		if got.ID != "col-id" || got.Number != 42 || got.Name != "col-name" ||
+			!got.StartsAt.Equal(colStart) || !got.EndsAt.Equal(colEnd) {
+			t.Errorf("blob won over columns: %+v", got)
+		}
+		// The blob-only field must still flow through — overlay, not replace.
+		if !reflect.DeepEqual(got.IssueCountHistory, []int{1, 2, 3}) {
+			t.Errorf("blob-only history did not survive the overlay: %+v", got.IssueCountHistory)
+		}
+	})
+
+	t.Run("milestone", func(t *testing.T) {
+		t.Parallel()
+		blob := mustMarshal(api.ProjectMilestone{ID: "blob-id", Name: "blob-name", Description: "blob-desc", TargetDate: strPtr("2020-01-01"), SortOrder: 1})
+		got := DBMilestoneToAPIProjectMilestone(ProjectMilestone{
+			ID:          "col-id",
+			Name:        "col-name",
+			Description: sql.NullString{String: "col-desc", Valid: true},
+			TargetDate:  sql.NullString{String: "2026-12-31", Valid: true},
+			SortOrder:   sql.NullFloat64{Float64: 9, Valid: true},
+			Data:        blob,
+		})
+		if got.ID != "col-id" || got.Name != "col-name" || got.Description != "col-desc" ||
+			got.TargetDate == nil || *got.TargetDate != "2026-12-31" || got.SortOrder != 9 {
+			t.Errorf("blob won over columns: %+v", got)
+		}
+	})
+}

--- a/internal/fs/attachments.go
+++ b/internal/fs/attachments.go
@@ -157,7 +157,6 @@ var _ fs.NodeReader = (*EmbeddedFileNode)(nil)
 
 func (n *EmbeddedFileNode) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
 	file := n.fileSnapshot()
-	now := time.Now()
 	out.Mode = 0444 // Read-only
 	n.SetOwner(out)
 	if file.FileSize > 0 {
@@ -168,7 +167,15 @@ func (n *EmbeddedFileNode) Getattr(ctx context.Context, fh fs.FileHandle, out *f
 		// Use 1MB as a reasonable placeholder for images.
 		out.Size = 1024 * 1024
 	}
-	out.SetTimes(&now, &now, &now)
+	// Real times from the row (this was the package's last fabricated now(),
+	// reshuffling attachments/ on every ls -lt): ctime = when the file was
+	// first extracted, mtime/atime = when its metadata last synced. A zero
+	// time reports unset.
+	mtime := file.SyncedAt
+	if mtime.IsZero() {
+		mtime = file.CreatedAt
+	}
+	out.SetTimes(nonZeroTime(mtime), nonZeroTime(mtime), nonZeroTime(file.CreatedAt))
 	return 0
 }
 

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -994,6 +994,12 @@ func (w *Worker) syncIssueDetailsBatch(ctx context.Context, issues []struct {
 
 	// Touch synced_at for all fetched issues so the FS layer doesn't immediately
 	// re-trigger on-demand fetches for the data we just stored.
+	//
+	// Relations are DELIBERATELY not touched, though the loop above syncs five
+	// collections: nothing consults relations staleness (the repo has no
+	// relations SWR path, and the dead GetIssueRelationsSyncedAt query was
+	// deleted in PR #186), so a TouchIssueRelations would be dead machinery —
+	// don't "fix" the symmetry.
 	now := db.Now()
 	for _, issue := range issues {
 		if err := w.store.Queries().TouchIssueComments(ctx, db.TouchIssueCommentsParams{SyncedAt: now, IssueID: issue.ID}); err != nil {


### PR DESCRIPTION
The four small candidates from the round-15 scoped review, batched:

1. **EmbeddedFileNode real times** — the package's last fabricated `now()`; `attachments/` stops reshuffling on `ls -lt`. The data was always in the row; `api.EmbeddedFile` gains `CreatedAt` and the node reports `ctime=CreatedAt`, `mtime/atime=SyncedAt`.
2. **`TestOverlayColumnsWin`** — guards the overlay converters' blind spot: a future column forgotten in the overlay would silently serve the blob's stale copy (the inverse of the bug round 14 fixed). Disagreeing-blob rows assert every column wins; cycle also asserts blob-only fields survive.
3. **`IssueRelationFields`/`IssueInverseRelationFields` fragments** — the relation projection was inlined identically in two places; fragment discipline restored (queryIssue, queryIssueDetails, and the batch query all reference + append).
4. **Touch-asymmetry comment** — the "relations deliberately skip the Touch pass" reasoning now lives at the site instead of a PR description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)