### PR TITLE
refactor(fs): labelsEdit — one module for the labels front half of a project edit

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -120,7 +120,13 @@ set licensing a full-table prune; retired labels are IN the drain, live-verified
 2026-07-08), and a `labels:` names list in project.md that resolves and validates
 in `internal/fs/projectlabels.go` — all **pure functions over a catalog slice**
 (no mount, no interface) — then rides the existing single `UpdateProject` call
-(`ProjectUpdateInput.LabelIds *[]string`, pointer-or-omit full-set write).
+(`ProjectUpdateInput.LabelIds *[]string`, pointer-or-omit full-set write). The
+front-half composition lives in `labelsEdit` (same file, sibling of `scalarEdit`
+in the edit-front-half family): it composes the pure primitives and owns the
+whole label decision — guard timing, the single `changed` computation, `applyTo`
+pointer-or-omit, and the guarded `divergences` compare — so
+`ProjectInfoNode.Flush` makes one call instead of smearing label knowledge
+across three points.
 
 Load-bearing invariant: **render unknown label IDs verbatim; the resolver accepts
 exact-ID passthrough** (catalog IDs and current-member IDs) — a cold or stale
@@ -168,12 +174,15 @@ junction row inline (rather than the old deferred batch a mid-loop failure skipp
 keeps SQLite consistent with whatever the API actually accepted on a partial failure.
 Project labels deliberately do **not** reconcile through this module: `labelIds`
 is one atomic full-set input on the project update (no per-pair link mutation
-exists), so the labels edit is scalar-edit-shaped — see "Project-label selection".
+exists), so the labels edit is scalar-edit-shaped: `labelsEdit` — see
+"Project-label selection".
 
 ### Scalar edit (`scalarEdit`)
 The **deep module** owning the *scalar* front half of a project/initiative edit —
 the counterpart to Link reconciliation, which owns the *relational* (list) front
-half of the same two mirror-image handlers. `project.md` and `initiative.md` each
+half of the same two mirror-image handlers (`labelsEdit` — see "Project-label
+selection" — is the third sibling, owning project.md's full-set labels front
+half). `project.md` and `initiative.md` each
 expose exactly two editable scalars: a **name** (frontmatter) and a
 **description** (body). `scalarEdit` (`internal/fs/scalaredit.go`) is the diff of
 those two — `{name, desc *string, origName, origDesc string}` — and owns the

--- a/internal/fs/projectlabels.go
+++ b/internal/fs/projectlabels.go
@@ -1,11 +1,13 @@
 package fs
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/jra3/linear-fuse/internal/api"
+	"github.com/jra3/linear-fuse/internal/marshal"
 )
 
 // Project-label selection (see CONTEXT.md): the pure half of the workspace
@@ -244,6 +246,110 @@ func validateProjectLabelSelection(selected []api.ProjectLabel, currentIDs map[s
 		}
 	}
 	return nil
+}
+
+// labelsEdit is the labels front half of a project.md edit — sibling of
+// scalarEdit (scalar fields) and reconcileLinks (per-pair link lists) in the
+// edit-front-half family. It COMPOSES this file's pure primitives
+// (resolveProjectLabels, validateProjectLabelSelection, sameIDSet) and owns the
+// whole label decision in one place: parse the frontmatter list, fire the
+// stale-blob clobber guard in exactly the at-risk state, resolve + validate,
+// compute "changed" exactly once, map onto the update input (pointer-or-omit),
+// and classify the read-your-writes divergence. ProjectInfoNode.Flush used to
+// smear those concerns across three points (the front block, the input build,
+// and the commitWriteBack compare closure), stating the change test twice.
+type labelsEdit struct {
+	desiredIDs []string // resolved target set; nil means clear (when changed)
+	isChanged  bool     // the ONE change decision, computed at construction
+}
+
+// newLabelsEdit evaluates the labels edit. rawLabels/labelsPresent are the
+// parsed doc's `labels` frontmatter value and key presence; currentIDs is the
+// project's present label set. catalog fetches the workspace project-label
+// catalog (a fetch error degrades to a nil catalog — exact-ID passthrough via
+// the current set still resolves, the round-trip invariant). refreshCurrent is
+// the stale-blob clobber guard's fetch; the module decides WHEN it fires.
+//
+// Stale-blob clobber guard: a project blob predating the LabelIds field reads
+// current as empty, so an agent ADDING one label would full-set-write just that
+// label and silently wipe the project's real labels in Linear — invisible to
+// the divergence check (fresh == sent). refreshCurrent fires exactly once, in
+// exactly the at-risk state: current empty AND the write would apply labels.
+//
+// Change semantics (the mount-wide contract): key absent + current empty =
+// untouched; key absent + current non-empty = delete-the-line clear; an
+// explicit empty list clears too. The set diff is order-insensitive.
+//
+// A validation failure returns a *FieldError; the caller maps it to
+// SetWriteError + EINVAL.
+func newLabelsEdit(ctx context.Context, rawLabels any, labelsPresent bool, currentIDs []string,
+	catalog func(context.Context) ([]api.ProjectLabel, error),
+	refreshCurrent func(context.Context) []string,
+) (labelsEdit, *FieldError) {
+	desiredNames := marshal.StringSliceFromYAML(rawLabels)
+
+	if len(currentIDs) == 0 && len(desiredNames) > 0 {
+		currentIDs = refreshCurrent(ctx)
+	}
+
+	currentIDSet := make(map[string]bool, len(currentIDs))
+	for _, id := range currentIDs {
+		currentIDSet[id] = true
+	}
+
+	var e labelsEdit
+	if labelsPresent || len(currentIDs) > 0 {
+		if len(desiredNames) > 0 {
+			cat, err := catalog(ctx)
+			if err != nil {
+				cat = nil // ID passthrough via currentIDSet still resolves
+			}
+			ids, selected, ferr := resolveProjectLabels(cat, desiredNames, currentIDSet)
+			if ferr == nil {
+				ferr = validateProjectLabelSelection(selected, currentIDSet, cat)
+			}
+			if ferr != nil {
+				return labelsEdit{}, ferr
+			}
+			e.desiredIDs = ids
+		}
+		e.isChanged = !sameIDSet(e.desiredIDs, currentIDs)
+	}
+	return e, nil
+}
+
+// changed reports whether the label set needs an API update.
+func (e labelsEdit) changed() bool { return e.isChanged }
+
+// applyTo maps the edit onto the update input. Pointer-or-omit: untouched
+// labels leave LabelIds nil; a clear sends the empty set (live-verified:
+// labelIds: [] empties it). labelIds is a full-set atomic write — there is no
+// removedLabelIds analog, which is why labels are edit-shaped, not
+// reconcileLinks-shaped.
+func (e labelsEdit) applyTo(input *api.ProjectUpdateInput) {
+	if !e.isChanged {
+		return
+	}
+	ids := e.desiredIDs
+	if ids == nil {
+		ids = []string{}
+	}
+	input.LabelIds = &ids
+}
+
+// divergences classifies the read-your-writes result for the label set.
+// Guarded on changed: an untouched label set must produce zero label
+// divergence (a plain rename would otherwise EIO whenever another writer
+// touches labels concurrently). Order is not divergence — the set is.
+func (e labelsEdit) divergences(freshIDs []string) []writeBackResult {
+	if !e.isChanged || sameIDSet(freshIDs, e.desiredIDs) {
+		return nil
+	}
+	return []writeBackResult{{
+		message: fmt.Sprintf("Field: labels\nError: the write was accepted but the persisted label set differs (sent %d labels, %d persisted). Re-read the file to see the stored set.",
+			len(e.desiredIDs), len(freshIDs)),
+		fatal: true,
+	}}
 }
 
 // sameIDSet reports whether two label-ID lists carry the same set —

--- a/internal/fs/projectlabels_test.go
+++ b/internal/fs/projectlabels_test.go
@@ -1,6 +1,8 @@
 package fs
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -270,4 +272,207 @@ func TestProjectLabelCatalogTimes(t *testing.T) {
 	if !mtime.IsZero() || !ctime.IsZero() {
 		t.Errorf("empty catalog times = %v/%v, want zero", mtime, ctime)
 	}
+}
+
+// labelsEditHarness wires newLabelsEdit with a literal catalog and recording
+// closures — no mount, no API. refreshed is what the guard fetch returns;
+// catalogErr forces the cold-catalog degradation.
+type labelsEditHarness struct {
+	catalog      []api.ProjectLabel
+	catalogErr   error
+	catalogCalls int
+	refreshed    []string
+	refreshCalls int
+}
+
+func (h *labelsEditHarness) eval(t *testing.T, raw any, present bool, current []string) (labelsEdit, *FieldError) {
+	t.Helper()
+	return newLabelsEdit(context.Background(), raw, present, current,
+		func(context.Context) ([]api.ProjectLabel, error) {
+			h.catalogCalls++
+			return h.catalog, h.catalogErr
+		},
+		func(context.Context) []string {
+			h.refreshCalls++
+			return h.refreshed
+		})
+}
+
+func TestLabelsEdit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("key absent + current empty = untouched", func(t *testing.T) {
+		t.Parallel()
+		h := &labelsEditHarness{catalog: testCatalog()}
+		e, ferr := h.eval(t, nil, false, nil)
+		if ferr != nil {
+			t.Fatalf("unexpected error: %v", ferr.Detail())
+		}
+		if e.changed() {
+			t.Error("changed() = true for an untouched label set")
+		}
+		var input api.ProjectUpdateInput
+		e.applyTo(&input)
+		if input.LabelIds != nil {
+			t.Errorf("applyTo set LabelIds = %v, want nil omit", *input.LabelIds)
+		}
+		if h.refreshCalls != 0 {
+			t.Errorf("guard fired %d times on an untouched empty set, want 0", h.refreshCalls)
+		}
+		if h.catalogCalls != 0 {
+			t.Errorf("catalog fetched %d times with nothing to resolve, want 0", h.catalogCalls)
+		}
+	})
+
+	t.Run("key absent + current non-empty = clear", func(t *testing.T) {
+		t.Parallel()
+		h := &labelsEditHarness{catalog: testCatalog()}
+		e, ferr := h.eval(t, nil, false, []string{"id-bug"})
+		if ferr != nil {
+			t.Fatalf("unexpected error: %v", ferr.Detail())
+		}
+		if !e.changed() {
+			t.Fatal("changed() = false for a delete-the-line clear")
+		}
+		var input api.ProjectUpdateInput
+		e.applyTo(&input)
+		if input.LabelIds == nil || len(*input.LabelIds) != 0 {
+			t.Errorf("applyTo LabelIds = %v, want &[]string{} clear", input.LabelIds)
+		}
+	})
+
+	t.Run("explicit empty list = clear", func(t *testing.T) {
+		t.Parallel()
+		h := &labelsEditHarness{catalog: testCatalog()}
+		e, ferr := h.eval(t, []any{}, true, []string{"id-bug"})
+		if ferr != nil {
+			t.Fatalf("unexpected error: %v", ferr.Detail())
+		}
+		if !e.changed() {
+			t.Fatal("changed() = false for an explicit empty list")
+		}
+		var input api.ProjectUpdateInput
+		e.applyTo(&input)
+		if input.LabelIds == nil || len(*input.LabelIds) != 0 {
+			t.Errorf("applyTo LabelIds = %v, want &[]string{} clear", input.LabelIds)
+		}
+	})
+
+	t.Run("apply resolves names to IDs", func(t *testing.T) {
+		t.Parallel()
+		h := &labelsEditHarness{catalog: testCatalog()}
+		e, ferr := h.eval(t, []any{"bug"}, true, []string{"id-backend"})
+		if ferr != nil {
+			t.Fatalf("unexpected error: %v", ferr.Detail())
+		}
+		if !e.changed() {
+			t.Fatal("changed() = false for a real set change")
+		}
+		var input api.ProjectUpdateInput
+		e.applyTo(&input)
+		if input.LabelIds == nil || len(*input.LabelIds) != 1 || (*input.LabelIds)[0] != "id-bug" {
+			t.Errorf("applyTo LabelIds = %v, want [id-bug]", input.LabelIds)
+		}
+		if h.refreshCalls != 0 {
+			t.Errorf("guard fired %d times with a non-empty current set, want 0", h.refreshCalls)
+		}
+	})
+
+	t.Run("reordered list is not a change", func(t *testing.T) {
+		t.Parallel()
+		h := &labelsEditHarness{catalog: testCatalog()}
+		e, ferr := h.eval(t, []any{"Bug", "Backend"}, true, []string{"id-backend", "id-bug"})
+		if ferr != nil {
+			t.Fatalf("unexpected error: %v", ferr.Detail())
+		}
+		if e.changed() {
+			t.Error("changed() = true for an order-only difference")
+		}
+	})
+
+	t.Run("guard fires only when current empty and applying", func(t *testing.T) {
+		t.Parallel()
+		// The blob reads empty but the project really carries id-bug: the
+		// refreshed set feeds both resolution and the change decision, so
+		// re-saving the same label is NOT a change (no wipe-shaped write).
+		h := &labelsEditHarness{catalog: testCatalog(), refreshed: []string{"id-bug"}}
+		e, ferr := h.eval(t, []any{"Bug"}, true, nil)
+		if ferr != nil {
+			t.Fatalf("unexpected error: %v", ferr.Detail())
+		}
+		if h.refreshCalls != 1 {
+			t.Fatalf("guard fired %d times, want exactly 1", h.refreshCalls)
+		}
+		if e.changed() {
+			t.Error("changed() = true after refresh proved the set identical")
+		}
+	})
+
+	t.Run("guard silent when clearing", func(t *testing.T) {
+		t.Parallel()
+		// Key absent, current empty: nothing to apply, guard must not fire.
+		h := &labelsEditHarness{catalog: testCatalog(), refreshed: []string{"id-bug"}}
+		if _, ferr := h.eval(t, nil, true, nil); ferr != nil {
+			t.Fatalf("unexpected error: %v", ferr.Detail())
+		}
+		if h.refreshCalls != 0 {
+			t.Errorf("guard fired %d times with no labels to apply, want 0", h.refreshCalls)
+		}
+	})
+
+	t.Run("validation error passthrough", func(t *testing.T) {
+		t.Parallel()
+		h := &labelsEditHarness{catalog: testCatalog()}
+		_, ferr := h.eval(t, []any{"Area"}, true, nil) // group label
+		if ferr == nil {
+			t.Fatal("expected a FieldError for a group-label assignment")
+		}
+		if ferr.Field != "labels" || !strings.Contains(ferr.Message, "label group") {
+			t.Errorf("FieldError = %+v, want labels/group message", ferr)
+		}
+	})
+
+	t.Run("ID passthrough on cold catalog", func(t *testing.T) {
+		t.Parallel()
+		h := &labelsEditHarness{catalogErr: errors.New("catalog unavailable")}
+		e, ferr := h.eval(t, []any{"id-bug"}, true, []string{"id-bug"})
+		if ferr != nil {
+			t.Fatalf("cold catalog broke the round-trip invariant: %v", ferr.Detail())
+		}
+		if e.changed() {
+			t.Error("changed() = true re-saving the current set via ID passthrough")
+		}
+	})
+
+	t.Run("divergences nil when unchanged", func(t *testing.T) {
+		t.Parallel()
+		h := &labelsEditHarness{catalog: testCatalog()}
+		e, ferr := h.eval(t, nil, false, nil)
+		if ferr != nil {
+			t.Fatalf("unexpected error: %v", ferr.Detail())
+		}
+		// A concurrent writer changed labels; an untouched edit must not EIO.
+		if got := e.divergences([]string{"id-frontend"}); got != nil {
+			t.Errorf("divergences = %v for an unchanged set, want nil", got)
+		}
+	})
+
+	t.Run("divergence fatal on set mismatch", func(t *testing.T) {
+		t.Parallel()
+		h := &labelsEditHarness{catalog: testCatalog()}
+		e, ferr := h.eval(t, []any{"Bug"}, true, nil)
+		if ferr != nil {
+			t.Fatalf("unexpected error: %v", ferr.Detail())
+		}
+		if got := e.divergences([]string{"id-bug"}); got != nil {
+			t.Errorf("divergences = %v for a faithful persist, want nil", got)
+		}
+		got := e.divergences([]string{"id-bug", "id-frontend"})
+		if len(got) != 1 || !got[0].fatal {
+			t.Fatalf("divergences = %+v for a set mismatch, want one fatal result", got)
+		}
+		if !strings.Contains(got[0].message, "Field: labels") {
+			t.Errorf("divergence message %q missing Field: labels", got[0].message)
+		}
+	})
 }

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -426,51 +426,24 @@ func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Er
 		return syscall.EINVAL
 	}
 
-	// Labels: parse + guard + resolve + validate — all PURE, hoisted before
-	// any mutation so a validation failure cannot leave the initiatives
-	// reconcile partially applied.
+	// Labels front half: labelsEdit (sibling of scalarEdit) owns the parse,
+	// the stale-blob clobber guard, resolve + validate, and the one change
+	// decision — hoisted before any mutation so a validation failure cannot
+	// leave the initiatives reconcile partially applied. The refresh closure
+	// is interactive-promoted because it is a synchronous read inside a
+	// user-blocking flush; labelsEdit decides when it fires.
 	rawLabels, labelsPresent := doc.Frontmatter["labels"]
-	desiredNames := marshal.StringSliceFromYAML(rawLabels)
-
-	// Stale-blob clobber guard: a project blob predating the LabelIds field
-	// reads current as empty, so an agent ADDING one label would full-set-write
-	// just that label and silently wipe the project's real labels in Linear —
-	// invisible to the divergence check (fresh == sent). One targeted refresh
-	// in exactly the at-risk state; interactive-promoted because it is a
-	// synchronous read inside a user-blocking flush.
-	if len(p.project.LabelIds) == 0 && len(desiredNames) > 0 {
-		if fresh, err := p.lfs.verify().GetProject(api.WithInteractive(ctx), p.project.ID); err == nil && fresh != nil {
-			p.project.LabelIds = fresh.LabelIds
-		}
-	}
-
-	currentIDSet := make(map[string]bool, len(p.project.LabelIds))
-	for _, id := range p.project.LabelIds {
-		currentIDSet[id] = true
-	}
-
-	// Key absent + current empty = labels untouched. Key absent + current
-	// non-empty = delete-the-line clear (the mount-wide contract). An explicit
-	// empty list clears too.
-	var desiredIDs []string
-	labelsChanged := false
-	if labelsPresent || len(p.project.LabelIds) > 0 {
-		if len(desiredNames) > 0 {
-			catalog, err := p.lfs.GetProjectLabels(ctx)
-			if err != nil {
-				catalog = nil // ID passthrough via currentIDSet still resolves
+	labels, ferr := newLabelsEdit(ctx, rawLabels, labelsPresent, p.project.LabelIds,
+		p.lfs.GetProjectLabels,
+		func(ctx context.Context) []string {
+			if fresh, err := p.lfs.verify().GetProject(api.WithInteractive(ctx), p.project.ID); err == nil && fresh != nil {
+				p.project.LabelIds = fresh.LabelIds
 			}
-			ids, selected, ferr := resolveProjectLabels(catalog, desiredNames, currentIDSet)
-			if ferr == nil {
-				ferr = validateProjectLabelSelection(selected, currentIDSet, catalog)
-			}
-			if ferr != nil {
-				p.lfs.SetWriteError(p.project.ID, ferr.Detail())
-				return syscall.EINVAL
-			}
-			desiredIDs = ids
-		}
-		labelsChanged = !sameIDSet(desiredIDs, p.project.LabelIds)
+			return p.project.LabelIds
+		})
+	if ferr != nil {
+		p.lfs.SetWriteError(p.project.ID, ferr.Detail())
+		return syscall.EINVAL
 	}
 
 	// Extract initiatives from frontmatter (coerced via the shared marshal helper)
@@ -514,20 +487,13 @@ func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Er
 	}
 
 	// Persist editable scalar fields (name in frontmatter, description in
-	// body) plus the label set, in ONE UpdateProject call. Labels are a
-	// full-set atomic input (no removedLabelIds analog), so this is scalarEdit
-	// territory — deliberately not reconcileLinks, which exists for per-pair
-	// link mutations. Pointer-or-omit: untouched labels send nil.
+	// body) plus the label set, in ONE UpdateProject call. Each edit module
+	// maps itself onto the input pointer-or-omit; labelsEdit.applyTo owns the
+	// full-set labels semantics (see projectlabels.go).
 	edit := newScalarEdit(doc, p.project.Name, p.project.Description)
 	projectInput := api.ProjectUpdateInput{Name: edit.name, Description: edit.desc}
-	if labelsChanged {
-		ids := desiredIDs
-		if ids == nil {
-			ids = []string{} // clear (live-verified: labelIds: [] empties the set)
-		}
-		projectInput.LabelIds = &ids
-	}
-	if edit.changed() || labelsChanged {
+	labels.applyTo(&projectInput)
+	if edit.changed() || labels.changed() {
 		if err := p.lfs.mutator().UpdateProject(ctx, p.project.ID, projectInput); err != nil {
 			msg, errno := classifyMutationErr("update project", err)
 			p.lfs.SetWriteError(p.project.ID, msg)
@@ -548,19 +514,7 @@ func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Er
 			return p.lfs.UpsertProject(ctx, p.team.ID, *fresh)
 		},
 		compare: func(fresh *api.Project) []writeBackResult {
-			results := edit.divergences(fresh.Name, fresh.Description)
-			// Guarded on labelsChanged: an untouched label set must produce
-			// zero label divergence (a plain rename would otherwise EIO
-			// whenever another writer touches labels concurrently). Order is
-			// not divergence — the set is.
-			if labelsChanged && !sameIDSet(fresh.LabelIds, desiredIDs) {
-				results = append(results, writeBackResult{
-					message: fmt.Sprintf("Field: labels\nError: the write was accepted but the persisted label set differs (sent %d labels, %d persisted). Re-read the file to see the stored set.",
-						len(desiredIDs), len(fresh.LabelIds)),
-					fatal: true,
-				})
-			}
-			return results
+			return append(edit.divergences(fresh.Name, fresh.Description), labels.divergences(fresh.LabelIds)...)
 		},
 	})
 	if fresh != nil {


### PR DESCRIPTION
## Summary

Round-16 candidate #2. `ProjectInfoNode.Flush` smeared label-edit knowledge across three points — the parse/guard/resolve/validate block up front, the pointer-or-omit at input build, and the guarded divergence inside the `commitWriteBack` compare closure — and stated the `labelsChanged` decision twice. **`labelsEdit`** (in `internal/fs/projectlabels.go`, beside the pure primitives it composes) now owns the whole decision; Flush makes one call.

## Design

- `newLabelsEdit(ctx, rawLabels, labelsPresent, currentIDs, catalog, refreshCurrent) (labelsEdit, *FieldError)` — evaluates everything at construction. The two closures keep the module pure of the mount: `catalog` fetches the workspace catalog (fetch error degrades to nil catalog; exact-ID passthrough via the current set still resolves), `refreshCurrent` is the stale-blob clobber guard's fetch (caller wires the interactive-promoted `GetProject`; the **module** decides when it fires: only when current is empty and the write would apply labels).
- `changed()` — the ONE change computation (order-insensitive set diff).
- `applyTo(*api.ProjectUpdateInput)` — pointer-or-omit: nil when unchanged, `&[]string{}` on clear.
- `divergences(freshIDs)` — the guarded read-your-writes compare, moved verbatim: nil when unchanged (a plain rename must not EIO on a concurrent label writer), fatal on a persisted-set mismatch.
- Primitives (`resolveProjectLabels`, `validateProjectLabelSelection`, `sameIDSet`) are unchanged; `labelsEdit` composes them. Sibling of `scalarEdit` in the edit-front-half family (scalars / per-pair links / atomic full-set list).

## Behavior-preserving

Pinned semantics all carry through: key absent + current empty = untouched; key absent + current non-empty = clear; explicit empty list = clear; guard fires only in the empty-current-and-applying state; ID passthrough on a cold catalog; order is not a change; divergence guarded on changed.

## Testing

- New `TestLabelsEdit` (11 subtests) with literal catalogs and recording closures — no mount: untouched / both clears / apply / guard-fires (refreshed set feeds the change decision) / guard-silent / validation-error passthrough / cold-catalog ID round-trip / divergences-nil-when-unchanged / divergence-fatal-on-mismatch.
- The six integration tests in `internal/integration/projectlabels_test.go` pass **unchanged** (the behavior pin).
- `go build ./... && go vet ./... && go test ./internal/...` green; gofmt clean.

## Docs

CONTEXT.md: "Project-label selection" records the front-half composition; "Scalar edit" and "Link reconciliation" name the new sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)