### PR TITLE
feat(telemetry): sync+SWR instruments — the budget's consumers (phase 3 of #206)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -882,7 +882,11 @@ reads stale, and retriggers. The four doc/update tails run
 prune for these fetches — and convert errors now log-and-mark-unclean
 instead of a silent `continue`). The repo constructs its
 `reconcile.Extractor{Q, AuthHeader}` only when it has a client; fixture mode
-leaves `Deps.Extract` nil, which skips extraction.
+leaves `Deps.Extract` nil, which skips extraction. The coordinator also
+emits the SWR metrics (`linearfs.swr.triggers{kind,decision}` at the
+staleness check and `triggerBackgroundRefresh`'s three exits — which now
+takes the `refreshKind` and mints the dedup key itself — and
+`.refresh_outcomes{kind,outcome}` from the refresh goroutine).
 
 ### Detail sync outcome (`syncDetails`)
 The single entry point for issue-detail syncing (`internal/sync/worker.go`):
@@ -906,7 +910,9 @@ unclean issue — or one missing from the response, a trap for a violation of
 flow — is re-enqueued, un-stamped. The hazard class this closes: **an issue
 silently dropped or partially persisted must never be stamped fresh** (a
 stamp would mask its staleness from the SWR path until the next real change)
-**nor lose its retry**.
+**nor lose its retry**. The ledger also feeds the
+`linearfs.sync.detail_outcomes{outcome}` counter — gate paths included, so
+every issue leaving `syncDetails` is counted exactly once.
 
 The stamp's arrival also deleted `syncTeamIssues`' touch-on-unchanged block —
 under event-driven staleness an unchanged issue is fresh by definition
@@ -1053,7 +1059,23 @@ per-op series would blow up one line, `renderSummary` projects every
 attribute set onto a keep-list (`summaryAttrKeys`:
 outcome/decision/tier/axis/… — `op` is projected away and the collided
 series merged); the full-cardinality data is the JSONL export's job. Phase 3
-(sync + SWR instruments) still pending. Spec:
+completed the set with the budget's consumers, so leak and leaker share one
+view: `linearfs.sync.cycle_duration` (one sample per `syncAllTeams` cycle,
+budget-skipped cycles included — a burst of ~0s samples IS the skip
+signature), `.detail_outcomes{outcome=synced|deferred}` (the `syncDetails`
+ledger; gate paths fold in, every issue counted exactly once),
+`.prunes{collection}` (recorded inside `reconcile.Collection` when a prune
+actually executes — the attribute is the new `CollectionSpec.Kind` closed
+enum, never `Label`, which embeds issue IDs), `.pending_depth` (an
+observable `COUNT(*)` of `pending_detail_sync`, registered at Worker
+construction), and `linearfs.swr.triggers{kind,
+decision=triggered|fresh|deduped|sem_dropped}` /
+`.refresh_outcomes{kind, outcome=ok|error|orphaned}` bound at
+`SQLiteRepository` construction (kind = the six `refreshKind` constants).
+The sync instruments bind at Worker construction; `prunes` binds lazily on
+the first firing prune (the reconcile package has no construction point);
+the shared must-create helpers live in `telemetry/instruments.go`. That
+completes the metrics project (#206) — all three phases shipped. Spec:
 `docs/plans/2026-07-08-otel-metrics-design.md`.
 
 ### Repository read path (deliberately concrete — no interface)

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -943,5 +943,8 @@ DELETE FROM pending_detail_sync WHERE issue_id = ?;
 -- name: ListPendingDetailSync :many
 SELECT issue_id, identifier FROM pending_detail_sync ORDER BY queued_at;
 
+-- name: CountPendingDetailSync :one
+SELECT COUNT(*) FROM pending_detail_sync;
+
 -- name: ClearPendingDetailSync :exec
 DELETE FROM pending_detail_sync;

--- a/internal/db/queries.sql.go
+++ b/internal/db/queries.sql.go
@@ -21,6 +21,17 @@ func (q *Queries) ClearPendingDetailSync(ctx context.Context) error {
 	return err
 }
 
+const countPendingDetailSync = `-- name: CountPendingDetailSync :one
+SELECT COUNT(*) FROM pending_detail_sync
+`
+
+func (q *Queries) CountPendingDetailSync(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countPendingDetailSync)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const deleteAttachment = `-- name: DeleteAttachment :exec
 DELETE FROM attachments WHERE id = ?
 `

--- a/internal/reconcile/collection.go
+++ b/internal/reconcile/collection.go
@@ -9,13 +9,29 @@ package reconcile
 import (
 	"context"
 	"log"
+	"sync"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/jra3/linear-fuse/internal/telemetry"
 )
 
 // CollectionSpec declares how one collection reconciles into SQLite.
 // See CONTEXT.md "Sync reconcile tail (syncCollection)".
 type CollectionSpec[T any] struct {
 	// Label names the collection in log lines ("label", "cycle", "project", …).
+	// The detail labels embed the issue ID ("comment <id>"), so Label must
+	// NEVER become a metric attribute — that cardinality is unbounded.
 	Label string
+
+	// Kind is the collection's closed-enum name for the linearfs.sync.prunes
+	// metric attribute: state|label|cycle|project|member|initiative-project|
+	// project-label|comment|document|attachment|relation|inverse-relation
+	// (plus the repo's upsert-only update kinds, which never prune). Bounded
+	// by construction — every caller sets a constant string, never an ID.
+	Kind string
 
 	// Items is the complete, drained server-side set to reconcile. Completeness
 	// is what licenses prune — a truncated fetch would read as removals.
@@ -64,6 +80,29 @@ func Collection[T any](ctx context.Context, spec CollectionSpec[T]) (clean bool)
 	}
 	if err := spec.Prune(ctx); err != nil {
 		log.Printf("[reconcile] prune %s failed: %v", spec.Label, err)
+	} else {
+		prunesCounter().Add(ctx, 1, metric.WithAttributes(
+			attribute.String("collection", spec.Kind)))
 	}
 	return clean
+}
+
+// prunes is the linearfs.sync.prunes counter — a prune that actually
+// executed is the destructive half of the reconcile contract, so it is the
+// one worth counting (a suppressed prune records nothing). The package has
+// no construction point, so the instrument binds lazily on the first firing
+// prune; in production that is long after telemetry.Init registered the
+// provider, and without one the global no-op makes every Add free.
+var (
+	prunesOnce sync.Once
+	prunes     metric.Int64Counter
+)
+
+func prunesCounter() metric.Int64Counter {
+	prunesOnce.Do(func() {
+		prunes = telemetry.MustInt64Counter(otel.Meter("linearfs/sync"),
+			"linearfs.sync.prunes",
+			metric.WithDescription("Reconcile prunes that actually executed, by collection kind"))
+	})
+	return prunes
 }

--- a/internal/reconcile/details.go
+++ b/internal/reconcile/details.go
@@ -53,6 +53,7 @@ func PersistIssueDetails(ctx context.Context, deps Deps, issueID string, details
 
 	clean = Collection(ctx, CollectionSpec[api.Comment]{
 		Label: "comment " + issueID,
+		Kind:  "comment",
 		Items: details.Comments,
 		Upsert: func(ctx context.Context, comment api.Comment) error {
 			params, err := db.APICommentToDBComment(comment, issueID)
@@ -76,6 +77,7 @@ func PersistIssueDetails(ctx context.Context, deps Deps, issueID string, details
 
 	clean = Collection(ctx, CollectionSpec[api.Document]{
 		Label: "document " + issueID,
+		Kind:  "document",
 		Items: details.Documents,
 		Upsert: func(ctx context.Context, doc api.Document) error {
 			params, err := db.APIDocumentToDBDocument(doc)
@@ -91,6 +93,7 @@ func PersistIssueDetails(ctx context.Context, deps Deps, issueID string, details
 
 	clean = Collection(ctx, CollectionSpec[api.Attachment]{
 		Label: "attachment " + issueID,
+		Kind:  "attachment",
 		Items: details.Attachments,
 		Upsert: func(ctx context.Context, attachment api.Attachment) error {
 			params, err := db.APIAttachmentToDBAttachment(attachment, issueID)
@@ -110,6 +113,7 @@ func PersistIssueDetails(ctx context.Context, deps Deps, issueID string, details
 	// .rel file and one deleted there lingered as a phantom.
 	clean = Collection(ctx, CollectionSpec[api.IssueRelation]{
 		Label: "relation " + issueID,
+		Kind:  "relation",
 		Items: details.Relations,
 		Upsert: func(ctx context.Context, rel api.IssueRelation) error {
 			if rel.RelatedIssue == nil {
@@ -130,6 +134,7 @@ func PersistIssueDetails(ctx context.Context, deps Deps, issueID string, details
 	// this collection is upsert-only, like states.
 	clean = Collection(ctx, CollectionSpec[api.IssueRelation]{
 		Label: "inverse relation " + issueID,
+		Kind:  "inverse-relation",
 		Items: details.InverseRelations,
 		Upsert: func(ctx context.Context, rel api.IssueRelation) error {
 			if rel.Issue == nil {

--- a/internal/reconcile/metrics_test.go
+++ b/internal/reconcile/metrics_test.go
@@ -1,0 +1,94 @@
+package reconcile
+
+// Prune-counter tests. The linearfs.sync.prunes instrument binds lazily on
+// the first firing prune (the package has no construction point), so unlike
+// the api/sync/repo metrics tests — which install a fresh provider per test —
+// this package installs ONE manual-reader provider for the whole binary in
+// TestMain, before any test can bind the instrument. Cross-test isolation
+// comes from the collection attribute: each test asserts on its own unique
+// Kind, so other tests' prunes (including the empty-Kind ones from
+// collection_test) can never collide with an assertion.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+var metricsReader *sdkmetric.ManualReader
+
+func TestMain(m *testing.M) {
+	metricsReader = sdkmetric.NewManualReader()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(metricsReader)))
+	os.Exit(m.Run())
+}
+
+// prunesValue returns the linearfs.sync.prunes count for one collection kind,
+// or 0 when no such datapoint has been recorded.
+func prunesValue(t *testing.T, kind string) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := metricsReader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "linearfs.sync.prunes" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("prunes data is %T, want Sum[int64]", m.Data)
+			}
+			for _, dp := range sum.DataPoints {
+				if v, ok := dp.Attributes.Value("collection"); ok && v.AsString() == kind {
+					return dp.Value
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// metricSpec builds a minimal spec whose prune succeeds unless told otherwise.
+func metricSpec(kind string, upsertErr, pruneErr error) CollectionSpec[string] {
+	return CollectionSpec[string]{
+		Label:  "metrics test " + kind,
+		Kind:   kind,
+		Items:  []string{"a"},
+		Upsert: func(context.Context, string) error { return upsertErr },
+		Prune:  func(context.Context) error { return pruneErr },
+	}
+}
+
+// TestCollectionPruneRecordsMetric: a prune that actually executes records one
+// linearfs.sync.prunes count under its collection kind.
+func TestCollectionPruneRecordsMetric(t *testing.T) {
+	Collection(context.Background(), metricSpec("kind-fires", nil, nil))
+	if got := prunesValue(t, "kind-fires"); got != 1 {
+		t.Errorf("prunes{collection=kind-fires} = %d, want 1", got)
+	}
+}
+
+// TestCollectionSuppressedPruneRecordsNothing: an unclean pass suppresses the
+// prune, so nothing is counted — the metric counts executed prunes only.
+func TestCollectionSuppressedPruneRecordsNothing(t *testing.T) {
+	Collection(context.Background(), metricSpec("kind-suppressed", errors.New("upsert boom"), nil))
+	if got := prunesValue(t, "kind-suppressed"); got != 0 {
+		t.Errorf("prunes{collection=kind-suppressed} = %d, want 0 (suppressed prune)", got)
+	}
+}
+
+// TestCollectionFailedPruneRecordsNothing: a prune that ran but failed did not
+// delete anything — it must not count as an executed prune.
+func TestCollectionFailedPruneRecordsNothing(t *testing.T) {
+	Collection(context.Background(), metricSpec("kind-prune-err", nil, errors.New("prune boom")))
+	if got := prunesValue(t, "kind-prune-err"); got != 0 {
+		t.Errorf("prunes{collection=kind-prune-err} = %d, want 0 (prune failed)", got)
+	}
+}

--- a/internal/repo/metrics.go
+++ b/internal/repo/metrics.go
@@ -1,0 +1,75 @@
+package repo
+
+// OTEL instruments for the SWR layer (phase 3 of the metrics design,
+// docs/plans/2026-07-08-otel-metrics-design.md). The SWR triggers were
+// literally round 18's budget leak, so this pair shows leak AND leaker next
+// to the budget gauges. Instruments bind once, at SQLiteRepository
+// construction, from the globally registered provider (otel.Meter); with no
+// provider the global no-op makes every record free.
+//
+// Cardinality: kind is the six refreshKind constants; decision and outcome
+// are the closed enums below. Nothing else becomes an attribute.
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/jra3/linear-fuse/internal/api"
+	"github.com/jra3/linear-fuse/internal/telemetry"
+)
+
+// swrMetrics holds the SWR instruments (meter "linearfs/swr"). The recording
+// methods tolerate the zero value (nil instruments record nothing): several
+// tests build SQLiteRepository by struct literal, and telemetry must never
+// panic a read path.
+type swrMetrics struct {
+	triggers        metric.Int64Counter // linearfs.swr.triggers {kind, decision}
+	refreshOutcomes metric.Int64Counter // linearfs.swr.refresh_outcomes {kind, outcome}
+}
+
+func newSWRMetrics() swrMetrics {
+	m := otel.Meter("linearfs/swr")
+	return swrMetrics{
+		triggers: telemetry.MustInt64Counter(m, "linearfs.swr.triggers",
+			metric.WithDescription("SWR staleness verdicts, by kind and decision (triggered|fresh|deduped|sem_dropped)")),
+		refreshOutcomes: telemetry.MustInt64Counter(m, "linearfs.swr.refresh_outcomes",
+			metric.WithDescription("Completed background refreshes, by kind and outcome (ok|error|orphaned)")),
+	}
+}
+
+// recordTrigger counts one staleness verdict. fresh means swrStale said no;
+// triggered/deduped/sem_dropped are triggerBackgroundRefresh's three exits.
+// The nil-client (fixture-mode) returns record nothing — there is no SWR
+// machinery to observe.
+func (m swrMetrics) recordTrigger(kind refreshKind, decision string) {
+	if m.triggers == nil {
+		return
+	}
+	m.triggers.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("kind", string(kind)),
+		attribute.String("decision", decision)))
+}
+
+// recordRefreshOutcome counts one completed background refresh. The outcome
+// mirrors the module's orphan classification (orphanOnNotFound): a
+// not-found-shaped error means the local rows were orphans (deleted), any
+// other error is error, nil is ok.
+func (m swrMetrics) recordRefreshOutcome(kind refreshKind, err error) {
+	if m.refreshOutcomes == nil {
+		return
+	}
+	outcome := "ok"
+	switch {
+	case err == nil:
+	case api.IsNotFound(err):
+		outcome = "orphaned"
+	default:
+		outcome = "error"
+	}
+	m.refreshOutcomes.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("kind", string(kind)),
+		attribute.String("outcome", outcome)))
+}

--- a/internal/repo/metrics_test.go
+++ b/internal/repo/metrics_test.go
@@ -1,0 +1,236 @@
+package repo
+
+// SWR-instrument tests (phase-2 pattern, see internal/api/metrics_test.go):
+// a manual-reader SDK provider is installed as the global otel provider, the
+// instruments are bound (newSWRMetrics), and the collected metricdata is
+// asserted by hand. The specs under test carry recording closures, so nothing
+// touches SQLite or the network (the swr_test.go precedent).
+//
+// These tests are deliberately NOT parallel: they swap the global meter
+// provider. TestMain pins the global to an explicit no-op first, so
+// repositories built by the package's other (parallel) tests can never be
+// delegated onto a test provider and pollute a collection.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	noopmetric "go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/jra3/linear-fuse/internal/api"
+)
+
+func TestMain(m *testing.M) {
+	otel.SetMeterProvider(noopmetric.NewMeterProvider())
+	os.Exit(m.Run())
+}
+
+// withTestMeter installs a fresh SDK provider as the global meter provider
+// and returns its manual reader. Cleanup restores the no-op provider.
+func withTestMeter(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	otel.SetMeterProvider(provider)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(noopmetric.NewMeterProvider())
+		_ = provider.Shutdown(context.Background())
+	})
+	return reader
+}
+
+// newMetricsTestRepo is newSWRTestRepo plus bound instruments — call it only
+// after withTestMeter so the instruments bind to the test provider.
+func newMetricsTestRepo(t *testing.T) *SQLiteRepository {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &SQLiteRepository{
+		client:             api.NewClient("test-key"),
+		stalenessThreshold: defaultStalenessThreshold,
+		refreshing:         make(map[string]bool),
+		refreshContext:     ctx,
+		refreshCancel:      cancel,
+		refreshSem:         make(chan struct{}, maxConcurrentRefreshes),
+		metrics:            newSWRMetrics(),
+	}
+	t.Cleanup(r.Close)
+	return r
+}
+
+// swrCounterValue returns the named counter's count for {kind, key2=val2}, or
+// -1 when no such datapoint (or the whole metric) exists.
+func swrCounterValue(t *testing.T, reader *sdkmetric.ManualReader, name string, kind refreshKind, attrKey, attrVal string) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("%s data is %T, want Sum[int64]", name, m.Data)
+			}
+			for _, dp := range sum.DataPoints {
+				k, kok := dp.Attributes.Value(attribute.Key("kind"))
+				v, vok := dp.Attributes.Value(attribute.Key(attrKey))
+				if kok && vok && k.AsString() == string(kind) && v.AsString() == attrVal {
+					return dp.Value
+				}
+			}
+		}
+	}
+	return -1
+}
+
+// waitForCounter polls the reader until the datapoint reaches want (the
+// refresh-outcome recordings happen inside the background goroutine, after
+// the test's refresh closure has already returned).
+func waitForCounter(t *testing.T, reader *sdkmetric.ManualReader, name string, kind refreshKind, attrKey, attrVal string, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if got := swrCounterValue(t, reader, name, kind, attrKey, attrVal); got == want {
+			return
+		} else if time.Now().After(deadline) {
+			t.Fatalf("%s{kind=%s,%s=%s} = %d, want %d (timed out)", name, kind, attrKey, attrVal, got, want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// staleSpec is an always-stale TTL spec (never synced) with the given refresh.
+func staleSpec(kind refreshKind, id string, refresh func(context.Context) error) swrSpec {
+	return swrSpec{
+		kind:     kind,
+		id:       id,
+		syncedAt: func() (interface{}, error) { return nil, nil },
+		refresh:  refresh,
+	}
+}
+
+// TestSWRTriggersCounter drives all four decisions: fresh (swrStale says no),
+// sem_dropped (semaphore full), triggered, and deduped (same key in flight).
+func TestSWRTriggersCounter(t *testing.T) {
+	reader := withTestMeter(t)
+	r := newMetricsTestRepo(t)
+
+	// fresh: recently synced TTL surface — the refresh must not fire.
+	r.maybeRefreshSWR(swrSpec{
+		kind:     kindProjectDocs,
+		id:       "p1",
+		syncedAt: func() (interface{}, error) { return time.Now(), nil },
+		refresh: func(context.Context) error {
+			t.Error("fresh spec fired a refresh")
+			return nil
+		},
+	})
+
+	// sem_dropped: fill the semaphore, then a stale spec is dropped.
+	for i := 0; i < maxConcurrentRefreshes; i++ {
+		r.refreshSem <- struct{}{}
+	}
+	r.maybeRefreshSWR(staleSpec(kindHistory, "h-dropped", func(context.Context) error {
+		t.Error("sem-dropped spec fired a refresh")
+		return nil
+	}))
+	for i := 0; i < maxConcurrentRefreshes; i++ {
+		<-r.refreshSem
+	}
+
+	// triggered, then deduped while the first is still in flight.
+	started := make(chan struct{})
+	block := make(chan struct{})
+	r.maybeRefreshSWR(staleSpec(kindHistory, "h1", func(context.Context) error {
+		close(started)
+		<-block
+		return nil
+	}))
+	<-started
+	r.maybeRefreshSWR(staleSpec(kindHistory, "h1", func(context.Context) error {
+		t.Error("deduped spec fired a second refresh")
+		return nil
+	}))
+	close(block)
+
+	for _, tc := range []struct {
+		kind     refreshKind
+		decision string
+		want     int64
+	}{
+		{kindProjectDocs, "fresh", 1},
+		{kindHistory, "sem_dropped", 1},
+		{kindHistory, "triggered", 1},
+		{kindHistory, "deduped", 1},
+	} {
+		if got := swrCounterValue(t, reader, "linearfs.swr.triggers", tc.kind, "decision", tc.decision); got != tc.want {
+			t.Errorf("triggers{kind=%s,decision=%s} = %d, want %d", tc.kind, tc.decision, got, tc.want)
+		}
+	}
+}
+
+// TestSWRRefreshOutcomesCounter: a nil-error refresh is ok, a not-found error
+// is orphaned (mirroring the module's orphan classification), anything else
+// is error.
+func TestSWRRefreshOutcomesCounter(t *testing.T) {
+	reader := withTestMeter(t)
+	r := newMetricsTestRepo(t)
+
+	r.maybeRefreshSWR(staleSpec(kindProjectDocs, "ok1", func(context.Context) error {
+		return nil
+	}))
+	r.maybeRefreshSWR(staleSpec(kindProjectUpdates, "err1", func(context.Context) error {
+		return errors.New("boom")
+	}))
+	orphaned := make(chan struct{}, 1)
+	spec := staleSpec(kindInitiativeDocs, "gone1", func(context.Context) error {
+		return fmt.Errorf("GraphQL error: Entity not found: Initiative")
+	})
+	spec.orphan = func(context.Context) { orphaned <- struct{}{} }
+	r.maybeRefreshSWR(spec)
+
+	waitForCounter(t, reader, "linearfs.swr.refresh_outcomes", kindProjectDocs, "outcome", "ok", 1)
+	waitForCounter(t, reader, "linearfs.swr.refresh_outcomes", kindProjectUpdates, "outcome", "error", 1)
+	waitForCounter(t, reader, "linearfs.swr.refresh_outcomes", kindInitiativeDocs, "outcome", "orphaned", 1)
+
+	// The orphaned outcome coincides with the module's orphan classification
+	// actually firing.
+	select {
+	case <-orphaned:
+	case <-time.After(2 * time.Second):
+		t.Error("orphan closure did not fire for the not-found refresh")
+	}
+}
+
+// TestSWRMetricsNilClientRecordsNothing: fixture mode (nil client) returns
+// before any recording — both from the coordinator and from a direct trigger.
+func TestSWRMetricsNilClientRecordsNothing(t *testing.T) {
+	reader := withTestMeter(t)
+	r := &SQLiteRepository{metrics: newSWRMetrics()} // nil client
+
+	r.maybeRefreshSWR(staleSpec(kindHistory, "x", func(context.Context) error { return nil }))
+	r.triggerBackgroundRefresh(kindHistory, "y", func(context.Context) error { return nil })
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == "linearfs.swr.triggers" || m.Name == "linearfs.swr.refresh_outcomes" {
+				t.Errorf("%s recorded with a nil client", m.Name)
+			}
+		}
+	}
+}

--- a/internal/repo/sqlite.go
+++ b/internal/repo/sqlite.go
@@ -70,6 +70,9 @@ type SQLiteRepository struct {
 	// Semaphore to limit concurrent background refreshes
 	refreshSem chan struct{}
 
+	// SWR-layer instruments, bound at construction (zero value = no-op).
+	metrics swrMetrics
+
 	// Adaptive reconciliation: triggered by reactive orphan deletions,
 	// rate-limited by reconcileCooldown.
 	reconcileMu      sync.Mutex
@@ -89,6 +92,7 @@ func NewSQLiteRepository(store *db.Store, client *api.Client) *SQLiteRepository 
 		refreshContext:     ctx,
 		refreshCancel:      cancel,
 		refreshSem:         make(chan struct{}, maxConcurrentRefreshes),
+		metrics:            newSWRMetrics(),
 	}
 	if client != nil {
 		r.extractor = &reconcile.Extractor{Q: store.Queries(), AuthHeader: client.AuthHeader}
@@ -125,14 +129,21 @@ func (r *SQLiteRepository) Close() {
 // triggerBackgroundRefresh starts a background refresh if not already in progress.
 // Uses a semaphore to limit concurrency — if too many refreshes are in-flight,
 // new requests are dropped. This prevents stampedes after connectivity loss.
-func (r *SQLiteRepository) triggerBackgroundRefresh(key string, refreshFn func(context.Context) error) {
+//
+// It takes the refreshKind (not a pre-built key) so its three exits — the
+// round-18 leak surface — record linearfs.swr.triggers with the bounded kind
+// attribute; the dedup key is still minted only by refreshKind.key. The
+// nil-client return records nothing.
+func (r *SQLiteRepository) triggerBackgroundRefresh(kind refreshKind, id string, refreshFn func(context.Context) error) {
 	if r.client == nil {
 		return
 	}
 
+	key := kind.key(id)
 	r.refreshMu.Lock()
 	if r.refreshing[key] {
 		r.refreshMu.Unlock()
+		r.metrics.recordTrigger(kind, "deduped")
 		return
 	}
 	r.refreshing[key] = true
@@ -146,9 +157,11 @@ func (r *SQLiteRepository) triggerBackgroundRefresh(key string, refreshFn func(c
 		r.refreshMu.Lock()
 		delete(r.refreshing, key)
 		r.refreshMu.Unlock()
+		r.metrics.recordTrigger(kind, "sem_dropped")
 		return
 	}
 
+	r.metrics.recordTrigger(kind, "triggered")
 	go func() {
 		defer func() {
 			<-r.refreshSem
@@ -159,7 +172,9 @@ func (r *SQLiteRepository) triggerBackgroundRefresh(key string, refreshFn func(c
 
 		ctx, cancel := context.WithTimeout(r.refreshContext, refreshTimeout)
 		defer cancel()
-		if err := refreshFn(ctx); err != nil {
+		err := refreshFn(ctx)
+		r.metrics.recordRefreshOutcome(kind, err)
+		if err != nil {
 			if r.refreshContext.Err() == nil && ctx.Err() == nil {
 				log.Printf("[repo] background refresh %s failed: %v", key, err)
 			}
@@ -1041,6 +1056,7 @@ func (r *SQLiteRepository) refreshProjectDocuments(ctx context.Context, projectI
 
 	reconcile.Collection(ctx, reconcile.CollectionSpec[api.Document]{
 		Label: "project document " + projectID,
+		Kind:  "document",
 		Items: docs,
 		Upsert: func(ctx context.Context, doc api.Document) error {
 			params, err := db.APIDocumentToDBDocument(doc)
@@ -1084,6 +1100,7 @@ func (r *SQLiteRepository) refreshInitiativeDocuments(ctx context.Context, initi
 
 	reconcile.Collection(ctx, reconcile.CollectionSpec[api.Document]{
 		Label: "initiative document " + initiativeID,
+		Kind:  "document",
 		Items: docs,
 		Upsert: func(ctx context.Context, doc api.Document) error {
 			params, err := db.APIDocumentToDBDocument(doc)
@@ -1163,6 +1180,7 @@ func (r *SQLiteRepository) refreshProjectUpdates(ctx context.Context, projectID 
 
 	reconcile.Collection(ctx, reconcile.CollectionSpec[api.ProjectUpdate]{
 		Label: "project update " + projectID,
+		Kind:  "project-update",
 		Items: updates,
 		Upsert: func(ctx context.Context, update api.ProjectUpdate) error {
 			params, err := db.APIProjectUpdateToDBUpdate(update, projectID)
@@ -1206,6 +1224,7 @@ func (r *SQLiteRepository) refreshInitiativeUpdates(ctx context.Context, initiat
 
 	reconcile.Collection(ctx, reconcile.CollectionSpec[api.InitiativeUpdate]{
 		Label: "initiative update " + initiativeID,
+		Kind:  "initiative-update",
 		Items: updates,
 		Upsert: func(ctx context.Context, update api.InitiativeUpdate) error {
 			params, err := db.APIInitiativeUpdateToDBUpdate(update, initiativeID)

--- a/internal/repo/sqlite_test.go
+++ b/internal/repo/sqlite_test.go
@@ -1821,7 +1821,7 @@ func TestSQLiteRepository_TriggerBackgroundRefresh_NoClient(t *testing.T) {
 
 	// Should be a no-op with nil client
 	called := false
-	repo.triggerBackgroundRefresh("test-key", func(ctx context.Context) error {
+	repo.triggerBackgroundRefresh("test", "key", func(ctx context.Context) error {
 		called = true
 		return nil
 	})
@@ -2161,7 +2161,7 @@ func TestTriggerBackgroundRefresh_Timeout(t *testing.T) {
 
 	// Track whether refresh was called and whether context had deadline
 	called := make(chan bool, 1)
-	repoWithClient.triggerBackgroundRefresh("test-timeout", func(ctx context.Context) error {
+	repoWithClient.triggerBackgroundRefresh("test", "timeout", func(ctx context.Context) error {
 		_, hasDeadline := ctx.Deadline()
 		called <- hasDeadline
 		return nil
@@ -2193,7 +2193,7 @@ func TestTriggerBackgroundRefresh_SemaphoreDropsExcess(t *testing.T) {
 	blocker := make(chan struct{})
 	for i := 0; i < maxConcurrentRefreshes; i++ {
 		key := fmt.Sprintf("blocker-%d", i)
-		repo.triggerBackgroundRefresh(key, func(ctx context.Context) error {
+		repo.triggerBackgroundRefresh("test", key, func(ctx context.Context) error {
 			<-blocker // block until released
 			return nil
 		})
@@ -2204,7 +2204,7 @@ func TestTriggerBackgroundRefresh_SemaphoreDropsExcess(t *testing.T) {
 
 	// This refresh should be dropped (semaphore full)
 	dropped := true
-	repo.triggerBackgroundRefresh("should-be-dropped", func(ctx context.Context) error {
+	repo.triggerBackgroundRefresh("test", "should-be-dropped", func(ctx context.Context) error {
 		dropped = false
 		return nil
 	})
@@ -2233,7 +2233,7 @@ func TestTriggerBackgroundRefresh_DeduplicatesByKey(t *testing.T) {
 	blocker := make(chan struct{})
 
 	// First call should start
-	repo.triggerBackgroundRefresh("same-key", func(ctx context.Context) error {
+	repo.triggerBackgroundRefresh("test", "same-key", func(ctx context.Context) error {
 		atomic.AddInt32(&callCount, 1)
 		<-blocker
 		return nil
@@ -2242,7 +2242,7 @@ func TestTriggerBackgroundRefresh_DeduplicatesByKey(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Second call with same key should be deduplicated
-	repo.triggerBackgroundRefresh("same-key", func(ctx context.Context) error {
+	repo.triggerBackgroundRefresh("test", "same-key", func(ctx context.Context) error {
 		atomic.AddInt32(&callCount, 1)
 		return nil
 	})

--- a/internal/repo/swr.go
+++ b/internal/repo/swr.go
@@ -128,10 +128,11 @@ func (r *SQLiteRepository) maybeRefreshSWR(spec swrSpec) {
 
 	ts, err := spec.syncedAt()
 	if !swrStale(ts, err, changed, eventDriven, r.stalenessThreshold) {
+		r.metrics.recordTrigger(spec.kind, "fresh")
 		return
 	}
 
-	r.triggerBackgroundRefresh(spec.kind.key(spec.id), orphanOnNotFound(spec.refresh, spec.orphan))
+	r.triggerBackgroundRefresh(spec.kind, spec.id, orphanOnNotFound(spec.refresh, spec.orphan))
 }
 
 // issueChangedAt is the event source for issue-scoped surfaces (details,

--- a/internal/sync/metrics.go
+++ b/internal/sync/metrics.go
@@ -1,0 +1,83 @@
+package sync
+
+// OTEL instruments for the sync layer (phase 3 of the metrics design,
+// docs/plans/2026-07-08-otel-metrics-design.md) — the budget's consumers,
+// completing the rate-limit causal chain the api+budget instruments started.
+// Instruments are created once, at Worker construction, from the globally
+// registered provider (otel.Meter) — never per call; with no provider
+// registered the global no-op makes every record free. The fourth sync
+// instrument, linearfs.sync.prunes, lives in internal/reconcile (the module
+// that actually runs the prunes).
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/jra3/linear-fuse/internal/db"
+	"github.com/jra3/linear-fuse/internal/telemetry"
+)
+
+// syncMetrics holds the Worker-bound sync instruments (meter "linearfs/sync").
+type syncMetrics struct {
+	cycleDuration  metric.Float64Histogram // linearfs.sync.cycle_duration, seconds
+	detailOutcomes metric.Int64Counter     // linearfs.sync.detail_outcomes {outcome}
+}
+
+func newSyncMetrics() syncMetrics {
+	m := otel.Meter("linearfs/sync")
+	return syncMetrics{
+		cycleDuration: telemetry.MustFloat64Histogram(m, "linearfs.sync.cycle_duration",
+			metric.WithUnit("s"),
+			metric.WithDescription("Duration of one syncAllTeams cycle (budget-skipped cycles record ~0)")),
+		detailOutcomes: telemetry.MustInt64Counter(m, "linearfs.sync.detail_outcomes",
+			metric.WithDescription("Issues leaving syncDetails' per-issue ledger, by outcome (synced|deferred)")),
+	}
+}
+
+// recordCycle records one sync cycle's duration.
+func (sm syncMetrics) recordCycle(d time.Duration) {
+	sm.cycleDuration.Record(context.Background(), d.Seconds())
+}
+
+// recordDetailOutcomes counts issues leaving syncDetails' ledger. Every issue
+// lands in exactly one outcome, so summing both series gives issues processed.
+func (sm syncMetrics) recordDetailOutcomes(ctx context.Context, synced, deferred int) {
+	if synced > 0 {
+		sm.detailOutcomes.Add(ctx, int64(synced), metric.WithAttributes(
+			attribute.String("outcome", "synced")))
+	}
+	if deferred > 0 {
+		sm.detailOutcomes.Add(ctx, int64(deferred), metric.WithAttributes(
+			attribute.String("outcome", "deferred")))
+	}
+}
+
+// registerPendingDepthGauge installs the linearfs.sync.pending_depth
+// observable gauge: the pending_detail_sync backlog, counted only at export
+// intervals (a cheap COUNT on a single-purpose table). A count error skips
+// the observation — no data point beats a fabricated zero.
+func registerPendingDepthGauge(q *db.Queries) {
+	meter := otel.Meter("linearfs/sync")
+	depth, err := meter.Int64ObservableGauge("linearfs.sync.pending_depth",
+		metric.WithDescription("Issues queued in pending_detail_sync awaiting a detail-sync retry"))
+	if err != nil {
+		log.Printf("telemetry: pending_depth gauge not registered: %v", err)
+		return
+	}
+	_, err = meter.RegisterCallback(func(ctx context.Context, o metric.Observer) error {
+		n, err := q.CountPendingDetailSync(ctx)
+		if err != nil {
+			return nil // skip this observation; the collect must not fail on a DB hiccup
+		}
+		o.ObserveInt64(depth, n)
+		return nil
+	}, depth)
+	if err != nil {
+		log.Printf("telemetry: pending_depth callback not registered: %v", err)
+	}
+}

--- a/internal/sync/metrics_test.go
+++ b/internal/sync/metrics_test.go
@@ -1,0 +1,216 @@
+package sync
+
+// Sync-instrument tests (phase-2 pattern, see internal/api/metrics_test.go):
+// a manual-reader SDK provider is installed as the global otel provider, the
+// Worker is constructed (instruments bind at construction), and the collected
+// metricdata is asserted by hand.
+//
+// These tests are deliberately NOT parallel: they swap the global meter
+// provider. TestMain pins the global to an explicit no-op first, so Workers
+// built by the package's other (parallel) tests can never be delegated onto
+// a test provider and pollute a collection.
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	noopmetric "go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/jra3/linear-fuse/internal/api"
+	"github.com/jra3/linear-fuse/internal/db"
+)
+
+func TestMain(m *testing.M) {
+	otel.SetMeterProvider(noopmetric.NewMeterProvider())
+	os.Exit(m.Run())
+}
+
+// withTestMeter installs a fresh SDK provider as the global meter provider
+// and returns its manual reader. Cleanup restores the no-op provider.
+func withTestMeter(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	otel.SetMeterProvider(provider)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(noopmetric.NewMeterProvider())
+		_ = provider.Shutdown(context.Background())
+	})
+	return reader
+}
+
+func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	return rm
+}
+
+func findMetric(rm metricdata.ResourceMetrics, name string) (metricdata.Metrics, bool) {
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return m, true
+			}
+		}
+	}
+	return metricdata.Metrics{}, false
+}
+
+// outcomeValue returns the detail_outcomes count for one outcome, or -1 when
+// no such datapoint exists.
+func outcomeValue(t *testing.T, rm metricdata.ResourceMetrics, outcome string) int64 {
+	t.Helper()
+	m, ok := findMetric(rm, "linearfs.sync.detail_outcomes")
+	if !ok {
+		return -1
+	}
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	if !ok {
+		t.Fatalf("detail_outcomes data is %T, want Sum[int64]", m.Data)
+	}
+	for _, dp := range sum.DataPoints {
+		if v, ok := dp.Attributes.Value(attribute.Key("outcome")); ok && v.AsString() == outcome {
+			return dp.Value
+		}
+	}
+	return -1
+}
+
+// TestSyncDetailsRecordsOutcomes: one clean and one unclean issue through
+// syncDetails land as detail_outcomes datapoints — synced for the stamped
+// issue, deferred for the re-enqueued one — and a whole-batch gate (budget)
+// folds its deferrals into the same series.
+func TestSyncDetailsRecordsOutcomes(t *testing.T) {
+	reader := withTestMeter(t)
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	mock := newMockAPIClient()
+	// issue-bad's relation has no RelatedIssue, so its relation collection
+	// upsert fails → unclean → deferred. issue-ok gets the default empty
+	// details → clean → synced.
+	mock.detailsByIssue["issue-bad"] = &api.IssueDetails{
+		Relations: []api.IssueRelation{{ID: "rel-1"}},
+	}
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	outcome := worker.syncDetails(ctx, []issueRef{
+		{ID: "issue-ok", Identifier: "TST-1"},
+		{ID: "issue-bad", Identifier: "TST-2"},
+	})
+	if len(outcome.synced) != 1 || len(outcome.deferred) != 1 {
+		t.Fatalf("outcome = %d synced, %d deferred; want 1/1", len(outcome.synced), len(outcome.deferred))
+	}
+
+	rm := collectMetrics(t, reader)
+	if got := outcomeValue(t, rm, "synced"); got != 1 {
+		t.Errorf("detail_outcomes{outcome=synced} = %d, want 1", got)
+	}
+	if got := outcomeValue(t, rm, "deferred"); got != 1 {
+		t.Errorf("detail_outcomes{outcome=deferred} = %d, want 1", got)
+	}
+
+	// Gate path: budget over the defer threshold defers the whole batch.
+	worker.SetBudgetReporter(&mockBudgetReporter{count: 2000, pct: 90})
+	gated := worker.syncDetails(ctx, []issueRef{
+		{ID: "issue-g1", Identifier: "TST-3"},
+		{ID: "issue-g2", Identifier: "TST-4"},
+	})
+	if !gated.gated || len(gated.deferred) != 2 {
+		t.Fatalf("gated outcome = %+v; want gated with 2 deferred", gated)
+	}
+	rm = collectMetrics(t, reader)
+	if got := outcomeValue(t, rm, "deferred"); got != 3 {
+		t.Errorf("detail_outcomes{outcome=deferred} = %d, want 3 (1 unclean + 2 gated)", got)
+	}
+	if got := outcomeValue(t, rm, "synced"); got != 1 {
+		t.Errorf("detail_outcomes{outcome=synced} = %d, want 1 (unchanged by the gate)", got)
+	}
+}
+
+// TestSyncCycleDurationRecorded: one SyncNow records one cycle_duration
+// histogram sample.
+func TestSyncCycleDurationRecorded(t *testing.T) {
+	reader := withTestMeter(t)
+	store := openTestStore(t)
+	defer store.Close()
+
+	mock := newMockAPIClient()
+	mock.teams = []api.Team{{ID: "team-1", Key: "TST", Name: "Test"}}
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	if err := worker.SyncNow(context.Background()); err != nil {
+		t.Fatalf("SyncNow: %v", err)
+	}
+
+	rm := collectMetrics(t, reader)
+	m, ok := findMetric(rm, "linearfs.sync.cycle_duration")
+	if !ok {
+		t.Fatal("linearfs.sync.cycle_duration not recorded")
+	}
+	h, ok := m.Data.(metricdata.Histogram[float64])
+	if !ok {
+		t.Fatalf("cycle_duration data is %T, want Histogram[float64]", m.Data)
+	}
+	if len(h.DataPoints) != 1 || h.DataPoints[0].Count != 1 {
+		t.Errorf("cycle_duration datapoints = %d (count %v), want one sample", len(h.DataPoints), h.DataPoints)
+	}
+}
+
+// TestPendingDepthGauge: the observable gauge reports the pending_detail_sync
+// backlog at collect time — registered at Worker construction, read straight
+// from the table.
+func TestPendingDepthGauge(t *testing.T) {
+	reader := withTestMeter(t)
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	now := db.Now()
+	for _, id := range []string{"issue-1", "issue-2"} {
+		if err := store.Queries().UpsertPendingDetailSync(ctx, db.UpsertPendingDetailSyncParams{
+			IssueID: id, Identifier: "TST-" + id, QueuedAt: now,
+		}); err != nil {
+			t.Fatalf("seed pending: %v", err)
+		}
+	}
+
+	_ = NewWorker(newMockAPIClient(), store, Config{Interval: time.Hour})
+
+	rm := collectMetrics(t, reader)
+	m, ok := findMetric(rm, "linearfs.sync.pending_depth")
+	if !ok {
+		t.Fatal("linearfs.sync.pending_depth not observed")
+	}
+	g, ok := m.Data.(metricdata.Gauge[int64])
+	if !ok {
+		t.Fatalf("pending_depth data is %T, want Gauge[int64]", m.Data)
+	}
+	if len(g.DataPoints) != 1 || g.DataPoints[0].Value != 2 {
+		t.Errorf("pending_depth = %+v, want one datapoint of 2", g.DataPoints)
+	}
+
+	// Draining the queue is visible on the next collect.
+	if err := store.Queries().ClearPendingDetailSync(ctx); err != nil {
+		t.Fatalf("clear pending: %v", err)
+	}
+	rm = collectMetrics(t, reader)
+	m, ok = findMetric(rm, "linearfs.sync.pending_depth")
+	if !ok {
+		t.Fatal("pending_depth missing after clear")
+	}
+	g = m.Data.(metricdata.Gauge[int64])
+	if len(g.DataPoints) != 1 || g.DataPoints[0].Value != 0 {
+		t.Errorf("pending_depth after clear = %+v, want 0", g.DataPoints)
+	}
+}

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -90,6 +90,7 @@ type Worker struct {
 	budget    BudgetReporter     // optional: for rate limit budget logging
 	catchUp   CatchUpModeToggler // optional: controls repo staleness during catch-up
 	cycle     atomic.Int64       // sync-cycle counter; rotates the team order
+	metrics   syncMetrics        // sync-layer instruments, bound at construction
 
 	// Rate limit tracking for issue details sync
 	rateLimitMu     sync.RWMutex
@@ -118,6 +119,9 @@ func NewWorker(client APIClient, store *db.Store, cfg Config) *Worker {
 	if cfg.Interval == 0 {
 		cfg.Interval = 2 * time.Minute
 	}
+	// The observable pending-depth gauge registers here too: construction is
+	// the sync layer's one binding point (phase-2 pattern).
+	registerPendingDepthGauge(store.Queries())
 	return &Worker{
 		client:    client,
 		store:     store,
@@ -125,6 +129,7 @@ func NewWorker(client APIClient, store *db.Store, cfg Config) *Worker {
 		interval:  cfg.Interval,
 		stopCh:    make(chan struct{}),
 		doneCh:    make(chan struct{}),
+		metrics:   newSyncMetrics(),
 	}
 }
 
@@ -221,6 +226,13 @@ func (w *Worker) run(ctx context.Context) {
 }
 
 func (w *Worker) syncAllTeams(ctx context.Context) error {
+	// One linearfs.sync.cycle_duration sample per cycle, whichever caller
+	// invoked it (run's initial sync, the ticker, SyncNow). A budget-skipped
+	// cycle records its ~0s duration too — a burst of near-zero samples IS
+	// the signature of budget-gated skipping.
+	start := time.Now()
+	defer func() { w.metrics.recordCycle(time.Since(start)) }()
+
 	// Skip entire sync cycle when budget is critically high
 	if w.budgetExceeds(budgetSkipSyncPct) {
 		count, pct := 0, 0.0
@@ -533,6 +545,7 @@ func (w *Worker) syncProjectLabels(ctx context.Context, pruneCutoff time.Time) {
 	}
 	reconcile.Collection(ctx, reconcile.CollectionSpec[api.ProjectLabel]{
 		Label: "project-label",
+		Kind:  "project-label",
 		Items: plabels,
 		Upsert: func(ctx context.Context, l api.ProjectLabel) error {
 			params, err := db.APIProjectLabelToDBProjectLabel(l)
@@ -557,6 +570,7 @@ func (w *Worker) syncProjectLabels(ctx context.Context, pruneCutoff time.Time) {
 func (w *Worker) syncInitiativeProjects(ctx context.Context, initiative api.Initiative, pruneCutoff time.Time) {
 	reconcile.Collection(ctx, reconcile.CollectionSpec[api.InitiativeProject]{
 		Label: "initiative-project",
+		Kind:  "initiative-project",
 		Items: initiative.Projects.Nodes,
 		Upsert: func(ctx context.Context, project api.InitiativeProject) error {
 			return w.store.Queries().UpsertInitiativeProject(ctx, db.UpsertInitiativeProjectParams{
@@ -602,6 +616,7 @@ func (w *Worker) syncTeamMetadata(ctx context.Context, team api.Team) error {
 	// a prune — upsert-only (nil prune).
 	reconcile.Collection(ctx, reconcile.CollectionSpec[api.State]{
 		Label: "state",
+		Kind:  "state",
 		Items: meta.States,
 		Upsert: func(ctx context.Context, state api.State) error {
 			params, err := db.APIStateToDBState(state, team.ID)
@@ -618,6 +633,7 @@ func (w *Worker) syncTeamMetadata(ctx context.Context, team api.Team) error {
 	// workspace labels between teams.
 	reconcile.Collection(ctx, reconcile.CollectionSpec[api.Label]{
 		Label: "label",
+		Kind:  "label",
 		Items: meta.Labels,
 		Upsert: func(ctx context.Context, label api.Label) error {
 			params, err := db.APILabelToDBLabel(label)
@@ -636,6 +652,7 @@ func (w *Worker) syncTeamMetadata(ctx context.Context, team api.Team) error {
 
 	reconcile.Collection(ctx, reconcile.CollectionSpec[api.Cycle]{
 		Label: "cycle",
+		Kind:  "cycle",
 		Items: meta.Cycles,
 		Upsert: func(ctx context.Context, cycle api.Cycle) error {
 			params, err := db.APICycleToDBCycle(cycle, team.ID)
@@ -660,6 +677,7 @@ func (w *Worker) syncTeamMetadata(ctx context.Context, team api.Team) error {
 	// logged and swallowed, never suppressing the prune.
 	reconcile.Collection(ctx, reconcile.CollectionSpec[api.Project]{
 		Label: "project",
+		Kind:  "project",
 		Items: meta.Projects,
 		Upsert: func(ctx context.Context, project api.Project) error {
 			params, err := db.APIProjectToDBProject(project)
@@ -702,6 +720,7 @@ func (w *Worker) syncTeamMetadata(ctx context.Context, team api.Team) error {
 	// workspace-wide users table, which other teams share.
 	reconcile.Collection(ctx, reconcile.CollectionSpec[api.User]{
 		Label: "member",
+		Kind:  "member",
 		Items: meta.Members,
 		Upsert: func(ctx context.Context, member api.User) error {
 			params, err := db.APIUserToDBUser(member)
@@ -892,6 +911,9 @@ func (w *Worker) deferDetailIssues(ctx context.Context, issues []issueRef) {
 func (w *Worker) syncDetails(ctx context.Context, issues []issueRef) detailOutcome {
 	deferAll := func() detailOutcome {
 		w.deferDetailIssues(ctx, issues)
+		// The gate paths fold into the same ledger metric as the per-issue
+		// outcomes below: every issue leaves syncDetails counted exactly once.
+		w.metrics.recordDetailOutcomes(ctx, 0, len(issues))
 		return detailOutcome{deferred: issues, gated: true}
 	}
 
@@ -980,6 +1002,7 @@ func (w *Worker) syncDetails(ctx context.Context, issues []issueRef) detailOutco
 		_ = w.store.Queries().DeletePendingDetailSync(ctx, issue.ID)
 		outcome.synced = append(outcome.synced, issue)
 	}
+	w.metrics.recordDetailOutcomes(ctx, len(outcome.synced), len(outcome.deferred))
 	log.Printf("[sync] batch synced details: %d clean, %d deferred", len(outcome.synced), len(outcome.deferred))
 	return outcome
 }

--- a/internal/telemetry/instruments.go
+++ b/internal/telemetry/instruments.go
@@ -1,0 +1,38 @@
+package telemetry
+
+// Instrument-creation helpers for the linearfs.* instrument sites (phase 2
+// established the pattern privately in internal/api; the phase-3 sites in
+// sync/repo/reconcile share these instead of re-copying them). They degrade an
+// instrument-creation failure (an invalid name — a programming error) to a
+// logged no-op instead of a nil that would panic at record time: telemetry
+// must never take the process down. Callers still bind instruments once, at
+// construction, from otel.Meter — these helpers touch only the otel API
+// packages, never the SDK.
+
+import (
+	"log"
+
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// MustInt64Counter returns the counter, or a logged no-op on creation failure.
+func MustInt64Counter(m metric.Meter, name string, opts ...metric.Int64CounterOption) metric.Int64Counter {
+	c, err := m.Int64Counter(name, opts...)
+	if err != nil {
+		log.Printf("telemetry: creating %s: %v", name, err)
+		c, _ = noop.NewMeterProvider().Meter("noop").Int64Counter(name)
+	}
+	return c
+}
+
+// MustFloat64Histogram returns the histogram, or a logged no-op on creation
+// failure.
+func MustFloat64Histogram(m metric.Meter, name string, opts ...metric.Float64HistogramOption) metric.Float64Histogram {
+	h, err := m.Float64Histogram(name, opts...)
+	if err != nil {
+		log.Printf("telemetry: creating %s: %v", name, err)
+		h, _ = noop.NewMeterProvider().Meter("noop").Float64Histogram(name)
+	}
+	return h
+}


### PR DESCRIPTION
Phase 3 (final) of the OTEL metrics design (#206) — the sync + SWR instruments, the consumers of the rate budget. With the phase-2 api+budget set, one view now carries the full rate-limit causal chain: the leak (budget gauges) and the leaker (the SWR triggers, round 18's bug surface). **This completes the project's three phases.**

## Sync (meter `linearfs/sync`, bound at Worker construction)

- **`linearfs.sync.cycle_duration`** (histogram, s) — one sample per `syncAllTeams` cycle, recorded via defer inside the function so all three invokers (run's initial sync, the ticker, `SyncNow`) are covered. Budget-skipped cycles record ~0s: a burst of near-zero samples is the skip signature, on purpose.
- **`linearfs.sync.detail_outcomes{outcome=synced|deferred}`** (counter) — counted from `syncDetails`' ledger at its two exits (`deferAll` for the whole-batch gates, the final return for per-issue outcomes), so every issue leaving `syncDetails` lands in exactly one series exactly once.
- **`linearfs.sync.prunes{collection}`** (counter) — recorded inside `reconcile.Collection` when a prune **actually executes** (suppressed or failed prunes record nothing). `CollectionSpec` gains a **`Kind`** field — a closed enum (`state|label|cycle|project|member|initiative-project|project-label|comment|document|attachment|relation|inverse-relation` + the repo's upsert-only update kinds) set by all 16 call sites — because `Label` embeds issue IDs and must never become an attribute. The instrument binds lazily (`sync.Once`) on the first firing prune, since the reconcile package has no construction point; in production that is long after `telemetry.Init`.
- **`linearfs.sync.pending_depth`** (observable gauge) — `COUNT(*)` of `pending_detail_sync` via a new sqlc query (`CountPendingDetailSync`), evaluated only at export intervals; a count error skips the observation.

## SWR (meter `linearfs/swr`, bound at SQLiteRepository construction)

- **`linearfs.swr.triggers{kind, decision=triggered|fresh|deduped|sem_dropped}`** — `fresh` at `maybeRefreshSWR`'s staleness check; the other three at `triggerBackgroundRefresh`'s exits. The trigger now takes the `refreshKind` + id (not a pre-built key) and mints the dedup key itself, so the kind attribute is bounded by construction; both history call sites flow through `historySpec`, carrying the kind consistently. The nil-client (fixture-mode) returns record nothing.
- **`linearfs.swr.refresh_outcomes{kind, outcome=ok|error|orphaned}`** — recorded in the refresh goroutine when the fetch settles, mirroring the `orphanOnNotFound` classification (`api.IsNotFound` ⇒ orphaned).
- Zero-value `swrMetrics` records nothing — several tests build `SQLiteRepository` by struct literal, and telemetry must never panic a read path.

## Plumbing

- The phase-2 summary keep-list already carried `kind`/`collection`/`outcome`/`decision`, so the always-on journald line picks these series up with **no exporter change** (verified).
- The private must-create helpers become shared `telemetry.MustInt64Counter`/`MustFloat64Histogram` (`telemetry/instruments.go`) instead of a third and fourth private copy; `internal/api`'s phase-2 copies are left untouched.
- Cardinality: kinds = the 6 `refreshKind` constants, collection = the closed Kind enum, decisions/outcomes as listed. Nothing else becomes an attribute.

## Tests

Phase-2 style throughout (manual-reader provider, hand-rolled metricdata assertions, stdlib-only; `TestMain` pins a no-op provider in `sync` and `repo`):

- `sync`: ledger outcomes (clean + unclean issue, then a budget-gated batch folding into the same series), one `cycle_duration` sample per `SyncNow`, `pending_depth` seeded/cleared across collects.
- `reconcile`: prune fires ⇒ `{collection=kind}` counted; suppressed (unclean) and failed prunes record nothing. This package binds its instrument once, so `TestMain` installs one provider for the binary and tests isolate by unique `Kind`.
- `repo`: all four trigger decisions (fresh / triggered / deduped-in-flight / sem_dropped with a filled semaphore), all three refresh outcomes (poll-collected — the recording lands in the goroutine), and the nil-client no-recording contract.

`make build` / `go vet ./...` / `gofmt -l` clean; **full `go test ./...` green including integration** (33s); `-race` green on the three touched packages.

Closes the instrument sketch in `docs/plans/2026-07-08-otel-metrics-design.md`; CONTEXT.md's Telemetry / SWR-coordinator / detail-outcome entries updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)