### PR TITLE
refactor(fs): renameSave — one atomic-save Rename tail for the three entity dirs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,6 +32,31 @@ tested with a fake sink and stub closures — no FUSE mount, SQLite, or API.
 The **front half** of each edit (parse, resolve, call API) stays per-entity. For
 issues the resolve step is itself a deep module — see Name→ID resolution below.
 
+### Rename save (`renameSave`)
+The **deep module** owning the atomic-save Rename tail — the rename-shaped
+sibling of the WriteBack tail in the edit-path family. Editors and the Claude
+Code Edit/Write tools never write a file in place: they write a sibling scratch
+temp file (see the Edit buffer's scratch counterpart in
+`internal/fs/atomicwrite.go`, #145) and rename(2) it onto the canonical `.md`.
+The three entity directories that accept this (issue/project/initiative) each
+ended their Rename handler with the same hand-copied tail: same-directory check
+(`EXDEV`) → scratch-buffer lookup (`ENOTSUP` for non-scratch names — the
+canonical files aren't renamable) → target-name guard (`.error` names the one
+writable target, `ENOTSUP`) → flush the bytes through the file's normal edit
+path (a transient file node with a dirty edit buffer, so frontmatter
+validation, read-your-writes verification, and `.error` handling all apply) →
+**adopt on {0, EIO}** → `InvalidateRenamed`. The adopt-on-EIO line is the
+policy, now written once: `Flush` returns `EIO` only on a fatal
+read-your-writes divergence, by which point the write has already reached
+Linear — refusing to adopt would keep serving stale content while `.error`
+explains the divergence. Lives in `internal/fs/renamesave.go`; each directory
+hands it a small spec (target name, error key, dir/file inos,
+scratch/flush/adopt closures). It depends only on the `renameSink` seam
+(ErrorSink + `InvalidateRenamed`, satisfied by `*LinearFS` through the
+writeFeedback and kernelNotify promotions), and the scratch lookup is a spec
+closure, so it is unit-tested with a recording sink — no FUSE mount, inode
+tree, SQLite, or API.
+
 ### Create tail (`commitCreate`)
 The **deep module** that owns the invariant tail of every create (`_create` writes and
 `mkdir`), the create path's counterpart to the WriteBack tail: run the caller's

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -176,43 +176,33 @@ func (i *InitiativeNode) Create(ctx context.Context, name string, flags uint32, 
 }
 
 // Rename persists an editor's atomic save: a scratch temp file renamed onto
-// initiative.md is written through initiative.md's normal Flush path.
-// initiative.md is the only writable file here, so other targets are rejected.
+// initiative.md is written through initiative.md's normal Flush path. The tail
+// (EXDEV / target guard / flush / adopt-on-{0,EIO} / invalidate) is the shared
+// renameSave module.
 func (i *InitiativeNode) Rename(ctx context.Context, name string, newParent fs.InodeEmbedder, newName string, flags uint32) syscall.Errno {
 	initiative := i.entity()
 	if i.lfs.debug {
 		log.Printf("Rename in initiative %s: %s -> %s", initiative.Name, name, newName)
 	}
 
-	dirIno := i.EmbeddedInode().StableAttr().Ino
-	if newParent.EmbeddedInode().StableAttr().Ino != dirIno {
-		return syscall.EXDEV
-	}
-
-	content, ok := scratchRenameBytes(i, name)
-	if !ok {
-		return syscall.ENOTSUP
-	}
-
-	if newName != "initiative.md" {
-		i.lfs.SetWriteError(initiative.ID, fmt.Sprintf("Operation: rename %s -> %s\nError: only initiative.md is writable in this directory; save your changes onto initiative.md (atomic save-via-rename onto initiative.md is supported).", name, newName))
-		return syscall.ENOTSUP
-	}
-
-	fileNode := &InitiativeInfoNode{
-		BaseNode:     BaseNode{lfs: i.lfs},
-		initiative:   initiative,
-		initiativeID: initiative.ID,
-		editBuffer:   editBuffer{content: content, dirty: true},
-	}
-	errno := fileNode.Flush(ctx, nil)
-
-	if errno == 0 || errno == syscall.EIO {
-		i.setEntity(fileNode.initiative)
-		i.lfs.InvalidateRenamed(dirIno, name, newName, initiativeInfoIno(fileNode.initiative.ID))
-	}
-
-	return errno
+	var fileNode *InitiativeInfoNode
+	return renameSave(ctx, i.lfs, name, newParent, newName, renameSaveSpec{
+		targetName: "initiative.md",
+		errKey:     initiative.ID,
+		dirIno:     i.EmbeddedInode().StableAttr().Ino,
+		fileIno:    initiativeInfoIno(initiative.ID),
+		scratch:    func(oldName string) ([]byte, bool) { return scratchRenameBytes(i, oldName) },
+		flush: func(ctx context.Context, content []byte) syscall.Errno {
+			fileNode = &InitiativeInfoNode{
+				BaseNode:     BaseNode{lfs: i.lfs},
+				initiative:   initiative,
+				initiativeID: initiative.ID,
+				editBuffer:   editBuffer{content: content, dirty: true},
+			}
+			return fileNode.Flush(ctx, nil)
+		},
+		adopt: func() { i.setEntity(fileNode.initiative) },
+	})
 }
 
 // Unlink lets editors clean up an abandoned atomic-save temp file. Only scratch

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -3,7 +3,6 @@ package fs
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log"
 	"strings"
 	"syscall"
@@ -410,58 +409,33 @@ func (n *IssueDirectoryNode) Create(ctx context.Context, name string, flags uint
 	return newScratchInode(ctx, &n.BaseNode, issueDirIno(issue.ID), name, out)
 }
 
-// Rename persists an editor's atomic save: when a scratch temp file is renamed
-// onto issue.md, its buffered bytes are written through the same path a direct
-// in-place edit uses (frontmatter validation, read-your-writes verification,
-// .error handling, cache invalidation). issue.md is the only writable file here,
-// so renames onto any other target — or of the canonical files themselves — are
-// rejected.
+// Rename persists an editor's atomic save: a scratch temp file renamed onto
+// issue.md is written through issue.md's normal Flush path. The tail (EXDEV /
+// target guard / flush / adopt-on-{0,EIO} / invalidate) is the shared
+// renameSave module.
 func (n *IssueDirectoryNode) Rename(ctx context.Context, name string, newParent fs.InodeEmbedder, newName string, flags uint32) syscall.Errno {
 	issue := n.entity()
 	if n.lfs.debug {
 		log.Printf("Rename in %s: %s -> %s", issue.Identifier, name, newName)
 	}
 
-	// The atomic-save pattern keeps the temp file a sibling of issue.md.
-	if newParent.EmbeddedInode().StableAttr().Ino != n.EmbeddedInode().StableAttr().Ino {
-		return syscall.EXDEV
-	}
-
-	content, ok := scratchRenameBytes(n, name)
-	if !ok {
-		// name isn't a scratch file we created — e.g. an attempt to rename issue.md
-		// itself. The canonical files aren't renamable.
-		return syscall.ENOTSUP
-	}
-
-	if newName != "issue.md" {
-		// A scratch file only has somewhere to persist when renamed onto issue.md,
-		// the one editable file in this directory.
-		n.lfs.SetIssueError(issue.ID, fmt.Sprintf("Operation: rename %s -> %s\nError: only issue.md is writable in this directory; save your changes onto issue.md (atomic save-via-rename onto issue.md is supported).", name, newName))
-		return syscall.ENOTSUP
-	}
-
-	// Route the buffered bytes through the normal issue write path via a transient
-	// file node. Flush returns 0 on success, EINVAL on a parse/validation error,
-	// and EIO only on a fatal read-your-writes divergence (the write still reached
-	// Linear in that case).
-	fileNode := &IssueFileNode{
-		BaseNode:   BaseNode{lfs: n.lfs},
-		issue:      issue,
-		editBuffer: editBuffer{content: content, dirty: true},
-	}
-	errno := fileNode.Flush(ctx, nil)
-
-	if errno == 0 || errno == syscall.EIO {
-		// The write reached Linear. Adopt the fresh issue so issue.md re-renders the
-		// stored content, and drop the kernel caches: go-fuse will MvChild the spent
-		// scratch inode over issue.md, so issue.md must re-Lookup to a fresh
-		// IssueFileNode rather than serve the consumed scratch node.
-		n.setEntity(fileNode.issue)
-		n.lfs.InvalidateRenamed(issueDirIno(fileNode.issue.ID), name, newName, issueIno(fileNode.issue.ID))
-	}
-
-	return errno
+	var fileNode *IssueFileNode
+	return renameSave(ctx, n.lfs, name, newParent, newName, renameSaveSpec{
+		targetName: "issue.md",
+		errKey:     issue.ID,
+		dirIno:     n.EmbeddedInode().StableAttr().Ino,
+		fileIno:    issueIno(issue.ID),
+		scratch:    func(oldName string) ([]byte, bool) { return scratchRenameBytes(n, oldName) },
+		flush: func(ctx context.Context, content []byte) syscall.Errno {
+			fileNode = &IssueFileNode{
+				BaseNode:   BaseNode{lfs: n.lfs},
+				issue:      issue,
+				editBuffer: editBuffer{content: content, dirty: true},
+			}
+			return fileNode.Flush(ctx, nil)
+		},
+		adopt: func() { n.setEntity(fileNode.issue) },
+	})
 }
 
 // Unlink lets editors clean up an abandoned atomic-save temp file (when a save

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -296,43 +296,33 @@ func (p *ProjectNode) Create(ctx context.Context, name string, flags uint32, mod
 }
 
 // Rename persists an editor's atomic save: a scratch temp file renamed onto
-// project.md is written through project.md's normal Flush path. project.md is the
-// only writable file here, so other rename targets are rejected.
+// project.md is written through project.md's normal Flush path. The tail (EXDEV /
+// target guard / flush / adopt-on-{0,EIO} / invalidate) is the shared
+// renameSave module.
 func (p *ProjectNode) Rename(ctx context.Context, name string, newParent fs.InodeEmbedder, newName string, flags uint32) syscall.Errno {
 	team, project := p.entity()
 	if p.lfs.debug {
 		log.Printf("Rename in project %s: %s -> %s", project.Name, name, newName)
 	}
 
-	dirIno := p.EmbeddedInode().StableAttr().Ino
-	if newParent.EmbeddedInode().StableAttr().Ino != dirIno {
-		return syscall.EXDEV
-	}
-
-	content, ok := scratchRenameBytes(p, name)
-	if !ok {
-		return syscall.ENOTSUP
-	}
-
-	if newName != "project.md" {
-		p.lfs.SetWriteError(project.ID, fmt.Sprintf("Operation: rename %s -> %s\nError: only project.md is writable in this directory; save your changes onto project.md (atomic save-via-rename onto project.md is supported).", name, newName))
-		return syscall.ENOTSUP
-	}
-
-	fileNode := &ProjectInfoNode{
-		BaseNode:   BaseNode{lfs: p.lfs},
-		team:       team,
-		project:    project,
-		editBuffer: editBuffer{content: content, dirty: true},
-	}
-	errno := fileNode.Flush(ctx, nil)
-
-	if errno == 0 || errno == syscall.EIO {
-		p.setEntity(fileNode.project)
-		p.lfs.InvalidateRenamed(dirIno, name, newName, projectInfoIno(fileNode.project.ID))
-	}
-
-	return errno
+	var fileNode *ProjectInfoNode
+	return renameSave(ctx, p.lfs, name, newParent, newName, renameSaveSpec{
+		targetName: "project.md",
+		errKey:     project.ID,
+		dirIno:     p.EmbeddedInode().StableAttr().Ino,
+		fileIno:    projectInfoIno(project.ID),
+		scratch:    func(oldName string) ([]byte, bool) { return scratchRenameBytes(p, oldName) },
+		flush: func(ctx context.Context, content []byte) syscall.Errno {
+			fileNode = &ProjectInfoNode{
+				BaseNode:   BaseNode{lfs: p.lfs},
+				team:       team,
+				project:    project,
+				editBuffer: editBuffer{content: content, dirty: true},
+			}
+			return fileNode.Flush(ctx, nil)
+		},
+		adopt: func() { p.setEntity(fileNode.project) },
+	})
 }
 
 // Unlink lets editors clean up an abandoned atomic-save temp file. Only scratch

--- a/internal/fs/renamesave.go
+++ b/internal/fs/renamesave.go
@@ -1,0 +1,116 @@
+package fs
+
+import (
+	"context"
+	"fmt"
+	"syscall"
+
+	"github.com/hanwen/go-fuse/v2/fs"
+)
+
+// The atomic-save Rename tail.
+//
+// Editors and the Claude Code Edit/Write tools never write a file in place:
+// they write a sibling scratch temp file (atomicwrite.go, #145) and rename(2)
+// it over the canonical .md. The three entity directories that accept this
+// (issues/{ID}, projects/{slug}, initiatives/{slug}) each ended their Rename
+// handler with the same hand-copied tail: same-directory check → scratch-buffer
+// lookup → target-name guard → flush the buffered bytes through the file's
+// normal edit path → adopt the flushed entity → kernel-cache coherence. The
+// subtlest line — adopt even on EIO — was restated three times and tested
+// nowhere.
+//
+// renameSave is the module that owns that tail, the rename-shaped sibling of
+// commitWriteBack (editcommit.go) in the edit-path family. Each directory keeps
+// a per-entity spec (which file is writable, how to flush, how to adopt); the
+// policy lives here once. It depends only on the renameSink seam plus the
+// spec's closures — the scratch lookup is a closure too, so the tail needs no
+// inode tree — and is unit-tested with a recording sink and stub closures: no
+// FUSE mount, SQLite, or API.
+
+// renameSink is the minimal surface the atomic-save tail needs: .error
+// reporting for the wrong-target guard and the kernel-cache coherence policy
+// for the consumed scratch entry. *LinearFS satisfies it directly (writeFeedback
+// and kernelNotify promotions), so production wiring needs no adapter while
+// tests inject a fake.
+type renameSink interface {
+	errorSink
+	InvalidateRenamed(dirIno uint64, oldName, newName string, fileIno uint64)
+}
+
+// renameSaveSpec describes the per-entity parts of an atomic save. Everything
+// entity-specific lives in these fields and closures; the tail itself is
+// entity-neutral.
+type renameSaveSpec struct {
+	// targetName is the one writable file in the directory ("issue.md",
+	// "project.md", "initiative.md") — the only rename destination a scratch
+	// buffer has somewhere to persist to.
+	targetName string
+	// errKey identifies the entity's .error file for the wrong-target message
+	// (the entity ID).
+	errKey string
+	// dirIno is the entity directory's inode. The EXDEV same-directory check
+	// and the rename invalidation both key off it.
+	dirIno uint64
+	// fileIno is the canonical file's inode, dropped after a persisted save so
+	// the file re-Looks-up to a fresh node instead of serving the spent scratch
+	// inode go-fuse moved into place.
+	fileIno uint64
+	// scratch reports the buffered contents of the scratch file named name, and
+	// whether name refers to a scratch file this filesystem created.
+	// scratchRenameBytes(dir, name) in production; a seam so the tail is
+	// testable without an inode tree.
+	scratch func(name string) ([]byte, bool)
+	// flush routes the scratch bytes through the entity file's normal edit path:
+	// construct a transient file node with a dirty editBuffer and Flush it
+	// (frontmatter validation, read-your-writes verification, .error handling,
+	// cache invalidation). The closure captures the transient node so adopt can
+	// read the flushed entity back.
+	flush func(ctx context.Context, content []byte) syscall.Errno
+	// adopt stores the flushed node's fresh entity on the directory node so the
+	// canonical file re-renders the persisted content. Called exactly when the
+	// write reached Linear — flush errno 0 or EIO (see renameSave).
+	adopt func()
+}
+
+// renameSave persists an editor's atomic save: when a scratch temp file is
+// renamed onto spec.targetName, its buffered bytes are written through the same
+// path a direct in-place edit uses. The canonical file is the only writable
+// file in the directory, so renames onto any other target — or of the canonical
+// files themselves — are rejected.
+func renameSave(ctx context.Context, sink renameSink, name string, newParent fs.InodeEmbedder, newName string, spec renameSaveSpec) syscall.Errno {
+	// The atomic-save pattern keeps the temp file a sibling of the canonical file.
+	if newParent.EmbeddedInode().StableAttr().Ino != spec.dirIno {
+		return syscall.EXDEV
+	}
+
+	content, ok := spec.scratch(name)
+	if !ok {
+		// name isn't a scratch file we created — e.g. an attempt to rename the
+		// canonical .md itself. The canonical files aren't renamable.
+		return syscall.ENOTSUP
+	}
+
+	if newName != spec.targetName {
+		// A scratch file only has somewhere to persist when renamed onto the one
+		// editable file in this directory.
+		sink.SetWriteError(spec.errKey, fmt.Sprintf("Operation: rename %s -> %s\nError: only %s is writable in this directory; save your changes onto %s (atomic save-via-rename onto %s is supported).", name, newName, spec.targetName, spec.targetName, spec.targetName))
+		return syscall.ENOTSUP
+	}
+
+	errno := spec.flush(ctx, content)
+
+	if errno == 0 || errno == syscall.EIO {
+		// Adopt on EIO too: Flush returns EIO only on a fatal read-your-writes
+		// divergence, and by then the write has already reached Linear. Refusing
+		// to adopt would keep serving stale content while .error explains the
+		// divergence. Adopt the fresh entity so the canonical file re-renders
+		// the stored content, and drop the kernel caches: go-fuse will MvChild
+		// the spent scratch inode over the canonical file, so the file must
+		// re-Lookup to a fresh node rather than serve the consumed scratch node.
+		spec.adopt()
+		sink.InvalidateRenamed(spec.dirIno, name, newName, spec.fileIno)
+	}
+
+	return errno
+}

--- a/internal/fs/renamesave_test.go
+++ b/internal/fs/renamesave_test.go
@@ -1,0 +1,195 @@
+package fs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/hanwen/go-fuse/v2/fs"
+)
+
+// renameRecorder records the sink interactions so a test can assert what the
+// tail did without a LinearFS or a FUSE mount. It satisfies renameSink.
+type renameRecorder struct {
+	setKey, setMsg string
+	sets           int
+	clears         int
+	invalidates    []string
+}
+
+func (r *renameRecorder) SetWriteError(key, message string) {
+	r.setKey, r.setMsg = key, message
+	r.sets++
+}
+func (r *renameRecorder) ClearWriteError(key string) { r.clears++ }
+func (r *renameRecorder) InvalidateRenamed(dirIno uint64, oldName, newName string, fileIno uint64) {
+	r.invalidates = append(r.invalidates,
+		fmt.Sprintf("renamed(%d,%q,%q,%d)", dirIno, oldName, newName, fileIno))
+}
+
+// renameParent is a bare InodeEmbedder whose zero-value inode has ino 0, so a
+// spec with dirIno 0 reads as "same directory" and any nonzero dirIno as a
+// cross-directory rename — no inode tree needed.
+type renameParent struct{ fs.Inode }
+
+// recordingRenameSpec builds a spec whose closures record their calls.
+type recordingRenameSpec struct {
+	spec         renameSaveSpec
+	scratchCalls int
+	flushCalls   int
+	flushContent []byte
+	adoptCalls   int
+}
+
+func newRecordingRenameSpec(scratchOK bool, flushErrno syscall.Errno) *recordingRenameSpec {
+	r := &recordingRenameSpec{}
+	r.spec = renameSaveSpec{
+		targetName: "issue.md",
+		errKey:     "issue-1",
+		dirIno:     0, // matches the zero-value renameParent inode
+		fileIno:    99,
+		scratch: func(name string) ([]byte, bool) {
+			r.scratchCalls++
+			return []byte("scratch bytes"), scratchOK
+		},
+		flush: func(ctx context.Context, content []byte) syscall.Errno {
+			r.flushCalls++
+			r.flushContent = content
+			return flushErrno
+		},
+		adopt: func() { r.adoptCalls++ },
+	}
+	return r
+}
+
+func TestRenameSave_FlushOutcomes(t *testing.T) {
+	cases := []struct {
+		name            string
+		flushErrno      syscall.Errno
+		wantAdopts      int
+		wantInvalidates int
+	}{
+		// A clean save adopts the fresh entity and drops the kernel caches.
+		{"flush success adopts and invalidates", 0, 1, 1},
+		// The policy under test: Flush returns EIO only on a fatal
+		// read-your-writes divergence — the write still reached Linear, so the
+		// fresh entity is adopted (refusing would serve stale content while
+		// .error explains the divergence).
+		{"flush EIO still adopts and invalidates", syscall.EIO, 1, 1},
+		// EINVAL means the write never reached Linear (parse/validation
+		// failure): nothing to adopt, nothing to invalidate.
+		{"flush EINVAL adopts nothing", syscall.EINVAL, 0, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &renameRecorder{}
+			rec := newRecordingRenameSpec(true, tc.flushErrno)
+
+			errno := renameSave(context.Background(), sink, "issue.md.tmp.1",
+				&renameParent{}, "issue.md", rec.spec)
+
+			if errno != tc.flushErrno {
+				t.Errorf("errno = %v, want %v", errno, tc.flushErrno)
+			}
+			if rec.flushCalls != 1 {
+				t.Errorf("flush calls = %d, want 1", rec.flushCalls)
+			}
+			if string(rec.flushContent) != "scratch bytes" {
+				t.Errorf("flush content = %q, want the scratch buffer", rec.flushContent)
+			}
+			if rec.adoptCalls != tc.wantAdopts {
+				t.Errorf("adopt calls = %d, want %d", rec.adoptCalls, tc.wantAdopts)
+			}
+			if len(sink.invalidates) != tc.wantInvalidates {
+				t.Fatalf("invalidates = %v, want %d call(s)", sink.invalidates, tc.wantInvalidates)
+			}
+			if tc.wantInvalidates == 1 {
+				want := `renamed(0,"issue.md.tmp.1","issue.md",99)`
+				if sink.invalidates[0] != want {
+					t.Errorf("invalidate = %q, want %q", sink.invalidates[0], want)
+				}
+			}
+			if sink.sets != 0 {
+				t.Errorf("SetWriteError calls = %d, want 0", sink.sets)
+			}
+		})
+	}
+}
+
+func TestRenameSave_WrongTarget(t *testing.T) {
+	sink := &renameRecorder{}
+	rec := newRecordingRenameSpec(true, 0)
+
+	errno := renameSave(context.Background(), sink, "issue.md.tmp.1",
+		&renameParent{}, "notes.md", rec.spec)
+
+	if errno != syscall.ENOTSUP {
+		t.Errorf("errno = %v, want ENOTSUP", errno)
+	}
+	if sink.sets != 1 || sink.setKey != "issue-1" {
+		t.Fatalf("SetWriteError calls = %d (key %q), want 1 on %q", sink.sets, sink.setKey, "issue-1")
+	}
+	// The .error message must name the one writable target so an agent knows
+	// where to save.
+	if !strings.Contains(sink.setMsg, "only issue.md is writable") {
+		t.Errorf(".error message %q does not name the writable target", sink.setMsg)
+	}
+	if !strings.Contains(sink.setMsg, "rename issue.md.tmp.1 -> notes.md") {
+		t.Errorf(".error message %q does not describe the rejected rename", sink.setMsg)
+	}
+	if rec.flushCalls != 0 || rec.adoptCalls != 0 || len(sink.invalidates) != 0 {
+		t.Errorf("wrong target must stop before flush: flush=%d adopt=%d invalidates=%v",
+			rec.flushCalls, rec.adoptCalls, sink.invalidates)
+	}
+}
+
+func TestRenameSave_CrossDirectory(t *testing.T) {
+	sink := &renameRecorder{}
+	rec := newRecordingRenameSpec(true, 0)
+	// The zero-value parent inode has ino 0; a nonzero dirIno makes the rename
+	// cross-directory.
+	rec.spec.dirIno = 7
+
+	errno := renameSave(context.Background(), sink, "issue.md.tmp.1",
+		&renameParent{}, "issue.md", rec.spec)
+
+	if errno != syscall.EXDEV {
+		t.Errorf("errno = %v, want EXDEV", errno)
+	}
+	if rec.scratchCalls != 0 || rec.flushCalls != 0 || rec.adoptCalls != 0 {
+		t.Errorf("cross-directory rename must stop first: scratch=%d flush=%d adopt=%d",
+			rec.scratchCalls, rec.flushCalls, rec.adoptCalls)
+	}
+	if sink.sets != 0 || len(sink.invalidates) != 0 {
+		t.Errorf("cross-directory rename must touch nothing: sets=%d invalidates=%v",
+			sink.sets, sink.invalidates)
+	}
+}
+
+func TestRenameSave_NotAScratchFile(t *testing.T) {
+	sink := &renameRecorder{}
+	// e.g. an attempt to rename issue.md itself: the canonical files aren't
+	// renamable, and no .error is recorded (there is nothing to persist).
+	rec := newRecordingRenameSpec(false, 0)
+
+	errno := renameSave(context.Background(), sink, "issue.md",
+		&renameParent{}, "renamed.md", rec.spec)
+
+	if errno != syscall.ENOTSUP {
+		t.Errorf("errno = %v, want ENOTSUP", errno)
+	}
+	if rec.scratchCalls != 1 {
+		t.Errorf("scratch calls = %d, want 1", rec.scratchCalls)
+	}
+	if rec.flushCalls != 0 || rec.adoptCalls != 0 {
+		t.Errorf("non-scratch rename must stop before flush: flush=%d adopt=%d",
+			rec.flushCalls, rec.adoptCalls)
+	}
+	if sink.sets != 0 || len(sink.invalidates) != 0 {
+		t.Errorf("non-scratch rename must touch nothing: sets=%d invalidates=%v",
+			sink.sets, sink.invalidates)
+	}
+}


### PR DESCRIPTION
## The friction

An editor's atomic save (scratch temp file renamed onto the canonical `.md`) ran an invariant tail hand-copied across three entity directories:

- `IssueDirectoryNode.Rename` → `issue.md` (internal/fs/issues.go)
- `ProjectNode.Rename` → `project.md` (internal/fs/projects.go)
- `InitiativeNode.Rename` → `initiative.md` (internal/fs/initiatives.go)

The tail: same-dir check (`EXDEV`) → `scratchRenameBytes` → target-name guard (`.error` naming the one writable target, `ENOTSUP`) → transient file node with a dirty `editBuffer` → `Flush` → **adopt-on-{0, EIO}** → `InvalidateRenamed`. The subtlest line — the EIO-adopt policy — was restated three times, and the flush-adopt-invalidate sequence had zero dedicated tests.

## The EIO-adopt policy, written once

`Flush` returns `EIO` only on a fatal read-your-writes divergence — by which point the write has already **reached Linear**. Refusing to adopt would keep serving stale content while `.error` explains the divergence, so the fresh entity is adopted and the kernel caches dropped even on `EIO`. That comment now lives in exactly one place, `renameSave` (internal/fs/renamesave.go), the rename-shaped sibling of `commitWriteBack` in the edit-path family.

Each directory now hands the module a small `renameSaveSpec` (target name, error key, dir/file inos, scratch/flush/adopt closures); the three `Rename` methods shrink to spec constructions. The module depends only on the `renameSink` seam (`errorSink` + `InvalidateRenamed`, satisfied by `*LinearFS` through the writeFeedback/kernelNotify promotions), and the scratch lookup is a spec closure — so the tail needs no inode tree.

Behavior-preserving: same errnos, same `.error` wording, same debug logs, same invalidation (the issue site's `issueDirIno(issue.ID)` equals its live dir ino; `SetIssueError` is a `SetWriteError` alias, so all three sites were already keying the same error store).

## Test coverage (renamesave_test.go — recording sink, no FUSE mount)

- flush `0` → adopt called, `InvalidateRenamed(dir, old, new, fileIno)` fired, errno 0, flush received the scratch bytes
- flush `EIO` → adopt **still** called (the policy), invalidate fired, errno `EIO`
- flush `EINVAL` → adopt not called, no invalidate, errno `EINVAL`
- wrong `newName` → `.error` set with a message naming the writable target, `ENOTSUP`, flush never called
- different parent dir → `EXDEV`, nothing else runs (scratch never consulted)
- name not a scratch file → `ENOTSUP`, nothing recorded

Verified: `make build`, `go vet ./...`, `gofmt -l internal/` clean, full `go test ./...` green including the FUSE integration suite (which exercises the live atomic-save path end-to-end).

CONTEXT.md gains a "Rename save (`renameSave`)" entry next to the WriteBack tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)