### PR TITLE
refactor(test): kill the integration tests' private frontmatter fork

### DIFF
--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/jra3/linear-fuse/internal/marshal"
 	"github.com/jra3/linear-fuse/internal/testutil/mockmutation"
-	"gopkg.in/yaml.v3"
 )
 
 // enableMockMutations swaps in the in-memory mutation fake (T0/#155) for the
@@ -273,72 +272,33 @@ func waitForCacheExpiry() {
 	time.Sleep(150 * time.Millisecond) // Cache TTL is 100ms, wait a bit longer
 }
 
-// Frontmatter helpers
+// Frontmatter helpers — thin delegations to the marshal seam. The tests must
+// parse and re-render frontmatter with the SAME implementation the product
+// uses (marshal.Parse/marshal.Render), never a private fork: a fork validates
+// the mount against a stale copy of its own contract, and Sprintf-built YAML
+// is the exact idiom the catalog-render fix killed (a `Q3: Bets` name emitted
+// invalid YAML).
 
-type Document struct {
-	Frontmatter map[string]any
-	Body        string
-}
-
-func parseFrontmatter(content []byte) (*Document, error) {
-	str := string(content)
-
-	if !strings.HasPrefix(str, "---\n") {
-		return &Document{Body: str}, nil
-	}
-
-	end := strings.Index(str[4:], "\n---")
-	if end == -1 {
-		return nil, fmt.Errorf("unterminated frontmatter")
-	}
-
-	yamlContent := str[4 : 4+end]
-	body := strings.TrimPrefix(str[4+end+4:], "\n")
-
-	var frontmatter map[string]any
-	if err := yaml.Unmarshal([]byte(yamlContent), &frontmatter); err != nil {
-		return nil, fmt.Errorf("failed to parse frontmatter: %w", err)
-	}
-
-	return &Document{
-		Frontmatter: frontmatter,
-		Body:        body,
-	}, nil
+func parseFrontmatter(content []byte) (*marshal.Document, error) {
+	return marshal.Parse(content)
 }
 
 func modifyFrontmatter(content []byte, field string, value any) ([]byte, error) {
-	doc, err := parseFrontmatter(content)
+	doc, err := marshal.Parse(content)
 	if err != nil {
 		return nil, err
-	}
-
-	if doc.Frontmatter == nil {
-		doc.Frontmatter = make(map[string]any)
 	}
 	doc.Frontmatter[field] = value
-
-	yamlBytes, err := yaml.Marshal(doc.Frontmatter)
-	if err != nil {
-		return nil, err
-	}
-
-	return []byte(fmt.Sprintf("---\n%s---\n%s", string(yamlBytes), doc.Body)), nil
+	return marshal.Render(doc)
 }
 
 func removeFrontmatterField(content []byte, field string) ([]byte, error) {
-	doc, err := parseFrontmatter(content)
+	doc, err := marshal.Parse(content)
 	if err != nil {
 		return nil, err
 	}
-
 	delete(doc.Frontmatter, field)
-
-	yamlBytes, err := yaml.Marshal(doc.Frontmatter)
-	if err != nil {
-		return nil, err
-	}
-
-	return []byte(fmt.Sprintf("---\n%s---\n%s", string(yamlBytes), doc.Body)), nil
+	return marshal.Render(doc)
 }
 
 // Directory listing helpers

--- a/internal/marshal/frontmatter_test.go
+++ b/internal/marshal/frontmatter_test.go
@@ -8,23 +8,23 @@ import (
 func TestParse(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name           string
-		content        string
+		name            string
+		content         string
 		wantFrontmatter map[string]any
-		wantBody       string
-		wantErr        bool
+		wantBody        string
+		wantErr         bool
 	}{
 		{
-			name:           "empty content",
-			content:        "",
+			name:            "empty content",
+			content:         "",
 			wantFrontmatter: map[string]any{},
-			wantBody:       "",
+			wantBody:        "",
 		},
 		{
-			name:           "body only - no frontmatter",
-			content:        "Just a regular markdown document.\n\nWith multiple paragraphs.",
+			name:            "body only - no frontmatter",
+			content:         "Just a regular markdown document.\n\nWith multiple paragraphs.",
 			wantFrontmatter: map[string]any{},
-			wantBody:       "Just a regular markdown document.\n\nWith multiple paragraphs.",
+			wantBody:        "Just a regular markdown document.\n\nWith multiple paragraphs.",
 		},
 		{
 			name:    "valid frontmatter with body",
@@ -53,10 +53,10 @@ func TestParse(t *testing.T) {
 			wantBody: "Description",
 		},
 		{
-			name:           "empty frontmatter",
-			content:        "---\n---\nBody after empty frontmatter",
+			name:            "empty frontmatter",
+			content:         "---\n---\nBody after empty frontmatter",
 			wantFrontmatter: map[string]any{},
-			wantBody:       "Body after empty frontmatter",
+			wantBody:        "Body after empty frontmatter",
 		},
 		{
 			name:    "unclosed frontmatter",


### PR DESCRIPTION
Round-17 also-ran (report card 5). The integration helpers re-implemented `marshal.Parse` and re-rendered frontmatter via `yaml.Marshal` + `Sprintf` — a hand-maintained fork of the seam the product owns. A marshal fix or edge-case change never reached the tests; they validated the mount against a stale copy of its own contract. The Sprintf-YAML idiom is the same one the catalog-render fix (PR #195) killed in product code.

Now: `parseFrontmatter`/`modifyFrontmatter`/`removeFrontmatterField` are thin delegations to `marshal.Parse`/`marshal.Render`; the local `Document` type is deleted (field names match `marshal.Document`, so all call sites are untouched). Also folds in the pending gofmt-only realignment of `internal/marshal/frontmatter_test.go`.

Verified: vet + gofmt clean, marshal tests green, full FUSE integration suite green (33.4s) — the suite passing on the delegated helpers is the drop-in proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)