### PR TITLE
fix(fs): catalog frontmatter through the marshal render seam (Q3: Bets invalid-YAML bug)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -216,7 +216,13 @@ was observable only through a mounted filesystem. The editable-only split
 the writer's bytes) is now pinned by unit tests on the exact frontmatter key
 sets. The fs nodes keep one-line wrappers that degrade a render failure to an
 empty file. The parse side stays with [[scalar-edit]] (name/description) and
-[[link-reconciliation]] (the member lists).
+[[link-reconciliation]] (the member lists). The read-only catalog renders
+(team.md, states.md, labels.md, project-labels.md, user.md, cycle.md, updates,
+label files) also route their frontmatter through this seam
+(`renderWithFrontmatter`, internal/fs/catalogrender.go) — they used to
+fmt.Sprintf-concatenate YAML, so a name like `Q3: Bets` emitted invalid YAML
+in exactly the files agents machine-parse after a `.error`; the bodies stay
+hand-built prose/tables.
 
 ### Create trigger (`createFileNode`)
 The **deep module** owning the write-only `_create` file (and the named-file

--- a/internal/fs/catalogrender.go
+++ b/internal/fs/catalogrender.go
@@ -1,0 +1,26 @@
+package fs
+
+import "github.com/jra3/linear-fuse/internal/marshal"
+
+// renderWithFrontmatter renders a generated file through the marshal seam:
+// frontmatter built as Go data (yaml.v3 encodes it), hand-built body appended
+// verbatim. This replaces the fmt.Sprintf-concatenated YAML the catalog
+// renderers used to emit, where a value like `Q3: Bets` (colon), a
+// double-quoted name, or a `#hex` color landed unquoted/mis-quoted and the
+// frontmatter stopped parsing as YAML — exactly the files agents machine-parse
+// after a validation .error. The encoder quotes whatever the value requires;
+// the prose/table BODY stays hand-built and is passed through untouched.
+//
+// Ordering: yaml.v3 sorts map keys deterministically (the same canonical order
+// issue.md and the .meta sidecars already carry), so output is byte-stable
+// across renders. Key ORDER inside the block is not part of any file's
+// contract — top-level key NAMES are (`team:`, `states:`, `labels:`, …).
+func renderWithFrontmatter(fm map[string]any, body string) []byte {
+	out, err := marshal.Render(&marshal.Document{Frontmatter: fm, Body: body})
+	if err != nil {
+		// Maps of scalars/lists cannot fail to marshal; if one somehow does,
+		// degrade to the body (these files promise to exist, never error).
+		return []byte(body)
+	}
+	return out
+}

--- a/internal/fs/cycles.go
+++ b/internal/fs/cycles.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"syscall"
 	"time"
@@ -201,36 +202,30 @@ func cycleMarkdown(team api.Team, cycle api.Cycle) []byte {
 		cycleName = fmt.Sprintf("Cycle %d", cycle.Number)
 	}
 
-	return []byte(fmt.Sprintf(`---
-id: %s
-number: %d
-name: %s
-team: %s
-startsAt: %q
-endsAt: %q
-status: %s
-progress:
-  completed: %d
-  total: %d
-  percentage: %.1f
----
-
+	// Frontmatter goes through renderWithFrontmatter so a hostile cycle name
+	// stays valid YAML. percentage keeps the historical one-decimal rounding
+	// (yaml.v3 renders an integral float as a bare integer — YAML-equivalent).
+	fm := map[string]any{
+		"id":       cycle.ID,
+		"number":   cycle.Number,
+		"name":     cycleName,
+		"team":     team.Key,
+		"startsAt": cycle.StartsAt.Format(time.RFC3339),
+		"endsAt":   cycle.EndsAt.Format(time.RFC3339),
+		"status":   status,
+		"progress": map[string]any{
+			"completed":  completed,
+			"total":      total,
+			"percentage": math.Round(percentage*10) / 10,
+		},
+	}
+	body := fmt.Sprintf(`
 # %s
 
 - **Duration:** %s - %s
 - **Progress:** %d/%d issues (%.1f%%)
 - **Status:** %s
 `,
-		cycle.ID,
-		cycle.Number,
-		cycleName,
-		team.Key,
-		cycle.StartsAt.Format(time.RFC3339),
-		cycle.EndsAt.Format(time.RFC3339),
-		status,
-		completed,
-		total,
-		percentage,
 		cycleName,
 		cycle.StartsAt.Format("Jan 2, 2006"),
 		cycle.EndsAt.Format("Jan 2, 2006"),
@@ -238,7 +233,8 @@ progress:
 		total,
 		percentage,
 		status,
-	))
+	)
+	return renderWithFrontmatter(fm, body)
 }
 
 // isCurrent checks if a cycle is the current active cycle

--- a/internal/fs/cycles_test.go
+++ b/internal/fs/cycles_test.go
@@ -148,7 +148,7 @@ func TestCycleFileNode_GenerateContent(t *testing.T) {
 		"status: current",
 		"completed: 3",
 		"total: 10",
-		"percentage: 30.0",
+		"percentage: 30",
 		"# Sprint 5",
 	}
 
@@ -184,8 +184,8 @@ func TestCycleFileNode_GenerateContent_EmptyHistory(t *testing.T) {
 	if !contains(contentStr, "total: 0") {
 		t.Error("expected total: 0 for empty history")
 	}
-	if !contains(contentStr, "percentage: 0.0") {
-		t.Error("expected percentage: 0.0 for empty history")
+	if !contains(contentStr, "percentage: 0") {
+		t.Error("expected percentage: 0 for empty history")
 	}
 	if !contains(contentStr, "status: upcoming") {
 		t.Error("expected status: upcoming for future cycle")

--- a/internal/fs/labels.go
+++ b/internal/fs/labels.go
@@ -223,32 +223,26 @@ func labelFilename(label api.Label) string {
 	return name + ".md"
 }
 
-// labelToMarkdown converts a label to markdown with YAML frontmatter
+// labelToMarkdown converts a label to markdown with YAML frontmatter, routed
+// through renderWithFrontmatter so hostile names/descriptions stay valid YAML
+// (Go %q quoting was ALMOST YAML — not guaranteed).
 func labelToMarkdown(label *api.Label) []byte {
-	content := fmt.Sprintf(`---
-id: %s
-name: %q
-color: %q
-description: %q
----
-
+	fm := map[string]any{
+		"id":          label.ID,
+		"name":        label.Name,
+		"color":       label.Color,
+		"description": label.Description,
+	}
+	body := fmt.Sprintf(`
 # %s
 
 - **Color:** %s
 - **ID:** %s
-`,
-		label.ID,
-		label.Name,
-		label.Color,
-		label.Description,
-		label.Name,
-		label.Color,
-		label.ID,
-	)
+`, label.Name, label.Color, label.ID)
 	if label.Description != "" {
-		content += fmt.Sprintf("\n%s\n", label.Description)
+		body += fmt.Sprintf("\n%s\n", label.Description)
 	}
-	return []byte(content)
+	return renderWithFrontmatter(fm, body)
 }
 
 // LabelFileNode represents a single label file (read-write)

--- a/internal/fs/labels_test.go
+++ b/internal/fs/labels_test.go
@@ -73,9 +73,9 @@ func TestLabelToMarkdown(t *testing.T) {
 			},
 			wantContain: []string{
 				"id: label-123",
-				`name: "Bug"`,
-				`color: "#FF0000"`,
-				`description: "Something is broken"`,
+				"name: Bug",
+				`color: '#FF0000'`,
+				"description: Something is broken",
 				"# Bug",
 				"**Color:** #FF0000",
 				"**ID:** label-123",
@@ -92,8 +92,8 @@ func TestLabelToMarkdown(t *testing.T) {
 			},
 			wantContain: []string{
 				"id: label-456",
-				`name: "Feature"`,
-				`color: "#00FF00"`,
+				"name: Feature",
+				`color: '#00FF00'`,
 				"# Feature",
 			},
 		},
@@ -105,7 +105,7 @@ func TestLabelToMarkdown(t *testing.T) {
 				Color: "#0000FF",
 			},
 			wantContain: []string{
-				`name: "Bug: Critical"`,
+				`name: 'Bug: Critical'`,
 				"# Bug: Critical",
 			},
 		},

--- a/internal/fs/projectlabels.go
+++ b/internal/fs/projectlabels.go
@@ -18,30 +18,33 @@ import (
 // projectLabelsMarkdown renders the root project-labels.md catalog. The
 // assignment rules live IN the file — it is what an agent reads after a
 // validation .error — and the render is stable for an empty catalog (never
-// ENOENT; the README promises the file exists).
+// ENOENT; the README promises the file exists). The frontmatter goes through
+// renderWithFrontmatter so hostile names (`Q3: Bets`, quotes) stay valid YAML.
 func projectLabelsMarkdown(labels []api.ProjectLabel) []byte {
-	var yaml, table strings.Builder
+	entries := make([]map[string]any, 0, len(labels))
+	var table strings.Builder
 	for _, l := range labels {
-		yaml.WriteString(fmt.Sprintf("  - id: %s\n    name: %s\n", l.ID, l.Name))
+		entry := map[string]any{"id": l.ID, "name": l.Name}
 		if l.Color != "" {
-			yaml.WriteString(fmt.Sprintf("    color: %q\n", l.Color))
+			entry["color"] = l.Color
 		}
 		if l.Description != "" {
-			yaml.WriteString(fmt.Sprintf("    description: %q\n", l.Description))
+			entry["description"] = l.Description
 		}
 		if l.IsGroup {
-			yaml.WriteString("    group: true\n")
+			entry["group"] = true
 		}
 		if l.Parent != nil {
 			parent := l.Parent.Name
 			if parent == "" {
 				parent = l.Parent.ID
 			}
-			yaml.WriteString(fmt.Sprintf("    parent: %s\n", parent))
+			entry["parent"] = parent
 		}
 		if l.RetiredAt != nil {
-			yaml.WriteString("    retired: true\n")
+			entry["retired"] = true
 		}
+		entries = append(entries, entry)
 
 		group := "—"
 		if l.Parent != nil {
@@ -74,10 +77,7 @@ func projectLabelsMarkdown(labels []api.ProjectLabel) []byte {
 ` + body
 	}
 
-	return []byte(fmt.Sprintf(`---
-labels:
-%s---
-
+	return renderWithFrontmatter(map[string]any{"labels": entries}, fmt.Sprintf(`
 # Project Labels (workspace-wide)
 
 Assign in any project.md frontmatter: `+"`labels: [Platform, Q3-Bet]`"+`
@@ -89,7 +89,7 @@ Rules:
 - At most ONE child from each group may be on a project at a time.
 - Labels marked `+"`retired: true`"+` cannot be newly assigned; existing assignments remain.
 
-%s`, yaml.String(), body))
+%s`, body))
 }
 
 // projectLabelCatalogTimes derives the catalog file's times from the entities

--- a/internal/fs/projectlabels_test.go
+++ b/internal/fs/projectlabels_test.go
@@ -3,11 +3,13 @@ package fs
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/jra3/linear-fuse/internal/api"
+	"github.com/jra3/linear-fuse/internal/marshal"
 )
 
 func testCatalog() []api.ProjectLabel {
@@ -46,7 +48,7 @@ func TestProjectLabelsMarkdown(t *testing.T) {
 		"| Legacy | — | — | retired |",      // retired row flag
 		"At most ONE child from each group", // rules prose lives in-file
 		"a raw label ID is also accepted",   // ID-passthrough documented
-		"description: \"bug work\"",
+		"description: bug work",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("catalog render missing %q:\n%s", want, got)
@@ -55,6 +57,41 @@ func TestProjectLabelsMarkdown(t *testing.T) {
 	// Frontmatter top key matches the labels.md idiom.
 	if !strings.HasPrefix(got, "---\nlabels:\n") {
 		t.Errorf("catalog frontmatter key is off-idiom:\n%s", got[:40])
+	}
+}
+
+// TestProjectLabelsMarkdownHostileNames pins the injection fix: hand-built
+// YAML emitted `name: Q3: Bets` unquoted, which is INVALID YAML — in exactly
+// the file agents machine-parse after a validation .error. The render must
+// stay parseable and recover hostile names byte-exactly.
+func TestProjectLabelsMarkdownHostileNames(t *testing.T) {
+	t.Parallel()
+	hostile := []string{`Q3: Bets`, `He said "no"`, `#urgent`, `[wip] thing`}
+	catalog := make([]api.ProjectLabel, 0, len(hostile))
+	for i, name := range hostile {
+		catalog = append(catalog, api.ProjectLabel{
+			ID:          fmt.Sprintf("id-%d", i),
+			Name:        name,
+			Description: `desc with: colon and "quotes"`,
+		})
+	}
+
+	doc, err := marshal.Parse(projectLabelsMarkdown(catalog))
+	if err != nil {
+		t.Fatalf("catalog render is not parseable YAML frontmatter: %v", err)
+	}
+	entries, ok := doc.Frontmatter["labels"].([]any)
+	if !ok || len(entries) != len(hostile) {
+		t.Fatalf("labels frontmatter = %T with %v entries, want list of %d", doc.Frontmatter["labels"], entries, len(hostile))
+	}
+	for i, want := range hostile {
+		entry, ok := entries[i].(map[string]any)
+		if !ok {
+			t.Fatalf("entry %d = %T, want map", i, entries[i])
+		}
+		if got := entry["name"]; got != want {
+			t.Errorf("entry %d name round-tripped to %v, want %q", i, got, want)
+		}
 	}
 }
 

--- a/internal/fs/teams.go
+++ b/internal/fs/teams.go
@@ -205,93 +205,72 @@ func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 	return nil, syscall.ENOENT
 }
 
-// teamMarkdown renders the team.md content for a team.
+// teamMarkdown renders the team.md content for a team. Frontmatter goes
+// through renderWithFrontmatter so hostile names stay valid YAML.
 func teamMarkdown(team api.Team) []byte {
-	return []byte(fmt.Sprintf(`---
-id: %s
-key: %s
-name: %q
-icon: %q
-created: %q
-updated: %q
----
-
+	fm := map[string]any{
+		"id":      team.ID,
+		"key":     team.Key,
+		"name":    team.Name,
+		"icon":    team.Icon,
+		"created": team.CreatedAt.Format(time.RFC3339),
+		"updated": team.UpdatedAt.Format(time.RFC3339),
+	}
+	body := fmt.Sprintf(`
 # %s
 
 - **Key:** %s
 - **ID:** %s
-`,
-		team.ID,
-		team.Key,
-		team.Name,
-		team.Icon,
-		team.CreatedAt.Format(time.RFC3339),
-		team.UpdatedAt.Format(time.RFC3339),
-		team.Name,
-		team.Key,
-		team.ID,
-	))
+`, team.Name, team.Key, team.ID)
+	return renderWithFrontmatter(fm, body)
 }
 
 // statesMarkdown renders the states.md content for a team's workflow states.
+// Frontmatter goes through renderWithFrontmatter so a state named with a
+// colon (or any YAML-hostile character) stays machine-parseable.
 func statesMarkdown(team api.Team, states []api.State) []byte {
-	var statesYAML string
-	for _, state := range states {
-		statesYAML += fmt.Sprintf("  - id: %s\n    name: %s\n    type: %s\n",
-			state.ID, state.Name, state.Type)
-	}
-
+	entries := make([]map[string]any, 0, len(states))
 	var table string
 	for _, state := range states {
+		entries = append(entries, map[string]any{
+			"id": state.ID, "name": state.Name, "type": state.Type,
+		})
 		table += fmt.Sprintf("| %s | %s | %s |\n", state.Name, state.Type, state.ID)
 	}
 
-	return []byte(fmt.Sprintf(`---
-team: %s
-states:
-%s---
-
+	fm := map[string]any{"team": team.Key, "states": entries}
+	body := fmt.Sprintf(`
 # Workflow States for %s
 
 | Name | Type | ID |
 |------|------|-----|
-%s`,
-		team.Key,
-		statesYAML,
-		team.Key,
-		table,
-	))
+%s`, team.Key, table)
+	return renderWithFrontmatter(fm, body)
 }
 
 // labelsMarkdown renders the labels.md content for a team's labels.
+// Frontmatter goes through renderWithFrontmatter so a label named with a
+// colon (or any YAML-hostile character) stays machine-parseable.
 func labelsMarkdown(team api.Team, labels []api.Label) []byte {
-	var labelsYAML string
-	for _, label := range labels {
-		labelsYAML += fmt.Sprintf("  - id: %s\n    name: %s\n    color: %q\n",
-			label.ID, label.Name, label.Color)
-		if label.Description != "" {
-			labelsYAML += fmt.Sprintf("    description: %q\n", label.Description)
-		}
-	}
-
+	entries := make([]map[string]any, 0, len(labels))
 	var table string
 	for _, label := range labels {
+		entry := map[string]any{
+			"id": label.ID, "name": label.Name, "color": label.Color,
+		}
+		if label.Description != "" {
+			entry["description"] = label.Description
+		}
+		entries = append(entries, entry)
 		table += fmt.Sprintf("| %s | %s | %s |\n", label.Name, label.Color, label.ID)
 	}
 
-	return []byte(fmt.Sprintf(`---
-team: %s
-labels:
-%s---
-
+	fm := map[string]any{"team": team.Key, "labels": entries}
+	body := fmt.Sprintf(`
 # Labels for %s
 
 | Name | Color | ID |
 |------|-------|-----|
-%s`,
-		team.Key,
-		labelsYAML,
-		team.Key,
-		table,
-	))
+%s`, team.Key, table)
+	return renderWithFrontmatter(fm, body)
 }

--- a/internal/fs/teams_test.go
+++ b/internal/fs/teams_test.go
@@ -1,0 +1,79 @@
+package fs
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jra3/linear-fuse/internal/api"
+	"github.com/jra3/linear-fuse/internal/marshal"
+)
+
+// TestTeamCatalogHostileNames pins the injection fix for the team catalogs:
+// the hand-built frontmatter emitted `name: Q3: Triage` unquoted (invalid
+// YAML) in states.md/labels.md — the reference files agents machine-parse to
+// find valid values after a validation .error. Renders must stay parseable
+// YAML and recover hostile names byte-exactly.
+func TestTeamCatalogHostileNames(t *testing.T) {
+	t.Parallel()
+	team := api.Team{ID: "team-1", Key: "ENG", Name: `Team "Core": Platform`,
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)}
+
+	t.Run("states.md", func(t *testing.T) {
+		t.Parallel()
+		states := []api.State{{ID: "s1", Name: "Q3: Triage", Type: "triage"}}
+		doc, err := marshal.Parse(statesMarkdown(team, states))
+		if err != nil {
+			t.Fatalf("states.md render is not parseable YAML frontmatter: %v", err)
+		}
+		if doc.Frontmatter["team"] != "ENG" {
+			t.Errorf("team key = %v, want ENG", doc.Frontmatter["team"])
+		}
+		entries, _ := doc.Frontmatter["states"].([]any)
+		if len(entries) != 1 {
+			t.Fatalf("states = %v, want 1 entry", doc.Frontmatter["states"])
+		}
+		entry, _ := entries[0].(map[string]any)
+		if got := entry["name"]; got != "Q3: Triage" {
+			t.Errorf("state name round-tripped to %v, want %q", got, "Q3: Triage")
+		}
+	})
+
+	t.Run("labels.md", func(t *testing.T) {
+		t.Parallel()
+		labels := []api.Label{{ID: "l1", Name: `He said "ship it"`, Color: "#5e6ad2",
+			Description: "desc: with colon"}}
+		doc, err := marshal.Parse(labelsMarkdown(team, labels))
+		if err != nil {
+			t.Fatalf("labels.md render is not parseable YAML frontmatter: %v", err)
+		}
+		entries, _ := doc.Frontmatter["labels"].([]any)
+		if len(entries) != 1 {
+			t.Fatalf("labels = %v, want 1 entry", doc.Frontmatter["labels"])
+		}
+		entry, _ := entries[0].(map[string]any)
+		if got := entry["name"]; got != `He said "ship it"` {
+			t.Errorf("label name round-tripped to %v, want %q", got, `He said "ship it"`)
+		}
+		if got := entry["color"]; got != "#5e6ad2" {
+			t.Errorf("label color round-tripped to %v, want #5e6ad2 (a plain # starts a YAML comment)", got)
+		}
+	})
+
+	t.Run("team.md", func(t *testing.T) {
+		t.Parallel()
+		content := teamMarkdown(team)
+		doc, err := marshal.Parse(content)
+		if err != nil {
+			t.Fatalf("team.md render is not parseable YAML frontmatter: %v", err)
+		}
+		if got := doc.Frontmatter["name"]; got != team.Name {
+			t.Errorf("team name round-tripped to %v, want %q", got, team.Name)
+		}
+		// The prose body survives untouched below the frontmatter.
+		if !strings.Contains(string(content), "- **Key:** ENG") {
+			t.Errorf("team.md body missing the key bullet:\n%s", content)
+		}
+	})
+}

--- a/internal/fs/updates.go
+++ b/internal/fs/updates.go
@@ -1,9 +1,7 @@
 package fs
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/hanwen/go-fuse/v2/fs"
@@ -29,20 +27,18 @@ func (b *BaseNode) lookupUpdateFile(ctx context.Context, out *fuse.EntryOut, nam
 // — they differ only in the api type they carry — so both pass their fields in
 // here rather than each hand-rolling the identical writer. The read-only update
 // files are served through renderFile with a closure over this. Its naming
-// sibling is updateEntryName (indexedlisting.go).
+// sibling is updateEntryName (indexedlisting.go). Frontmatter goes through
+// renderWithFrontmatter so a hostile author name stays valid YAML.
 func updateMarkdown(id, health string, created, updated time.Time, user *api.User, body string) []byte {
-	var buf bytes.Buffer
-	buf.WriteString("---\n")
-	buf.WriteString(fmt.Sprintf("id: %s\n", id))
-	buf.WriteString(fmt.Sprintf("health: %s\n", health))
-	buf.WriteString(fmt.Sprintf("created: %q\n", created.Format(time.RFC3339)))
-	buf.WriteString(fmt.Sprintf("updated: %q\n", updated.Format(time.RFC3339)))
-	if user != nil {
-		buf.WriteString(fmt.Sprintf("author: %s\n", user.Email))
-		buf.WriteString(fmt.Sprintf("authorName: %s\n", user.Name))
+	fm := map[string]any{
+		"id":      id,
+		"health":  health,
+		"created": created.Format(time.RFC3339),
+		"updated": updated.Format(time.RFC3339),
 	}
-	buf.WriteString("---\n\n")
-	buf.WriteString(body)
-	buf.WriteString("\n")
-	return buf.Bytes()
+	if user != nil {
+		fm["author"] = user.Email
+		fm["authorName"] = user.Name
+	}
+	return renderWithFrontmatter(fm, "\n"+body+"\n")
 }

--- a/internal/fs/users.go
+++ b/internal/fs/users.go
@@ -146,35 +146,27 @@ func (u *UserNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 	return nil, syscall.ENOENT
 }
 
-// userMarkdown renders the user.md content for a user.
+// userMarkdown renders the user.md content for a user. Frontmatter goes
+// through renderWithFrontmatter so hostile display names stay valid YAML.
 func userMarkdown(user api.User) []byte {
 	status := "active"
 	if !user.Active {
 		status = "inactive"
 	}
 
-	return []byte(fmt.Sprintf(`---
-id: %s
-name: %s
-email: %s
-displayName: %s
-status: %s
----
-
+	fm := map[string]any{
+		"id":          user.ID,
+		"name":        user.Name,
+		"email":       user.Email,
+		"displayName": user.DisplayName,
+		"status":      status,
+	}
+	body := fmt.Sprintf(`
 # %s
 
 - **Email:** %s
 - **ID:** %s
 - **Status:** %s
-`,
-		user.ID,
-		user.Name,
-		user.Email,
-		user.DisplayName,
-		status,
-		user.Name,
-		user.Email,
-		user.ID,
-		status,
-	))
+`, user.Name, user.Email, user.ID, status)
+	return renderWithFrontmatter(fm, body)
 }


### PR DESCRIPTION
## The bug

A project label named `Q3: Bets` — or any catalog entry with a colon, double quote, leading `#`, or leading bracket — rendered as **invalid YAML** in `project-labels.md`:

```yaml
labels:
  - id: id-1
    name: Q3: Bets     # <- two colons, YAML parse error
```

That file is exactly what an agent machine-parses after a validation `.error` points it there. The same hand-concatenated-`fmt.Sprintf` hazard sat in seven more read-only renders: `states.md`, `labels.md`, `team.md`, `user.md`, `cycle.md`, status-update files, and the per-label `labels/*.md`.

## The fix

Each renderer now builds its frontmatter as Go data and routes it through the existing marshal Entity-render seam via a small adapter, `renderWithFrontmatter` (`internal/fs/catalogrender.go`): yaml.v3 quotes whatever a value requires, and its deterministic key sort is the same canonical order `issue.md` and the `.meta` sidecars already carry.

Contract kept:
- **Top-level key names unchanged** — `labels:`, `team:`/`states:`, entry key sets identical (including conditional keys like `description`, `group`, `retired`).
- **Bodies byte-identical** — the prose/tables stay hand-built; only the block between the `---` fences goes through the encoder.
- Output differences are YAML-equivalent only: quoting style (`name: 'Bug: Critical'`, `color: '#FF0000'`), key order, `percentage: 30` for integral floats.

## Converted

`projectLabelsMarkdown`, `teamMarkdown`, `statesMarkdown`, `labelsMarkdown`, `userMarkdown`, `cycleMarkdown`, `updateMarkdown`, `labelToMarkdown`.

Excluded: `commentToMarkdown` (already encodes via `yaml.Marshal` — no injection hazard) and everything in `internal/marshal` (already on the seam).

## Tests

- New hostile-name round-trips (render → `marshal.Parse` → exact-name recovery): `Q3: Bets`, `He said "no"`, `#urgent`, `[wip] thing` for the project-label catalog; colon/quote/`#hex` cases for the team catalogs (new `teams_test.go`).
- Existing assertions updated only where quoting/format legitimately changed; all semantic assertions untouched.
- Full `./internal/...` suite green, including `TestProjectLabelsCatalogFile` and `TestGeneratedReadmeMatchesBehavior` (integration tests parse frontmatter semantically, so they passed unchanged).
- CONTEXT.md "Entity render" entry records that catalog frontmatter now routes through the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)