### PR TITLE
refactor(errors): one classifier for every mutation error

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,6 +48,18 @@ status updates — updates were the last holdout, hand-rolling the tail with no
 directly, and `persist` is always explicit — no mutation wrapper hides an upsert.
 Unit-tested through the ErrorSink/notifier fakes, no FUSE mount.
 
+The classifier (`classifyMutationErr`) is the single owner of that failure
+model, shared by the create and delete tails **and every edit-mutation site**
+(issue/comment/label/document/milestone flushes and renames, the project/
+initiative scalar+reconcile paths — the flushes/renames used to bypass it with
+a flat `EIO`, violating the README's documented contract). Rate-limit and
+not-found detection are the api package's predicates (`api.IsRateLimited` —
+structural `GraphQLError.Code == "RATELIMITED"` plus message fallbacks, and
+deliberately excluding the client-side "circuit breaker" transient, which
+stays a `retryableCreateErr` concern; `api.IsNotFound` — the "Entity not
+found" rejection), the single owners the client's GraphQL-errors branch, the
+sync worker's backoff, and the repo's orphan defense also delegate to.
+
 For status updates the front half is the shared `parseUpdateContent` (one parser for
 both project and initiative updates): an explicitly-written unknown `health:` is a
 `FieldError` (→ `EINVAL`), never silently coerced to `onTrack`, and frontmatter with

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -303,7 +303,7 @@ func (c *Client) query(ctx context.Context, query string, variables map[string]a
 			UserError:              first.Extensions.UserError,
 			UserPresentableMessage: first.Extensions.UserPresentableMessage,
 		}
-		if strings.Contains(errMsg, "RATELIMITED") || strings.Contains(strings.ToLower(errMsg), "rate limit") {
+		if IsRateLimited(queryErr) {
 			adm.rateLimited(resp.Header)
 			log.Printf("[ratelimit] ERROR: %s rate limited by Linear API: %s", opName, errMsg)
 		} else {

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"errors"
+	"strings"
+)
+
+// Error predicates: the package-level classification of Linear API failures.
+//
+// Every layer above the client (fs mutation handlers, the repo's orphan
+// defense, the sync worker's backoff) needs to answer the same two questions
+// about an error — "was that a rate limit?" and "does the entity no longer
+// exist?" — and each used to answer with its own substring sniff, so the
+// checks drifted (different substrings, different case handling). These two
+// predicates are the single owners. Both prefer the structured *GraphQLError
+// (errors.As, so wrapping is transparent) and keep the message fallbacks for
+// errors that never carried the type: HTTP-level failures are plain
+// fmt.Errorf strings carrying Linear's error envelope verbatim.
+
+// IsRateLimited reports whether err is Linear telling us the account's
+// request or complexity budget is exhausted. Structured check first: Linear
+// tags budget exhaustion with extensions {code: "RATELIMITED"}. The message
+// fallbacks cover HTTP 429/400 failures that surface as plain strings
+// ("RATELIMITED" in Linear's error envelope, or a "rate limit ..." message,
+// case-insensitive).
+//
+// Deliberately NOT absorbed: the client's "circuit breaker" connectivity
+// error. That is a client-side transient, not the server rate limiting us —
+// callers that retry on both (retryableCreateErr) check it separately.
+func IsRateLimited(err error) bool {
+	if err == nil {
+		return false
+	}
+	var gqlErr *GraphQLError
+	if errors.As(err, &gqlErr) && gqlErr.Code == "RATELIMITED" {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "RATELIMITED") ||
+		strings.Contains(strings.ToLower(msg), "rate limit")
+}
+
+// IsNotFound reports whether err is Linear's "Entity not found" rejection —
+// the entity the request referenced no longer exists upstream. Structured
+// check first ("Entity not found: <Type> - ..." is Linear's standard message
+// on the GraphQL error); the fallback covers not-found rejections that arrive
+// as plain strings (e.g. an HTTP 400 whose body carries the error envelope).
+//
+// For a delete this is idempotent success (the entity is already gone); for a
+// refresh it marks the local row an orphan to be cleaned up.
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var gqlErr *GraphQLError
+	if errors.As(err, &gqlErr) && strings.Contains(gqlErr.Message, "Entity not found") {
+		return true
+	}
+	return strings.Contains(err.Error(), "Entity not found")
+}

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIsRateLimited(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{
+			"typed GraphQLError with RATELIMITED code",
+			&GraphQLError{Message: "you shall not pass", Code: "RATELIMITED"},
+			true,
+		},
+		{
+			"typed error wrapped via %w",
+			fmt.Errorf("query TeamIssues failed: %w", &GraphQLError{Message: "x", Code: "RATELIMITED"}),
+			true,
+		},
+		{
+			"plain string carrying RATELIMITED (HTTP 400 envelope)",
+			errors.New(`API error (status 400): {"errors":[{"extensions":{"code":"RATELIMITED"}}]}`),
+			true,
+		},
+		{
+			"plain string, case-insensitive rate limit phrasing",
+			errors.New("Rate limit exceeded"),
+			true,
+		},
+		{
+			"client-side deferred rate limit message",
+			errors.New("rate limit: query GetIssue deferred (reserve)"),
+			true,
+		},
+		{
+			"circuit breaker is NOT rate limiting",
+			errors.New("circuit breaker open: skipping GetIssue (connectivity down)"),
+			false,
+		},
+		{
+			"typed GraphQLError with unrelated code",
+			&GraphQLError{Message: "labelIds contain parent labels", Code: "INPUT_ERROR", UserError: true},
+			false,
+		},
+		{"unrelated error", errors.New("boom"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsRateLimited(tc.err); got != tc.want {
+				t.Errorf("IsRateLimited(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsNotFound(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{
+			"typed GraphQLError with Entity not found message",
+			&GraphQLError{Message: "Entity not found: Issue - Could not find referenced Issue."},
+			true,
+		},
+		{
+			"typed error wrapped via %w",
+			fmt.Errorf("refresh failed: %w", &GraphQLError{Message: "Entity not found: Project"}),
+			true,
+		},
+		{
+			"plain string carrying the envelope (HTTP 400)",
+			errors.New(`API error (status 400): {"errors":[{"message":"Entity not found: Comment - Could not find referenced Comment."}]}`),
+			true,
+		},
+		{
+			"typed GraphQLError with unrelated message",
+			&GraphQLError{Message: "something else went wrong"},
+			false,
+		},
+		{"rate limit is not not-found", errors.New("Rate limit exceeded"), false},
+		{"unrelated error", errors.New("boom"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsNotFound(tc.err); got != tc.want {
+				t.Errorf("IsNotFound(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/fs/comments.go
+++ b/internal/fs/comments.go
@@ -209,8 +209,9 @@ func (n *CommentNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno 
 	updatedComment, err := n.lfs.UpdateComment(ctx, n.issueID, n.comment.ID, body)
 	if err != nil {
 		log.Printf("Failed to update comment: %v", err)
-		n.lfs.SetWriteError(commentErrKey, "Operation: update comment\nError: "+err.Error())
-		return syscall.EIO
+		msg, errno := classifyMutationErr("update comment", err)
+		n.lfs.SetWriteError(commentErrKey, msg)
+		return errno
 	}
 
 	// Edit-commit tail: verify read-your-writes against the API's echoed response,

--- a/internal/fs/createcommit.go
+++ b/internal/fs/createcommit.go
@@ -128,9 +128,13 @@ func commitCreate[T any](ctx context.Context, sink createSink, spec createSpec[T
 
 // classifyMutationErr maps a mutation failure to its .error message and errno.
 // This is the single owner of the write failure model the generated README
-// documents — shared by the create and delete tails: bad input -> EINVAL,
-// missing reference -> ENOENT, transient -> EAGAIN, backend failure -> EIO —
-// either way the reason lands in .error.
+// documents — shared by the create and delete tails and by every edit-mutation
+// site (issue/comment/label/document/milestone flushes and renames, the
+// project/initiative scalar+reconcile paths): bad input -> EINVAL, missing
+// reference -> ENOENT, transient -> EAGAIN, backend failure -> EIO — either
+// way the reason lands in .error. Rate-limit/not-found detection delegates to
+// the api package's predicates (api.IsRateLimited via retryableCreateErr,
+// api.IsNotFound via the delete tail's remoteAlreadyGone).
 func classifyMutationErr(op string, err error) (string, syscall.Errno) {
 	var nferr *notFoundError
 	if errors.As(err, &nferr) {

--- a/internal/fs/deletecommit.go
+++ b/internal/fs/deletecommit.go
@@ -3,9 +3,10 @@ package fs
 import (
 	"context"
 	"log"
-	"strings"
 	"syscall"
 	"time"
+
+	"github.com/jra3/linear-fuse/internal/api"
 )
 
 // The delete-commit tail.
@@ -140,9 +141,8 @@ func forgetWithRetry[T any](ctx context.Context, forget func(ctx context.Context
 }
 
 // remoteAlreadyGone reports whether a delete mutation failed because Linear no
-// longer has the entity ("Entity not found" is Linear's standard phrasing —
-// the same detection the repo layer uses for reads). For a delete that is
-// success, not failure.
+// longer has the entity — the shared predicate the repo layer's orphan defense
+// uses too. For a delete that is success, not failure.
 func remoteAlreadyGone(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "Entity not found")
+	return api.IsNotFound(err)
 }

--- a/internal/fs/documents.go
+++ b/internal/fs/documents.go
@@ -182,8 +182,9 @@ func (n *DocsNode) Rename(ctx context.Context, name string, newParent fs.InodeEm
 	updatedDoc, err := n.lfs.UpdateDocument(ctx, doc.ID, map[string]any{"title": newTitle}, n.issueID, n.teamID, n.projectID)
 	if err != nil {
 		log.Printf("Failed to rename document: %v", err)
-		n.lfs.SetWriteError(collectionErrorKey("docs", n.parentID()), "Operation: rename document "+name+" -> "+newName+"\nError: "+err.Error())
-		return syscall.EIO
+		msg, errno := classifyMutationErr("rename document "+name+" -> "+newName, err)
+		n.lfs.SetWriteError(collectionErrorKey("docs", n.parentID()), msg)
+		return errno
 	}
 	// Upsert to SQLite so it's immediately visible
 	if err := n.lfs.UpsertDocument(ctx, *updatedDoc); err != nil {
@@ -341,8 +342,9 @@ func (n *DocumentFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.E
 	updatedDoc, err := n.lfs.UpdateDocument(ctx, n.document.ID, update, n.issueID, n.teamID, n.projectID)
 	if err != nil {
 		log.Printf("Failed to update document: %v", err)
-		n.lfs.SetWriteError(docErrKey, "Operation: update document "+documentFilename(n.document)+"\nError: "+err.Error())
-		return syscall.EIO
+		msg, errno := classifyMutationErr("update document "+documentFilename(n.document), err)
+		n.lfs.SetWriteError(docErrKey, msg)
+		return errno
 	}
 
 	// Edit-commit tail: verify read-your-writes against the API's echoed response,

--- a/internal/fs/editclassify_test.go
+++ b/internal/fs/editclassify_test.go
@@ -1,0 +1,119 @@
+package fs
+
+import (
+	"context"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/jra3/linear-fuse/internal/api"
+)
+
+// These tests pin the edit-mutation failure model: an edit site's mutation
+// failure routes through classifyMutationErr (the same classifier the create
+// and delete tails use), so a rate-limited edit returns EAGAIN with a retry
+// hint in .error, and a structured Linear input rejection (userError: true)
+// returns EINVAL carrying the server's user-presentable message — never the
+// old flat EIO the hand-rolled sites returned.
+
+// failingMutator satisfies MutationClient by embedding the interface (nil) and
+// overriding only the update methods under test; anything else panics, which
+// is fine — these tests exercise the mutation-error path exclusively.
+type failingMutator struct {
+	MutationClient
+	err error
+}
+
+func (f failingMutator) UpdateComment(ctx context.Context, commentID, body string) (*api.Comment, error) {
+	return nil, f.err
+}
+
+func (f failingMutator) UpdateLabel(ctx context.Context, id string, input map[string]any) (*api.Label, error) {
+	return nil, f.err
+}
+
+// newEditTestLFS builds the minimal LinearFS an edit error path touches: the
+// writeFeedback store (.error) plus the injected failing mutation client.
+func newEditTestLFS(t *testing.T, err error) *LinearFS {
+	t.Helper()
+	lfs := &LinearFS{writeFeedback: newWriteFeedback(nil)}
+	lfs.InjectTestMutationClient(failingMutator{err: err})
+	return lfs
+}
+
+func TestCommentEditFlush_RateLimitedIsEAGAIN(t *testing.T) {
+	rl := &api.GraphQLError{Message: "Rate limit exceeded", Code: "RATELIMITED"}
+	lfs := newEditTestLFS(t, rl)
+
+	n := &CommentNode{
+		BaseNode: BaseNode{lfs: lfs},
+		issueID:  "issue-1",
+		comment:  api.Comment{ID: "c-1", Body: "old body"},
+	}
+	n.content = []byte("new body")
+	n.dirty = true
+
+	errno := n.Flush(context.Background(), nil)
+
+	if errno != syscall.EAGAIN {
+		t.Fatalf("Flush errno = %v, want EAGAIN", errno)
+	}
+	we := lfs.GetWriteError(collectionErrorKey("comments", "issue-1"))
+	if we == nil {
+		t.Fatal(".error not set for rate-limited comment edit")
+	}
+	if !strings.Contains(we.Message, "rate-limited") || !strings.Contains(we.Message, "retry") {
+		t.Errorf(".error = %q, want a rate-limited retry hint", we.Message)
+	}
+	if !strings.Contains(we.Message, "update comment") {
+		t.Errorf(".error = %q, want the op name 'update comment'", we.Message)
+	}
+}
+
+func TestLabelEditFlush_UserErrorIsEINVALWithPresentableMessage(t *testing.T) {
+	rejection := &api.GraphQLError{
+		Message:                "labelIds contain parent labels",
+		Code:                   "INPUT_ERROR",
+		UserError:              true,
+		UserPresentableMessage: "The label 'X' is a group and cannot be assigned directly.",
+	}
+	lfs := newEditTestLFS(t, rejection)
+
+	n := &LabelFileNode{
+		BaseNode: BaseNode{lfs: lfs},
+		label:    api.Label{ID: "l-1", Name: "Old Name"},
+		teamID:   "team-1",
+	}
+	n.content = []byte("---\nname: New Name\n---\n")
+	n.dirty = true
+
+	errno := n.Flush(context.Background(), nil)
+
+	if errno != syscall.EINVAL {
+		t.Fatalf("Flush errno = %v, want EINVAL", errno)
+	}
+	we := lfs.GetWriteError(collectionErrorKey("labels", "team-1"))
+	if we == nil {
+		t.Fatal(".error not set for rejected label edit")
+	}
+	if !strings.Contains(we.Message, rejection.UserPresentableMessage) {
+		t.Errorf(".error = %q, want the server's user-presentable message %q",
+			we.Message, rejection.UserPresentableMessage)
+	}
+}
+
+func TestLabelEditFlush_BackendFailureStaysEIO(t *testing.T) {
+	lfs := newEditTestLFS(t, &api.GraphQLError{Message: "internal server error"})
+
+	n := &LabelFileNode{
+		BaseNode: BaseNode{lfs: lfs},
+		label:    api.Label{ID: "l-1", Name: "Old Name"},
+		teamID:   "team-1",
+	}
+	n.content = []byte("---\nname: New Name\n---\n")
+	n.dirty = true
+
+	if errno := n.Flush(context.Background(), nil); errno != syscall.EIO {
+		t.Fatalf("Flush errno = %v, want EIO for an unclassified backend failure", errno)
+	}
+}

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -178,8 +178,10 @@ func retryableCreateErr(err error) bool {
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
-	msg := err.Error()
-	return strings.Contains(msg, "rate limit") || strings.Contains(msg, "circuit breaker")
+	// Rate-limit detection is the shared predicate's job; the circuit breaker
+	// stays here — it is a client-side connectivity transient (worth retrying),
+	// not the server rate limiting us, so api.IsRateLimited excludes it.
+	return api.IsRateLimited(err) || strings.Contains(err.Error(), "circuit breaker")
 }
 
 // Mkdir creates a new issue from a directory name
@@ -552,8 +554,9 @@ func (i *IssueFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errn
 	// Call Linear API to update
 	if err := i.lfs.mutator().UpdateIssue(ctx, i.issue.ID, updates); err != nil {
 		log.Printf("Failed to update issue %s: %v", i.issue.Identifier, err)
-		i.lfs.SetIssueError(i.issue.ID, "API error: "+err.Error())
-		return syscall.EIO
+		msg, errno := classifyMutationErr("update issue", err)
+		i.lfs.SetIssueError(i.issue.ID, msg)
+		return errno
 	}
 
 	if i.lfs.debug {

--- a/internal/fs/labels.go
+++ b/internal/fs/labels.go
@@ -170,8 +170,9 @@ func (n *LabelsNode) Rename(ctx context.Context, name string, newParent fs.Inode
 	updatedLabel, err := n.lfs.UpdateLabel(ctx, label.ID, map[string]any{"name": newLabelName}, n.teamID)
 	if err != nil {
 		log.Printf("Failed to rename label: %v", err)
-		n.lfs.SetWriteError(collectionErrorKey("labels", n.teamID), "Operation: rename label "+name+" -> "+newName+"\nError: "+err.Error())
-		return syscall.EIO
+		msg, errno := classifyMutationErr("rename label "+name+" -> "+newName, err)
+		n.lfs.SetWriteError(collectionErrorKey("labels", n.teamID), msg)
+		return errno
 	}
 	// Upsert to SQLite so it's immediately visible
 	if err := n.lfs.UpsertLabel(ctx, n.teamID, *updatedLabel); err != nil {
@@ -316,8 +317,9 @@ func (n *LabelFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errn
 	updatedLabel, err := n.lfs.UpdateLabel(ctx, n.label.ID, update, n.teamID)
 	if err != nil {
 		log.Printf("Failed to update label: %v", err)
-		n.lfs.SetWriteError(collectionErrorKey("labels", n.teamID), "Operation: update label "+labelFilename(n.label)+"\nError: "+err.Error())
-		return syscall.EIO
+		msg, errno := classifyMutationErr("update label "+labelFilename(n.label), err)
+		n.lfs.SetWriteError(collectionErrorKey("labels", n.teamID), msg)
+		return errno
 	}
 	// Edit-commit tail: persist the label, verify read-your-writes against the
 	// API's echoed response (labels have no single-entity getter), and surface

--- a/internal/fs/milestones.go
+++ b/internal/fs/milestones.go
@@ -208,8 +208,9 @@ func (n *MilestoneFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.
 	updated, err := n.lfs.UpdateProjectMilestone(ctx, n.milestone.ID, input)
 	if err != nil {
 		log.Printf("Failed to update milestone: %v", err)
-		n.lfs.SetWriteError(milestoneErrKey, "Operation: update milestone "+milestoneFilename(n.milestone)+"\nError: "+err.Error())
-		return syscall.EIO
+		msg, errno := classifyMutationErr("update milestone "+milestoneFilename(n.milestone), err)
+		n.lfs.SetWriteError(milestoneErrKey, msg)
+		return errno
 	}
 	// Edit-commit tail. LinearFS.UpdateProjectMilestone already upserted to SQLite
 	// (after routing through the mutation seam), so persist is nil; verify

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -299,7 +299,7 @@ cat the .error next to the file (or _create) you wrote to see what went wrong:
 Failure model (every writable surface follows this contract):
 - Bad input (invalid field, unknown name, missing required field) -> EINVAL
 - Reference to something that doesn't exist (a relation target, rm of an unknown name) -> ENOENT
-- Rate-limited or timed out (nothing was created; retry shortly) -> EAGAIN
+- Rate-limited or timed out (the write did not take effect; retry shortly) -> EAGAIN
 - Backend/API failure -> EIO
 - Whatever the errno, the reason lands in .error; success clears it.
 So an edit that "fails" or appears to no-op is explained at the sibling .error.

--- a/internal/repo/sqlite.go
+++ b/internal/repo/sqlite.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -851,8 +850,9 @@ func (r *SQLiteRepository) MaybeRefreshIssueDetails(issueID string) {
 // error, indicating the issue (or other entity) no longer exists upstream.
 // When seen on a refresh, the local row is an orphan and should be deleted —
 // otherwise every FUSE traversal retriggers the same failing refresh forever.
+// Detection is the shared api.IsNotFound predicate.
 func isEntityNotFound(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "Entity not found")
+	return api.IsNotFound(err)
 }
 
 // deleteOrphanIssue removes an issue and all its sub-resources from SQLite.

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -739,15 +739,11 @@ func (w *Worker) syncTeamMetadata(ctx context.Context, team api.Team) error {
 // Rate Limit Handling
 // =============================================================================
 
-// isRateLimitError checks if an error indicates a rate limit
+// isRateLimitError checks if an error indicates a rate limit. Detection is
+// the shared api.IsRateLimited predicate (its case-insensitive "rate limit"
+// fallback subsumes the "Rate limit exceeded" phrasing this used to match).
 func isRateLimitError(err error) bool {
-	if err == nil {
-		return false
-	}
-	errStr := err.Error()
-	return strings.Contains(errStr, "RATELIMITED") ||
-		strings.Contains(errStr, "Rate limit exceeded") ||
-		strings.Contains(errStr, "rate limit")
+	return api.IsRateLimited(err)
 }
 
 // budgetExceeds returns true if the current hourly budget usage exceeds the given threshold.


### PR DESCRIPTION
## The contract violation being closed

The generated README's `<validation_errors>` section documents a failure model that "every writable surface follows": bad input → `EINVAL`, missing reference → `ENOENT`, rate-limited/timed out → `EAGAIN`, backend failure → `EIO`, with the reason in `.error`. The create and delete tails honor it via the shared `classifyMutationErr` — but **seven edit-mutation sites bypassed the classifier entirely** and returned a flat `EIO` for *any* mutation failure:

- `issues.go` Flush (`UpdateIssue`)
- `comments.go` edit Flush
- `labels.go` Rename + Flush
- `documents.go` Rename + Flush
- `milestones.go` edit Flush

So a rate-limited issue edit read as a hard backend failure instead of "retry shortly", and a structured Linear input rejection (`userError: true`) lost its user-presentable message. All seven now route through `classifyMutationErr`, preserving each site's op string — the errno/message change (`EIO` → `EAGAIN`/`EINVAL`/`ENOENT` where classified, user-presentable message preferred) is the point.

## One owner for the two detection questions

Rate-limited and not-found detection was string-sniffed independently at five sites with drifting substrings. Two nil-safe package-level predicates in the new `internal/api/errors.go` are now the single owners:

- **`api.IsRateLimited`** — structural `GraphQLError.Code == "RATELIMITED"` first (`errors.As`, so wrapping is transparent), message fallbacks retained (`"RATELIMITED"`, case-insensitive `"rate limit"`) for HTTP-level plain-string errors. Deliberately does **not** absorb `"circuit breaker"` — a client-side connectivity transient, not the server rate limiting us; it stays a `retryableCreateErr` concern.
- **`api.IsNotFound`** — structural "Entity not found" check on the typed error plus the plain-string fallback (HTTP-400 envelope errors, as pinned by the existing delete-tail test).

Consolidated callers: fs `retryableCreateErr` (keeps ctx-canceled/deadline + circuit breaker), fs `remoteAlreadyGone`, repo `isEntityNotFound`, sync `isRateLimitError` (its `"Rate limit exceeded"` match is subsumed by the case-insensitive fallback), and the client's GraphQL-errors branch (structural code check first, message fallback retained). The raw pre-parse HTTP body sniff in `client.go` (budget accounting on non-200 responses) is deliberately untouched.

## Tests

- `internal/api/errors_test.go`: both predicates — typed `GraphQLError` with code, wrapped via `%w`, plain-string fallbacks, nil, negatives including "circuit breaker is NOT rate limiting".
- `internal/fs/editclassify_test.go`: edit sites now classify — a rate-limited comment edit returns `EAGAIN` with a retry hint in `.error`; a `userError` label edit returns `EINVAL` carrying the server's user-presentable message; an unclassified backend failure stays `EIO`. Uses a failing `MutationClient` via `InjectTestMutationClient`, no mount.

## Docs

- CONTEXT.md "Create tail" entry records that the classifier now covers every edit-mutation site and the predicates live in `api`.
- `generateReadme` failure-model text already described the target behavior (that's the point); one create-flavored parenthetical generalized ("nothing was created" → "the write did not take effect") now that edits conform.

Full suite green: `go build ./... && go vet ./... && go test ./internal/...` (including integration, ~33s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)