### PR TITLE
fix(api): all-or-nothing result contract for GetIssueDetailsBatch

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -957,8 +957,15 @@ func (c *Client) GetIssueDetails(ctx context.Context, issueID string) (*IssueDet
 	return result.Issue.toDetails(), nil
 }
 
-// GetIssueDetailsBatch fetches comments, documents, and attachments for multiple issues in a single query.
-// Returns a map of issueID -> IssueDetails. Uses GraphQL aliases to batch requests.
+// GetIssueDetailsBatch fetches comments, documents, attachments, and relations
+// for multiple issues in a single query, using GraphQL aliases to batch requests.
+//
+// The result is all-or-nothing: a nil-error return guarantees the map holds a
+// non-nil entry for every requested issue ID. A missing alias, a null alias,
+// or a payload that fails to decode fails the whole call with an error naming
+// the issue. Callers prune SQLite rows against these details, so a silent gap
+// (or a null decoded as five empty, "complete" collections) would prune a live
+// issue's details.
 func (c *Client) GetIssueDetailsBatch(ctx context.Context, issueIDs []string) (map[string]*IssueDetails, error) {
 	if len(issueIDs) == 0 {
 		return make(map[string]*IssueDetails), nil
@@ -1000,18 +1007,24 @@ func (c *Client) GetIssueDetailsBatch(ctx context.Context, issueIDs []string) (m
 		return nil, err
 	}
 
-	// Parse each aliased result
+	// Parse each aliased result. Unmarshalling into a pointer distinguishes a
+	// null alias (issue not found) from a present payload — a zero
+	// issueDetailsPayload is indistinguishable from a real issue with no
+	// details.
 	result := make(map[string]*IssueDetails, len(issueIDs))
 	for i, id := range issueIDs {
 		alias := fmt.Sprintf("i%d", i)
 		raw, ok := rawResult[alias]
 		if !ok {
-			continue
+			return nil, fmt.Errorf("issue details batch: alias %s (issue %s) missing from response", alias, id)
 		}
 
-		var issueData issueDetailsPayload
+		var issueData *issueDetailsPayload
 		if err := json.Unmarshal(raw, &issueData); err != nil {
-			continue
+			return nil, fmt.Errorf("issue details batch: alias %s (issue %s): %w", alias, id, err)
+		}
+		if issueData == nil {
+			return nil, fmt.Errorf("issue details batch: alias %s (issue %s) is null", alias, id)
 		}
 
 		result[id] = issueData.toDetails()

--- a/internal/api/details_batch_test.go
+++ b/internal/api/details_batch_test.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jra3/linear-fuse/internal/testutil"
+)
+
+// GetIssueDetailsBatch's contract is all-or-nothing: a nil-error return
+// guarantees a non-nil entry for every requested ID. Sync-worker prunes rely
+// on it — a silently-missing or null alias decoded as empty collections would
+// prune a live issue's details.
+
+func detailsPayload(commentIDs ...string) map[string]any {
+	comments := []map[string]any{}
+	for _, id := range commentIDs {
+		comments = append(comments, map[string]any{"id": id, "body": "text"})
+	}
+	empty := map[string]any{"nodes": []map[string]any{}}
+	return map[string]any{
+		"comments":         map[string]any{"nodes": comments},
+		"documents":        empty,
+		"attachments":      empty,
+		"relations":        empty,
+		"inverseRelations": empty,
+	}
+}
+
+func TestGetIssueDetailsBatchAllAliasesPresent(t *testing.T) {
+	t.Parallel()
+	mock := testutil.NewMockLinearServer()
+	defer mock.Close()
+
+	mock.SetResponse("IssueDetailsBatch", map[string]any{
+		"i0": detailsPayload("comment-1"),
+		"i1": detailsPayload(),
+	})
+
+	c := NewClient("test")
+	c.SetAPIURL(mock.URL())
+
+	details, err := c.GetIssueDetailsBatch(context.Background(), []string{"issue-a", "issue-b"})
+	if err != nil {
+		t.Fatalf("GetIssueDetailsBatch: %v", err)
+	}
+	if len(details) != 2 {
+		t.Fatalf("details = %d entries, want 2", len(details))
+	}
+	for _, id := range []string{"issue-a", "issue-b"} {
+		if details[id] == nil {
+			t.Fatalf("details[%s] is nil, want non-nil for every requested ID", id)
+		}
+	}
+	if len(details["issue-a"].Comments) != 1 || details["issue-a"].Comments[0].ID != "comment-1" {
+		t.Errorf("issue-a comments = %+v, want [comment-1]", details["issue-a"].Comments)
+	}
+}
+
+func TestGetIssueDetailsBatchMissingAliasFails(t *testing.T) {
+	t.Parallel()
+	mock := testutil.NewMockLinearServer()
+	defer mock.Close()
+
+	// i1 is absent from the response entirely.
+	mock.SetResponse("IssueDetailsBatch", map[string]any{
+		"i0": detailsPayload(),
+	})
+
+	c := NewClient("test")
+	c.SetAPIURL(mock.URL())
+
+	details, err := c.GetIssueDetailsBatch(context.Background(), []string{"issue-a", "issue-b"})
+	if err == nil {
+		t.Fatal("expected error for missing alias, got nil")
+	}
+	if !strings.Contains(err.Error(), "issue-b") {
+		t.Errorf("error = %q, want it to name issue-b", err)
+	}
+	if details != nil {
+		t.Errorf("details = %v, want nil map on error", details)
+	}
+}
+
+func TestGetIssueDetailsBatchNullAliasFails(t *testing.T) {
+	t.Parallel()
+	mock := testutil.NewMockLinearServer()
+	defer mock.Close()
+
+	// A null alias is how GraphQL reports an issue that doesn't exist. It must
+	// not decode into an empty payload whose collections all look "complete".
+	mock.SetResponse("IssueDetailsBatch", map[string]any{
+		"i0": detailsPayload(),
+		"i1": nil,
+	})
+
+	c := NewClient("test")
+	c.SetAPIURL(mock.URL())
+
+	details, err := c.GetIssueDetailsBatch(context.Background(), []string{"issue-a", "issue-b"})
+	if err == nil {
+		t.Fatal("expected error for null alias, got nil")
+	}
+	if !strings.Contains(err.Error(), "issue-b") {
+		t.Errorf("error = %q, want it to name issue-b", err)
+	}
+	if !strings.Contains(err.Error(), "null") {
+		t.Errorf("error = %q, want it to say the alias was null", err)
+	}
+	if details != nil {
+		t.Errorf("details = %v, want nil map on error", details)
+	}
+}
+
+func TestGetIssueDetailsBatchDecodeFailureFails(t *testing.T) {
+	t.Parallel()
+	mock := testutil.NewMockLinearServer()
+	defer mock.Close()
+
+	// comments is a string where an object is expected: decode failure.
+	broken := detailsPayload()
+	broken["comments"] = "not-a-connection"
+	mock.SetResponse("IssueDetailsBatch", map[string]any{
+		"i0": detailsPayload(),
+		"i1": broken,
+	})
+
+	c := NewClient("test")
+	c.SetAPIURL(mock.URL())
+
+	details, err := c.GetIssueDetailsBatch(context.Background(), []string{"issue-a", "issue-b"})
+	if err == nil {
+		t.Fatal("expected error for undecodable alias, got nil")
+	}
+	if !strings.Contains(err.Error(), "issue-b") {
+		t.Errorf("error = %q, want it to name issue-b", err)
+	}
+	if details != nil {
+		t.Errorf("details = %v, want nil map on error", details)
+	}
+}


### PR DESCRIPTION
Step 1 of the detail-outcome/SWR-refresh design (docs/plans/2026-07-08-detail-outcome-swr-refresh-design.md, hazard 2).

## The hazard

`GetIssueDetailsBatch` silently `continue`d when an alias was missing from the response or failed `json.Unmarshal`. Worse, a `null` alias (GraphQL's shape for an issue that doesn't exist) unmarshalled into a zero `issueDetailsPayload`, and `toDetails()` never returns nil — so callers received an **empty** `IssueDetails` whose five empty collections each look "complete" (len 0 < page size), feeding a full prune of a live issue's comments/docs/attachments/relations in the sync worker.

## The contract

A nil-error return now guarantees the map contains a non-nil entry for **every** requested ID. Any missing alias, JSON-null alias, or decode failure fails the whole call with an error naming the alias and issue ID. This mirrors `drainFrom`'s all-or-nothing contract (internal/api/paginate.go) — prune callers rely on nil-error meaning complete. Null detection is via unmarshalling into a `*issueDetailsPayload` and checking nil, which distinguishes a null alias from a real issue with no details.

`internal/sync/worker.go` is intentionally untouched — a later step in the design rewrites the batch consumer (including its now-stale comment and the dead `details == nil` guard).

## Tests

New `internal/api/details_batch_test.go`, using the existing `testutil.MockLinearServer` synthetic-response pattern:

- happy path — all aliases present, map complete with a non-nil entry per requested ID
- missing alias → error naming the issue ID
- explicitly null alias → error naming the issue ID and saying "null"
- type-mismatched field (decode failure) → error naming the issue ID

`make build`, `go vet ./...`, and the full `go test ./...` (including the FUSE integration suite) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)