### PR TITLE
refactor(repo): swrRefresh coordinator — one staleness/dedup/orphan owner for the six SWR surfaces

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -677,9 +677,11 @@ sync-side sibling of the write-path tails (`commitCreate`/`commitWriteBack`/
 `paginate`'s completeness licenses. Its shape is `convert → upsert-all →
 prune-if-clean`. It now lives in the shared package **`internal/reconcile`**
 as `reconcile.Collection(ctx, reconcile.CollectionSpec[T])` — extracted from
-`internal/sync` so the repo's SWR refresh path can join as a second caller (a
-later step; neither `sync` nor `repo` imports the other, so the shared policy
-lives between them). The package also hosts `PersistIssueDetails` (the
+`internal/sync` so the repo's SWR refresh path could join as a second caller,
+which it now has (see "SWR refresh coordinator" below: `refreshIssueDetails`
+routes through `PersistIssueDetails`, the four doc/update refresh tails
+through `Collection`; neither `sync` nor `repo` imports the other, so the
+shared policy lives between them). The package also hosts `PersistIssueDetails` (the
 per-issue five-collection persist described below, deps = `{*db.Queries,
 Extract hook}`) and the embedded-file `Extractor` (pure CDN-URL parse + the
 HEAD/upsert I/O tail; nil `HTTPClient` = `http.DefaultClient`, injectable for
@@ -751,8 +753,61 @@ passes the ids swapped), and only the owner's fetch is a completeness set for
 its rows: the outgoing collection prunes via `PruneIssueRelations` (scoped
 `issue_id` + cutoff), the inverse collection is **upsert-only** (its rows are
 owned by the other issue; pruning them here would delete against someone
-else's partial view). `refreshIssueDetails` (the repo's SWR path) persists
-both families best-effort like its siblings.
+else's partial view). `refreshIssueDetails` (the repo's SWR path) now routes
+through `PersistIssueDetails` too, so both families get the same treatment
+there — prunes-when-complete, the clean guard, and embedded-file extraction,
+none of which its old hand-rolled upsert loops carried.
+
+### SWR refresh coordinator (`swrRefresh`)
+The repo's six stale-while-revalidate surfaces — issue details, issue
+history, project/initiative documents, project/initiative updates — route
+through one coordinator, `maybeRefreshSWR(swrSpec)` in
+`internal/repo/swr.go`. Before it, two staleness policies lived in three
+implementations (the TTL `staleSince`/`maybeRefresh` pair; the event-driven
+`issue.updatedAt > synced_at` comparison hand-copied in
+`MaybeRefreshIssueDetails` and `maybeRefreshHistory`), the history fetch
+closure was pasted verbatim at both its call sites, every refresh tail
+restated `isEntityNotFound → deleteOrphan*`, and the dedup keys were bare
+strings built at six sites.
+
+The spec is `swrSpec{kind, id, syncedAt, changedAt, refresh, orphan}`. Dedup
+keys are minted only by `refreshKind.key(id)` over typed kind constants — no
+bare-string keys remain. The staleness decision is the pure `swrStale`
+(`staleSince` stays as its tested TTL core), with the flavor selected by
+`changedAt`: `nil` means **TTL** (threshold-driven), non-nil means
+**event-driven** (stale when never synced — zero/nil/query error — or
+changed-after-synced; `ok=false` from `changedAt` means the entity isn't in
+the DB, which suppresses the refresh — discovery belongs to the sync worker).
+**Catch-up mode (`SetCatchUpMode`, the 30-minute threshold) reaches ONLY the
+TTL flavor — explicit, grilled policy, not an accident**: extending the
+suppression to event-driven surfaces would save duplicate fetches the
+rateBudget ladder already governs, at the cost of silently-empty `comments/`
+listings during big syncs — the worst failure mode for an agent-facing
+filesystem. Flipping later is a one-line change in `swrStale`. Orphan
+classification lives in the module (`orphanOnNotFound` wraps `spec.refresh`;
+on `api.IsNotFound` it calls `spec.orphan`), so refresh tails no longer
+inspect their own errors; the nil-client (fixture mode) check sits at the
+module entry, before any closure is consulted.
+
+Per-surface notes: the issue-details spec derives one `syncedAt` from the
+**min** of the three sub-resource `MAX(synced_at)`s (the issue changed after
+the min iff it changed after at least one family — exactly the old
+any-stale-triggers booleans), with `changedAt` = the issue's `updatedAt`. The
+history fetch exists once as `historySpec`; the cold-cache call site attaches
+an always-`nil` `syncedAt` (never synced ⇒ always stale, preserving the old
+unconditional cold trigger with no issue-in-DB gate) and the warm site
+attaches the cached instant plus `issueChangedAt`. The refresh tails
+reconcile through `internal/reconcile`: `refreshIssueDetails` takes its prune
+cutoff BEFORE the fetch and calls `reconcile.PersistIssueDetails` — giving
+the SWR path prunes-when-complete, the clean guard, and embedded-file
+extraction, three recorded behavior improvements over its old hand-rolled
+upsert loops (the `clean` return is ignored: there is no freshness stamp to
+gate here; an unclean pass simply stays stale and retriggers) — and the four
+doc/update tails run `reconcile.Collection` with nil `Prune` (upsert-only;
+nothing licenses a prune for these fetches — and convert errors now
+log-and-mark-unclean instead of a silent `continue`). The repo constructs its
+`reconcile.Extractor{Q, AuthHeader}` only when it has a client; fixture mode
+leaves `Deps.Extract` nil, which skips extraction.
 
 ### Reverse conversion contract (hydrate-then-overlay)
 Every DB→API reverse conversion in `internal/db/convert.go` **starts from the

--- a/internal/repo/sqlite.go
+++ b/internal/repo/sqlite.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jra3/linear-fuse/internal/api"
 	"github.com/jra3/linear-fuse/internal/db"
+	"github.com/jra3/linear-fuse/internal/reconcile"
 )
 
 // Default staleness threshold for on-demand data (comments, documents, updates).
@@ -55,6 +56,11 @@ type SQLiteRepository struct {
 	currentUser        *api.User     // Cached current user
 	stalenessThreshold time.Duration // How long before data is considered stale
 
+	// extractor owns embedded-file extraction (HEAD + upsert) for the SWR
+	// issue-details path. Nil in fixture mode (no client) — Deps.Extract nil
+	// skips extraction.
+	extractor *reconcile.Extractor
+
 	// Track in-flight refreshes to avoid duplicate API calls
 	refreshMu      sync.Mutex
 	refreshing     map[string]bool
@@ -75,7 +81,7 @@ type SQLiteRepository struct {
 // If client is nil, the repository will only serve data from SQLite.
 func NewSQLiteRepository(store *db.Store, client *api.Client) *SQLiteRepository {
 	ctx, cancel := context.WithCancel(context.Background())
-	return &SQLiteRepository{
+	r := &SQLiteRepository{
 		store:              store,
 		client:             client,
 		stalenessThreshold: defaultStalenessThreshold,
@@ -84,6 +90,10 @@ func NewSQLiteRepository(store *db.Store, client *api.Client) *SQLiteRepository 
 		refreshCancel:      cancel,
 		refreshSem:         make(chan struct{}, maxConcurrentRefreshes),
 	}
+	if client != nil {
+		r.extractor = &reconcile.Extractor{Q: store.Queries(), AuthHeader: client.AuthHeader}
+	}
+	return r
 }
 
 // SetStalenessThreshold sets how long before on-demand data is considered stale
@@ -810,49 +820,35 @@ func (r *SQLiteRepository) GetIssueComments(ctx context.Context, issueID string)
 // attachments/ directories. This avoids triggering API calls when reading
 // issue.md (which calls GetIssueAttachments for the links: frontmatter field).
 func (r *SQLiteRepository) MaybeRefreshIssueDetails(issueID string) {
-	if r.client == nil {
-		return
-	}
-
-	bgCtx := context.Background()
-
-	// Get issue's updated_at
-	issueUpdatedAt, err := r.store.Queries().GetIssueUpdatedAt(bgCtx, issueID)
-	if err != nil {
-		// Issue not in DB yet — let sync worker handle it
-		return
-	}
-
-	// Get sub-resource synced_at timestamps (MAX across rows, or nil if none)
-	commentsSyncedAt, _ := r.store.Queries().GetIssueCommentsSyncedAt(bgCtx, issueID)
-	docsSyncedAt, _ := r.store.Queries().GetIssueDocumentsSyncedAt(bgCtx, sql.NullString{String: issueID, Valid: true})
-	attachSyncedAt, _ := r.store.Queries().GetIssueAttachmentsSyncedAt(bgCtx, issueID)
-
-	// Parse timestamps (handle SQLite space-separated format + nil for empty tables)
-	issueTime := issueUpdatedAt
-	commentsTime := parseTime(commentsSyncedAt)
-	docsTime := parseTime(docsSyncedAt)
-	attachTime := parseTime(attachSyncedAt)
-
-	// Refresh if issue changed after last sync OR never synced (zero time)
-	commentsStale := commentsTime.IsZero() || issueTime.After(commentsTime)
-	docsStale := docsTime.IsZero() || issueTime.After(docsTime)
-	attachStale := attachTime.IsZero() || issueTime.After(attachTime)
-
-	if commentsStale || docsStale || attachStale {
-		r.triggerBackgroundRefresh("issue-details:"+issueID, func(ctx context.Context) error {
+	r.maybeRefreshSWR(swrSpec{
+		kind: kindIssueDetails,
+		id:   issueID,
+		// The oldest of the three sub-resource MAX(synced_at)s — any-stale
+		// triggers, exactly as the three hand-compared booleans behaved: the
+		// min is zero (never synced) iff any family is, and the issue changed
+		// after the min iff it changed after at least one family. Query errors
+		// are deliberately swallowed (nil → zero → stale), as before.
+		syncedAt: func() (interface{}, error) {
+			bg := context.Background()
+			q := r.store.Queries()
+			commentsSyncedAt, _ := q.GetIssueCommentsSyncedAt(bg, issueID)
+			docsSyncedAt, _ := q.GetIssueDocumentsSyncedAt(bg, sql.NullString{String: issueID, Valid: true})
+			attachSyncedAt, _ := q.GetIssueAttachmentsSyncedAt(bg, issueID)
+			oldest := parseTime(commentsSyncedAt)
+			if t := parseTime(docsSyncedAt); t.Before(oldest) {
+				oldest = t
+			}
+			if t := parseTime(attachSyncedAt); t.Before(oldest) {
+				oldest = t
+			}
+			return oldest, nil
+		},
+		changedAt: r.issueChangedAt(issueID),
+		refresh: func(ctx context.Context) error {
 			return r.refreshIssueDetails(ctx, issueID)
-		})
-	}
-}
-
-// isEntityNotFound reports whether err is Linear's "Entity not found" GraphQL
-// error, indicating the issue (or other entity) no longer exists upstream.
-// When seen on a refresh, the local row is an orphan and should be deleted —
-// otherwise every FUSE traversal retriggers the same failing refresh forever.
-// Detection is the shared api.IsNotFound predicate.
-func isEntityNotFound(err error) bool {
-	return api.IsNotFound(err)
+		},
+		orphan: func(ctx context.Context) { r.deleteOrphanIssue(ctx, issueID) },
+	})
 }
 
 // deleteOrphanIssue removes an issue and all its sub-resources from SQLite.
@@ -944,65 +940,26 @@ func (r *SQLiteRepository) deleteOrphanInitiative(ctx context.Context, initiativ
 	r.maybeScheduleReconcile()
 }
 
-// refreshIssueDetails fetches comments, documents, and attachments in a single
-// API call and stores them all in SQLite.
+// refreshIssueDetails fetches comments, documents, attachments, and relations
+// in a single API call and persists them through reconcile.PersistIssueDetails
+// — the same five-collection tail the sync worker uses, so the SWR path gets
+// prunes-when-complete, the clean guard, and embedded-file extraction, which
+// the old hand-rolled upsert loops all lacked. The cutoff is taken BEFORE the
+// fetch so rows written mid-flight survive pruning. The clean return is
+// ignored: the SWR path has no freshness stamp to gate (no Touch*/dequeue
+// here — an unclean pass simply stays stale and retriggers).
 func (r *SQLiteRepository) refreshIssueDetails(ctx context.Context, issueID string) error {
+	pruneCutoff := db.Now()
 	details, err := r.client.GetIssueDetails(ctx, issueID)
 	if err != nil {
-		if isEntityNotFound(err) {
-			r.deleteOrphanIssue(ctx, issueID)
-		}
 		return err
 	}
 
-	for _, comment := range details.Comments {
-		params, err := db.APICommentToDBComment(comment, issueID)
-		if err != nil {
-			continue
-		}
-		if err := r.store.Queries().UpsertComment(ctx, params); err != nil {
-			log.Printf("[repo] upsert comment %s failed: %v", comment.ID, err)
-		}
+	deps := reconcile.Deps{Q: r.store.Queries()}
+	if r.extractor != nil {
+		deps.Extract = r.extractor.ExtractAndStore
 	}
-
-	for _, doc := range details.Documents {
-		params, err := db.APIDocumentToDBDocument(doc)
-		if err != nil {
-			continue
-		}
-		if err := r.store.Queries().UpsertDocument(ctx, params); err != nil {
-			log.Printf("[repo] upsert document %s failed: %v", doc.ID, err)
-		}
-	}
-
-	for _, attachment := range details.Attachments {
-		params, err := db.APIAttachmentToDBAttachment(attachment, issueID)
-		if err != nil {
-			continue
-		}
-		if err := r.store.Queries().UpsertAttachment(ctx, params); err != nil {
-			log.Printf("[repo] upsert attachment %s failed: %v", attachment.ID, err)
-		}
-	}
-
-	for _, rel := range details.Relations {
-		if rel.RelatedIssue == nil {
-			continue
-		}
-		if err := r.store.Queries().UpsertIssueRelation(ctx, db.IssueRelationUpsertParams(rel, issueID, rel.RelatedIssue.ID)); err != nil {
-			log.Printf("[repo] upsert relation %s failed: %v", rel.ID, err)
-		}
-	}
-
-	for _, rel := range details.InverseRelations {
-		if rel.Issue == nil {
-			continue
-		}
-		if err := r.store.Queries().UpsertIssueRelation(ctx, db.IssueRelationUpsertParams(rel, rel.Issue.ID, issueID)); err != nil {
-			log.Printf("[repo] upsert inverse relation %s failed: %v", rel.ID, err)
-		}
-	}
-
+	_ = reconcile.PersistIssueDetails(ctx, deps, issueID, details, pruneCutoff)
 	return nil
 }
 
@@ -1031,65 +988,46 @@ func (r *SQLiteRepository) GetIssueDocuments(ctx context.Context, issueID string
 	return db.DBDocumentsToAPIDocuments(docs)
 }
 
-// staleSince reports whether a cached entity's last-sync instant is older than
-// threshold. A query error or a nil instant (never synced) counts as stale, so
-// the caller refreshes. Pure, so the parseTime/threshold rule — historically a
-// source of timezone-comparison bugs — is unit-tested directly.
-func staleSince(syncedAt interface{}, err error, threshold time.Duration) bool {
-	return err != nil || syncedAt == nil || time.Since(parseTime(syncedAt)) > threshold
-}
-
-// maybeRefresh triggers a deduplicated background refresh when an entity's
-// cached rows are staler than the threshold. syncedAt returns the entity's
-// last-sync instant, key dedups concurrent refreshes, and refresh does the
-// fetch-and-upsert. In fixture mode (nil client) it never fires. The refresh
-// runs in the background so a directory listing (e.g. find) never blocks on
-// the API. This owns the staleness/trigger policy the four Get*Documents and
-// Get*Updates read paths used to each restate.
-func (r *SQLiteRepository) maybeRefresh(key string, syncedAt func() (interface{}, error), refresh func(context.Context) error) {
-	if r.client == nil {
-		return
-	}
-	ts, err := syncedAt()
-	if staleSince(ts, err, r.stalenessThreshold) {
-		r.triggerBackgroundRefresh(key, refresh)
-	}
-}
-
 func (r *SQLiteRepository) GetProjectDocuments(ctx context.Context, projectID string) ([]api.Document, error) {
 	docs, err := r.store.Queries().ListProjectDocuments(ctx, sql.NullString{String: projectID, Valid: true})
 	if err != nil {
 		return nil, fmt.Errorf("list project documents: %w", err)
 	}
 
-	r.maybeRefresh("project-docs:"+projectID, func() (interface{}, error) {
-		return r.store.Queries().GetProjectDocumentsSyncedAt(context.Background(), sql.NullString{String: projectID, Valid: true})
-	}, func(ctx context.Context) error {
-		return r.refreshProjectDocuments(ctx, projectID)
+	r.maybeRefreshSWR(swrSpec{
+		kind: kindProjectDocs,
+		id:   projectID,
+		syncedAt: func() (interface{}, error) {
+			return r.store.Queries().GetProjectDocumentsSyncedAt(context.Background(), sql.NullString{String: projectID, Valid: true})
+		},
+		refresh: func(ctx context.Context) error {
+			return r.refreshProjectDocuments(ctx, projectID)
+		},
+		orphan: func(ctx context.Context) { r.deleteOrphanProject(ctx, projectID) },
 	})
 
 	return db.DBDocumentsToAPIDocuments(docs)
 }
 
-// refreshProjectDocuments fetches documents from API and stores in SQLite
+// refreshProjectDocuments fetches documents from API and stores in SQLite.
+// Upsert-only (nil Prune): nothing licenses a prune for this fetch.
 func (r *SQLiteRepository) refreshProjectDocuments(ctx context.Context, projectID string) error {
 	docs, err := r.client.GetProjectDocuments(ctx, projectID)
 	if err != nil {
-		if isEntityNotFound(err) {
-			r.deleteOrphanProject(ctx, projectID)
-		}
 		return err
 	}
 
-	for _, doc := range docs {
-		params, err := db.APIDocumentToDBDocument(doc)
-		if err != nil {
-			continue
-		}
-		if err := r.store.Queries().UpsertDocument(ctx, params); err != nil {
-			log.Printf("[repo] upsert document %s failed: %v", doc.ID, err)
-		}
-	}
+	reconcile.Collection(ctx, reconcile.CollectionSpec[api.Document]{
+		Label: "project document " + projectID,
+		Items: docs,
+		Upsert: func(ctx context.Context, doc api.Document) error {
+			params, err := db.APIDocumentToDBDocument(doc)
+			if err != nil {
+				return err
+			}
+			return r.store.Queries().UpsertDocument(ctx, params)
+		},
+	})
 	return nil
 }
 
@@ -1099,34 +1037,40 @@ func (r *SQLiteRepository) GetInitiativeDocuments(ctx context.Context, initiativ
 		return nil, fmt.Errorf("list initiative documents: %w", err)
 	}
 
-	r.maybeRefresh("initiative-docs:"+initiativeID, func() (interface{}, error) {
-		return r.store.Queries().GetInitiativeDocumentsSyncedAt(context.Background(), sql.NullString{String: initiativeID, Valid: true})
-	}, func(ctx context.Context) error {
-		return r.refreshInitiativeDocuments(ctx, initiativeID)
+	r.maybeRefreshSWR(swrSpec{
+		kind: kindInitiativeDocs,
+		id:   initiativeID,
+		syncedAt: func() (interface{}, error) {
+			return r.store.Queries().GetInitiativeDocumentsSyncedAt(context.Background(), sql.NullString{String: initiativeID, Valid: true})
+		},
+		refresh: func(ctx context.Context) error {
+			return r.refreshInitiativeDocuments(ctx, initiativeID)
+		},
+		orphan: func(ctx context.Context) { r.deleteOrphanInitiative(ctx, initiativeID) },
 	})
 
 	return db.DBDocumentsToAPIDocuments(docs)
 }
 
-// refreshInitiativeDocuments fetches documents from API and stores in SQLite
+// refreshInitiativeDocuments fetches documents from API and stores in SQLite.
+// Upsert-only (nil Prune): nothing licenses a prune for this fetch.
 func (r *SQLiteRepository) refreshInitiativeDocuments(ctx context.Context, initiativeID string) error {
 	docs, err := r.client.GetInitiativeDocuments(ctx, initiativeID)
 	if err != nil {
-		if isEntityNotFound(err) {
-			r.deleteOrphanInitiative(ctx, initiativeID)
-		}
 		return err
 	}
 
-	for _, doc := range docs {
-		params, err := db.APIDocumentToDBDocument(doc)
-		if err != nil {
-			continue
-		}
-		if err := r.store.Queries().UpsertDocument(ctx, params); err != nil {
-			log.Printf("[repo] upsert document %s failed: %v", doc.ID, err)
-		}
-	}
+	reconcile.Collection(ctx, reconcile.CollectionSpec[api.Document]{
+		Label: "initiative document " + initiativeID,
+		Items: docs,
+		Upsert: func(ctx context.Context, doc api.Document) error {
+			params, err := db.APIDocumentToDBDocument(doc)
+			if err != nil {
+				return err
+			}
+			return r.store.Queries().UpsertDocument(ctx, params)
+		},
+	})
 	return nil
 }
 
@@ -1172,34 +1116,40 @@ func (r *SQLiteRepository) GetProjectUpdates(ctx context.Context, projectID stri
 		return nil, fmt.Errorf("list project updates: %w", err)
 	}
 
-	r.maybeRefresh("project-updates:"+projectID, func() (interface{}, error) {
-		return r.store.Queries().GetProjectUpdatesSyncedAt(context.Background(), projectID)
-	}, func(ctx context.Context) error {
-		return r.refreshProjectUpdates(ctx, projectID)
+	r.maybeRefreshSWR(swrSpec{
+		kind: kindProjectUpdates,
+		id:   projectID,
+		syncedAt: func() (interface{}, error) {
+			return r.store.Queries().GetProjectUpdatesSyncedAt(context.Background(), projectID)
+		},
+		refresh: func(ctx context.Context) error {
+			return r.refreshProjectUpdates(ctx, projectID)
+		},
+		orphan: func(ctx context.Context) { r.deleteOrphanProject(ctx, projectID) },
 	})
 
 	return db.DBProjectUpdatesToAPIUpdates(updates)
 }
 
-// refreshProjectUpdates fetches updates from API and stores in SQLite
+// refreshProjectUpdates fetches updates from API and stores in SQLite.
+// Upsert-only (nil Prune): nothing licenses a prune for this fetch.
 func (r *SQLiteRepository) refreshProjectUpdates(ctx context.Context, projectID string) error {
 	updates, err := r.client.GetProjectUpdates(ctx, projectID)
 	if err != nil {
-		if isEntityNotFound(err) {
-			r.deleteOrphanProject(ctx, projectID)
-		}
 		return err
 	}
 
-	for _, update := range updates {
-		params, err := db.APIProjectUpdateToDBUpdate(update, projectID)
-		if err != nil {
-			continue
-		}
-		if err := r.store.Queries().UpsertProjectUpdate(ctx, params); err != nil {
-			log.Printf("[repo] upsert project update %s failed: %v", update.ID, err)
-		}
-	}
+	reconcile.Collection(ctx, reconcile.CollectionSpec[api.ProjectUpdate]{
+		Label: "project update " + projectID,
+		Items: updates,
+		Upsert: func(ctx context.Context, update api.ProjectUpdate) error {
+			params, err := db.APIProjectUpdateToDBUpdate(update, projectID)
+			if err != nil {
+				return err
+			}
+			return r.store.Queries().UpsertProjectUpdate(ctx, params)
+		},
+	})
 	return nil
 }
 
@@ -1209,34 +1159,40 @@ func (r *SQLiteRepository) GetInitiativeUpdates(ctx context.Context, initiativeI
 		return nil, fmt.Errorf("list initiative updates: %w", err)
 	}
 
-	r.maybeRefresh("initiative-updates:"+initiativeID, func() (interface{}, error) {
-		return r.store.Queries().GetInitiativeUpdatesSyncedAt(context.Background(), initiativeID)
-	}, func(ctx context.Context) error {
-		return r.refreshInitiativeUpdates(ctx, initiativeID)
+	r.maybeRefreshSWR(swrSpec{
+		kind: kindInitiativeUpdates,
+		id:   initiativeID,
+		syncedAt: func() (interface{}, error) {
+			return r.store.Queries().GetInitiativeUpdatesSyncedAt(context.Background(), initiativeID)
+		},
+		refresh: func(ctx context.Context) error {
+			return r.refreshInitiativeUpdates(ctx, initiativeID)
+		},
+		orphan: func(ctx context.Context) { r.deleteOrphanInitiative(ctx, initiativeID) },
 	})
 
 	return db.DBInitiativeUpdatesToAPIUpdates(updates)
 }
 
-// refreshInitiativeUpdates fetches updates from API and stores in SQLite
+// refreshInitiativeUpdates fetches updates from API and stores in SQLite.
+// Upsert-only (nil Prune): nothing licenses a prune for this fetch.
 func (r *SQLiteRepository) refreshInitiativeUpdates(ctx context.Context, initiativeID string) error {
 	updates, err := r.client.GetInitiativeUpdates(ctx, initiativeID)
 	if err != nil {
-		if isEntityNotFound(err) {
-			r.deleteOrphanInitiative(ctx, initiativeID)
-		}
 		return err
 	}
 
-	for _, update := range updates {
-		params, err := db.APIInitiativeUpdateToDBUpdate(update, initiativeID)
-		if err != nil {
-			continue
-		}
-		if err := r.store.Queries().UpsertInitiativeUpdate(ctx, params); err != nil {
-			log.Printf("[repo] upsert initiative update %s failed: %v", update.ID, err)
-		}
-	}
+	reconcile.Collection(ctx, reconcile.CollectionSpec[api.InitiativeUpdate]{
+		Label: "initiative update " + initiativeID,
+		Items: updates,
+		Upsert: func(ctx context.Context, update api.InitiativeUpdate) error {
+			params, err := db.APIInitiativeUpdateToDBUpdate(update, initiativeID)
+			if err != nil {
+				return err
+			}
+			return r.store.Queries().UpsertInitiativeUpdate(ctx, params)
+		},
+	})
 	return nil
 }
 
@@ -1297,8 +1253,12 @@ func (r *SQLiteRepository) GetAttachmentByID(ctx context.Context, id string) (*a
 func (r *SQLiteRepository) GetIssueHistory(ctx context.Context, issueID string) ([]api.IssueHistoryEntry, error) {
 	cache, err := r.store.Queries().GetIssueHistoryCache(ctx, issueID)
 	if err == nil {
-		// Have cached data — check staleness and maybe refresh in background
-		r.maybeRefreshHistory(issueID, cache.SyncedAt)
+		// Have cached data — event-driven refresh if the issue changed after
+		// the history was cached.
+		spec := r.historySpec(issueID)
+		spec.syncedAt = func() (interface{}, error) { return cache.SyncedAt, nil }
+		spec.changedAt = r.issueChangedAt(issueID)
+		r.maybeRefreshSWR(spec)
 
 		var entries []api.IssueHistoryEntry
 		if err := json.Unmarshal(cache.Data, &entries); err != nil {
@@ -1309,51 +1269,33 @@ func (r *SQLiteRepository) GetIssueHistory(ctx context.Context, issueID string) 
 
 	// No cached data — trigger a background fetch and return empty immediately.
 	// This avoids blocking the FUSE dispatch goroutine on a cold-cache API call.
-	// History will be available on next access once the background fetch completes.
-	if r.client == nil {
-		return nil, nil
-	}
-	r.triggerBackgroundRefresh("history:"+issueID, func(ctx context.Context) error {
-		entries, err := r.client.GetIssueHistory(ctx, issueID)
-		if err != nil {
-			if isEntityNotFound(err) {
-				r.deleteOrphanIssue(ctx, issueID)
-			}
-			return err
-		}
-		r.upsertHistoryCache(ctx, issueID, entries)
-		return nil
-	})
+	// History will be available on next access once the background fetch
+	// completes. syncedAt reporting nil = never synced, so the spec always
+	// reads stale here (no GetIssueUpdatedAt gate: an issue unknown to the DB
+	// still gets its cold fetch, as before).
+	spec := r.historySpec(issueID)
+	spec.syncedAt = func() (interface{}, error) { return nil, nil }
+	r.maybeRefreshSWR(spec)
 	return nil, nil
 }
 
-func (r *SQLiteRepository) maybeRefreshHistory(issueID string, cachedSyncedAt time.Time) {
-	if r.client == nil {
-		return
-	}
-
-	bgCtx := context.Background()
-	issueUpdatedAt, err := r.store.Queries().GetIssueUpdatedAt(bgCtx, issueID)
-	if err != nil {
-		return
-	}
-
-	issueTime := issueUpdatedAt
-	historyTime := cachedSyncedAt
-
-	// Refresh if issue changed after history was cached OR never cached
-	if historyTime.IsZero() || issueTime.After(historyTime) {
-		r.triggerBackgroundRefresh("history:"+issueID, func(ctx context.Context) error {
+// historySpec is the single constructor behind both history refresh call
+// sites in GetIssueHistory — the cold-cache trigger and the warm event-driven
+// check (whose fetch closures used to be pasted verbatim). Callers attach the
+// staleness inputs (syncedAt/changedAt) they own.
+func (r *SQLiteRepository) historySpec(issueID string) swrSpec {
+	return swrSpec{
+		kind: kindHistory,
+		id:   issueID,
+		refresh: func(ctx context.Context) error {
 			entries, err := r.client.GetIssueHistory(ctx, issueID)
 			if err != nil {
-				if isEntityNotFound(err) {
-					r.deleteOrphanIssue(ctx, issueID)
-				}
 				return err
 			}
 			r.upsertHistoryCache(ctx, issueID, entries)
 			return nil
-		})
+		},
+		orphan: func(ctx context.Context) { r.deleteOrphanIssue(ctx, issueID) },
 	}
 }
 

--- a/internal/repo/sqlite_test.go
+++ b/internal/repo/sqlite_test.go
@@ -1848,9 +1848,9 @@ func TestSQLiteRepository_MaybeRefreshIssueDetails_NoClient(t *testing.T) {
 }
 
 // The four Get*Documents/Get*Updates read paths must be safe no-ops in fixture
-// mode (nil client): maybeRefresh short-circuits, so the read returns whatever
-// is cached without touching the API. Exercised through the real Get* methods
-// now that the per-entity maybeRefresh* wrappers fold into one helper.
+// mode (nil client): maybeRefreshSWR short-circuits, so the read returns
+// whatever is cached without touching the API. Exercised through the real
+// Get* methods now that the per-entity wrappers fold into the coordinator.
 func TestSQLiteRepository_StaleReadPaths_NoClient(t *testing.T) {
 	t.Parallel()
 	store, cleanup := setupTestDB(t)
@@ -2196,26 +2196,6 @@ func TestSetCatchUpMode(t *testing.T) {
 	repo.SetCatchUpMode(false)
 	if repo.stalenessThreshold != defaultStalenessThreshold {
 		t.Errorf("expected default staleness %v after disabling catch-up, got %v", defaultStalenessThreshold, repo.stalenessThreshold)
-	}
-}
-
-func TestIsEntityNotFound(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{"nil error", nil, false},
-		{"unrelated error", fmt.Errorf("connection refused"), false},
-		{"linear not-found wrapped", fmt.Errorf("GraphQL error: Entity not found: Issue"), true},
-		{"raw not-found", fmt.Errorf("Entity not found"), true},
-		{"rate limit", fmt.Errorf("rate limit wait cancelled: context canceled"), false},
-	}
-	for _, c := range cases {
-		if got := isEntityNotFound(c.err); got != c.want {
-			t.Errorf("%s: isEntityNotFound(%v) = %v, want %v", c.name, c.err, got, c.want)
-		}
 	}
 }
 
@@ -2648,7 +2628,7 @@ func TestReconcileAgainst_DeletesOrphans(t *testing.T) {
 }
 
 // TestStaleSince pins the staleness rule the four Get*Documents/Get*Updates
-// read paths share via maybeRefresh — the parseTime/threshold comparison that
+// read paths share via maybeRefreshSWR — the parseTime/threshold comparison that
 // has historically hidden timezone bugs.
 func TestStaleSince(t *testing.T) {
 	t.Parallel()
@@ -2670,21 +2650,6 @@ func TestStaleSince(t *testing.T) {
 				t.Errorf("staleSince(%v, %v) = %v, want %v", c.syncedAt, c.err, got, c.want)
 			}
 		})
-	}
-}
-
-// TestMaybeRefreshNilClientNoop: in fixture mode (nil client) maybeRefresh must
-// short-circuit before even querying syncedAt — no refresh, no query.
-func TestMaybeRefreshNilClientNoop(t *testing.T) {
-	t.Parallel()
-	repo := &SQLiteRepository{} // nil client
-	queried := false
-	repo.maybeRefresh("k",
-		func() (interface{}, error) { queried = true; return nil, nil },
-		func(_ context.Context) error { return nil },
-	)
-	if queried {
-		t.Error("maybeRefresh queried syncedAt with a nil client; want a no-op")
 	}
 }
 

--- a/internal/repo/swr.go
+++ b/internal/repo/swr.go
@@ -1,0 +1,144 @@
+package repo
+
+// swrRefresh coordinator: the one owner of the repo's stale-while-revalidate
+// policy. Every SWR surface (six today) routes through maybeRefreshSWR with a
+// swrSpec; the module owns the staleness decision (both flavors), the typed
+// dedup key, and the orphan-on-not-found classification that the individual
+// refresh tails used to each restate by hand.
+
+import (
+	"context"
+	"time"
+
+	"github.com/jra3/linear-fuse/internal/api"
+)
+
+// refreshKind names one SWR surface. Dedup keys are minted only through
+// key(), so two surfaces can never collide (or silently diverge) on a
+// hand-built string.
+type refreshKind string
+
+const (
+	kindIssueDetails      refreshKind = "issue-details"
+	kindHistory           refreshKind = "history"
+	kindProjectDocs       refreshKind = "project-docs"
+	kindInitiativeDocs    refreshKind = "initiative-docs"
+	kindProjectUpdates    refreshKind = "project-updates"
+	kindInitiativeUpdates refreshKind = "initiative-updates"
+)
+
+// key is the one factory for a refresh's dedup-map key.
+func (k refreshKind) key(id string) string {
+	return string(k) + ":" + id
+}
+
+// swrSpec declares one SWR surface: how to decide staleness, how to refresh,
+// and what to delete when the entity turns out to be gone upstream.
+type swrSpec struct {
+	kind refreshKind
+	id   string
+
+	// syncedAt returns the raw synced_at source (typically a MAX() aggregate,
+	// which sqlc types as interface{}); the module applies parseTime.
+	syncedAt func() (interface{}, error)
+
+	// changedAt selects the staleness flavor: nil means TTL (threshold-driven);
+	// non-nil means event-driven — it returns the entity's last-change instant,
+	// and ok=false means the instant is unknown (entity not in DB), which
+	// suppresses the refresh entirely (discovery belongs to the sync worker).
+	changedAt func() (time.Time, bool)
+
+	// refresh does the fetch + persist. It runs in the background, deduplicated
+	// by kind.key(id).
+	refresh func(ctx context.Context) error
+
+	// orphan deletes the local rows when refresh's error is Linear's
+	// entity-not-found rejection (the deleteOrphan* helpers). The module owns
+	// this classification; refresh tails don't inspect their own errors.
+	orphan func(ctx context.Context)
+}
+
+// swrStale is the pure staleness decision behind maybeRefreshSWR, one function
+// for both flavors (the staleSince precedent — this comparison has
+// historically hidden timezone bugs, so it is unit-tested directly):
+//
+//   - TTL (eventDriven=false): staleSince against the threshold. This is the
+//     ONLY flavor the catch-up threshold (SetCatchUpMode) reaches — explicit,
+//     grilled policy, not an accident: extending catch-up suppression to the
+//     event-driven surfaces would save duplicate fetches the rateBudget ladder
+//     already governs, at the cost of silently-empty comments/ listings during
+//     big syncs — the worst failure mode for an agent-facing filesystem.
+//     Flipping later is a one-line policy change here.
+//   - Event-driven (eventDriven=true): stale when never synced (query error,
+//     nil, or zero instant) or when the entity changed after the last sync.
+//     The threshold is deliberately not consulted.
+func swrStale(syncedAt interface{}, syncedErr error, changed time.Time, eventDriven bool, threshold time.Duration) bool {
+	if !eventDriven {
+		return staleSince(syncedAt, syncedErr, threshold)
+	}
+	if syncedErr != nil || syncedAt == nil {
+		return true
+	}
+	synced := parseTime(syncedAt)
+	return synced.IsZero() || changed.After(synced)
+}
+
+// staleSince reports whether a cached entity's last-sync instant is older than
+// threshold. A query error or a nil instant (never synced) counts as stale, so
+// the caller refreshes. Pure, so the parseTime/threshold rule — historically a
+// source of timezone-comparison bugs — is unit-tested directly.
+func staleSince(syncedAt interface{}, err error, threshold time.Duration) bool {
+	return err != nil || syncedAt == nil || time.Since(parseTime(syncedAt)) > threshold
+}
+
+// orphanOnNotFound wraps a refresh with the orphan classification: when the
+// refresh fails with Linear's "Entity not found" rejection, the local row is
+// an orphan and orphan deletes it — otherwise every FUSE traversal would
+// retrigger the same failing refresh forever. Any other error passes through
+// untouched. Pure over its closures, so it is unit-tested with recorders.
+func orphanOnNotFound(refresh func(context.Context) error, orphan func(context.Context)) func(context.Context) error {
+	return func(ctx context.Context) error {
+		err := refresh(ctx)
+		if err != nil && orphan != nil && api.IsNotFound(err) {
+			orphan(ctx)
+		}
+		return err
+	}
+}
+
+// maybeRefreshSWR is the one entry point for stale-while-revalidate: decide
+// staleness per the spec's flavor and, if stale, trigger the deduplicated
+// background refresh (wrapped with the orphan classification). In fixture
+// mode (nil client) it never fires — before even querying syncedAt.
+func (r *SQLiteRepository) maybeRefreshSWR(spec swrSpec) {
+	if r.client == nil {
+		return
+	}
+
+	var changed time.Time
+	eventDriven := spec.changedAt != nil
+	if eventDriven {
+		var ok bool
+		changed, ok = spec.changedAt()
+		if !ok {
+			return // change instant unknown (entity not in DB) — no refresh
+		}
+	}
+
+	ts, err := spec.syncedAt()
+	if !swrStale(ts, err, changed, eventDriven, r.stalenessThreshold) {
+		return
+	}
+
+	r.triggerBackgroundRefresh(spec.kind.key(spec.id), orphanOnNotFound(spec.refresh, spec.orphan))
+}
+
+// issueChangedAt is the event source for issue-scoped surfaces (details,
+// history): the issue's updated_at column. ok=false when the issue isn't in
+// the DB yet — the sync worker owns discovery, so no refresh fires.
+func (r *SQLiteRepository) issueChangedAt(issueID string) func() (time.Time, bool) {
+	return func() (time.Time, bool) {
+		t, err := r.store.Queries().GetIssueUpdatedAt(context.Background(), issueID)
+		return t, err == nil
+	}
+}

--- a/internal/repo/swr_test.go
+++ b/internal/repo/swr_test.go
@@ -1,0 +1,278 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jra3/linear-fuse/internal/api"
+)
+
+// newSWRTestRepo builds a repository with a (never-dialed) client and live
+// refresh machinery but no store — the specs under test carry recording
+// closures, so nothing touches SQLite or the network.
+func newSWRTestRepo(t *testing.T) *SQLiteRepository {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &SQLiteRepository{
+		client:             api.NewClient("test-key"),
+		stalenessThreshold: defaultStalenessThreshold,
+		refreshing:         make(map[string]bool),
+		refreshContext:     ctx,
+		refreshCancel:      cancel,
+		refreshSem:         make(chan struct{}, maxConcurrentRefreshes),
+	}
+	t.Cleanup(r.Close)
+	return r
+}
+
+// TestRefreshKindKey pins the one dedup-key factory: distinct kinds with the
+// same id must produce distinct keys, in the kind:id shape the dedup map has
+// always used.
+func TestRefreshKindKey(t *testing.T) {
+	t.Parallel()
+	kinds := []refreshKind{
+		kindIssueDetails, kindHistory,
+		kindProjectDocs, kindInitiativeDocs,
+		kindProjectUpdates, kindInitiativeUpdates,
+	}
+	seen := make(map[string]refreshKind)
+	for _, k := range kinds {
+		key := k.key("same-id")
+		if want := string(k) + ":same-id"; key != want {
+			t.Errorf("%s.key() = %q, want %q", k, key, want)
+		}
+		if prev, dup := seen[key]; dup {
+			t.Errorf("kinds %s and %s collide on key %q", prev, k, key)
+		}
+		seen[key] = k
+	}
+}
+
+// TestSWRStale pins the staleness decision for both flavors — the pure core
+// behind maybeRefreshSWR.
+func TestSWRStale(t *testing.T) {
+	t.Parallel()
+	const threshold = time.Hour
+	now := time.Now()
+
+	cases := []struct {
+		name        string
+		syncedAt    interface{}
+		syncedErr   error
+		changed     time.Time
+		eventDriven bool
+		threshold   time.Duration
+		want        bool
+	}{
+		// TTL flavor (threshold-driven — the flavor SetCatchUpMode reaches).
+		{"ttl: never synced (nil) is stale", nil, nil, time.Time{}, false, threshold, true},
+		{"ttl: query error is stale", now, fmt.Errorf("boom"), time.Time{}, false, threshold, true},
+		{"ttl: recently synced is fresh", now, nil, time.Time{}, false, threshold, false},
+		{"ttl: older than threshold is stale", now.Add(-2 * threshold), nil, time.Time{}, false, threshold, true},
+		// The threshold is live for TTL: the same instant flips with the
+		// threshold — this is the seam catch-up mode (30min) moves.
+		{"ttl: 10min-old stale at 5min threshold", now.Add(-10 * time.Minute), nil, time.Time{}, false, defaultStalenessThreshold, true},
+		{"ttl: 10min-old fresh at catch-up threshold", now.Add(-10 * time.Minute), nil, time.Time{}, false, catchUpStaleness, false},
+
+		// Event-driven flavor (changed-vs-synced; threshold ignored).
+		{"event: never synced (nil) is stale", nil, nil, now, true, threshold, true},
+		{"event: never synced (zero) is stale", time.Time{}, nil, now, true, threshold, true},
+		{"event: query error is stale", now, fmt.Errorf("boom"), now, true, threshold, true},
+		{"event: changed after synced is stale", now.Add(-time.Minute), nil, now, true, threshold, true},
+		{"event: unchanged since synced is fresh", now, nil, now.Add(-time.Minute), true, threshold, false},
+		// SetCatchUpMode must NOT reach this flavor: the same
+		// changed-after-synced inputs are stale at any threshold, including
+		// the catch-up one.
+		{"event: threshold ignored (tiny)", now.Add(-10 * time.Minute), nil, now, true, time.Nanosecond, true},
+		{"event: threshold ignored (catch-up)", now.Add(-10 * time.Minute), nil, now, true, catchUpStaleness, true},
+		{"event: fresh at tiny threshold too", now.Add(-10 * time.Minute), nil, now.Add(-time.Hour), true, time.Nanosecond, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := swrStale(c.syncedAt, c.syncedErr, c.changed, c.eventDriven, c.threshold); got != c.want {
+				t.Errorf("swrStale(%v, %v, %v, %v, %v) = %v, want %v",
+					c.syncedAt, c.syncedErr, c.changed, c.eventDriven, c.threshold, got, c.want)
+			}
+		})
+	}
+}
+
+// TestOrphanOnNotFound pins the module-owned orphan classification: only a
+// not-found-shaped refresh error triggers the orphan closure; every error
+// passes through unchanged.
+func TestOrphanOnNotFound(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	notFound := fmt.Errorf("GraphQL error: Entity not found: Issue")
+	other := fmt.Errorf("connection refused")
+
+	cases := []struct {
+		name       string
+		refreshErr error
+		wantOrphan bool
+	}{
+		{"not-found triggers orphan", notFound, true},
+		{"other error does not", other, false},
+		{"success does not", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			orphaned := false
+			wrapped := orphanOnNotFound(
+				func(context.Context) error { return c.refreshErr },
+				func(context.Context) { orphaned = true },
+			)
+			if err := wrapped(ctx); err != c.refreshErr {
+				t.Errorf("wrapped refresh error = %v, want passthrough %v", err, c.refreshErr)
+			}
+			if orphaned != c.wantOrphan {
+				t.Errorf("orphan called = %v, want %v", orphaned, c.wantOrphan)
+			}
+		})
+	}
+
+	// nil orphan must be tolerated (a spec may have nothing to delete).
+	wrapped := orphanOnNotFound(func(context.Context) error { return notFound }, nil)
+	if err := wrapped(ctx); err != notFound {
+		t.Errorf("nil-orphan wrapped error = %v, want %v", err, notFound)
+	}
+}
+
+// TestMaybeRefreshSWR_NilClientNoop: in fixture mode (nil client) the
+// coordinator must short-circuit before consulting any closure.
+func TestMaybeRefreshSWR_NilClientNoop(t *testing.T) {
+	t.Parallel()
+	repo := &SQLiteRepository{} // nil client
+	touched := false
+	repo.maybeRefreshSWR(swrSpec{
+		kind:      kindProjectDocs,
+		id:        "p1",
+		syncedAt:  func() (interface{}, error) { touched = true; return nil, nil },
+		changedAt: func() (time.Time, bool) { touched = true; return time.Time{}, true },
+		refresh:   func(context.Context) error { touched = true; return nil },
+	})
+	if touched {
+		t.Error("maybeRefreshSWR consulted a closure with a nil client; want a no-op")
+	}
+}
+
+// TestMaybeRefreshSWR_ChangedAtUnknownNoRefresh: ok=false from changedAt
+// (entity not in DB) suppresses the refresh without even querying syncedAt —
+// discovery belongs to the sync worker.
+func TestMaybeRefreshSWR_ChangedAtUnknownNoRefresh(t *testing.T) {
+	t.Parallel()
+	repo := newSWRTestRepo(t)
+	queried := false
+	fired := false
+	repo.maybeRefreshSWR(swrSpec{
+		kind:      kindIssueDetails,
+		id:        "unknown-issue",
+		syncedAt:  func() (interface{}, error) { queried = true; return nil, nil },
+		changedAt: func() (time.Time, bool) { return time.Time{}, false },
+		refresh:   func(context.Context) error { fired = true; return nil },
+	})
+	time.Sleep(50 * time.Millisecond)
+	if queried || fired {
+		t.Errorf("queried=%v fired=%v; want neither when changedAt reports unknown", queried, fired)
+	}
+}
+
+// TestMaybeRefreshSWR_EventDrivenFires: the event-driven flavor triggers the
+// background refresh on changed-after-synced and on never-synced.
+func TestMaybeRefreshSWR_EventDrivenFires(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	cases := []struct {
+		name     string
+		syncedAt interface{}
+	}{
+		{"changed after synced", now.Add(-time.Minute)},
+		{"never synced", nil},
+	}
+	for i, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			repo := newSWRTestRepo(t)
+			fired := make(chan struct{}, 1)
+			repo.maybeRefreshSWR(swrSpec{
+				kind:      kindHistory,
+				id:        fmt.Sprintf("issue-%d", i),
+				syncedAt:  func() (interface{}, error) { return c.syncedAt, nil },
+				changedAt: func() (time.Time, bool) { return now, true },
+				refresh: func(context.Context) error {
+					fired <- struct{}{}
+					return nil
+				},
+			})
+			select {
+			case <-fired:
+			case <-time.After(2 * time.Second):
+				t.Error("event-driven refresh did not fire")
+			}
+		})
+	}
+}
+
+// TestMaybeRefreshSWR_CatchUpReachesTTLOnly pins the grilled policy at the
+// module level: with catch-up mode active (30min threshold), a 10min-old TTL
+// surface stays quiet while an event-driven surface with the same 10min-old
+// synced_at (and a fresher change) still fires.
+func TestMaybeRefreshSWR_CatchUpReachesTTLOnly(t *testing.T) {
+	t.Parallel()
+	repo := newSWRTestRepo(t)
+	repo.SetCatchUpMode(true)
+
+	syncedTenMinAgo := time.Now().Add(-10 * time.Minute)
+	var ttlFired atomic.Bool
+	repo.maybeRefreshSWR(swrSpec{
+		kind:     kindProjectDocs,
+		id:       "p1",
+		syncedAt: func() (interface{}, error) { return syncedTenMinAgo, nil },
+		refresh: func(context.Context) error {
+			ttlFired.Store(true)
+			return nil
+		},
+	})
+
+	eventFired := make(chan struct{}, 1)
+	repo.maybeRefreshSWR(swrSpec{
+		kind:      kindIssueDetails,
+		id:        "i1",
+		syncedAt:  func() (interface{}, error) { return syncedTenMinAgo, nil },
+		changedAt: func() (time.Time, bool) { return time.Now(), true },
+		refresh: func(context.Context) error {
+			eventFired <- struct{}{}
+			return nil
+		},
+	})
+
+	select {
+	case <-eventFired:
+	case <-time.After(2 * time.Second):
+		t.Error("event-driven refresh suppressed by catch-up mode; the threshold must reach TTL only")
+	}
+	time.Sleep(50 * time.Millisecond)
+	if ttlFired.Load() {
+		t.Error("TTL refresh fired for 10min-old data in catch-up mode (30min threshold)")
+	}
+
+	// Same TTL spec fires once catch-up mode is off (5min threshold).
+	repo.SetCatchUpMode(false)
+	ttlFired2 := make(chan struct{}, 1)
+	repo.maybeRefreshSWR(swrSpec{
+		kind:     kindProjectDocs,
+		id:       "p2",
+		syncedAt: func() (interface{}, error) { return syncedTenMinAgo, nil },
+		refresh: func(context.Context) error {
+			ttlFired2 <- struct{}{}
+			return nil
+		},
+	})
+	select {
+	case <-ttlFired2:
+	case <-time.After(2 * time.Second):
+		t.Error("TTL refresh did not fire for 10min-old data at the default 5min threshold")
+	}
+}


### PR DESCRIPTION
Step 4 of 4 in the detailOutcome + swrRefresh design (`docs/plans/2026-07-08-detail-outcome-swr-refresh-design.md`; steps 1 = #198, 2 = #199).

## The friction collapsed

- **Two staleness policies in three implementations**: `staleSince`/`maybeRefresh` (TTL, threshold-driven) and the event-driven `issue.updatedAt > synced_at` comparison hand-copied in `MaybeRefreshIssueDetails` and `maybeRefreshHistory`.
- **The history fetch closure pasted verbatim twice** (cold-cache and warm paths of `GetIssueHistory`).
- **`isEntityNotFound → deleteOrphan*` restated in every refresh tail** (issue details, history ×2, project/initiative docs, project/initiative updates).
- **Bare-string dedup keys built at 6 sites.**

Now one coordinator owns all of it: `maybeRefreshSWR(swrSpec{kind, id, syncedAt, changedAt, refresh, orphan})` in `internal/repo/swr.go`. Typed `refreshKind` constants + a single `key()` factory mint the dedup keys (same `kind:id` strings as before). The staleness decision is the pure `swrStale` — `changedAt == nil` selects the TTL flavor (with `staleSince` kept as its tested core), non-nil selects event-driven (never-synced or changed-after-synced; `ok=false` = entity not in DB = no refresh, as today). Orphan classification moved into the module: `orphanOnNotFound` wraps every `refresh` and calls `spec.orphan` on `api.IsNotFound`; the tails dropped their per-error branches. The nil-client (fixture-mode) check sits at the module entry. The history spec exists once (`historySpec`); both call sites attach only the staleness inputs they own. The issue-details spec derives `syncedAt` from the min of the three sub-resource `MAX(synced_at)`s — equivalent to the old any-stale-triggers booleans.

## Three recorded behavior improvements (deliberate, from the grilling)

`refreshIssueDetails` replaces its five hand-rolled upsert loops with `reconcile.PersistIssueDetails` (cutoff taken **before** the fetch), so the repo's SWR path now gets:

1. **Prunes-when-complete** — details removed upstream finally disappear from a SWR refresh (the old loops never pruned).
2. **The clean guard** — a failed upsert suppresses the prune, so a partial persist can't read as removals.
3. **Embedded-file extraction** — a comment fetched via SWR gets its `*.png` row immediately instead of waiting for the next worker detail sync. The repo builds `reconcile.Extractor{Q, AuthHeader}` only when it has a client; fixture mode leaves `Deps.Extract` nil.

Plus: the four doc/update tails route through `reconcile.Collection` with nil `Prune` (upsert-only — nothing licenses a prune for these fetches), which turns their inconsistent silent `continue` on convert errors into log-and-mark-unclean.

## Catch-up policy note

**Catch-up mode (`SetCatchUpMode`, 30min threshold) reaches ONLY the TTL flavor — explicit, grilled policy, not an accident** (commented at `swrStale`, recorded in CONTEXT.md): extending suppression to the event-driven surfaces would save duplicate fetches the rateBudget ladder already governs, at the cost of silently-empty `comments/` listings during big syncs — the worst failure mode for an agent-facing filesystem. Flipping later is a one-line change.

## Tests

- `TestSWRStale` — pins both flavors of the pure staleness decision: TTL respects threshold changes (the seam catch-up mode moves); event-driven fires on changed-after-synced and never-synced and **ignores the threshold** (asserted at tiny and catch-up values).
- `TestMaybeRefreshSWR_CatchUpReachesTTLOnly` — module-level: with catch-up active, a 10min-old TTL surface stays quiet while an event-driven surface with the same synced_at fires.
- `TestOrphanOnNotFound` — not-found-shaped refresh error triggers the orphan recorder; other errors and success don't; errors pass through; nil orphan tolerated.
- `TestRefreshKindKey` — all six kinds with the same id produce distinct `kind:id` keys.
- `TestMaybeRefreshSWR_NilClientNoop`, `TestMaybeRefreshSWR_ChangedAtUnknownNoRefresh`, `TestMaybeRefreshSWR_EventDrivenFires`.
- Deleted `TestIsEntityNotFound` (predicate covered by `api.TestIsNotFound`) and the old `TestMaybeRefreshNilClientNoop` (superseded).

`make build`, `go vet ./...`, `go test ./...` (incl. integration) all green. (`gofmt -l` flags `internal/marshal/frontmatter_test.go` — pre-existing on main, untouched here.)

CONTEXT.md: new "SWR refresh coordinator (`swrRefresh`)" entry; amended the "Sync reconcile tail" second-caller sentence (the repo has now joined) and the relations paragraph's SWR sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)