### PR TITLE
refactor(sync): syncDetails outcome ledger — clean-gated touch/dequeue, defer on any failure

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -724,9 +724,9 @@ versus swallow.
 
 The **per-issue detail sync** (an issue's comments, documents, attachments,
 relations, and inverse relations) reconciles through the same tail, five calls
-per issue — written once as `reconcile.PersistIssueDetails`, which
-`syncIssueDetailsBatch` calls per issue (its `clean` return is ignored until
-the detail-outcome step consumes it). Here completeness is *page*-shaped
+per issue — written once as `reconcile.PersistIssueDetails`, which the
+worker's `syncDetails` calls per issue (its `clean` return gates that issue's
+touch/dequeue — see the detail-outcome entry below). Here completeness is *page*-shaped
 rather than *drain*-shaped: a full page (`len == IssueDetailsPageSize`, or
 `IssueRelationsPageSize` for the relation connections) may be truncated, so
 `PersistIssueDetails` composes a `pruneWhenComplete(complete, fn)` policy that
@@ -753,6 +753,28 @@ its rows: the outgoing collection prunes via `PruneIssueRelations` (scoped
 owned by the other issue; pruning them here would delete against someone
 else's partial view). `refreshIssueDetails` (the repo's SWR path) persists
 both families best-effort like its siblings.
+
+### Detail sync outcome (`syncDetails`)
+The single entry point for issue-detail syncing (`internal/sync/worker.go`):
+`syncDetails(ctx, []issueRef) detailOutcome` merged the old
+`deferDetailIssues`/`syncOrDeferDetailBatch`/`syncIssueDetailsBatch` trio so
+**all the gates live in one place** — budget (`budgetDeferDetailPct`),
+rate-limited before the fetch, rate-limited mid-fetch, and any other fetch
+failure (which used to log-and-return, silently dropping the worker-side
+retry for team-sync-sourced issues; now it defers like the rest). A gate
+defers the whole batch to `pending_detail_sync` and returns `gated=true`,
+which the now-thin `drainPendingDetailSync` loop breaks on (re-deferring an
+already-pending issue merely re-stamps its `QueuedAt`). The return is a
+per-issue **ledger** — `{synced, deferred []issueRef, gated bool}`, every
+issue landing in exactly one slice: only an issue whose
+`reconcile.PersistIssueDetails` came back **clean** is touched
+(comments/documents/attachments `synced_at` stamped; relations deliberately
+not) and dequeued from pending; an unclean issue — or one missing from the
+response, a trap for a violation of `GetIssueDetailsBatch`'s documented
+all-or-nothing contract, not expected flow — is re-enqueued, un-touched. The
+hazard class this closes: **an issue silently dropped or partially persisted
+must never be stamped fresh** (a touch would mask its staleness from the SWR
+path until the next real change) **nor lose its retry**.
 
 ### Reverse conversion contract (hydrate-then-overlay)
 Every DB→API reverse conversion in `internal/db/convert.go` **starts from the

--- a/internal/sync/prune_test.go
+++ b/internal/sync/prune_test.go
@@ -377,10 +377,7 @@ func TestDeferDetailIssues(t *testing.T) {
 	ctx := context.Background()
 
 	worker := NewWorker(newMockAPIClient(), store, Config{Interval: time.Hour})
-	worker.deferDetailIssues(ctx, []struct {
-		ID         string
-		Identifier string
-	}{
+	worker.deferDetailIssues(ctx, []issueRef{
 		{ID: "issue-1", Identifier: "TST-1"},
 		{ID: "issue-2", Identifier: "TST-2"},
 	})

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -343,10 +343,7 @@ func (w *Worker) syncTeam(ctx context.Context, team api.Team) error {
 // syncTeamIssues fetches issues ordered by updatedAt DESC and stops when hitting unchanged issues
 func (w *Worker) syncTeamIssues(ctx context.Context, teamID string, lastSyncedUpdatedAt time.Time) (added, updated, pages int, err error) {
 	var cursor string
-	var pendingDetailIssues []struct {
-		ID         string
-		Identifier string
-	}
+	var pendingDetailIssues []issueRef
 
 	for {
 		// Check for cancellation
@@ -404,14 +401,13 @@ func (w *Worker) syncTeamIssues(ctx context.Context, teamID string, lastSyncedUp
 			}
 
 			// Queue for batch details sync
-			pendingDetailIssues = append(pendingDetailIssues, struct {
-				ID         string
-				Identifier string
-			}{ID: issue.ID, Identifier: issue.Identifier})
+			pendingDetailIssues = append(pendingDetailIssues, issueRef{ID: issue.ID, Identifier: issue.Identifier})
 
-			// Sync details in batches (or defer if budget is tight)
+			// Sync details in batches. The outcome is ignored here: any
+			// gated/deferred issue landed in pending_detail_sync, so the next
+			// cycle's drain retries it.
 			if len(pendingDetailIssues) >= detailsBatchSize {
-				w.syncOrDeferDetailBatch(ctx, pendingDetailIssues)
+				w.syncDetails(ctx, pendingDetailIssues)
 				pendingDetailIssues = nil
 			}
 
@@ -442,9 +438,9 @@ func (w *Worker) syncTeamIssues(ctx context.Context, teamID string, lastSyncedUp
 		cursor = pageInfo.EndCursor
 	}
 
-	// Sync any remaining pending issue details
+	// Sync any remaining pending issue details (outcome ignored, see above)
 	if len(pendingDetailIssues) > 0 {
-		w.syncOrDeferDetailBatch(ctx, pendingDetailIssues)
+		w.syncDetails(ctx, pendingDetailIssues)
 	}
 
 	return added, updated, pages, nil
@@ -843,14 +839,32 @@ func (w *Worker) probeBudget(ctx context.Context) bool {
 // Issue Details Sync (Comments and Documents)
 // =============================================================================
 
-// deferDetailIssues enqueues every issue to pending_detail_sync for a later
-// cycle, stamping one QueuedAt for the batch. Shared by the three defer paths
-// (budget low, rate-limited before the fetch, rate-limited mid-fetch) so the
-// enqueue contract lives in one place and a fourth path cannot drift.
-func (w *Worker) deferDetailIssues(ctx context.Context, issues []struct {
+// issueRef identifies an issue for detail syncing: the ID the API keys on and
+// the identifier used in log lines and the pending queue.
+type issueRef struct {
 	ID         string
 	Identifier string
-}) {
+}
+
+// detailOutcome is syncDetails' per-issue ledger: every issue handed in lands
+// in exactly one of the two slices. synced holds issues whose details
+// persisted cleanly (touched + dequeued); deferred holds everything else
+// (re-enqueued to pending_detail_sync, NOT touched, NOT dequeued).
+// gated=true means conditions preclude further detail syncing this cycle —
+// budget too tight, rate-limited, or a failed fetch — so a batching loop
+// (drainPendingDetailSync) should stop rather than burn more batches.
+type detailOutcome struct {
+	synced   []issueRef
+	deferred []issueRef
+	gated    bool
+}
+
+// deferDetailIssues enqueues every issue to pending_detail_sync for a later
+// cycle, stamping one QueuedAt for the batch. Shared by syncDetails' defer
+// paths (the whole-batch gates and the per-issue unclean/contract-violation
+// cases) so the enqueue contract lives in one place and a new path cannot
+// drift.
+func (w *Worker) deferDetailIssues(ctx context.Context, issues []issueRef) {
 	now := db.Now()
 	for _, issue := range issues {
 		_ = w.store.Queries().UpsertPendingDetailSync(ctx, db.UpsertPendingDetailSyncParams{
@@ -861,36 +875,37 @@ func (w *Worker) deferDetailIssues(ctx context.Context, issues []struct {
 	}
 }
 
-// syncOrDeferDetailBatch syncs issue details if budget allows, otherwise
-// defers to pending_detail_sync for a later cycle.
-func (w *Worker) syncOrDeferDetailBatch(ctx context.Context, issues []struct {
-	ID         string
-	Identifier string
-}) {
+// syncDetails is the single entry point for issue-detail syncing
+// (comments/documents/attachments/relations). It owns every gate — budget,
+// rate-limited before the fetch, rate-limited mid-fetch, fetch failure —
+// fetches the batch in one API call, persists per issue through
+// reconcile.PersistIssueDetails, and returns a per-issue outcome ledger.
+//
+// Only a CLEAN issue (all five collections persisted without error) is
+// touched (synced_at stamped) and dequeued from pending_detail_sync. ANY
+// failure — a gate, a fetch error, or a single collection's upsert — defers
+// the affected issues to pending_detail_sync instead: an issue that was
+// silently dropped or partially persisted must never be stamped fresh
+// (masking staleness from the SWR path) nor lose its worker-side retry.
+func (w *Worker) syncDetails(ctx context.Context, issues []issueRef) detailOutcome {
+	deferAll := func() detailOutcome {
+		w.deferDetailIssues(ctx, issues)
+		return detailOutcome{deferred: issues, gated: true}
+	}
+
+	// Gate 1: budget too tight for detail fetches this cycle.
 	if w.budgetExceeds(budgetDeferDetailPct) {
-		w.deferDetailIssues(ctx, issues)
-		return
+		return deferAll()
 	}
-	w.syncIssueDetailsBatch(ctx, issues)
-}
 
-// syncIssueDetailsBatch fetches and stores comments and documents for multiple issues in a single API call
-func (w *Worker) syncIssueDetailsBatch(ctx context.Context, issues []struct {
-	ID         string
-	Identifier string
-}) {
-	// H-5: If rate limited, persist issues to pending_detail_sync so they survive the backoff
+	// Gate 2 (H-5): already rate limited — defer so the issues survive the backoff.
 	if w.isRateLimited() {
-		w.deferDetailIssues(ctx, issues)
-		return
+		return deferAll()
 	}
 
-	// Extract IDs
 	ids := make([]string, len(issues))
-	idToIdentifier := make(map[string]string, len(issues))
 	for i, issue := range issues {
 		ids[i] = issue.ID
-		idToIdentifier[issue.ID] = issue.Identifier
 	}
 
 	// The prune cutoff is taken BEFORE the fetch: any row upserted after this
@@ -903,13 +918,15 @@ func (w *Worker) syncIssueDetailsBatch(ctx context.Context, issues []struct {
 	detailsMap, err := w.client.GetIssueDetailsBatch(ctx, ids)
 	if err != nil {
 		if isRateLimitError(err) {
+			// Gate 3: rate limited mid-fetch.
 			w.setRateLimited()
-			// H-5: Persist the issues we couldn't sync so they survive the backoff
-			w.deferDetailIssues(ctx, issues)
-			return
+			return deferAll()
 		}
-		log.Printf("[sync] batch fetch details failed: %v", err)
-		return
+		// Gate 4: any other fetch failure. Deferring (not just logging) keeps
+		// the worker-side retry for team-sync-sourced issues, which otherwise
+		// exist nowhere but this call's arguments.
+		log.Printf("[sync] batch fetch details failed, deferring %d issues: %v", len(issues), err)
+		return deferAll()
 	}
 
 	// Store each issue's comments/documents/attachments/relations through
@@ -918,32 +935,46 @@ func (w *Worker) syncIssueDetailsBatch(ctx context.Context, issues []struct {
 	// contributes COMPLETENESS (page-size checks), so a prune fires only when
 	// the fetch was clean AND complete.
 	//
-	// The prunes must run before the Touch* pass below, which re-stamps ALL of
-	// an issue's rows and would exempt phantoms from the cutoff. Completeness
-	// still relies on the API client's all-or-nothing batch semantics — c.query
-	// fails the WHOLE batch on any GraphQL error, so a partially-failed response
-	// never reaches this loop as a short-but-"complete" details struct.
+	// The prunes must run before an issue's Touch* below, which re-stamps ALL
+	// of that issue's rows and would exempt phantoms from the cutoff (prunes
+	// run inside PersistIssueDetails; the touches come after). Completeness
+	// relies on GetIssueDetailsBatch's documented all-or-nothing contract: a
+	// nil error guarantees a non-nil map entry for every requested ID, so a
+	// partially-failed response never reaches this loop as a
+	// short-but-"complete" details struct. The nil branch below is a trap for
+	// a violation of that contract, not expected flow.
 	deps := reconcile.Deps{Q: w.store.Queries(), Extract: w.extractor.ExtractAndStore}
-	for issueID, details := range detailsMap {
-		if details == nil {
-			continue
-		}
-		// The clean return is deliberately ignored for now: the touch/dequeue
-		// loop below still stamps every requested issue (a later step gates it
-		// on cleanliness).
-		_ = reconcile.PersistIssueDetails(ctx, deps, issueID, details, pruneCutoff)
-	}
-
-	// Touch synced_at for all fetched issues so the FS layer doesn't immediately
-	// re-trigger on-demand fetches for the data we just stored.
-	//
-	// Relations are DELIBERATELY not touched, though the loop above syncs five
-	// collections: nothing consults relations staleness (the repo has no
-	// relations SWR path, and the dead GetIssueRelationsSyncedAt query was
-	// deleted in PR #186), so a TouchIssueRelations would be dead machinery —
-	// don't "fix" the symmetry.
+	var outcome detailOutcome
 	now := db.Now()
 	for _, issue := range issues {
+		details := detailsMap[issue.ID]
+		if details == nil {
+			log.Printf("[sync] CONTRACT VIOLATION: GetIssueDetailsBatch returned nil error but no details for %s (%s) — deferring", issue.Identifier, issue.ID)
+			w.deferDetailIssues(ctx, []issueRef{issue})
+			outcome.deferred = append(outcome.deferred, issue)
+			continue
+		}
+
+		clean := reconcile.PersistIssueDetails(ctx, deps, issue.ID, details, pruneCutoff)
+		if !clean {
+			// A collection's convert/upsert failed. The clean guard already
+			// suppressed that collection's prune; here the issue must ALSO
+			// keep its retry (re-enqueue for the next cycle's drain) and must
+			// NOT be stamped fresh — a touch would hide the stale rows from
+			// the SWR path until the next real change.
+			w.deferDetailIssues(ctx, []issueRef{issue})
+			outcome.deferred = append(outcome.deferred, issue)
+			continue
+		}
+
+		// Touch synced_at so the FS layer doesn't immediately re-trigger
+		// on-demand fetches for the data we just stored.
+		//
+		// Relations are DELIBERATELY not touched, though the loop above syncs five
+		// collections: nothing consults relations staleness (the repo has no
+		// relations SWR path, and the dead GetIssueRelationsSyncedAt query was
+		// deleted in PR #186), so a TouchIssueRelations would be dead machinery —
+		// don't "fix" the symmetry.
 		if err := w.store.Queries().TouchIssueComments(ctx, db.TouchIssueCommentsParams{SyncedAt: now, IssueID: issue.ID}); err != nil {
 			log.Printf("[sync] touch comments %s: %v", issue.Identifier, err)
 		}
@@ -953,19 +984,21 @@ func (w *Worker) syncIssueDetailsBatch(ctx context.Context, issues []struct {
 		if err := w.store.Queries().TouchIssueAttachments(ctx, db.TouchIssueAttachmentsParams{SyncedAt: now, IssueID: issue.ID}); err != nil {
 			log.Printf("[sync] touch attachments %s: %v", issue.Identifier, err)
 		}
-		// H-5: Remove successfully synced issues from pending queue
+		// H-5: Remove the cleanly synced issue from the pending queue
 		_ = w.store.Queries().DeletePendingDetailSync(ctx, issue.ID)
+		outcome.synced = append(outcome.synced, issue)
 	}
-	log.Printf("[sync] batch synced details for %d issues", len(detailsMap))
+	log.Printf("[sync] batch synced details: %d clean, %d deferred", len(outcome.synced), len(outcome.deferred))
+	return outcome
 }
 
-// drainPendingDetailSync processes issues that were queued for detail sync but skipped
-// due to rate limiting.  Called at the start of each sync cycle when not rate-limited.
+// drainPendingDetailSync processes issues that were queued for detail sync
+// but skipped due to rate limiting, budget, or an earlier failure. Called at
+// the start of each sync cycle. All the gates live inside syncDetails; this
+// is just a batching loop that stops when an outcome reports gated (nothing
+// more can sync this cycle). A gated syncDetails re-defers its batch, which
+// merely re-stamps the already-pending rows' QueuedAt — harmless.
 func (w *Worker) drainPendingDetailSync(ctx context.Context) {
-	if w.isRateLimited() {
-		return
-	}
-
 	pending, err := w.store.Queries().ListPendingDetailSync(ctx)
 	if err != nil || len(pending) == 0 {
 		return
@@ -973,37 +1006,20 @@ func (w *Worker) drainPendingDetailSync(ctx context.Context) {
 
 	log.Printf("[sync] draining %d pending detail syncs", len(pending))
 
-	// Convert to the same struct used by syncIssueDetailsBatch
-	type issueRef struct {
-		ID         string
-		Identifier string
-	}
 	issues := make([]issueRef, len(pending))
 	for i, row := range pending {
 		issues[i] = issueRef{ID: row.IssueID, Identifier: row.Identifier}
 	}
 
-	// Process in batches
 	for len(issues) > 0 {
-		if w.isRateLimited() || w.budgetExceeds(budgetDeferDetailPct) {
-			break
-		}
 		batch := issues
 		if len(batch) > detailsBatchSize {
 			batch = issues[:detailsBatchSize]
 		}
 		issues = issues[len(batch):]
 
-		batchArg := make([]struct {
-			ID         string
-			Identifier string
-		}, len(batch))
-		for i, ref := range batch {
-			batchArg[i] = struct {
-				ID         string
-				Identifier string
-			}{ID: ref.ID, Identifier: ref.Identifier}
+		if outcome := w.syncDetails(ctx, batch); outcome.gated {
+			break
 		}
-		w.syncIssueDetailsBatch(ctx, batchArg)
 	}
 }

--- a/internal/sync/worker_test.go
+++ b/internal/sync/worker_test.go
@@ -44,6 +44,7 @@ type mockAPIClient struct {
 	simulateError    error
 	rateLimitResetAt time.Time                    // M-3: configurable reset time for adaptive backoff tests
 	detailsByIssue   map[string]*api.IssueDetails // issueID -> canned details for GetIssueDetailsBatch
+	detailsCalls     int32                        // number of GetIssueDetailsBatch calls (incl. failed ones)
 	onDetailsBatch   func()                       // if set, runs inside GetIssueDetailsBatch (simulates writes racing the fetch)
 	onTeamMetadata   func()                       // if set, runs inside GetTeamMetadata (simulates writes racing the fetch)
 	onWorkspace      func()                       // if set, runs inside GetWorkspace (simulates writes racing the fetch)
@@ -191,6 +192,7 @@ func (m *mockAPIClient) GetIssueDetails(ctx context.Context, issueID string) (*a
 }
 
 func (m *mockAPIClient) GetIssueDetailsBatch(ctx context.Context, issueIDs []string) (map[string]*api.IssueDetails, error) {
+	atomic.AddInt32(&m.detailsCalls, 1)
 	if m.simulateError != nil {
 		return nil, m.simulateError
 	}
@@ -849,16 +851,16 @@ func TestPendingDetailSyncQueueAndDrain(t *testing.T) {
 	cfg := Config{Interval: time.Hour}
 	worker := NewWorker(mock, store, cfg)
 
-	issues := []struct {
-		ID         string
-		Identifier string
-	}{
+	issues := []issueRef{
 		{ID: "issue-1", Identifier: "TST-1"},
 		{ID: "issue-2", Identifier: "TST-2"},
 	}
 
-	// Call syncIssueDetailsBatch directly; the rate-limit error should queue the issues
-	worker.syncIssueDetailsBatch(ctx, issues)
+	// Call syncDetails directly; the rate-limit error should queue the issues
+	outcome := worker.syncDetails(ctx, issues)
+	if !outcome.gated {
+		t.Error("rate-limit fetch failure should gate the outcome")
+	}
 
 	// Verify both issues landed in the pending queue
 	pending, err := store.Queries().ListPendingDetailSync(ctx)
@@ -917,10 +919,7 @@ func TestDetailsSyncPrunesStaleRows(t *testing.T) {
 	mock.detailsByIssue["issue-1"] = &api.IssueDetails{Comments: []api.Comment{live}}
 	worker := NewWorker(mock, store, Config{Interval: time.Hour})
 
-	worker.syncIssueDetailsBatch(ctx, []struct {
-		ID         string
-		Identifier string
-	}{{ID: "issue-1", Identifier: "TST-1"}})
+	worker.syncDetails(ctx, []issueRef{{ID: "issue-1", Identifier: "TST-1"}})
 
 	comments, err := store.Queries().ListIssueComments(ctx, "issue-1")
 	if err != nil {
@@ -962,10 +961,7 @@ func TestDetailsSyncPruneSparesMidFetchCreates(t *testing.T) {
 	}
 	worker := NewWorker(mock, store, Config{Interval: time.Hour})
 
-	worker.syncIssueDetailsBatch(ctx, []struct {
-		ID         string
-		Identifier string
-	}{{ID: "issue-1", Identifier: "TST-1"}})
+	worker.syncDetails(ctx, []issueRef{{ID: "issue-1", Identifier: "TST-1"}})
 
 	comments, err := store.Queries().ListIssueComments(ctx, "issue-1")
 	if err != nil {
@@ -1003,10 +999,7 @@ func TestDetailsSyncFullPageSkipsPrune(t *testing.T) {
 	mock.detailsByIssue["issue-1"] = &api.IssueDetails{Comments: full}
 	worker := NewWorker(mock, store, Config{Interval: time.Hour})
 
-	worker.syncIssueDetailsBatch(ctx, []struct {
-		ID         string
-		Identifier string
-	}{{ID: "issue-1", Identifier: "TST-1"}})
+	worker.syncDetails(ctx, []issueRef{{ID: "issue-1", Identifier: "TST-1"}})
 
 	comments, err := store.Queries().ListIssueComments(ctx, "issue-1")
 	if err != nil {
@@ -1030,10 +1023,10 @@ func TestDetailsSyncPrunesStaleDocsAndAttachments(t *testing.T) {
 	ctx := context.Background()
 
 	old := time.Now().Add(-time.Minute)
-	issueRef := &api.Issue{ID: "issue-1"} // documents key their issue_id off document.Issue.ID
+	docIssue := &api.Issue{ID: "issue-1"} // documents key their issue_id off document.Issue.ID
 
-	liveDoc := api.Document{ID: "doc-live", SlugID: "slug-live", Title: "Live", Issue: issueRef, CreatedAt: time.Now(), UpdatedAt: time.Now()}
-	staleDoc := api.Document{ID: "doc-stale", SlugID: "slug-stale", Title: "Stale", Issue: issueRef, CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	liveDoc := api.Document{ID: "doc-live", SlugID: "slug-live", Title: "Live", Issue: docIssue, CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	staleDoc := api.Document{ID: "doc-stale", SlugID: "slug-stale", Title: "Stale", Issue: docIssue, CreatedAt: time.Now(), UpdatedAt: time.Now()}
 	for _, d := range []api.Document{liveDoc, staleDoc} {
 		params, err := db.APIDocumentToDBDocument(d)
 		if err != nil {
@@ -1066,10 +1059,7 @@ func TestDetailsSyncPrunesStaleDocsAndAttachments(t *testing.T) {
 	}
 	worker := NewWorker(mock, store, Config{Interval: time.Hour})
 
-	worker.syncIssueDetailsBatch(ctx, []struct {
-		ID         string
-		Identifier string
-	}{{ID: "issue-1", Identifier: "TST-1"}})
+	worker.syncDetails(ctx, []issueRef{{ID: "issue-1", Identifier: "TST-1"}})
 
 	docs, err := store.Queries().ListIssueDocuments(ctx, sql.NullString{String: "issue-1", Valid: true})
 	if err != nil {
@@ -1310,7 +1300,11 @@ func TestSyncAllTeamsProceedsWhenBudgetOK(t *testing.T) {
 	}
 }
 
-func TestSyncOrDeferDetailBatchDefersWhenBudgetHigh(t *testing.T) {
+// TestSyncDetailsDefersWhenBudgetHigh: the budget gate — above the defer
+// threshold, syncDetails must not spend an API call; the whole batch lands in
+// pending_detail_sync (deferred) and the outcome is gated so a draining loop
+// stops.
+func TestSyncDetailsDefersWhenBudgetHigh(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
 	defer store.Close()
@@ -1320,15 +1314,22 @@ func TestSyncOrDeferDetailBatchDefersWhenBudgetHigh(t *testing.T) {
 	worker := NewWorker(mock, store, cfg)
 	worker.SetBudgetReporter(&mockBudgetReporter{count: 1100, pct: 73.0}) // >70%
 
-	issues := []struct {
-		ID         string
-		Identifier string
-	}{
+	issues := []issueRef{
 		{ID: "issue-1", Identifier: "TST-1"},
 		{ID: "issue-2", Identifier: "TST-2"},
 	}
 
-	worker.syncOrDeferDetailBatch(context.Background(), issues)
+	outcome := worker.syncDetails(context.Background(), issues)
+
+	if !outcome.gated {
+		t.Error("budget gate should report gated")
+	}
+	if len(outcome.deferred) != 2 || len(outcome.synced) != 0 {
+		t.Errorf("outcome = %d deferred / %d synced, want 2 / 0", len(outcome.deferred), len(outcome.synced))
+	}
+	if calls := atomic.LoadInt32(&mock.detailsCalls); calls != 0 {
+		t.Errorf("expected 0 GetIssueDetailsBatch calls when budget exceeded, got %d", calls)
+	}
 
 	// Should have been queued to pending_detail_sync, not API-called
 	pending, err := store.Queries().ListPendingDetailSync(context.Background())
@@ -1340,7 +1341,7 @@ func TestSyncOrDeferDetailBatchDefersWhenBudgetHigh(t *testing.T) {
 	}
 }
 
-func TestSyncOrDeferDetailBatchSyncsWhenBudgetOK(t *testing.T) {
+func TestSyncDetailsSyncsWhenBudgetOK(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
 	defer store.Close()
@@ -1350,14 +1351,18 @@ func TestSyncOrDeferDetailBatchSyncsWhenBudgetOK(t *testing.T) {
 	worker := NewWorker(mock, store, cfg)
 	worker.SetBudgetReporter(&mockBudgetReporter{count: 300, pct: 20.0}) // <70%
 
-	issues := []struct {
-		ID         string
-		Identifier string
-	}{
+	issues := []issueRef{
 		{ID: "issue-1", Identifier: "TST-1"},
 	}
 
-	worker.syncOrDeferDetailBatch(context.Background(), issues)
+	outcome := worker.syncDetails(context.Background(), issues)
+
+	if outcome.gated {
+		t.Error("a clean sync should not gate")
+	}
+	if len(outcome.synced) != 1 || len(outcome.deferred) != 0 {
+		t.Errorf("outcome = %d synced / %d deferred, want 1 / 0", len(outcome.synced), len(outcome.deferred))
+	}
 
 	// Should NOT be in pending queue (was synced directly)
 	pending, err := store.Queries().ListPendingDetailSync(context.Background())
@@ -1366,6 +1371,224 @@ func TestSyncOrDeferDetailBatchSyncsWhenBudgetOK(t *testing.T) {
 	}
 	if len(pending) != 0 {
 		t.Errorf("expected 0 pending detail syncs (direct sync), got %d", len(pending))
+	}
+}
+
+// seedFutureComment inserts a comment for issueID whose synced_at is one hour
+// in the FUTURE. It survives any prune (synced_at > any cutoff taken now) and
+// makes touching detectable: TouchIssueComments would drag synced_at back to
+// "now", so synced_at still being in the future proves the issue was NOT
+// touched, and synced_at near now proves it WAS.
+func seedFutureComment(t *testing.T, store *db.Store, issueID, commentID string) time.Time {
+	t.Helper()
+	params, err := db.APICommentToDBComment(api.Comment{ID: commentID, Body: "touch sentinel", CreatedAt: time.Now(), UpdatedAt: time.Now()}, issueID)
+	if err != nil {
+		t.Fatalf("convert sentinel comment: %v", err)
+	}
+	// db.Now() (UTC) rather than time.Now(): SQLite compares these as strings,
+	// so a local-zone timestamp would misorder against the store's UTC cutoffs.
+	future := db.Now().Add(time.Hour)
+	params.SyncedAt = future
+	if err := store.Queries().UpsertComment(context.Background(), params); err != nil {
+		t.Fatalf("seed sentinel comment: %v", err)
+	}
+	return future
+}
+
+// commentSyncedAt reads back a comment's synced_at.
+func commentSyncedAt(t *testing.T, store *db.Store, issueID, commentID string) time.Time {
+	t.Helper()
+	comments, err := store.Queries().ListIssueComments(context.Background(), issueID)
+	if err != nil {
+		t.Fatalf("list comments: %v", err)
+	}
+	for _, c := range comments {
+		if c.ID == commentID {
+			return c.SyncedAt
+		}
+	}
+	t.Fatalf("comment %s not found for %s", commentID, issueID)
+	return time.Time{}
+}
+
+// TestSyncDetailsCleanIssueTouchedAndDequeued: the happy half of the ledger —
+// a cleanly persisted issue is touched (synced_at stamped to now), removed
+// from pending_detail_sync, and reported in outcome.synced.
+func TestSyncDetailsCleanIssueTouchedAndDequeued(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	// Pre-enqueue the issue so the dequeue is observable.
+	if err := store.Queries().UpsertPendingDetailSync(ctx, db.UpsertPendingDetailSyncParams{
+		IssueID: "issue-1", Identifier: "TST-1", QueuedAt: db.Now(),
+	}); err != nil {
+		t.Fatalf("seed pending: %v", err)
+	}
+	seedFutureComment(t, store, "issue-1", "comment-sentinel")
+
+	mock := newMockAPIClient() // default: empty (clean) details
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	outcome := worker.syncDetails(ctx, []issueRef{{ID: "issue-1", Identifier: "TST-1"}})
+
+	if outcome.gated {
+		t.Error("clean sync should not gate")
+	}
+	if len(outcome.synced) != 1 || outcome.synced[0].ID != "issue-1" {
+		t.Errorf("outcome.synced = %v, want [issue-1]", outcome.synced)
+	}
+	if len(outcome.deferred) != 0 {
+		t.Errorf("outcome.deferred = %v, want empty", outcome.deferred)
+	}
+
+	// Touched: the sentinel's future synced_at was dragged back to now.
+	if got := commentSyncedAt(t, store, "issue-1", "comment-sentinel"); got.After(time.Now().Add(30 * time.Minute)) {
+		t.Errorf("sentinel synced_at = %v, still in the future — clean issue was not touched", got)
+	}
+
+	// Dequeued from pending_detail_sync.
+	pending, err := store.Queries().ListPendingDetailSync(ctx)
+	if err != nil {
+		t.Fatalf("ListPendingDetailSync: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Errorf("expected clean issue dequeued, but %d still pending", len(pending))
+	}
+}
+
+// TestSyncDetailsUncleanIssueDeferredNotTouched: the masked-staleness hazard —
+// an issue whose persist was unclean (one collection's upsert failed) must NOT
+// be stamped fresh (a touch would hide its stale rows from the SWR path) and
+// must NOT lose its retry (it stays in pending_detail_sync). The failure is
+// injected as pure data: a relation with RelatedIssue == nil fails the
+// relations collection's upsert closure.
+func TestSyncDetailsUncleanIssueDeferredNotTouched(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	future := seedFutureComment(t, store, "issue-1", "comment-sentinel")
+
+	mock := newMockAPIClient()
+	mock.detailsByIssue["issue-1"] = &api.IssueDetails{
+		Relations: []api.IssueRelation{{ID: "rel-broken", Type: "blocks", RelatedIssue: nil, CreatedAt: time.Now(), UpdatedAt: time.Now()}},
+	}
+	// issue-2 rides in the same batch and is clean — the ledger is per issue.
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	outcome := worker.syncDetails(ctx, []issueRef{
+		{ID: "issue-1", Identifier: "TST-1"},
+		{ID: "issue-2", Identifier: "TST-2"},
+	})
+
+	if outcome.gated {
+		t.Error("a per-issue unclean persist should not gate the batch")
+	}
+	if len(outcome.deferred) != 1 || outcome.deferred[0].ID != "issue-1" {
+		t.Errorf("outcome.deferred = %v, want [issue-1]", outcome.deferred)
+	}
+	if len(outcome.synced) != 1 || outcome.synced[0].ID != "issue-2" {
+		t.Errorf("outcome.synced = %v, want [issue-2]", outcome.synced)
+	}
+
+	// NOT touched: the sentinel's synced_at is still the future value.
+	if got := commentSyncedAt(t, store, "issue-1", "comment-sentinel"); !got.After(time.Now().Add(30 * time.Minute)) {
+		t.Errorf("sentinel synced_at = %v (seeded %v) — unclean issue was touched, masking staleness", got, future)
+	}
+
+	// NOT dequeued: the issue keeps its retry.
+	pending, err := store.Queries().ListPendingDetailSync(ctx)
+	if err != nil {
+		t.Fatalf("ListPendingDetailSync: %v", err)
+	}
+	if len(pending) != 1 || pending[0].IssueID != "issue-1" {
+		ids := []string{}
+		for _, p := range pending {
+			ids = append(ids, p.IssueID)
+		}
+		t.Errorf("pending = %v, want [issue-1] (unclean issue re-enqueued, clean one not)", ids)
+	}
+}
+
+// TestSyncDetailsFetchFailureDefersAll: a non-rate-limit batch fetch failure
+// must defer every issue to pending_detail_sync (the old code logged and
+// returned, silently dropping the worker-side retry for team-sync-sourced
+// issues) and gate the outcome.
+func TestSyncDetailsFetchFailureDefersAll(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	mock := newMockAPIClient()
+	mock.simulateError = errors.New("boom: internal server error")
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	outcome := worker.syncDetails(ctx, []issueRef{
+		{ID: "issue-1", Identifier: "TST-1"},
+		{ID: "issue-2", Identifier: "TST-2"},
+	})
+
+	if !outcome.gated {
+		t.Error("fetch failure should gate the outcome")
+	}
+	if len(outcome.deferred) != 2 || len(outcome.synced) != 0 {
+		t.Errorf("outcome = %d deferred / %d synced, want 2 / 0", len(outcome.deferred), len(outcome.synced))
+	}
+	if worker.isRateLimited() {
+		t.Error("a non-rate-limit failure must not set the rate-limit backoff")
+	}
+
+	pending, err := store.Queries().ListPendingDetailSync(ctx)
+	if err != nil {
+		t.Fatalf("ListPendingDetailSync: %v", err)
+	}
+	if len(pending) != 2 {
+		t.Errorf("expected both issues deferred to pending after fetch failure, got %d", len(pending))
+	}
+}
+
+// TestDrainStopsWhenGated: the drain loop must stop at the first gated
+// outcome instead of burning an API call per remaining batch — with more than
+// one batch pending and a persistently failing fetch, exactly one
+// GetIssueDetailsBatch call is made.
+func TestDrainStopsWhenGated(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	// Two batches' worth of pending issues.
+	for i := 0; i < detailsBatchSize+1; i++ {
+		if err := store.Queries().UpsertPendingDetailSync(ctx, db.UpsertPendingDetailSyncParams{
+			IssueID:    fmt.Sprintf("issue-%02d", i),
+			Identifier: fmt.Sprintf("TST-%02d", i),
+			QueuedAt:   db.Now(),
+		}); err != nil {
+			t.Fatalf("seed pending: %v", err)
+		}
+	}
+
+	mock := newMockAPIClient()
+	mock.simulateError = errors.New("boom: internal server error") // non-rate-limit → gate 4 every time
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	worker.drainPendingDetailSync(ctx)
+
+	if calls := atomic.LoadInt32(&mock.detailsCalls); calls != 1 {
+		t.Errorf("GetIssueDetailsBatch called %d times, want 1 — drain must stop on a gated outcome", calls)
+	}
+
+	// Nothing was lost: every issue is still pending.
+	pending, err := store.Queries().ListPendingDetailSync(ctx)
+	if err != nil {
+		t.Fatalf("ListPendingDetailSync: %v", err)
+	}
+	if len(pending) != detailsBatchSize+1 {
+		t.Errorf("pending = %d, want %d (gated batches keep their retry)", len(pending), detailsBatchSize+1)
 	}
 }
 
@@ -1422,10 +1645,7 @@ func TestDetailsSyncPersistsAndPrunesRelations(t *testing.T) {
 	}
 	worker := NewWorker(mock, store, Config{Interval: time.Hour})
 
-	worker.syncIssueDetailsBatch(ctx, []struct {
-		ID         string
-		Identifier string
-	}{{ID: "issue-1", Identifier: "TST-1"}})
+	worker.syncDetails(ctx, []issueRef{{ID: "issue-1", Identifier: "TST-1"}})
 
 	// Outgoing: the live relation persisted, the phantom pruned.
 	rels, err := store.Queries().ListIssueRelations(ctx, "issue-1")
@@ -1478,10 +1698,7 @@ func TestDetailsSyncRelationUpsertFailureSuppressesPrune(t *testing.T) {
 	}
 	worker := NewWorker(mock, store, Config{Interval: time.Hour})
 
-	worker.syncIssueDetailsBatch(ctx, []struct {
-		ID         string
-		Identifier string
-	}{{ID: "issue-1", Identifier: "TST-1"}})
+	worker.syncDetails(ctx, []issueRef{{ID: "issue-1", Identifier: "TST-1"}})
 
 	if _, err := store.Queries().GetIssueRelation(ctx, "rel-stale"); err != nil {
 		t.Errorf("unclean relation sync must suppress the prune, but rel-stale is gone: %v", err)


### PR DESCRIPTION
Step 3 of the round-17 detailOutcome design (`docs/plans/2026-07-08-detail-outcome-swr-refresh-design.md`), on top of #198 (all-or-nothing `GetIssueDetailsBatch`) and #199 (`internal/reconcile`).

## What

`deferDetailIssues` + `syncOrDeferDetailBatch` + `syncIssueDetailsBatch` merge into **one entry point owning all gates**:

```go
type issueRef struct{ ID, Identifier string } // replaces the anonymous struct everywhere

func (w *Worker) syncDetails(ctx context.Context, issues []issueRef) detailOutcome
type detailOutcome struct{ synced, deferred []issueRef; gated bool }
```

## Ledger semantics

Every issue handed in lands in exactly one slice:

- **synced** — `reconcile.PersistIssueDetails` came back *clean* (all five collections persisted): touch comments/documents/attachments `synced_at` (relations deliberately not — no relations SWR path exists) + dequeue from `pending_detail_sync`.
- **deferred** — everything else: re-enqueued to `pending_detail_sync`, NOT touched, NOT dequeued.
- **gated=true** — conditions preclude further detail syncing this cycle: budget over `budgetDeferDetailPct`, rate-limited before the fetch, rate-limited mid-fetch, or any other fetch failure. Each defers the whole batch. `drainPendingDetailSync` is now a thin batching loop that breaks on `gated` (its hand-copied budget/rate-limit checks deleted — the module owns them; re-deferring an already-pending issue just re-stamps `QueuedAt`).

## Hazards closed

1. **Per-issue masked staleness**: the old code persisted over the *returned* map but touched/dequeued over the *requested* slice — an issue whose upsert failed was still stamped fresh (hiding its stale rows from the SWR path) and deleted from pending (losing its retry). Now touch/dequeue is clean-gated per issue.
2. **Lost retry on whole-batch failure**: a non-rate-limit fetch failure used to log and return without deferring, dropping the worker-side retry for team-sync-sourced issues entirely. Now it logs and defers like the other gates.
3. **Dead nil guard → contract trap**: post-#198 a nil error guarantees a non-nil map entry per requested ID; the remaining `details == nil` branch logs loudly as a client-contract violation and treats the issue as deferred (no touch/dequeue).

## Test coverage (`worker_test.go`, fake-APIClient + fixture-store patterns)

- clean issue → touched (future-dated `synced_at` sentinel dragged back to now) + dequeued + in `synced`
- unclean issue (relation with `RelatedIssue == nil` — pure data injection failing the relations upsert closure) → NOT touched (sentinel still future), NOT dequeued, in `deferred`; a clean issue in the same batch still syncs
- whole-batch non-rate-limit fetch failure → all issues deferred to pending + `gated` (and no rate-limit backoff set)
- budget gate (fake `BudgetReporter` > 70%) → deferred + `gated` + zero `GetIssueDetailsBatch` calls
- drain stops at the first gated outcome: two batches pending, persistently failing fetch → exactly one API call, nothing lost from pending

CONTEXT.md gains the "Detail sync outcome (`syncDetails`)" entry right after "Sync reconcile tail" (whose now-stale `syncIssueDetailsBatch`/clean-ignored sentence is updated to point at it).

`make build`, `go vet ./...`, `go test ./...` (integration included) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)