### PR TITLE
ci: bump setup-go to 1.25 to match go.mod

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.25'
 
       - name: Install FUSE
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.25'
 
       - name: Run unit tests
         run: go test -v -race ./...
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.25'
 
       - name: Install FUSE
         run: |
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.25'
 
       - name: Install FUSE
         run: |


### PR DESCRIPTION
PR #207's otel dependency raised go.mod's go directive to 1.25.0; CI's pinned 1.22 broke the coverage step ('go: no such tool "covdata"') after the implicit GOTOOLCHAIN switch — all tests passed, only the tooling failed. This PR's own run is the proof of the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)