### PR TITLE
test: deflake TestWorkerContextCancellation

### DIFF
--- a/internal/sync/worker_test.go
+++ b/internal/sync/worker_test.go
@@ -513,9 +513,15 @@ func TestWorkerContextCancellation(t *testing.T) {
 	worker.Start(ctx)
 	time.Sleep(20 * time.Millisecond)
 
-	// Cancel context should stop worker
+	// Cancel context should stop worker. Poll with a deadline rather than a
+	// fixed grace: the worker only observes cancellation between sync steps,
+	// and on a loaded CI runner the in-flight initial sync can take well over
+	// the old 100ms (observed flaking on the shared runners).
 	cancel()
-	time.Sleep(100 * time.Millisecond)
+	deadline := time.Now().Add(10 * time.Second)
+	for worker.Running() && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	if worker.Running() {
 		t.Error("Worker should stop when context is cancelled")


### PR DESCRIPTION
`TestWorkerContextCancellation` failed on the PR #189 CI run: it gives the worker a fixed 100ms to observe cancellation, but the worker only checks ctx between sync steps, and the in-flight initial sync exceeded that on the loaded runner (the `prune failed: database is closed` lines in its logs are the same too-early teardown racing the deferred `store.Close`). Not a #189 regression — that diff only added a comment to worker.go — just a timing flake finally caught in the act.

Fix: poll `worker.Running()` with a 10s deadline instead of a fixed sleep. Passes 10× with `-race` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)