### PR TITLE
Project labels: workspace catalog + project.md labels: (#130)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -89,6 +89,52 @@ the handler maps it to `EINVAL`. This collapsed the issue-`Flush` front half fro
 `Resolve*` lookups, satisfied by `*LinearFS`), so the whole path is unit-tested with a
 fake resolver — no repo, SQLite, or API. The individual `Resolve*` methods remain as
 shared primitives (also used singly by initiatives and projects).
+`resolveProjectLabels` (see "Project-label selection") is the second multi-name
+resolver — same `FieldError` contract, but a pure function over a catalog slice
+rather than a method on the resolver seam.
+
+### Project-label selection (`projectlabels.go`)
+The workspace project-label surface (#130). Linear's `ProjectLabel` is
+**workspace-scoped** — the schema has no team edge at all (contrast `IssueLabel`'s
+nullable team edge, which is why issue `labels.md` lives per-team) — with a
+lifecycle issue labels lack: **groups** (`isGroup` containers; only one child per
+group may be applied) and **retirement** (kept on existing projects, not newly
+assignable). The surface: a root read-only `project-labels.md` **renderFile**
+(never-ENOENT, groups/retired flagged, the assignment rules as prose in-file — it
+is the file an agent reads after a validation `.error`), a per-team
+`project-labels.md` **symlinkNode** alias, a `project_labels` twin table synced by
+a workspace **syncCollection** pass (complete unfiltered drain = the completeness
+set licensing a full-table prune; retired labels are IN the drain, live-verified
+2026-07-08), and a `labels:` names list in project.md that resolves and validates
+in `internal/fs/projectlabels.go` — all **pure functions over a catalog slice**
+(no mount, no interface) — then rides the existing single `UpdateProject` call
+(`ProjectUpdateInput.LabelIds *[]string`, pointer-or-omit full-set write).
+
+Load-bearing invariant: **render unknown label IDs verbatim; the resolver accepts
+exact-ID passthrough** (catalog IDs and current-member IDs) — a cold or stale
+catalog can never strip labels on an untouched save, and IDs are the documented
+duplicate-name disambiguation (bare-name ties: prefer-current, then the single
+active candidate, else a loud ambiguity error listing candidate IDs — never a
+silent sibling pick). Validation policy in one sentence: **we enforce what
+Linear's docs say about label assignment, even where the API is lax** —
+live-verified that the wire *accepts* retired assignment; the mount still rejects
+newly-applied retired labels (carried-through ones pass, since a full-set write
+re-sends them) and group/one-child-per-group violations, with errors that name
+the assignable children. The stale-blob clobber guard (one interactive-promoted
+`GetProject` refresh iff current `LabelIds` is empty and the write changes
+labels) closes the pre-upgrade-blob wipe: a full-set write computed against an
+empty stale set would silently erase the project's real labels.
+
+**Unification with issue labels was evaluated and rejected** (recorded so no
+future round re-derives the merge): a `kind` column on `labels` breaks on
+`GetLabelByName`'s `(team_id = ? OR team_id IS NULL)` union (project-label names
+would resolve as issue labels and feed ProjectLabel IDs to `issueUpdate.labelIds`)
+and on `ListTeamLabels` (project labels would leak into every team's `labels.md`
+and `labels/` CRUD dir, where `rm` fires `issueLabelDelete`); the scoping axis,
+prune regime, and lifecycle all differ; and GraphQL fragments cannot span
+`IssueLabel`/`ProjectLabel`, so the one expensive share is forbidden by the wire
+anyway. Sharing happens only through the already-generic seams (renderFile,
+symlinkNode, syncCollection, hydrate-then-overlay, FieldError, paginate, ino).
 
 ### Link reconciliation (`reconcileLinks`)
 The **deep module** owning the *relational* front half of an edit — the counterpart
@@ -108,6 +154,9 @@ name lists — so it returns a **`FieldError`** (bad name → `EINVAL` via
 unit-tested with recording closures (no FUSE mount, SQLite, or API). Persisting each
 junction row inline (rather than the old deferred batch a mid-loop failure skipped)
 keeps SQLite consistent with whatever the API actually accepted on a partial failure.
+Project labels deliberately do **not** reconcile through this module: `labelIds`
+is one atomic full-set input on the project update (no per-pair link mutation
+exists), so the labels edit is scalar-edit-shaped — see "Project-label selection".
 
 ### Scalar edit (`scalarEdit`)
 The **deep module** owning the *scalar* front half of a project/initiative edit —
@@ -599,10 +648,11 @@ The **deep module** owning the invariant tail of every metadata sync — the
 sync-side sibling of the write-path tails (`commitCreate`/`commitWriteBack`/
 `commitDelete`) and the module that actually **performs the metadata prunes**
 `paginate`'s completeness licenses. Its shape is `convert → upsert-all →
-prune-if-clean`. Six sites reconcile through it: `states` (upsert-only),
+prune-if-clean`. Seven sites reconcile through it: `states` (upsert-only),
 `labels`, `cycles`, `projects` (entity + `project_teams` junction + nested
-milestones), `members` (entity + `team_members` junction), and
-`initiativeProjects` (junction-only). Each restated the same `clean`-flag idiom
+milestones), `members` (entity + `team_members` junction),
+`initiativeProjects` (junction-only), and `projectLabels` (the workspace
+catalog — a complete unfiltered drain licenses its full-table prune). Each restated the same `clean`-flag idiom
 by hand — declare `xClean := true`, loop upserting, `if xClean { Prune }` — so a
 new metadata kind copy-pasted it and a forgotten flag would let a *partial* fetch
 read as removals (silent data loss). `initiativeProjects` even hand-rolled a

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -113,9 +113,30 @@ type graphQLRequest struct {
 type graphQLResponse struct {
 	Data   json.RawMessage `json:"data"`
 	Errors []struct {
-		Message string `json:"message"`
+		Message    string `json:"message"`
+		Extensions struct {
+			Code                   string `json:"code"`
+			UserError              bool   `json:"userError"`
+			UserPresentableMessage string `json:"userPresentableMessage"`
+		} `json:"extensions"`
 	} `json:"errors,omitempty"`
 }
+
+// GraphQLError is a structured GraphQL rejection. Linear tags input
+// rejections with extensions {code: "INPUT_ERROR", userError: true,
+// userPresentableMessage: "..."} — the presentable message is far more
+// actionable than the terse internal one (live example: internal "labelIds
+// contain parent labels" vs presentable "The label 'X' is a group and cannot
+// be assigned to projects directly."). Error() keeps the legacy "GraphQL
+// error: <message>" shape so existing string matches keep working.
+type GraphQLError struct {
+	Message                string
+	Code                   string
+	UserError              bool
+	UserPresentableMessage string
+}
+
+func (e *GraphQLError) Error() string { return "GraphQL error: " + e.Message }
 
 func (c *Client) query(ctx context.Context, query string, variables map[string]any, result any) error {
 	// Extract operation name for stats and logging
@@ -274,8 +295,14 @@ func (c *Client) query(ctx context.Context, query string, variables map[string]a
 	}
 
 	if len(gqlResp.Errors) > 0 {
-		errMsg := gqlResp.Errors[0].Message
-		queryErr = fmt.Errorf("GraphQL error: %s", errMsg)
+		first := gqlResp.Errors[0]
+		errMsg := first.Message
+		queryErr = &GraphQLError{
+			Message:                errMsg,
+			Code:                   first.Extensions.Code,
+			UserError:              first.Extensions.UserError,
+			UserPresentableMessage: first.Extensions.UserPresentableMessage,
+		}
 		if strings.Contains(errMsg, "RATELIMITED") || strings.Contains(strings.ToLower(errMsg), "rate limit") {
 			adm.rateLimited(resp.Header)
 			log.Printf("[ratelimit] ERROR: %s rate limited by Linear API: %s", opName, errMsg)

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -585,6 +585,14 @@ func (c *Client) GetTeamProjects(ctx context.Context, teamID string) ([]Project,
 		map[string]any{"teamId": teamID}, "team", "projects")
 }
 
+// GetProjectLabels drains the workspace project-label catalog to completion.
+// No filter deliberately: the drain must include retired and group labels —
+// completeness is what licenses the sync pass's full-table prune (see
+// queryProjectLabelsPage).
+func (c *Client) GetProjectLabels(ctx context.Context) ([]ProjectLabel, error) {
+	return fetchAll[ProjectLabel](ctx, c, queryProjectLabelsPage, nil, "projectLabels")
+}
+
 // GetProjectMilestones fetches milestones for a project
 func (c *Client) GetProjectMilestones(ctx context.Context, projectID string) ([]ProjectMilestone, error) {
 	var result struct {

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -156,6 +156,27 @@ fragment LabelFields on IssueLabel {
 }
 `
 
+// ProjectLabelFields is the shared projection for a workspace project label.
+// Defined mutation-less in this slice so future catalog CRUD mutations project
+// through it (see CLAUDE.md: mutations must project through the entity's
+// fragment). parent selects only the id — the catalog is always fully in hand
+// locally, so parent/group names stitch at the repo read, not on the wire.
+// retiredAt is doc-tagged [Internal] in the schema but live-verified selectable
+// by API-key clients (2026-07-08).
+const projectLabelFieldsFragment = `
+fragment ProjectLabelFields on ProjectLabel {
+  id
+  name
+  color
+  description
+  isGroup
+  retiredAt
+  createdAt
+  updatedAt
+  parent { id }
+}
+`
+
 // AttachmentFieldsFragment is a GraphQL fragment for attachment fields.
 const AttachmentFieldsFragment = `
 fragment AttachmentFields on Attachment {
@@ -322,6 +343,21 @@ query WorkspaceLabelsPage($after: String) {
 }
 ` + labelFieldsFragment
 
+// queryProjectLabelsPage drains the workspace project-label catalog. No
+// filter: the drain must include retired and group labels — completeness is
+// what licenses the sync pass's full-table prune (retirement is
+// keep-but-not-newly-assignable, so a retired label absent from the drain
+// would read as deleted and be pruned, which live verification 2026-07-08
+// confirmed does not happen: retired labels ARE in the default drain).
+var queryProjectLabelsPage = `
+query ProjectLabelsPage($after: String) {
+  projectLabels(first: 250, after: $after) {
+    pageInfo { hasNextPage endCursor }
+    nodes { ...ProjectLabelFields }
+  }
+}
+` + projectLabelFieldsFragment
+
 const queryTeamStates = `
 query TeamStates($teamId: String!) {
   team(id: $teamId) {
@@ -387,6 +423,7 @@ query TeamProjects($teamId: String!, $after: String) {
         targetDate
         createdAt
         updatedAt
+        labelIds
         lead {
           id
           name
@@ -424,6 +461,7 @@ query Project($id: String!) {
     targetDate
     createdAt
     updatedAt
+    labelIds
     lead {
       id
       name
@@ -553,6 +591,7 @@ mutation CreateProject($input: ProjectCreateInput!) {
       state
       createdAt
       updatedAt
+      labelIds
     }
   }
 }

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -403,6 +403,47 @@ query TeamCycles($teamId: String!) {
 }
 `
 
+// ProjectFields is the shared projection for a project — the team-projects
+// page, the single-project fetch (the WriteBack verify read), and the create
+// mutation's echo all project through it, per the fragment rule: an inlined
+// copy silently drifts when one site gains a field (the create echo had
+// already drifted, omitting startDate/targetDate/lead/status/initiatives/
+// milestones/labelIds). References ProjectMilestoneFields; queries appending
+// this fragment get that one with it.
+const projectFieldsFragment = `
+fragment ProjectFields on Project {
+  id
+  name
+  slugId
+  description
+  url
+  state
+  startDate
+  targetDate
+  createdAt
+  updatedAt
+  labelIds
+  lead {
+    id
+    name
+    email
+  }
+  status {
+    id
+    name
+  }
+  initiatives {
+    nodes {
+      id
+      name
+    }
+  }
+  projectMilestones {
+    nodes { ...ProjectMilestoneFields }
+  }
+}
+` + projectMilestoneFieldsFragment
+
 // queryTeamProjects pages at 50: the nested initiatives/projectMilestones
 // selections cost ~187 complexity points per project node, so 50 is the
 // largest page that fits Linear's 10k complexity budget (measured live:
@@ -412,77 +453,17 @@ query TeamProjects($teamId: String!, $after: String) {
   team(id: $teamId) {
     projects(first: 50, after: $after) {
       pageInfo { hasNextPage endCursor }
-      nodes {
-        id
-        name
-        slugId
-        description
-        url
-        state
-        startDate
-        targetDate
-        createdAt
-        updatedAt
-        labelIds
-        lead {
-          id
-          name
-          email
-        }
-        status {
-          id
-          name
-        }
-        initiatives {
-          nodes {
-            id
-            name
-          }
-        }
-        projectMilestones {
-          nodes { ...ProjectMilestoneFields }
-        }
-      }
+      nodes { ...ProjectFields }
     }
   }
 }
-` + projectMilestoneFieldsFragment
+` + projectFieldsFragment
 
 var queryProject = `
 query Project($id: String!) {
-  project(id: $id) {
-    id
-    name
-    slugId
-    description
-    url
-    state
-    startDate
-    targetDate
-    createdAt
-    updatedAt
-    labelIds
-    lead {
-      id
-      name
-      email
-    }
-    status {
-      id
-      name
-    }
-    initiatives {
-      nodes {
-        id
-        name
-      }
-    }
-    projectMilestones {
-      nodes { ...ProjectMilestoneFields }
-    }
-  }
+  project(id: $id) { ...ProjectFields }
 }
-` + projectMilestoneFieldsFragment
+` + projectFieldsFragment
 
 var queryProjectMilestones = `
 query ProjectMilestones($projectId: String!) {
@@ -578,24 +559,14 @@ mutation CreateInitiativeUpdate($initiativeId: String!, $body: String!, $health:
 }
 ` + initiativeUpdateFieldsFragment
 
-const mutationCreateProject = `
+var mutationCreateProject = `
 mutation CreateProject($input: ProjectCreateInput!) {
   projectCreate(input: $input) {
     success
-    project {
-      id
-      name
-      slugId
-      description
-      url
-      state
-      createdAt
-      updatedAt
-      labelIds
-    }
+    project { ...ProjectFields }
   }
 }
-`
+` + projectFieldsFragment
 
 const mutationArchiveProject = `
 mutation ArchiveProject($id: String!) {

--- a/internal/api/ratebudget.go
+++ b/internal/api/ratebudget.go
@@ -117,6 +117,7 @@ var opBaseTier = map[string]priority{
 	"TeamProjects":             pSkeleton,
 	"Workspace":                pSkeleton,
 	"WorkspaceLabelsPage":      pSkeleton,
+	"ProjectLabelsPage":        pSkeleton,
 	"WorkspaceUsersPage":       pSkeleton,
 	"WorkspaceInitiativesPage": pSkeleton,
 	"InitiativeProjectsPage":   pSkeleton,

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -132,6 +132,28 @@ type Project struct {
 	Status      *Status             `json:"status"`
 	Initiatives *ProjectInitiatives `json:"initiatives"`
 	Milestones  *ProjectMilestones  `json:"projectMilestones"`
+	// LabelIds are the project's ProjectLabel IDs (a cheap scalar on the wire;
+	// names resolve locally against the project_labels catalog).
+	LabelIds []string `json:"labelIds"`
+}
+
+// ProjectLabel is a WORKSPACE-scoped label applied to projects. Deliberately
+// not unified with Label (IssueLabel): no team edge, group/retirement
+// lifecycle, disjoint mutations. See CONTEXT.md "Project-label selection".
+// IsGroup labels are containers and cannot be applied directly; only one
+// child per group may be applied. RetiredAt != nil means not newly assignable
+// but valid on existing projects (the wire ACCEPTS retired assignment — the
+// mount enforces the documented semantics as policy).
+type ProjectLabel struct {
+	ID          string        `json:"id"`
+	Name        string        `json:"name"`
+	Color       string        `json:"color"`
+	Description string        `json:"description"`
+	IsGroup     bool          `json:"isGroup"`
+	Parent      *ProjectLabel `json:"parent,omitempty"` // id from wire; Name stitched by the repo read
+	RetiredAt   *time.Time    `json:"retiredAt,omitempty"`
+	CreatedAt   time.Time     `json:"createdAt"`
+	UpdatedAt   time.Time     `json:"updatedAt"`
 }
 
 // ProjectMilestones is a collection of milestones within a project
@@ -168,6 +190,9 @@ type ProjectMilestone struct {
 type ProjectUpdateInput struct {
 	Name        *string `json:"name,omitempty"`
 	Description *string `json:"description,omitempty"`
+	// LabelIds is a full-set write (no removedLabelIds analog exists).
+	// nil = untouched; &[]string{} = clear all labels.
+	LabelIds *[]string `json:"labelIds,omitempty"`
 }
 
 // InitiativeUpdateInput is the input for updating an initiative's mutable fields.

--- a/internal/db/convert.go
+++ b/internal/db/convert.go
@@ -275,6 +275,93 @@ func DBLabelsToAPILabels(labels []Label) []api.Label {
 }
 
 // =============================================================================
+// ProjectLabel Conversion (workspace-scoped catalog; see CONTEXT.md
+// "Project-label selection")
+// =============================================================================
+
+func boolToInt64(b bool) int64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// APIProjectLabelToDBProjectLabel converts an api.ProjectLabel to
+// UpsertProjectLabelParams. parent_id comes from the label's own Parent edge
+// (only the ID is fetched; names stitch locally at the repo read).
+func APIProjectLabelToDBProjectLabel(label api.ProjectLabel) (UpsertProjectLabelParams, error) {
+	data, err := json.Marshal(label)
+	if err != nil {
+		return UpsertProjectLabelParams{}, err
+	}
+	params := UpsertProjectLabelParams{
+		ID:          label.ID,
+		Name:        label.Name,
+		Color:       sql.NullString{String: label.Color, Valid: label.Color != ""},
+		Description: sql.NullString{String: label.Description, Valid: label.Description != ""},
+		IsGroup:     boolToInt64(label.IsGroup),
+		CreatedAt:   sql.NullTime{Time: label.CreatedAt, Valid: !label.CreatedAt.IsZero()},
+		UpdatedAt:   sql.NullTime{Time: label.UpdatedAt, Valid: !label.UpdatedAt.IsZero()},
+		SyncedAt:    Now(),
+		Data:        data,
+	}
+	if label.Parent != nil {
+		params.ParentID = sql.NullString{String: label.Parent.ID, Valid: label.Parent.ID != ""}
+	}
+	if label.RetiredAt != nil {
+		params.RetiredAt = sql.NullTime{Time: *label.RetiredAt, Valid: true}
+	}
+	return params, nil
+}
+
+// DBProjectLabelToAPIProjectLabel converts a db.ProjectLabel to
+// api.ProjectLabel. Hydrate-then-overlay: see the reverse-conversion contract
+// at DBMilestoneToAPIProjectMilestone. Parent comes strictly from the
+// parent_id column — the authoritative source — never from the blob's copy;
+// only the ID is populated here (the repo read stitches Parent.Name over the
+// catalog's id→row map).
+func DBProjectLabelToAPIProjectLabel(label ProjectLabel) api.ProjectLabel {
+	var l api.ProjectLabel
+	if len(label.Data) > 0 {
+		// Best-effort: on a bad blob keep the zero struct and rely on the columns.
+		_ = json.Unmarshal(label.Data, &l)
+	}
+	l.ID = label.ID
+	l.Name = label.Name
+	l.Color = NullStringValue(label.Color)
+	l.Description = NullStringValue(label.Description)
+	l.IsGroup = label.IsGroup != 0
+	if label.ParentID.Valid {
+		l.Parent = &api.ProjectLabel{ID: label.ParentID.String}
+	} else {
+		l.Parent = nil
+	}
+	if label.RetiredAt.Valid {
+		t := label.RetiredAt.Time
+		l.RetiredAt = &t
+	} else {
+		l.RetiredAt = nil
+	}
+	if label.CreatedAt.Valid {
+		l.CreatedAt = label.CreatedAt.Time
+	}
+	if label.UpdatedAt.Valid {
+		l.UpdatedAt = label.UpdatedAt.Time
+	}
+	return l
+}
+
+// DBProjectLabelsToAPIProjectLabels converts a slice of db.ProjectLabel to
+// api.ProjectLabel
+func DBProjectLabelsToAPIProjectLabels(labels []ProjectLabel) []api.ProjectLabel {
+	result := make([]api.ProjectLabel, len(labels))
+	for i, label := range labels {
+		result[i] = DBProjectLabelToAPIProjectLabel(label)
+	}
+	return result
+}
+
+// =============================================================================
 // User Conversion
 // =============================================================================
 

--- a/internal/db/convert_test.go
+++ b/internal/db/convert_test.go
@@ -906,6 +906,65 @@ func TestLabelRoundTrip(t *testing.T) {
 	}
 }
 
+// TestProjectLabelRoundTrip pins the contract for the workspace project-label
+// catalog. Parent carries only the ID through the round-trip (names stitch at
+// the repo read); retirement is a kept lifecycle state, not deletion.
+func TestProjectLabelRoundTrip(t *testing.T) {
+	t.Parallel()
+	retired := time.Date(2026, 7, 8, 5, 3, 11, 0, time.UTC)
+	created := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	updated := time.Date(2026, 6, 7, 8, 9, 10, 0, time.UTC)
+	orig := api.ProjectLabel{
+		ID:          "plabel-rt",
+		Name:        "Platform",
+		Color:       "#5e6ad2",
+		Description: "Platform work",
+		IsGroup:     false,
+		Parent:      &api.ProjectLabel{ID: "plabel-group"},
+		RetiredAt:   &retired,
+		CreatedAt:   created,
+		UpdatedAt:   updated,
+	}
+
+	params, err := APIProjectLabelToDBProjectLabel(orig)
+	if err != nil {
+		t.Fatalf("forward: %v", err)
+	}
+	row := ProjectLabel{
+		ID: params.ID, Name: params.Name, Color: params.Color,
+		Description: params.Description, IsGroup: params.IsGroup,
+		ParentID: params.ParentID, RetiredAt: params.RetiredAt,
+		CreatedAt: params.CreatedAt, UpdatedAt: params.UpdatedAt,
+		Data: params.Data,
+	}
+	got := DBProjectLabelToAPIProjectLabel(row)
+	// Parent comes back ID-only regardless of what the blob carried.
+	want := orig
+	want.Parent = &api.ProjectLabel{ID: "plabel-group"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("round-trip mismatch:\n got=%+v\nwant=%+v", got, want)
+	}
+
+	// A group label with no parent and no retirement.
+	group := api.ProjectLabel{ID: "plabel-g", Name: "Area", IsGroup: true, CreatedAt: created, UpdatedAt: updated}
+	gp, err := APIProjectLabelToDBProjectLabel(group)
+	if err != nil {
+		t.Fatalf("forward (group): %v", err)
+	}
+	gRow := ProjectLabel{ID: gp.ID, Name: gp.Name, IsGroup: gp.IsGroup, CreatedAt: gp.CreatedAt, UpdatedAt: gp.UpdatedAt, Data: gp.Data}
+	gGot := DBProjectLabelToAPIProjectLabel(gRow)
+	if !gGot.IsGroup || gGot.Parent != nil || gGot.RetiredAt != nil {
+		t.Errorf("group round-trip: %+v", gGot)
+	}
+
+	corrupt := row
+	corrupt.Data = []byte("{not json")
+	if got := DBProjectLabelToAPIProjectLabel(corrupt); got.ID != orig.ID || got.Name != orig.Name ||
+		got.Parent == nil || got.Parent.ID != "plabel-group" || got.RetiredAt == nil {
+		t.Errorf("corrupt data row did not fall back to columns: %+v", got)
+	}
+}
+
 // TestUserRoundTrip pins the contract for users.
 func TestUserRoundTrip(t *testing.T) {
 	t.Parallel()
@@ -1464,6 +1523,38 @@ func TestOverlayColumnsWin(t *testing.T) {
 		// The blob-only field must still flow through — overlay, not replace.
 		if !reflect.DeepEqual(got.IssueCountHistory, []int{1, 2, 3}) {
 			t.Errorf("blob-only history did not survive the overlay: %+v", got.IssueCountHistory)
+		}
+	})
+
+	t.Run("project-label", func(t *testing.T) {
+		t.Parallel()
+		colRetired := time.Date(2026, 7, 8, 0, 0, 0, 0, time.UTC)
+		blob := mustMarshal(api.ProjectLabel{
+			ID: "blob-id", Name: "blob-name", Color: "blob-color",
+			Description: "blob-desc", IsGroup: true,
+			Parent: &api.ProjectLabel{ID: "blob-parent", Name: "smuggled-name"},
+		})
+		got := DBProjectLabelToAPIProjectLabel(ProjectLabel{
+			ID:          "col-id",
+			Name:        "col-name",
+			Color:       sql.NullString{String: "col-color", Valid: true},
+			Description: sql.NullString{String: "col-desc", Valid: true},
+			IsGroup:     0,
+			ParentID:    sql.NullString{String: "col-parent", Valid: true},
+			RetiredAt:   sql.NullTime{Time: colRetired, Valid: true},
+			Data:        blob,
+		})
+		if got.ID != "col-id" || got.Name != "col-name" || got.Color != "col-color" ||
+			got.Description != "col-desc" || got.IsGroup {
+			t.Errorf("blob won over columns: %+v", got)
+		}
+		// Parent is strictly column-derived: the blob's smuggled Name must not
+		// survive (only the ID is populated; the repo read stitches names).
+		if got.Parent == nil || got.Parent.ID != "col-parent" || got.Parent.Name != "" {
+			t.Errorf("parent not column-derived: %+v", got.Parent)
+		}
+		if got.RetiredAt == nil || !got.RetiredAt.Equal(colRetired) {
+			t.Errorf("retired_at column did not win: %+v", got.RetiredAt)
 		}
 	})
 

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -217,6 +217,20 @@ type Project struct {
 	Data        json.RawMessage `json:"data"`
 }
 
+type ProjectLabel struct {
+	ID          string          `json:"id"`
+	Name        string          `json:"name"`
+	Color       sql.NullString  `json:"color"`
+	Description sql.NullString  `json:"description"`
+	IsGroup     int64           `json:"is_group"`
+	ParentID    sql.NullString  `json:"parent_id"`
+	RetiredAt   sql.NullTime    `json:"retired_at"`
+	CreatedAt   sql.NullTime    `json:"created_at"`
+	UpdatedAt   sql.NullTime    `json:"updated_at"`
+	SyncedAt    time.Time       `json:"synced_at"`
+	Data        json.RawMessage `json:"data"`
+}
+
 type ProjectMilestone struct {
 	ID          string          `json:"id"`
 	ProjectID   string          `json:"project_id"`

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -277,6 +277,35 @@ DELETE FROM labels WHERE id = ?;
 DELETE FROM labels WHERE team_id = ?;
 
 -- =============================================================================
+-- Project labels queries (workspace-scoped catalog; see schema.sql)
+-- =============================================================================
+
+-- name: ListProjectLabels :many
+SELECT * FROM project_labels ORDER BY name COLLATE NOCASE;
+
+-- name: UpsertProjectLabel :exec
+INSERT INTO project_labels (id, name, color, description, is_group, parent_id,
+    retired_at, created_at, updated_at, synced_at, data)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+    name = excluded.name,
+    color = excluded.color,
+    description = excluded.description,
+    is_group = excluded.is_group,
+    parent_id = excluded.parent_id,
+    retired_at = excluded.retired_at,
+    created_at = excluded.created_at,
+    updated_at = excluded.updated_at,
+    synced_at = excluded.synced_at,
+    data = excluded.data;
+
+-- Workspace-wide prune, licensed ONLY by a complete drain of Query.projectLabels.
+-- The drain includes retired labels (live-verified 2026-07-08), so retirement
+-- never reads as removal here; only true deletion/archival does.
+-- name: PruneProjectLabels :exec
+DELETE FROM project_labels WHERE synced_at < ?;
+
+-- =============================================================================
 -- Users queries
 -- =============================================================================
 

--- a/internal/db/queries.sql.go
+++ b/internal/db/queries.sql.go
@@ -2185,6 +2185,49 @@ func (q *Queries) ListProjectIssues(ctx context.Context, projectID sql.NullStrin
 	return items, nil
 }
 
+const listProjectLabels = `-- name: ListProjectLabels :many
+
+SELECT id, name, color, description, is_group, parent_id, retired_at, created_at, updated_at, synced_at, data FROM project_labels ORDER BY name COLLATE NOCASE
+`
+
+// =============================================================================
+// Project labels queries (workspace-scoped catalog; see schema.sql)
+// =============================================================================
+func (q *Queries) ListProjectLabels(ctx context.Context) ([]ProjectLabel, error) {
+	rows, err := q.db.QueryContext(ctx, listProjectLabels)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ProjectLabel{}
+	for rows.Next() {
+		var i ProjectLabel
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.Color,
+			&i.Description,
+			&i.IsGroup,
+			&i.ParentID,
+			&i.RetiredAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.SyncedAt,
+			&i.Data,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listProjectMilestones = `-- name: ListProjectMilestones :many
 SELECT id, project_id, name, description, target_date, sort_order, created_at, updated_at, synced_at, data FROM project_milestones WHERE project_id = ? ORDER BY sort_order
 `
@@ -3994,6 +4037,18 @@ func (q *Queries) PruneIssueRelations(ctx context.Context, arg PruneIssueRelatio
 	return err
 }
 
+const pruneProjectLabels = `-- name: PruneProjectLabels :exec
+DELETE FROM project_labels WHERE synced_at < ?
+`
+
+// Workspace-wide prune, licensed ONLY by a complete drain of Query.projectLabels.
+// The drain includes retired labels (live-verified 2026-07-08), so retirement
+// never reads as removal here; only true deletion/archival does.
+func (q *Queries) PruneProjectLabels(ctx context.Context, syncedAt time.Time) error {
+	_, err := q.db.ExecContext(ctx, pruneProjectLabels, syncedAt)
+	return err
+}
+
 const pruneProjectTeams = `-- name: PruneProjectTeams :exec
 DELETE FROM project_teams WHERE team_id = ? AND synced_at < ?
 `
@@ -4855,6 +4910,54 @@ func (q *Queries) UpsertProject(ctx context.Context, arg UpsertProjectParams) er
 		arg.TargetDate,
 		arg.LeadID,
 		arg.Url,
+		arg.CreatedAt,
+		arg.UpdatedAt,
+		arg.SyncedAt,
+		arg.Data,
+	)
+	return err
+}
+
+const upsertProjectLabel = `-- name: UpsertProjectLabel :exec
+INSERT INTO project_labels (id, name, color, description, is_group, parent_id,
+    retired_at, created_at, updated_at, synced_at, data)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+    name = excluded.name,
+    color = excluded.color,
+    description = excluded.description,
+    is_group = excluded.is_group,
+    parent_id = excluded.parent_id,
+    retired_at = excluded.retired_at,
+    created_at = excluded.created_at,
+    updated_at = excluded.updated_at,
+    synced_at = excluded.synced_at,
+    data = excluded.data
+`
+
+type UpsertProjectLabelParams struct {
+	ID          string          `json:"id"`
+	Name        string          `json:"name"`
+	Color       sql.NullString  `json:"color"`
+	Description sql.NullString  `json:"description"`
+	IsGroup     int64           `json:"is_group"`
+	ParentID    sql.NullString  `json:"parent_id"`
+	RetiredAt   sql.NullTime    `json:"retired_at"`
+	CreatedAt   sql.NullTime    `json:"created_at"`
+	UpdatedAt   sql.NullTime    `json:"updated_at"`
+	SyncedAt    time.Time       `json:"synced_at"`
+	Data        json.RawMessage `json:"data"`
+}
+
+func (q *Queries) UpsertProjectLabel(ctx context.Context, arg UpsertProjectLabelParams) error {
+	_, err := q.db.ExecContext(ctx, upsertProjectLabel,
+		arg.ID,
+		arg.Name,
+		arg.Color,
+		arg.Description,
+		arg.IsGroup,
+		arg.ParentID,
+		arg.RetiredAt,
 		arg.CreatedAt,
 		arg.UpdatedAt,
 		arg.SyncedAt,

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -101,6 +101,31 @@ CREATE INDEX IF NOT EXISTS idx_labels_team ON labels(team_id);
 CREATE INDEX IF NOT EXISTS idx_labels_name ON labels(name);
 
 -- =============================================================================
+-- Project labels (Linear "ProjectLabel"). WORKSPACE-scoped: the schema has no
+-- team edge, so unlike `labels` there is no team_id column at all. Deliberately
+-- a twin of `labels`, not a kind-column extension of it: scoping, prune regime,
+-- and lifecycle (retirement) all differ -- see CONTEXT.md "Project-label
+-- selection". Retired labels are KEPT (retirement is keep-but-not-newly-
+-- assignable, not deletion) so name resolution on existing projects keeps
+-- working.
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS project_labels (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    color TEXT,
+    description TEXT,
+    is_group INTEGER NOT NULL DEFAULT 0,  -- groups cannot be applied directly
+    parent_id TEXT,                       -- group parent; NULL = top-level
+    retired_at DATETIME,                  -- NULL = active
+    created_at DATETIME,
+    updated_at DATETIME,
+    synced_at DATETIME NOT NULL,
+    data JSON NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_labels_name ON project_labels(name);
+
+-- =============================================================================
 -- Users (workspace members)
 -- =============================================================================
 CREATE TABLE IF NOT EXISTS users (

--- a/internal/fs/createcommit.go
+++ b/internal/fs/createcommit.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"syscall"
 	"time"
+
+	"github.com/jra3/linear-fuse/internal/api"
 )
 
 // The create-commit tail.
@@ -140,6 +142,19 @@ func classifyMutationErr(op string, err error) (string, syscall.Errno) {
 	}
 	if retryableCreateErr(err) {
 		return "Operation: " + op + "\nError: the request was rate-limited or timed out before it completed, so the operation did not take effect. Wait a few seconds and retry.", syscall.EAGAIN
+	}
+	// A structured Linear input rejection (userError: true) is the caller's
+	// bad input, not a backend failure: EINVAL, preferring the server's
+	// user-presentable message over its terse internal one (live example:
+	// "The label 'X' is a group and cannot be assigned to projects directly."
+	// vs internal "labelIds contain parent labels").
+	var gqlErr *api.GraphQLError
+	if errors.As(err, &gqlErr) && gqlErr.UserError {
+		msg := gqlErr.UserPresentableMessage
+		if msg == "" {
+			msg = gqlErr.Message
+		}
+		return "Operation: " + op + "\nError: " + msg, syscall.EINVAL
 	}
 	return "Operation: " + op + "\nError: " + err.Error(), syscall.EIO
 }

--- a/internal/fs/ino.go
+++ b/internal/fs/ino.go
@@ -53,6 +53,10 @@ func relationIno(relationID string) uint64  { return ino("relation", relationID)
 func labelsDirIno(teamID string) uint64 { return ino("labels", teamID) }
 func labelIno(labelID string) uint64    { return ino("label", labelID) }
 
+// projectLabelsCatalogIno is the root project-labels.md catalog file — a
+// workspace singleton, so the id is a constant.
+func projectLabelsCatalogIno() uint64 { return ino("project-labels-catalog", "workspace") }
+
 // Projects -----------------------------------------------------------------
 
 func projectsDirIno(teamID string) uint64     { return ino("projects", teamID) }

--- a/internal/fs/ino_test.go
+++ b/internal/fs/ino_test.go
@@ -46,6 +46,7 @@ func TestInodeNamespaceDistinct(t *testing.T) {
 		"relationIno":             relationIno(id),
 		"labelsDirIno":            labelsDirIno(id),
 		"labelIno":                labelIno(id),
+		"projectLabelsCatalogIno": projectLabelsCatalogIno(), // workspace singleton (no id)
 		"projectsDirIno":          projectsDirIno(id),
 		"projectDirIno":           projectDirIno(id),
 		"projectInfoIno":          projectInfoIno(id),

--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -772,6 +772,38 @@ func (lfs *LinearFS) GetInitiatives(ctx context.Context) ([]api.Initiative, erro
 	return lfs.repo.GetInitiatives(ctx)
 }
 
+// GetProjectLabels returns the workspace project-label catalog (Parent names
+// stitched by the repo read).
+func (lfs *LinearFS) GetProjectLabels(ctx context.Context) ([]api.ProjectLabel, error) {
+	return lfs.repo.GetProjectLabels(ctx)
+}
+
+// projectLabelNames maps a project's labelIds to catalog names for rendering.
+// An ID missing from the catalog renders VERBATIM, never dropped — the
+// round-trip invariant: a cold or stale catalog must not cause an untouched
+// save to strip a label (the resolver accepts exact-ID passthrough for the
+// same reason; see resolveProjectLabels).
+func (lfs *LinearFS) projectLabelNames(ctx context.Context, ids []string) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+	byID := make(map[string]string)
+	if catalog, err := lfs.GetProjectLabels(ctx); err == nil {
+		for _, l := range catalog {
+			byID[l.ID] = l.Name
+		}
+	}
+	names := make([]string, len(ids))
+	for i, id := range ids {
+		if name, ok := byID[id]; ok && name != "" {
+			names[i] = name
+		} else {
+			names[i] = id
+		}
+	}
+	return names
+}
+
 // MountFS mounts an existing LinearFS instance at the given path.
 // This is useful for testing when you need to configure LinearFS before mounting.
 func MountFS(mountpoint string, lfs *LinearFS, debug bool) (*fuse.Server, error) {

--- a/internal/fs/projectlabels.go
+++ b/internal/fs/projectlabels.go
@@ -1,0 +1,106 @@
+package fs
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jra3/linear-fuse/internal/api"
+)
+
+// Project-label selection (see CONTEXT.md): the pure half of the workspace
+// project-label surface — catalog rendering here, name→ID resolution and the
+// selection policy in this file's siblings (write path). Everything in this
+// file is unit-testable with a literal catalog slice: no mount, no interface.
+
+// projectLabelsMarkdown renders the root project-labels.md catalog. The
+// assignment rules live IN the file — it is what an agent reads after a
+// validation .error — and the render is stable for an empty catalog (never
+// ENOENT; the README promises the file exists).
+func projectLabelsMarkdown(labels []api.ProjectLabel) []byte {
+	var yaml, table strings.Builder
+	for _, l := range labels {
+		yaml.WriteString(fmt.Sprintf("  - id: %s\n    name: %s\n", l.ID, l.Name))
+		if l.Color != "" {
+			yaml.WriteString(fmt.Sprintf("    color: %q\n", l.Color))
+		}
+		if l.Description != "" {
+			yaml.WriteString(fmt.Sprintf("    description: %q\n", l.Description))
+		}
+		if l.IsGroup {
+			yaml.WriteString("    group: true\n")
+		}
+		if l.Parent != nil {
+			parent := l.Parent.Name
+			if parent == "" {
+				parent = l.Parent.ID
+			}
+			yaml.WriteString(fmt.Sprintf("    parent: %s\n", parent))
+		}
+		if l.RetiredAt != nil {
+			yaml.WriteString("    retired: true\n")
+		}
+
+		group := "—"
+		if l.Parent != nil {
+			group = l.Parent.Name
+			if group == "" {
+				group = l.Parent.ID
+			}
+		}
+		color := "—"
+		if l.Color != "" {
+			color = l.Color
+		}
+		var flags []string
+		if l.IsGroup {
+			flags = append(flags, "group (assign a child)")
+		}
+		if l.RetiredAt != nil {
+			flags = append(flags, "retired")
+		}
+		table.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s |\n",
+			l.Name, group, color, strings.Join(flags, ", "), l.ID))
+	}
+
+	body := table.String()
+	if len(labels) == 0 {
+		body = "No project labels defined.\n"
+	} else {
+		body = `| Name | Group | Color | Flags | ID |
+|------|-------|-------|-------|-----|
+` + body
+	}
+
+	return []byte(fmt.Sprintf(`---
+labels:
+%s---
+
+# Project Labels (workspace-wide)
+
+Assign in any project.md frontmatter: `+"`labels: [Platform, Q3-Bet]`"+`
+(Names are resolved case-insensitively; a raw label ID is also accepted.)
+
+Rules:
+- Labels marked `+"`group: true`"+` are containers and CANNOT be assigned; assign one
+  of their children instead.
+- At most ONE child from each group may be on a project at a time.
+- Labels marked `+"`retired: true`"+` cannot be newly assigned; existing assignments remain.
+
+%s`, yaml.String(), body))
+}
+
+// projectLabelCatalogTimes derives the catalog file's times from the entities
+// themselves — mtime = newest UpdatedAt, ctime = oldest CreatedAt; zero when
+// the catalog is empty (renderFile's never-fabricate-now() contract).
+func projectLabelCatalogTimes(labels []api.ProjectLabel) (mtime, ctime time.Time) {
+	for _, l := range labels {
+		if l.UpdatedAt.After(mtime) {
+			mtime = l.UpdatedAt
+		}
+		if !l.CreatedAt.IsZero() && (ctime.IsZero() || l.CreatedAt.Before(ctime)) {
+			ctime = l.CreatedAt
+		}
+	}
+	return mtime, ctime
+}

--- a/internal/fs/projectlabels.go
+++ b/internal/fs/projectlabels.go
@@ -104,3 +104,162 @@ func projectLabelCatalogTimes(labels []api.ProjectLabel) (mtime, ctime time.Time
 	}
 	return mtime, ctime
 }
+
+const seeCatalog = " See project-labels.md for valid project labels."
+
+// resolveProjectLabels resolves a project.md labels: list (names and/or raw
+// IDs) against the catalog, returning the deduplicated ID set plus the
+// resolved entities for validation. currentIDs is the project's present
+// labelIds set.
+//
+// Resolution order per entry:
+//  1. Exact-ID passthrough — a catalog ID, or a current-member ID absent from
+//     the catalog (stale/cold catalog). The round-trip invariant: the render
+//     side emits unknown IDs verbatim, so re-saving an untouched file must
+//     resolve them back, never EINVAL.
+//  2. Case-insensitive name match. On a duplicate-name tie: prefer a label
+//     already on the project (untouched files round-trip), then the single
+//     active candidate over retired ones, else a loud ambiguity error listing
+//     candidate IDs — never a silent sibling pick (assign by ID to
+//     disambiguate).
+func resolveProjectLabels(catalog []api.ProjectLabel, names []string, currentIDs map[string]bool) ([]string, []api.ProjectLabel, *FieldError) {
+	byID := make(map[string]api.ProjectLabel, len(catalog))
+	byName := make(map[string][]api.ProjectLabel)
+	for _, l := range catalog {
+		byID[l.ID] = l
+		key := strings.ToLower(l.Name)
+		byName[key] = append(byName[key], l)
+	}
+
+	var ids []string
+	var selected []api.ProjectLabel
+	seen := make(map[string]bool)
+	add := func(l api.ProjectLabel) {
+		if !seen[l.ID] {
+			seen[l.ID] = true
+			ids = append(ids, l.ID)
+			selected = append(selected, l)
+		}
+	}
+
+	for _, raw := range names {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			continue
+		}
+		if l, ok := byID[name]; ok { // exact catalog ID
+			add(l)
+			continue
+		}
+		if currentIDs[name] { // current member the catalog does not know
+			add(api.ProjectLabel{ID: name, Name: name})
+			continue
+		}
+		candidates := byName[strings.ToLower(name)]
+		switch len(candidates) {
+		case 0:
+			return nil, nil, &FieldError{Field: "labels", Value: name,
+				Message: "unknown project label." + seeCatalog}
+		case 1:
+			add(candidates[0])
+		default:
+			picked := false
+			for _, c := range candidates { // (a) prefer a label already applied
+				if currentIDs[c.ID] {
+					add(c)
+					picked = true
+					break
+				}
+			}
+			if !picked { // (b) prefer the single active candidate
+				var active []api.ProjectLabel
+				for _, c := range candidates {
+					if c.RetiredAt == nil {
+						active = append(active, c)
+					}
+				}
+				if len(active) == 1 {
+					add(active[0])
+					picked = true
+				}
+			}
+			if !picked { // (c) loud ambiguity, never a coin flip
+				candIDs := make([]string, len(candidates))
+				for i, c := range candidates {
+					candIDs[i] = c.ID
+				}
+				return nil, nil, &FieldError{Field: "labels", Value: name,
+					Message: fmt.Sprintf("ambiguous project label name; %d labels share it. Assign by ID instead: %s.",
+						len(candidates), strings.Join(candIDs, ", "))}
+			}
+		}
+	}
+	return ids, selected, nil
+}
+
+// validateProjectLabelSelection enforces the documented assignment semantics
+// BEFORE any mutation — deliberately stricter than the API where its
+// enforcement is lax (live-verified 2026-07-08: the wire accepts retired
+// assignment; the docs forbid it). Policy in one sentence: we enforce what
+// Linear's docs say about label assignment, even where the API is lax.
+// Rules: a group label cannot be applied (the error names its assignable
+// children); a retired label cannot be NEWLY applied (existing assignments
+// carry through — labelIds is a full-set write, so carried labels re-send);
+// at most one child per group among the selected set.
+func validateProjectLabelSelection(selected []api.ProjectLabel, currentIDs map[string]bool, catalog []api.ProjectLabel) *FieldError {
+	childrenOf := func(groupID string) []string {
+		var names []string
+		for _, l := range catalog {
+			if l.Parent != nil && l.Parent.ID == groupID && !l.IsGroup && l.RetiredAt == nil {
+				names = append(names, l.Name)
+			}
+		}
+		return names
+	}
+
+	groupPick := make(map[string]string) // group ID -> first selected child name
+	for _, l := range selected {
+		if l.IsGroup {
+			msg := fmt.Sprintf("%q is a label group and cannot be applied directly.", l.Name)
+			if children := childrenOf(l.ID); len(children) > 0 {
+				msg += " Apply one of its children instead: " + strings.Join(children, ", ") + "."
+			}
+			return &FieldError{Field: "labels", Value: l.Name, Message: msg + seeCatalog}
+		}
+		if l.RetiredAt != nil && !currentIDs[l.ID] {
+			return &FieldError{Field: "labels", Value: l.Name,
+				Message: fmt.Sprintf("%q is retired and cannot be newly applied (existing assignments are unaffected).", l.Name) + seeCatalog}
+		}
+		if l.Parent != nil {
+			groupName := l.Parent.Name
+			if groupName == "" {
+				groupName = l.Parent.ID
+			}
+			if prev, ok := groupPick[l.Parent.ID]; ok {
+				return &FieldError{Field: "labels",
+					Message: fmt.Sprintf("at most one child from each label group may be applied: %q and %q are both children of %q.",
+						prev, l.Name, groupName) + seeCatalog}
+			}
+			groupPick[l.Parent.ID] = l.Name
+		}
+	}
+	return nil
+}
+
+// sameIDSet reports whether two label-ID lists carry the same set —
+// order-insensitive, so a reordered frontmatter list is not a change.
+func sameIDSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	set := make(map[string]bool, len(a))
+	for _, id := range a {
+		set[id] = true
+	}
+	for _, id := range b {
+		if !set[id] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/fs/projectlabels_test.go
+++ b/internal/fs/projectlabels_test.go
@@ -67,6 +67,194 @@ func TestProjectLabelsMarkdownEmpty(t *testing.T) {
 	}
 }
 
+func TestResolveProjectLabels(t *testing.T) {
+	t.Parallel()
+	catalog := testCatalog()
+	none := map[string]bool{}
+
+	t.Run("case-insensitive name hit", func(t *testing.T) {
+		t.Parallel()
+		ids, selected, ferr := resolveProjectLabels(catalog, []string{"backend", "BUG"}, none)
+		if ferr != nil {
+			t.Fatalf("unexpected error: %v", ferr.Detail())
+		}
+		if len(ids) != 2 || ids[0] != "id-backend" || ids[1] != "id-bug" {
+			t.Errorf("ids = %v", ids)
+		}
+		if len(selected) != 2 || selected[0].Name != "Backend" {
+			t.Errorf("selected = %+v", selected)
+		}
+	})
+
+	t.Run("unknown name errors with catalog pointer", func(t *testing.T) {
+		t.Parallel()
+		_, _, ferr := resolveProjectLabels(catalog, []string{"Nope"}, none)
+		if ferr == nil || !strings.Contains(ferr.Detail(), "project-labels.md") {
+			t.Errorf("want unknown-name error pointing at the catalog, got %v", ferr)
+		}
+	})
+
+	t.Run("catalog-ID passthrough", func(t *testing.T) {
+		t.Parallel()
+		ids, _, ferr := resolveProjectLabels(catalog, []string{"id-bug"}, none)
+		if ferr != nil || len(ids) != 1 || ids[0] != "id-bug" {
+			t.Errorf("ids = %v, err = %v", ids, ferr)
+		}
+	})
+
+	t.Run("current-member ID passthrough survives a cold catalog", func(t *testing.T) {
+		t.Parallel()
+		// The round-trip invariant: render emitted a verbatim ID the catalog
+		// does not know; re-saving the untouched file must resolve, not EINVAL.
+		current := map[string]bool{"id-ghost": true}
+		ids, _, ferr := resolveProjectLabels(nil, []string{"id-ghost"}, current)
+		if ferr != nil || len(ids) != 1 || ids[0] != "id-ghost" {
+			t.Errorf("ids = %v, err = %v", ids, ferr)
+		}
+	})
+
+	t.Run("duplicates dedup to a set", func(t *testing.T) {
+		t.Parallel()
+		ids, _, ferr := resolveProjectLabels(catalog, []string{"Bug", "bug", "id-bug"}, none)
+		if ferr != nil || len(ids) != 1 {
+			t.Errorf("ids = %v, err = %v", ids, ferr)
+		}
+	})
+
+	dupCatalog := func(retiredSecond bool) []api.ProjectLabel {
+		twin := api.ProjectLabel{ID: "id-twin-2", Name: "Platform"}
+		if retiredSecond {
+			retired := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+			twin.RetiredAt = &retired
+		}
+		return []api.ProjectLabel{{ID: "id-twin-1", Name: "Platform"}, twin}
+	}
+
+	t.Run("duplicate name prefers the label already applied", func(t *testing.T) {
+		t.Parallel()
+		current := map[string]bool{"id-twin-2": true}
+		ids, _, ferr := resolveProjectLabels(dupCatalog(false), []string{"Platform"}, current)
+		if ferr != nil || len(ids) != 1 || ids[0] != "id-twin-2" {
+			t.Errorf("ids = %v, err = %v — want the current member to win", ids, ferr)
+		}
+	})
+
+	t.Run("duplicate name prefers the single active candidate", func(t *testing.T) {
+		t.Parallel()
+		ids, _, ferr := resolveProjectLabels(dupCatalog(true), []string{"Platform"}, none)
+		if ferr != nil || len(ids) != 1 || ids[0] != "id-twin-1" {
+			t.Errorf("ids = %v, err = %v — want active over retired", ids, ferr)
+		}
+	})
+
+	t.Run("unresolvable duplicate errors loudly listing IDs", func(t *testing.T) {
+		t.Parallel()
+		_, _, ferr := resolveProjectLabels(dupCatalog(false), []string{"Platform"}, none)
+		if ferr == nil {
+			t.Fatal("want ambiguity error, got silent pick")
+		}
+		if d := ferr.Detail(); !strings.Contains(d, "id-twin-1") || !strings.Contains(d, "id-twin-2") {
+			t.Errorf("ambiguity error must list candidate IDs: %s", d)
+		}
+	})
+
+	t.Run("empty catalog with a name errors", func(t *testing.T) {
+		t.Parallel()
+		_, _, ferr := resolveProjectLabels(nil, []string{"Platform"}, none)
+		if ferr == nil {
+			t.Fatal("want unknown-name error on empty catalog")
+		}
+	})
+}
+
+func TestValidateProjectLabelSelection(t *testing.T) {
+	t.Parallel()
+	catalog := testCatalog()
+	byName := make(map[string]api.ProjectLabel)
+	for _, l := range catalog {
+		byName[l.Name] = l
+	}
+	none := map[string]bool{}
+
+	t.Run("clean selection passes", func(t *testing.T) {
+		t.Parallel()
+		sel := []api.ProjectLabel{byName["Backend"], byName["Bug"]}
+		if ferr := validateProjectLabelSelection(sel, none, catalog); ferr != nil {
+			t.Errorf("unexpected error: %v", ferr.Detail())
+		}
+	})
+
+	t.Run("group rejected, error names assignable children", func(t *testing.T) {
+		t.Parallel()
+		ferr := validateProjectLabelSelection([]api.ProjectLabel{byName["Area"]}, none, catalog)
+		if ferr == nil {
+			t.Fatal("want group rejection")
+		}
+		d := ferr.Detail()
+		if !strings.Contains(d, "Backend") || !strings.Contains(d, "Frontend") {
+			t.Errorf("group error must name the assignable children: %s", d)
+		}
+	})
+
+	t.Run("retired newly applied rejected", func(t *testing.T) {
+		t.Parallel()
+		ferr := validateProjectLabelSelection([]api.ProjectLabel{byName["Legacy"]}, none, catalog)
+		if ferr == nil || !strings.Contains(ferr.Detail(), "retired") {
+			t.Errorf("want retired-new rejection, got %v", ferr)
+		}
+	})
+
+	t.Run("retired carried through passes", func(t *testing.T) {
+		t.Parallel()
+		current := map[string]bool{"id-legacy": true}
+		if ferr := validateProjectLabelSelection([]api.ProjectLabel{byName["Legacy"]}, current, catalog); ferr != nil {
+			t.Errorf("carried-through retired label must pass: %v", ferr.Detail())
+		}
+	})
+
+	t.Run("two children of one group rejected naming all parties", func(t *testing.T) {
+		t.Parallel()
+		sel := []api.ProjectLabel{byName["Backend"], byName["Frontend"]}
+		ferr := validateProjectLabelSelection(sel, none, catalog)
+		if ferr == nil {
+			t.Fatal("want one-child-per-group rejection")
+		}
+		d := ferr.Detail()
+		for _, want := range []string{"Backend", "Frontend", "Area"} {
+			if !strings.Contains(d, want) {
+				t.Errorf("group-exclusivity error missing %q: %s", want, d)
+			}
+		}
+	})
+
+	t.Run("children of different groups pass", func(t *testing.T) {
+		t.Parallel()
+		other := api.ProjectLabel{ID: "id-x", Name: "X", Parent: &api.ProjectLabel{ID: "id-other-group", Name: "Other"}}
+		sel := []api.ProjectLabel{byName["Backend"], other}
+		if ferr := validateProjectLabelSelection(sel, none, append(catalog, other)); ferr != nil {
+			t.Errorf("children of distinct groups must pass: %v", ferr.Detail())
+		}
+	})
+}
+
+func TestSameIDSet(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		a, b []string
+		want bool
+	}{
+		{nil, nil, true},
+		{[]string{"a"}, nil, false},
+		{[]string{"a", "b"}, []string{"b", "a"}, true}, // order-insensitive
+		{[]string{"a", "b"}, []string{"a", "c"}, false},
+	}
+	for _, c := range cases {
+		if got := sameIDSet(c.a, c.b); got != c.want {
+			t.Errorf("sameIDSet(%v, %v) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
 func TestProjectLabelCatalogTimes(t *testing.T) {
 	t.Parallel()
 	mtime, ctime := projectLabelCatalogTimes(testCatalog())

--- a/internal/fs/projectlabels_test.go
+++ b/internal/fs/projectlabels_test.go
@@ -1,0 +1,85 @@
+package fs
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jra3/linear-fuse/internal/api"
+)
+
+func testCatalog() []api.ProjectLabel {
+	retired := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	group := api.ProjectLabel{ID: "id-area", Name: "Area", IsGroup: true,
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)}
+	return []api.ProjectLabel{
+		group,
+		{ID: "id-backend", Name: "Backend", Color: "#5e6ad2",
+			Parent:    &api.ProjectLabel{ID: "id-area", Name: "Area"},
+			CreatedAt: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+			UpdatedAt: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)},
+		{ID: "id-frontend", Name: "Frontend",
+			Parent:    &api.ProjectLabel{ID: "id-area", Name: "Area"},
+			CreatedAt: time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC),
+			UpdatedAt: time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)},
+		{ID: "id-bug", Name: "Bug", Description: "bug work",
+			CreatedAt: time.Date(2026, 1, 4, 0, 0, 0, 0, time.UTC),
+			UpdatedAt: time.Date(2026, 3, 3, 0, 0, 0, 0, time.UTC)},
+		{ID: "id-legacy", Name: "Legacy", RetiredAt: &retired,
+			CreatedAt: time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC),
+			UpdatedAt: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)},
+	}
+}
+
+func TestProjectLabelsMarkdown(t *testing.T) {
+	t.Parallel()
+	got := string(projectLabelsMarkdown(testCatalog()))
+
+	for _, want := range []string{
+		"group: true",                       // group flagged in frontmatter
+		"parent: Area",                      // child carries parent name
+		"retired: true",                     // retired flagged, not hidden
+		"group (assign a child)",            // table flag spells out the rule
+		"| Legacy | — | — | retired |",      // retired row flag
+		"At most ONE child from each group", // rules prose lives in-file
+		"a raw label ID is also accepted",   // ID-passthrough documented
+		"description: \"bug work\"",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("catalog render missing %q:\n%s", want, got)
+		}
+	}
+	// Frontmatter top key matches the labels.md idiom.
+	if !strings.HasPrefix(got, "---\nlabels:\n") {
+		t.Errorf("catalog frontmatter key is off-idiom:\n%s", got[:40])
+	}
+}
+
+func TestProjectLabelsMarkdownEmpty(t *testing.T) {
+	t.Parallel()
+	got := string(projectLabelsMarkdown(nil))
+	// Stable, never-ENOENT surface: header + rules + explicit emptiness.
+	for _, want := range []string{"# Project Labels", "Rules:", "No project labels defined."} {
+		if !strings.Contains(got, want) {
+			t.Errorf("empty catalog render missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestProjectLabelCatalogTimes(t *testing.T) {
+	t.Parallel()
+	mtime, ctime := projectLabelCatalogTimes(testCatalog())
+	if want := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC); !mtime.Equal(want) {
+		t.Errorf("mtime = %v, want newest UpdatedAt %v", mtime, want)
+	}
+	if want := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC); !ctime.Equal(want) {
+		t.Errorf("ctime = %v, want oldest CreatedAt %v", ctime, want)
+	}
+
+	// Empty catalog: zero times (never fabricate now()).
+	mtime, ctime = projectLabelCatalogTimes(nil)
+	if !mtime.IsZero() || !ctime.IsZero() {
+		t.Errorf("empty catalog times = %v/%v, want zero", mtime, ctime)
+	}
+}

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -252,7 +252,7 @@ func (p *ProjectNode) manifest() *dirManifest {
 	// project.md is editable-only; identity/status/dates live in project.meta.
 	m.file("project.md", projectInfoIno(project.ID), func(ctx context.Context) (fs.InodeEmbedder, []byte, syscall.Errno) {
 		node := &ProjectInfoNode{BaseNode: BaseNode{lfs: lfs}, team: team, project: project}
-		content := node.generateContent()
+		content := node.generateContent(ctx)
 		node.content = content
 		return node, content, 0
 	})
@@ -362,9 +362,11 @@ var _ fs.NodeSetattrer = (*ProjectInfoNode)(nil)
 
 // generateContent renders the editable-only project.md via
 // marshal.ProjectToMarkdown; a render failure serves an empty file rather
-// than failing the node.
-func (p *ProjectInfoNode) generateContent() []byte {
-	out, err := marshal.ProjectToMarkdown(&p.project)
+// than failing the node. Label IDs render as catalog names; an ID the catalog
+// does not know renders verbatim (round-trip invariant — see projectLabelNames).
+func (p *ProjectInfoNode) generateContent(ctx context.Context) []byte {
+	labelNames := p.lfs.projectLabelNames(ctx, p.project.LabelIds)
+	out, err := marshal.ProjectToMarkdown(&p.project, labelNames)
 	if err != nil {
 		return []byte{}
 	}
@@ -424,6 +426,53 @@ func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Er
 		return syscall.EINVAL
 	}
 
+	// Labels: parse + guard + resolve + validate — all PURE, hoisted before
+	// any mutation so a validation failure cannot leave the initiatives
+	// reconcile partially applied.
+	rawLabels, labelsPresent := doc.Frontmatter["labels"]
+	desiredNames := marshal.StringSliceFromYAML(rawLabels)
+
+	// Stale-blob clobber guard: a project blob predating the LabelIds field
+	// reads current as empty, so an agent ADDING one label would full-set-write
+	// just that label and silently wipe the project's real labels in Linear —
+	// invisible to the divergence check (fresh == sent). One targeted refresh
+	// in exactly the at-risk state; interactive-promoted because it is a
+	// synchronous read inside a user-blocking flush.
+	if len(p.project.LabelIds) == 0 && len(desiredNames) > 0 {
+		if fresh, err := p.lfs.verify().GetProject(api.WithInteractive(ctx), p.project.ID); err == nil && fresh != nil {
+			p.project.LabelIds = fresh.LabelIds
+		}
+	}
+
+	currentIDSet := make(map[string]bool, len(p.project.LabelIds))
+	for _, id := range p.project.LabelIds {
+		currentIDSet[id] = true
+	}
+
+	// Key absent + current empty = labels untouched. Key absent + current
+	// non-empty = delete-the-line clear (the mount-wide contract). An explicit
+	// empty list clears too.
+	var desiredIDs []string
+	labelsChanged := false
+	if labelsPresent || len(p.project.LabelIds) > 0 {
+		if len(desiredNames) > 0 {
+			catalog, err := p.lfs.GetProjectLabels(ctx)
+			if err != nil {
+				catalog = nil // ID passthrough via currentIDSet still resolves
+			}
+			ids, selected, ferr := resolveProjectLabels(catalog, desiredNames, currentIDSet)
+			if ferr == nil {
+				ferr = validateProjectLabelSelection(selected, currentIDSet, catalog)
+			}
+			if ferr != nil {
+				p.lfs.SetWriteError(p.project.ID, ferr.Detail())
+				return syscall.EINVAL
+			}
+			desiredIDs = ids
+		}
+		labelsChanged = !sameIDSet(desiredIDs, p.project.LabelIds)
+	}
+
 	// Extract initiatives from frontmatter (coerced via the shared marshal helper)
 	newInitiatives := marshal.StringSliceFromYAML(doc.Frontmatter["initiatives"])
 
@@ -464,12 +513,21 @@ func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Er
 		return errno
 	}
 
-	// Persist editable scalar fields (name in frontmatter, description in body).
-	// The body maps to the project's description, matching generateContent().
-	// scalarEdit owns the diff, name coercion, and the divergence compare below.
+	// Persist editable scalar fields (name in frontmatter, description in
+	// body) plus the label set, in ONE UpdateProject call. Labels are a
+	// full-set atomic input (no removedLabelIds analog), so this is scalarEdit
+	// territory — deliberately not reconcileLinks, which exists for per-pair
+	// link mutations. Pointer-or-omit: untouched labels send nil.
 	edit := newScalarEdit(doc, p.project.Name, p.project.Description)
 	projectInput := api.ProjectUpdateInput{Name: edit.name, Description: edit.desc}
-	if edit.changed() {
+	if labelsChanged {
+		ids := desiredIDs
+		if ids == nil {
+			ids = []string{} // clear (live-verified: labelIds: [] empties the set)
+		}
+		projectInput.LabelIds = &ids
+	}
+	if edit.changed() || labelsChanged {
 		if err := p.lfs.mutator().UpdateProject(ctx, p.project.ID, projectInput); err != nil {
 			msg, errno := classifyMutationErr("update project", err)
 			p.lfs.SetWriteError(p.project.ID, msg)
@@ -490,7 +548,19 @@ func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Er
 			return p.lfs.UpsertProject(ctx, p.team.ID, *fresh)
 		},
 		compare: func(fresh *api.Project) []writeBackResult {
-			return edit.divergences(fresh.Name, fresh.Description)
+			results := edit.divergences(fresh.Name, fresh.Description)
+			// Guarded on labelsChanged: an untouched label set must produce
+			// zero label divergence (a plain rename would otherwise EIO
+			// whenever another writer touches labels concurrently). Order is
+			// not divergence — the set is.
+			if labelsChanged && !sameIDSet(fresh.LabelIds, desiredIDs) {
+				results = append(results, writeBackResult{
+					message: fmt.Sprintf("Field: labels\nError: the write was accepted but the persisted label set differs (sent %d labels, %d persisted). Re-read the file to see the stored set.",
+						len(desiredIDs), len(fresh.LabelIds)),
+					fatal: true,
+				})
+			}
+			return results
 		},
 	})
 	if fresh != nil {

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -109,6 +109,7 @@ Mount point: %s (all paths below are relative to this mount point)
 <directory_structure>
 teams/{KEY}/
   team.md, states.md, labels.md     [read-only metadata]
+  project-labels.md                 [symlink to ../../project-labels.md]
   issues/                           [mkdir "Title" for quick create]
     _create                         [write full frontmatter+body to create one issue with all fields]
     .error                          [read-only: last failed issue creation]
@@ -160,6 +161,8 @@ teams/{KEY}/
   cycles/
     current                         [symlink to active cycle]
     {name}/                         [issue symlinks]
+
+project-labels.md                   [read-only: workspace project-label catalog (groups, retired)]
 
 initiatives/{slug}/
   initiative.md                     [read/write: editable fields + body ONLY]
@@ -222,6 +225,21 @@ cycle: "Sprint 42"
 ---
 Description body (editable)
 </issue_frontmatter>
+
+<project_frontmatter>
+project.md holds only editable fields (below) + the description body. Read-only
+identity/status/lead/dates live in the sibling project.meta. A successful write
+never rewrites project.md.
+---
+name: "API Gateway"                         [editable]
+initiatives: ["Platform Modernization"]     [names; see initiatives/]
+labels: [Backend, Q3-Bet]                   [must match project-labels.md; groups
+                                             cannot be applied; max one child per
+                                             group; retired = existing-only; raw
+                                             label IDs also accepted]
+---
+Project description (editable - the body maps to the description)
+</project_frontmatter>
 
 <initiative_frontmatter>
 initiative.md holds only editable fields (below) + the description body. Read-only
@@ -287,7 +305,9 @@ Failure model (every writable surface follows this contract):
 So an edit that "fails" or appears to no-op is explained at the sibling .error.
 
 Validated issue fields: status, assignee, labels, priority, project, milestone, cycle, parent
-Reference files: states.md (valid statuses), labels.md (valid labels), initiatives/ (valid initiatives)
+Validated project fields: initiatives, labels
+Reference files: states.md (valid statuses), labels.md (valid issue labels),
+project-labels.md (valid project labels), initiatives/ (valid initiatives)
 </validation_errors>
 
 <important_notes>
@@ -300,6 +320,9 @@ Reference files: states.md (valid statuses), labels.md (valid labels), initiativ
 - Cache TTL: 60s for issues, 10min for states/labels/users
 - Timestamps: mtime=updatedAt, ctime=createdAt from Linear
 - Project slugs: Use slug (e.g., "api-gateway"), not name, in initiative.md
+- Project labels are workspace-wide (see project-labels.md). A label group cannot
+  be applied directly (pick one of its children; max one child per group); a
+  retired label stays on existing projects but cannot be newly applied
 </important_notes>
 
 <claude_code_instructions>
@@ -332,6 +355,7 @@ WRITING ISSUE CONTENT:
 - To update an issue: use Edit tool on the issue.md file
 - Only edit fields you intend to change; leave others untouched
 - Check <mount>/teams/ENG/states.md and labels.md for valid values before editing
+- Check <mount>/project-labels.md before editing labels: in project.md
 
 BASH PATTERNS TO AVOID:
 - Avoid: for x in list; do cat $x; done  → instead: parallel Read tool calls

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -30,6 +30,7 @@ func (r *RootNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrO
 func (r *RootNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	entries := []fuse.DirEntry{
 		{Name: "README.md", Mode: syscall.S_IFREG},
+		{Name: "project-labels.md", Mode: syscall.S_IFREG},
 		{Name: "teams", Mode: syscall.S_IFDIR},
 		{Name: "users", Mode: syscall.S_IFDIR},
 		{Name: "my", Mode: syscall.S_IFDIR},
@@ -47,6 +48,18 @@ func (r *RootNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 		return r.lookupRenderFile(ctx, out, "README.md", func(context.Context) ([]byte, time.Time, time.Time) {
 			return []byte(generateReadme(lfs.MountPoint())), time.Time{}, time.Time{}
 		}, 0, inheritTimeout), 0
+
+	case "project-labels.md":
+		// The workspace project-label catalog (ProjectLabel has no team edge,
+		// so this is a root surface like initiatives/). SQLite-only read; an
+		// error or empty catalog still renders — the surface never ENOENTs.
+		lfs := r.lfs
+		return r.lookupRenderFile(ctx, out, "project-labels.md",
+			func(ctx context.Context) ([]byte, time.Time, time.Time) {
+				labels, _ := lfs.GetProjectLabels(ctx)
+				mtime, ctime := projectLabelCatalogTimes(labels)
+				return projectLabelsMarkdown(labels), mtime, ctime
+			}, projectLabelsCatalogIno(), inheritTimeout), 0
 
 	case "teams":
 		node := &TeamsNode{BaseNode: BaseNode{lfs: r.lfs}}

--- a/internal/fs/teams.go
+++ b/internal/fs/teams.go
@@ -87,6 +87,7 @@ func (t *TeamNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 		{Name: "team.md", Mode: syscall.S_IFREG},
 		{Name: "states.md", Mode: syscall.S_IFREG},
 		{Name: "labels.md", Mode: syscall.S_IFREG},
+		{Name: "project-labels.md", Mode: syscall.S_IFLNK},
 		{Name: "by", Mode: syscall.S_IFDIR},
 		{Name: "cycles", Mode: syscall.S_IFDIR},
 		{Name: "projects", Mode: syscall.S_IFDIR},
@@ -130,6 +131,15 @@ func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 			}
 			return labelsMarkdown(team, labels), team.UpdatedAt, team.CreatedAt
 		}, 0, inheritTimeout), 0
+
+	case "project-labels.md":
+		// Ergonomics alias beside states.md/labels.md, where agents already
+		// look for validation references. A symlink (not a per-team file)
+		// honestly discloses the workspace scoping — ProjectLabel has no team
+		// edge. Zero times: stamping catalog times here would need a catalog
+		// load per team-Lookup; a stat THROUGH the link reports the render
+		// file's real times.
+		return t.newSymlinkInode(ctx, out, "../../project-labels.md", time.Time{}, time.Time{}), 0
 
 	case "by":
 		out.Attr.Mode = 0755 | syscall.S_IFDIR

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -206,8 +206,11 @@ func populateTestFixtures(ctx context.Context, store *db.Store) error {
 	labels := fixtures.FixtureAPILabels()
 	users := fixtures.FixtureAPIUsers()
 
-	// Create a project
+	// Create a project, pre-labeled with a group child + a retired label (the
+	// carried-through case: labelIds is a full-set write, so a save that keeps
+	// Legacy must re-send it and pass validation).
 	project := fixtures.FixtureAPIProject()
+	project.LabelIds = []string{"plabel-backend", "plabel-legacy"}
 
 	// Create issues with various configurations
 	issues := []api.Issue{
@@ -312,6 +315,11 @@ func populateTestFixtures(ctx context.Context, store *db.Store) error {
 	// Populate cycle
 	cycle := fixtures.FixtureAPICycle()
 	if err := fixtures.PopulateCycle(ctx, store, cycle, team.ID); err != nil {
+		return err
+	}
+
+	// Populate the workspace project-label catalog
+	if err := fixtures.PopulateProjectLabels(ctx, store, fixtures.FixtureAPIProjectLabels()); err != nil {
 		return err
 	}
 

--- a/internal/integration/projectlabels_test.go
+++ b/internal/integration/projectlabels_test.go
@@ -1,0 +1,307 @@
+package integration
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jra3/linear-fuse/internal/db"
+	"github.com/jra3/linear-fuse/internal/testutil/fixtures"
+)
+
+// writeProjectMD is claudeToolWrite without the t.Fatal on commit failure —
+// validation tests need the flush errno back.
+func writeProjectMD(t *testing.T, path string, content string) error {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		t.Fatalf("open %s for write: %v", path, err)
+	}
+	if _, err := f.Write([]byte(content)); err != nil {
+		_ = f.Close()
+		t.Fatalf("write %s: %v", path, err)
+	}
+	syncErr := f.Sync()
+	closeErr := f.Close()
+	if syncErr != nil {
+		return syncErr
+	}
+	return closeErr
+}
+
+func projectMDPath() string {
+	return filepath.Join(projectsPath(testTeamKey), "test-project", "project.md")
+}
+
+func projectErrorPath() string {
+	return filepath.Join(projectsPath(testTeamKey), "test-project", ".error")
+}
+
+// TestProjectLabelsCatalogFile: the root catalog renders names, group/retired
+// markers, and the assignment rules; it is read-only; and — because renderFile
+// serves it DIRECT_IO with no node-level cache — a sync-side row upserted
+// mid-test is visible on the very next read, with NO kernel invalidation
+// surface needed (tested, not asserted).
+func TestProjectLabelsCatalogFile(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode: asserts the seeded synthetic catalog")
+	}
+	path := filepath.Join(mountPoint, "project-labels.md")
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat catalog: %v", err)
+	}
+	if info.Mode().Perm() != 0444 {
+		t.Errorf("catalog mode = %v, want 0444", info.Mode().Perm())
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read catalog: %v", err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		"Area", "Backend", "Frontend", "Ops", "Legacy", // all five, retired included
+		"group: true", "retired: true", "parent: Area",
+		"At most ONE child from each group", // the rules prose
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("catalog missing %q:\n%s", want, content)
+		}
+	}
+
+	// DIRECT_IO freshness: a catalog row upserted straight to the store (the
+	// sync worker's write path) appears on the next read, no invalidation.
+	params, err := db.APIProjectLabelToDBProjectLabel(fixtures.FixtureAPIProjectLabels()[3])
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	params.ID, params.Name = "plabel-midtest", "Midtest-Fresh"
+	if err := testStore.Queries().UpsertProjectLabel(context.Background(), params); err != nil {
+		t.Fatalf("mid-test upsert: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testStore.DB().Exec("DELETE FROM project_labels WHERE id = 'plabel-midtest'")
+	})
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("re-read catalog: %v", err)
+	}
+	if !strings.Contains(string(after), "Midtest-Fresh") {
+		t.Error("mid-test catalog upsert not visible on next read (DIRECT_IO regression)")
+	}
+}
+
+// TestProjectLabelsTeamSymlink: the per-team alias resolves to the root
+// catalog and reads through.
+func TestProjectLabelsTeamSymlink(t *testing.T) {
+	link := filepath.Join(mountPoint, "teams", testTeamKey, "project-labels.md")
+	target, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("readlink: %v", err)
+	}
+	if target != "../../project-labels.md" {
+		t.Errorf("symlink target = %q, want ../../project-labels.md", target)
+	}
+	data, err := os.ReadFile(link)
+	if err != nil {
+		t.Fatalf("read through symlink: %v", err)
+	}
+	if !strings.Contains(string(data), "# Project Labels") {
+		t.Error("read through the symlink did not reach the catalog")
+	}
+}
+
+// TestProjectLabelsRenderAndAssign: project.md renders labelIds as names;
+// editing the list resolves names back to IDs, sends ONE full-set
+// UpdateProject through the mock, and survives a re-read. The retired label
+// already on the project carries through (full-set write re-sends it).
+func TestProjectLabelsRenderAndAssign(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode: drives the mock mutation client")
+	}
+	enableMockMutations(t)
+
+	orig, err := os.ReadFile(projectMDPath())
+	if err != nil {
+		t.Fatalf("read project.md: %v", err)
+	}
+	if !strings.Contains(string(orig), "labels:") ||
+		!strings.Contains(string(orig), "Backend") || !strings.Contains(string(orig), "Legacy") {
+		t.Fatalf("project.md should render labels [Backend Legacy] as names:\n%s", orig)
+	}
+	t.Cleanup(func() { _ = writeProjectMD(t, projectMDPath(), string(orig)) })
+
+	// Swap Backend -> Frontend (same group, one child at a time), keep the
+	// retired Legacy (carried through).
+	edited := strings.Replace(string(orig), "Backend", "Frontend", 1)
+	if err := writeProjectMD(t, projectMDPath(), edited); err != nil {
+		t.Fatalf("labeled save failed: %v", err)
+	}
+	if data, _ := os.ReadFile(projectErrorPath()); strings.TrimSpace(string(data)) != "" {
+		t.Fatalf(".error non-empty after a valid label edit: %q", data)
+	}
+	after, err := readFileWithRetry(projectMDPath(), defaultWaitTime)
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if !strings.Contains(string(after), "Frontend") || strings.Contains(string(after), "Backend") {
+		t.Errorf("label edit did not persist through the mock round-trip:\n%s", after)
+	}
+	if !strings.Contains(string(after), "Legacy") {
+		t.Errorf("carried-through retired label was dropped by the full-set write:\n%s", after)
+	}
+}
+
+// TestProjectLabelsValidationErrors: each policy rejection is EINVAL with an
+// actionable .error that names the offense and points at the catalog — before
+// any mutation fires (no mock injected: a mutation attempt would fail loudly
+// with a different message).
+func TestProjectLabelsValidationErrors(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode legibility check")
+	}
+	orig, err := os.ReadFile(projectMDPath())
+	if err != nil {
+		t.Fatalf("read project.md: %v", err)
+	}
+	base := string(orig)
+	t.Cleanup(func() { _ = writeProjectMD(t, projectMDPath(), base) })
+
+	swap := func(from, to string) string {
+		s := strings.Replace(base, from, to, 1)
+		if s == base {
+			t.Fatalf("fixture drift: %q not present in project.md:\n%s", from, base)
+		}
+		return s
+	}
+
+	cases := []struct {
+		name      string
+		content   string
+		errSubstr []string
+	}{
+		{"unknown name", swap("Backend", "Nonexistent-Label"),
+			[]string{"unknown project label", "project-labels.md"}},
+		{"group cannot be applied", swap("Backend", "Area"),
+			[]string{"label group", "Backend", "Frontend"}}, // error names the children
+		// Legacy -> Frontend leaves [Backend, Frontend]: two children of Area.
+		{"two children of one group", swap("Legacy", "Frontend"),
+			[]string{"one child", "Area"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := writeProjectMD(t, projectMDPath(), tc.content); err == nil {
+				t.Fatal("expected EINVAL, save succeeded")
+			}
+			data := readFileUntilContains(t, projectErrorPath(), tc.errSubstr[0], errorVisibilityWait)
+			for _, want := range tc.errSubstr {
+				if !strings.Contains(string(data), want) {
+					t.Errorf(".error missing %q: %q", want, data)
+				}
+			}
+		})
+	}
+}
+
+// TestProjectLabelsRetiredNewlyApplied: clearing labels then re-adding the
+// retired one flips it from carried-through (allowed) to newly-applied
+// (policy-rejected — deliberately stricter than the API, which live-verified
+// accepts it).
+func TestProjectLabelsRetiredNewlyApplied(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode: drives the mock mutation client")
+	}
+	enableMockMutations(t)
+
+	orig, err := os.ReadFile(projectMDPath())
+	if err != nil {
+		t.Fatalf("read project.md: %v", err)
+	}
+	t.Cleanup(func() { _ = writeProjectMD(t, projectMDPath(), string(orig)) })
+
+	// Step 1: delete the labels block entirely (the key line plus its YAML
+	// list items) — the mount-wide delete-the-line clear contract.
+	var kept []string
+	inLabels := false
+	for _, line := range strings.Split(string(orig), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "labels:") {
+			inLabels = true
+			continue
+		}
+		if inLabels && strings.HasPrefix(trimmed, "- ") {
+			continue
+		}
+		inLabels = false
+		kept = append(kept, line)
+	}
+	if err := writeProjectMD(t, projectMDPath(), strings.Join(kept, "\n")); err != nil {
+		t.Fatalf("delete-the-line clear failed: %v", err)
+	}
+	after, err := readFileWithRetry(projectMDPath(), defaultWaitTime)
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if strings.Contains(string(after), "labels:") {
+		t.Fatalf("labels line survived the clear:\n%s", after)
+	}
+
+	// Step 2: with the set now empty, applying the retired label is NEW — the
+	// policy rejects what the wire would accept.
+	relabeled := strings.Replace(string(after), "name:", "labels: [Legacy]\nname:", 1)
+	if err := writeProjectMD(t, projectMDPath(), relabeled); err == nil {
+		t.Fatal("expected EINVAL newly applying a retired label, save succeeded")
+	}
+	data := readFileUntilContains(t, projectErrorPath(), "retired", errorVisibilityWait)
+	if !strings.Contains(string(data), "retired") || !strings.Contains(string(data), "Legacy") {
+		t.Errorf(".error should explain the retired rejection: %q", data)
+	}
+}
+
+// TestProjectLabelsStaleIDRoundTrip: a labelId the catalog does not know
+// renders VERBATIM, and re-saving the untouched file is a no-op success — the
+// round-trip invariant that keeps a cold/stale catalog from stripping labels.
+func TestProjectLabelsStaleIDRoundTrip(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode: seeds a ghost labelId straight into the store")
+	}
+	enableMockMutations(t)
+	ctx := context.Background()
+
+	ghost := fixtures.FixtureAPIProject()
+	ghost.ID, ghost.Slug, ghost.Name = "project-ghost", "ghost-project", "Ghost Project"
+	ghost.LabelIds = []string{"plabel-vanished"}
+	if err := fixtures.PopulateProject(ctx, testStore, ghost, fixtures.FixtureAPITeam().ID); err != nil {
+		t.Fatalf("seed ghost project: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testStore.DB().Exec("DELETE FROM projects WHERE id = 'project-ghost'")
+		_, _ = testStore.DB().Exec("DELETE FROM project_teams WHERE project_id = 'project-ghost'")
+	})
+
+	path := filepath.Join(projectsPath(testTeamKey), "ghost-project", "project.md")
+	data, err := readFileWithRetry(path, defaultWaitTime)
+	if err != nil {
+		t.Fatalf("read ghost project.md: %v", err)
+	}
+	if !strings.Contains(string(data), "plabel-vanished") {
+		t.Fatalf("unknown labelId must render verbatim, never dropped:\n%s", data)
+	}
+
+	// Untouched re-save: the verbatim ID resolves via current-member
+	// passthrough, the set diff is empty, no mutation fires, no .error.
+	if err := writeProjectMD(t, path, string(data)); err != nil {
+		t.Fatalf("untouched re-save of a stale-ID render failed: %v", err)
+	}
+	errPath := filepath.Join(projectsPath(testTeamKey), "ghost-project", ".error")
+	if e, _ := os.ReadFile(errPath); strings.TrimSpace(string(e)) != "" {
+		t.Errorf(".error non-empty after an untouched stale-ID save: %q", e)
+	}
+	if after, _ := os.ReadFile(path); !strings.Contains(string(after), "plabel-vanished") {
+		t.Errorf("stale labelId stripped by the no-op save:\n%s", after)
+	}
+}

--- a/internal/integration/readme_test.go
+++ b/internal/integration/readme_test.go
@@ -66,4 +66,25 @@ func TestGeneratedReadmeMatchesBehavior(t *testing.T) {
 	if strings.Contains(readme, "instead surface the result") {
 		t.Error("README carves attachments/relations out of .last, but every create surface reports to .last now")
 	}
+
+	// Project labels (#130): the README must teach the catalog surface and the
+	// assignment rules ("one child" pins group exclusivity; "retired" pins the
+	// lifecycle; the reference-files line must point at the catalog).
+	for _, want := range []string{"project-labels.md", "one child", "retired", "Validated project fields"} {
+		if !strings.Contains(readme, want) {
+			t.Errorf("README does not mention %q", want)
+		}
+	}
+	// And the documented surface must really exist, read-only, with the
+	// group marker the rules refer to.
+	catalog, err := os.ReadFile(filepath.Join(mountPoint, "project-labels.md"))
+	if err != nil {
+		t.Fatalf("README documents project-labels.md but it is unreadable: %v", err)
+	}
+	if !strings.Contains(string(catalog), "group") {
+		t.Error("project-labels.md does not carry the group marker the README describes")
+	}
+	if info, err := os.Stat(filepath.Join(mountPoint, "project-labels.md")); err == nil && info.Mode().Perm() != 0444 {
+		t.Errorf("project-labels.md mode = %v, want 0444 (README: read-only)", info.Mode().Perm())
+	}
 }

--- a/internal/marshal/project.go
+++ b/internal/marshal/project.go
@@ -7,11 +7,14 @@ import (
 )
 
 // ProjectToMarkdown renders the editable-only project.md: name, initiatives,
-// and the description body. Server-managed fields live in project.meta (see
-// ProjectMetaToMarkdown), so a successful write never rewrites the bytes the
-// writer wrote. The parse side is scalarEdit (name/description) plus
-// reconcileLinks (the initiatives list) in internal/fs.
-func ProjectToMarkdown(project *api.Project) ([]byte, error) {
+// labels, and the description body. Server-managed fields live in project.meta
+// (see ProjectMetaToMarkdown), so a successful write never rewrites the bytes
+// the writer wrote. The parse side is scalarEdit (name/description) plus
+// reconcileLinks (the initiatives list) plus resolveProjectLabels (the labels
+// list) in internal/fs. labelNames is the project's labelIds mapped to catalog
+// names by the caller — an unknown ID arrives verbatim (round-trip invariant);
+// the key is omitted when empty (delete-the-line clears).
+func ProjectToMarkdown(project *api.Project, labelNames []string) ([]byte, error) {
 	fm := map[string]any{"name": project.Name}
 
 	if project.Initiatives != nil && len(project.Initiatives.Nodes) > 0 {
@@ -20,6 +23,9 @@ func ProjectToMarkdown(project *api.Project) ([]byte, error) {
 			names[i] = init.Name
 		}
 		fm["initiatives"] = names
+	}
+	if len(labelNames) > 0 {
+		fm["labels"] = labelNames
 	}
 
 	return Render(&Document{Frontmatter: fm, Body: project.Description})

--- a/internal/marshal/project_test.go
+++ b/internal/marshal/project_test.go
@@ -24,9 +24,9 @@ func frontmatterKeys(t *testing.T, content []byte) ([]string, *Document) {
 }
 
 // TestProjectToMarkdown pins the editable-only contract for project.md: name,
-// the initiatives list, and the description body — and nothing server-managed
-// (id/url/status live in project.meta), so a successful write never rewrites
-// the bytes the writer wrote.
+// the initiatives list, the labels list, and the description body — and
+// nothing server-managed (id/url/status live in project.meta), so a successful
+// write never rewrites the bytes the writer wrote.
 func TestProjectToMarkdown(t *testing.T) {
 	t.Parallel()
 	project := &api.Project{
@@ -38,21 +38,34 @@ func TestProjectToMarkdown(t *testing.T) {
 		Initiatives: &api.ProjectInitiatives{Nodes: []api.ProjectInitiative{{Name: "Platform"}, {Name: "Modernization"}}},
 	}
 
-	content, err := ProjectToMarkdown(project)
+	content, err := ProjectToMarkdown(project, []string{"Backend", "Q3-Bet"})
 	if err != nil {
 		t.Fatalf("ProjectToMarkdown: %v", err)
 	}
 	keys, doc := frontmatterKeys(t, content)
-	if want := []string{"initiatives", "name"}; !reflect.DeepEqual(keys, want) {
+	if want := []string{"initiatives", "labels", "name"}; !reflect.DeepEqual(keys, want) {
 		t.Errorf("project.md frontmatter keys = %v, want %v (editable-only)", keys, want)
 	}
 	if doc.Body != project.Description {
 		t.Errorf("body = %q, want the description", doc.Body)
 	}
+	if got := StringSliceFromYAML(doc.Frontmatter["labels"]); !reflect.DeepEqual(got, []string{"Backend", "Q3-Bet"}) {
+		t.Errorf("labels = %v, want the caller-resolved names", got)
+	}
 
-	// No initiatives → no initiatives key at all (deleting the line clears).
+	// Labels but no initiatives.
+	content, err = ProjectToMarkdown(&api.Project{Name: "Labeled"}, []string{"Bug"})
+	if err != nil {
+		t.Fatalf("ProjectToMarkdown(labeled): %v", err)
+	}
+	if keys, _ := frontmatterKeys(t, content); !reflect.DeepEqual(keys, []string{"labels", "name"}) {
+		t.Errorf("labeled project frontmatter keys = %v, want [labels name]", keys)
+	}
+
+	// No initiatives and no labels → neither key at all (deleting the line
+	// clears; an empty list must not render).
 	bare := &api.Project{Name: "Bare"}
-	content, err = ProjectToMarkdown(bare)
+	content, err = ProjectToMarkdown(bare, nil)
 	if err != nil {
 		t.Fatalf("ProjectToMarkdown(bare): %v", err)
 	}

--- a/internal/repo/sqlite.go
+++ b/internal/repo/sqlite.go
@@ -559,6 +559,29 @@ func (r *SQLiteRepository) GetTeamLabels(ctx context.Context, teamID string) ([]
 	return db.DBLabelsToAPILabels(labels), nil
 }
 
+// GetProjectLabels returns the workspace project-label catalog, sorted by
+// name. The converter populates Parent strictly as an ID from the parent_id
+// column; the full catalog is in hand here, so parent names are stitched in
+// one in-memory pass over the id→name map (the wire never carries them —
+// see projectLabelFieldsFragment).
+func (r *SQLiteRepository) GetProjectLabels(ctx context.Context) ([]api.ProjectLabel, error) {
+	rows, err := r.store.Queries().ListProjectLabels(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list project labels: %w", err)
+	}
+	labels := db.DBProjectLabelsToAPIProjectLabels(rows)
+	byID := make(map[string]string, len(labels))
+	for _, l := range labels {
+		byID[l.ID] = l.Name
+	}
+	for i := range labels {
+		if p := labels[i].Parent; p != nil {
+			p.Name = byID[p.ID] // unknown parent stays name-less; render copes
+		}
+	}
+	return labels, nil
+}
+
 func (r *SQLiteRepository) GetLabelByName(ctx context.Context, teamID, name string) (*api.Label, error) {
 	return queryOne("get label by name",
 		func() (db.Label, error) {

--- a/internal/sync/prune_test.go
+++ b/internal/sync/prune_test.go
@@ -460,6 +460,93 @@ func TestWorkspaceSyncPruneSparesMidSyncLink(t *testing.T) {
 	}
 }
 
+func seedProjectLabel(t *testing.T, store *db.Store, id, name string, syncedAt time.Time) {
+	t.Helper()
+	if err := store.Queries().UpsertProjectLabel(context.Background(), db.UpsertProjectLabelParams{
+		ID:       id,
+		Name:     name,
+		SyncedAt: syncedAt,
+		Data:     []byte("{}"),
+	}); err != nil {
+		t.Fatalf("seed project_label %s: %v", id, err)
+	}
+}
+
+func projectLabelNames(t *testing.T, store *db.Store) []string {
+	t.Helper()
+	rows, err := store.Queries().ListProjectLabels(context.Background())
+	if err != nil {
+		t.Fatalf("list project labels: %v", err)
+	}
+	names := make([]string, len(rows))
+	for i, r := range rows {
+		names[i] = r.Name
+	}
+	return names
+}
+
+// TestWorkspaceSyncReconcilesProjectLabels: the complete catalog drain is the
+// completeness set — a row it no longer returns (label deleted in Linear) is
+// pruned, while a RETIRED label the drain still returns is upserted and KEPT
+// (retirement is keep-but-not-newly-assignable, not deletion).
+func TestWorkspaceSyncReconcilesProjectLabels(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	old := db.Now().Add(-time.Minute)
+	seedProjectLabel(t, store, "plabel-gone", "Deleted-In-Linear", old)
+	seedProjectLabel(t, store, "plabel-retired", "Legacy", old)
+
+	retired := time.Date(2026, 7, 8, 0, 0, 0, 0, time.UTC)
+	mock := newMockAPIClient()
+	mock.projectLabels = []api.ProjectLabel{
+		{ID: "plabel-retired", Name: "Legacy", RetiredAt: &retired},
+		{ID: "plabel-new", Name: "Platform"},
+	}
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	if err := worker.syncWorkspace(ctx); err != nil {
+		t.Fatalf("syncWorkspace: %v", err)
+	}
+
+	got := projectLabelNames(t, store)
+	if len(got) != 2 || got[0] != "Legacy" || got[1] != "Platform" {
+		t.Errorf("catalog = %v, want [Legacy Platform] (deleted pruned, retired kept)", got)
+	}
+	rows, err := store.Queries().ListProjectLabels(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !rows[0].RetiredAt.Valid {
+		t.Errorf("retired label lost its retired_at through the sync")
+	}
+}
+
+// TestProjectLabelFetchErrorIsIsolated: a failed catalog drain must neither
+// prune the catalog (no completeness set) nor fail the workspace pass
+// (log-and-continue isolation).
+func TestProjectLabelFetchErrorIsIsolated(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	seedProjectLabel(t, store, "plabel-stale", "Survivor", db.Now().Add(-time.Minute))
+
+	mock := newMockAPIClient()
+	mock.projectLabelsErr = errors.New("catalog down")
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	if err := worker.syncWorkspace(ctx); err != nil {
+		t.Fatalf("catalog failure must not fail the workspace pass: %v", err)
+	}
+	if got := projectLabelNames(t, store); len(got) != 1 || got[0] != "Survivor" {
+		t.Errorf("catalog = %v, want [Survivor] untouched after failed drain", got)
+	}
+}
+
 // TestWorkspaceFetchErrorPrunesNothing: a failed workspace fetch must leave
 // every junction row untouched.
 func TestWorkspaceFetchErrorPrunesNothing(t *testing.T) {

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -36,6 +36,10 @@ type APIClient interface {
 	// Consolidated workspace data (users + initiatives in one call)
 	GetWorkspace(ctx context.Context) (*api.WorkspaceData, error)
 
+	// Workspace project-label catalog (complete drain, retired included —
+	// completeness licenses the prune in syncProjectLabels)
+	GetProjectLabels(ctx context.Context) ([]api.ProjectLabel, error)
+
 	// Issue details (comments, documents, attachments)
 	GetIssueDetails(ctx context.Context, issueID string) (*api.IssueDetails, error)
 	GetIssueDetailsBatch(ctx context.Context, issueIDs []string) (map[string]*api.IssueDetails, error)
@@ -509,10 +513,46 @@ func (w *Worker) syncWorkspace(ctx context.Context) error {
 	}
 	log.Printf("[sync] synced %d initiatives", len(data.Initiatives))
 
+	// Project-label catalog (workspace-scoped; see CONTEXT.md "Project-label
+	// selection"). Isolated log-and-continue: a catalog failure must not block
+	// users/initiatives, and vice versa. Reuses pruneCutoff: taken before ANY
+	// fetch this pass, so it is strictly conservative for the synced_at <
+	// cutoff prune (the converter stamps SyncedAt at upsert time, after it).
+	// The drain includes retired labels (live-verified), so retirement never
+	// reads as removal — only true deletion/archival does.
+	w.syncProjectLabels(ctx, pruneCutoff)
+
 	if len(errs) > 0 {
 		return fmt.Errorf("workspace sync errors: %v", errs)
 	}
 	return nil
+}
+
+// syncProjectLabels reconciles the workspace project-label catalog. The
+// complete GetProjectLabels drain is the completeness set that licenses the
+// full-table prune; a fetch failure skips the pass entirely (no prune without
+// a complete drain).
+func (w *Worker) syncProjectLabels(ctx context.Context, pruneCutoff time.Time) {
+	plabels, err := w.client.GetProjectLabels(ctx)
+	if err != nil {
+		log.Printf("[sync] project labels fetch failed: %v", err)
+		return
+	}
+	syncCollection(ctx, syncCollectionSpec[api.ProjectLabel]{
+		label: "project-label",
+		items: plabels,
+		upsert: func(ctx context.Context, l api.ProjectLabel) error {
+			params, err := db.APIProjectLabelToDBProjectLabel(l)
+			if err != nil {
+				return err
+			}
+			return w.store.Queries().UpsertProjectLabel(ctx, params)
+		},
+		prune: func(ctx context.Context) error {
+			return w.store.Queries().PruneProjectLabels(ctx, pruneCutoff)
+		},
+	})
+	log.Printf("[sync] synced %d project labels", len(plabels))
 }
 
 // syncInitiativeProjects upserts an initiative's junction rows and prunes

--- a/internal/sync/worker_test.go
+++ b/internal/sync/worker_test.go
@@ -37,6 +37,8 @@ type mockAPIClient struct {
 	membersByTeam    map[string][]api.User    // teamID -> members
 	users            []api.User
 	initiatives      []api.Initiative
+	projectLabels    []api.ProjectLabel
+	projectLabelsErr error // if set, GetProjectLabels fails with this (catalog isolation tests)
 	pageSize         int
 	getTeamsCalls    int32
 	getIssuesCalls   int32
@@ -164,6 +166,17 @@ func (m *mockAPIClient) GetWorkspace(ctx context.Context) (*api.WorkspaceData, e
 		Users:       m.users,
 		Initiatives: m.initiatives,
 	}, nil
+}
+
+func (m *mockAPIClient) GetProjectLabels(ctx context.Context) ([]api.ProjectLabel, error) {
+	m.recordOp("GetProjectLabels")
+	if m.projectLabelsErr != nil {
+		return nil, m.projectLabelsErr
+	}
+	if m.simulateError != nil {
+		return nil, m.simulateError
+	}
+	return m.projectLabels, nil
 }
 
 // GetProjectMilestones removed — milestones now come inline from GetTeamProjects

--- a/internal/testutil/fixtures/api.go
+++ b/internal/testutil/fixtures/api.go
@@ -86,6 +86,22 @@ func FixtureAPILabels() []api.Label {
 	}
 }
 
+// FixtureAPIProjectLabels returns a mini workspace project-label catalog
+// exercising the group/retired lifecycle: group "Area" with children
+// "Backend"/"Frontend", standalone "Ops", and retired "Legacy". The live
+// workspace has no groups or retired labels, so tests must synthesize them.
+func FixtureAPIProjectLabels() []api.ProjectLabel {
+	retired := fixtureTime
+	area := &api.ProjectLabel{ID: "plabel-area", Name: "Area"}
+	return []api.ProjectLabel{
+		{ID: "plabel-area", Name: "Area", IsGroup: true, CreatedAt: fixtureTime, UpdatedAt: fixtureTime},
+		{ID: "plabel-backend", Name: "Backend", Color: "#5e6ad2", Parent: area, CreatedAt: fixtureTime, UpdatedAt: fixtureTime},
+		{ID: "plabel-frontend", Name: "Frontend", Color: "#f2994a", Parent: area, CreatedAt: fixtureTime, UpdatedAt: fixtureTime},
+		{ID: "plabel-ops", Name: "Ops", Color: "#4cb782", CreatedAt: fixtureTime, UpdatedAt: fixtureTime},
+		{ID: "plabel-legacy", Name: "Legacy", Color: "#95a2b3", RetiredAt: &retired, CreatedAt: fixtureTime, UpdatedAt: fixtureTime},
+	}
+}
+
 // FixtureAPIUser returns a test user.
 func FixtureAPIUser() api.User {
 	return api.User{

--- a/internal/testutil/fixtures/fstest.go
+++ b/internal/testutil/fixtures/fstest.go
@@ -231,6 +231,21 @@ func PopulateProject(ctx context.Context, store *db.Store, project api.Project, 
 	return nil
 }
 
+// PopulateProjectLabels inserts workspace project labels into the SQLite store.
+func PopulateProjectLabels(ctx context.Context, store *db.Store, labels []api.ProjectLabel) error {
+	q := store.Queries()
+	for _, label := range labels {
+		params, err := db.APIProjectLabelToDBProjectLabel(label)
+		if err != nil {
+			return err
+		}
+		if err := q.UpsertProjectLabel(ctx, params); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // PopulateCycle inserts a cycle into the SQLite store.
 func PopulateCycle(ctx context.Context, store *db.Store, cycle api.Cycle, teamID string) error {
 	q := store.Queries()

--- a/internal/testutil/mockmutation/mock.go
+++ b/internal/testutil/mockmutation/mock.go
@@ -306,6 +306,9 @@ func (c *Client) UpdateProject(ctx context.Context, projectID string, input api.
 	if input.Description != nil {
 		proj.Description = *input.Description
 	}
+	if input.LabelIds != nil { // full-set write, like the real mutation
+		proj.LabelIds = append([]string(nil), (*input.LabelIds)...)
+	}
 	c.projEdit[projectID] = proj
 	return nil
 }


### PR DESCRIPTION
Closes #130.

Level-2 slice per the accepted design (docs/plans/2026-07-07-project-labels-design.md — 11-agent redesign, grilled 2026-07-08, four live API spikes): **READ** (workspace catalog + labels on project.md) and **ASSIGN** (`labels:` frontmatter → `ProjectUpdateInput.labelIds`). No catalog CRUD; nothing forecloses it (the `ProjectLabelFields` fragment ships mutation-less so level-3 mutations project through it).

## What's here

**Read side** (`bdf1d15`)
- `project_labels` twin table (deliberately NOT a kind-column extension of `labels` — scoping, prune regime, and lifecycle all differ; the rejection is recorded in CONTEXT.md), hydrate-then-overlay converters, parent strictly from the `parent_id` column
- `ProjectLabelsPage` full unfiltered drain — completeness licenses the workspace sync pass's full-table prune; retired labels are IN the default drain (live-verified)
- Root `project-labels.md` renderFile: never-ENOENT, groups/retired flagged, assignment rules as prose in-file; per-team `project-labels.md` symlink via symlinkNode
- `labelIds` scalar on the three project queries (names resolve locally against the catalog)

**Write path** (`f07d034`)
- `resolveProjectLabels` + `validateProjectLabelSelection` + `sameIDSet` — pure functions over a catalog slice, in one new file
- Round-trip invariant: unknown IDs render verbatim; the resolver accepts exact-ID passthrough — a cold/stale catalog can never strip labels on an untouched save
- Validation policy (deliberately stricter than the API where its enforcement is lax — the wire *accepts* retired assignment, live-verified): groups rejected naming their assignable children, retired rejected only when NEWLY applied, one child per group; duplicate names tie-break prefer-current → single-active → loud ambiguity error listing IDs
- Stale-blob clobber guard: one interactive-promoted `GetProject` refresh exactly when current `LabelIds` is empty and labels change — closes the full-set-write wipe on pre-upgrade blobs
- `api.GraphQLError` carries Linear's structured extensions; `classifyMutationErr` maps `userError` rejections to EINVAL preferring `userPresentableMessage`

**Tests + docs** (`b413703`)
- Synthetic fixture catalog (live workspace has no groups/retired); 6 integration tests incl. the DIRECT_IO mid-test-upsert freshness proof, delete-the-line clear → retired-newly-applied rejection sequence, and the stale-ID no-op-resave invariant
- generateReadme: directory map, new `<project_frontmatter>` block, validated-fields + reference-files lines, agent instructions; `TestGeneratedReadmeMatchesBehavior` extended
- CONTEXT.md: "Project-label selection" concept + three cross-references

**Commit 2** (`5f34345`) — severable: `ProjectFields` fragment consolidates the three inlined project field lists (also heals the create echo's pre-existing drift: it omitted lead/status/dates/initiatives/milestones)

## Verification
- Unit: converter round-trips + columns-win overlay subtest; resolver/validation tables (13 cases); renderer incl. empty-catalog stability; sync reconcile + isolation tests
- Full integration suite green locally (fixture mode)
- Live spikes (2026-07-08, targeted GraphQL): retiredAt selectable despite `[Internal]` tag; retired labels in default drain; `labelIds: []` clears; group rejection message captured (drives the `.error` mapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)