### PR TITLE
test(fixtures): fixture parity for all schema tables + coverage conformance (round-18 card 5)

### DIFF
--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -842,6 +842,16 @@ func MountFS(mountpoint string, lfs *LinearFS, debug bool) (*fuse.Server, error)
 func (lfs *LinearFS) InjectTestStore(store *db.Store) error {
 	lfs.store = store
 	lfs.repo = repo.NewSQLiteRepository(store, nil)
+	// Mirror EnableSQLiteCache's viewer load (but never the API refresh): a
+	// fixture-populated viewer_cache row resolves the current user, so the
+	// my/ views are exercisable offline.
+	ctx := context.Background()
+	if cachedViewerID, err := store.Queries().GetViewerUserID(ctx); err == nil {
+		if dbUser, err := store.Queries().GetUser(ctx, cachedViewerID); err == nil {
+			apiUser := db.DBUserToAPIUser(dbUser)
+			lfs.repo.SetCurrentUser(&apiUser)
+		}
+	}
 	return nil
 }
 

--- a/internal/fs/relations.go
+++ b/internal/fs/relations.go
@@ -112,7 +112,16 @@ func (n *RelationsNode) createRelationFileNode(ctx context.Context, name string,
 		isInverse: isInverse,
 		issueID:   n.issueID,
 	}
-	return n.newRenderInode(ctx, out, name, node, relationIno(rel.ID), 30*time.Second), 0
+	// One relation surfaces as TWO files — blocks-B.rel under A and
+	// blocked-by-A.rel under B — with different renders. They must not share a
+	// stable ino: the bridge dedups nodes by ino AFTER the handler returns, and
+	// the refreshExisting probe (parent.GetChild) can't see across directories,
+	// so a shared ino served one endpoint's content for both paths.
+	inoKey := rel.ID
+	if isInverse {
+		inoKey += "/inverse"
+	}
+	return n.newRenderInode(ctx, out, name, node, relationIno(inoKey), 30*time.Second), 0
 }
 
 // inverseRelationType returns the inverse relation type name

--- a/internal/integration/fixture_extended_test.go
+++ b/internal/integration/fixture_extended_test.go
@@ -737,8 +737,9 @@ func TestFixtureAttachmentsDirectoryExists(t *testing.T) {
 }
 
 func TestFixtureAttachmentsDirectoryListing(t *testing.T) {
-	// TST-1 has 2 embedded files: screenshot.png and design.pdf
-	// Plus the _create and .error control files = 4 entries
+	// TST-1 has 2 embedded files (screenshot.png, design.pdf) and 1 external
+	// URL attachment (Design Spec.link), plus the _create/.error/.last
+	// control files
 	attachPath := attachmentsPath(testTeamKey, "TST-1")
 	entries, err := os.ReadDir(attachPath)
 	if err != nil {
@@ -751,13 +752,14 @@ func TestFixtureAttachmentsDirectoryListing(t *testing.T) {
 			realCount++
 		}
 	}
-	if realCount != 2 {
-		t.Errorf("Expected 2 attachment files (excluding control files), got %d", realCount)
+	if realCount != 3 {
+		t.Errorf("Expected 3 attachment files (excluding control files), got %d", realCount)
 	}
 
 	// Check for expected files
 	hasScreenshot := false
 	hasDesign := false
+	hasLink := false
 	hasCreate := false
 	for _, entry := range entries {
 		switch entry.Name() {
@@ -765,6 +767,8 @@ func TestFixtureAttachmentsDirectoryListing(t *testing.T) {
 			hasScreenshot = true
 		case "design.pdf":
 			hasDesign = true
+		case "Design Spec.link":
+			hasLink = true
 		case "_create":
 			hasCreate = true
 		}
@@ -775,6 +779,9 @@ func TestFixtureAttachmentsDirectoryListing(t *testing.T) {
 	}
 	if !hasDesign {
 		t.Error("Expected design.pdf in attachments")
+	}
+	if !hasLink {
+		t.Error("Expected Design Spec.link in attachments")
 	}
 	if !hasCreate {
 		t.Error("Expected _create trigger file in attachments")

--- a/internal/integration/fixture_parity_test.go
+++ b/internal/integration/fixture_parity_test.go
@@ -1,0 +1,305 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// =============================================================================
+// Fixture parity: the fixture set IS the fixture-mode test surface.
+//
+// Every table schema.sql creates must either be populated by the shared
+// fixture population (populateTestFixtures) or sit on the explicit exclusion
+// list below with a reason. A new table that lands in schema.sql without a
+// fixture (or an exclusion entry) fails TestSchemaFixtureCoverage — so a new
+// read surface can't silently become live-mode-only, which is exactly how
+// render drift escapes CI.
+// =============================================================================
+
+// fixtureExcludedTables are schema tables intentionally NOT populated by the
+// fixture set. Each entry needs a reason: either the table has no mount-visible
+// render, or it is written only by machinery the fixture harness bypasses.
+var fixtureExcludedTables = map[string]string{
+	"sync_meta":           "sync-worker bookkeeping (last-sync watermarks); no mount-visible render",
+	"pending_detail_sync": "sync-worker retry ledger for failed detail fetches; no mount-visible render",
+}
+
+// TestSchemaFixtureCoverage asserts fixture coverage tracks the schema's table
+// list: every table in the live fixture store (sqlite_master, i.e. schema.sql
+// as applied) is either populated with at least one row or explicitly excluded.
+func TestSchemaFixtureCoverage(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode conformance: audits the seeded fixture store")
+	}
+
+	ctx := context.Background()
+	rows, err := testStore.DB().QueryContext(ctx,
+		`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`)
+	if err != nil {
+		t.Fatalf("list tables: %v", err)
+	}
+	defer rows.Close()
+
+	var tables []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("scan table name: %v", err)
+		}
+		tables = append(tables, name)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate tables: %v", err)
+	}
+	if len(tables) == 0 {
+		t.Fatal("no tables found — schema not applied?")
+	}
+
+	seen := make(map[string]bool, len(tables))
+	for _, table := range tables {
+		seen[table] = true
+		if reason, ok := fixtureExcludedTables[table]; ok {
+			t.Logf("excluded: %s (%s)", table, reason)
+			continue
+		}
+		var count int
+		// Table names come from sqlite_master, not user input.
+		q := fmt.Sprintf("SELECT COUNT(*) FROM %q", table)
+		if err := testStore.DB().QueryRowContext(ctx, q).Scan(&count); err != nil {
+			t.Errorf("count %s: %v", table, err)
+			continue
+		}
+		if count == 0 {
+			t.Errorf("table %q has no fixture rows: add a Populate call to populateTestFixtures "+
+				"(internal/testutil/fixtures) or an entry in fixtureExcludedTables with a reason", table)
+		}
+	}
+
+	// The exclusion list must not carry stale entries for dropped tables.
+	for excluded := range fixtureExcludedTables {
+		if !seen[excluded] {
+			t.Errorf("fixtureExcludedTables lists %q, which is not in the schema anymore", excluded)
+		}
+	}
+}
+
+// =============================================================================
+// Newly fixture-testable surfaces. Minimal by design: the point is that these
+// surfaces exercise at all in fixture mode.
+// =============================================================================
+
+// TestFixtureRelationFiles: the seeded relation (TST-1 blocks TST-3) surfaces
+// as a .rel file on both endpoints, and its content names the other end.
+func TestFixtureRelationFiles(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode: asserts the seeded synthetic relation")
+	}
+
+	// Outgoing side: TST-1 blocks TST-3
+	outPath := filepath.Join(issueDirPath(testTeamKey, "TST-1"), "relations", "blocks-TST-3.rel")
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", outPath, err)
+	}
+	content := string(data)
+	for _, want := range []string{"type: blocks", "to: TST-3"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("outgoing .rel missing %q:\n%s", want, content)
+		}
+	}
+
+	// Inverse side: TST-3 is blocked by TST-1 (same stored row, other end)
+	inPath := filepath.Join(issueDirPath(testTeamKey, "TST-3"), "relations", "blocked-by-TST-1.rel")
+	data, err = os.ReadFile(inPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", inPath, err)
+	}
+	content = string(data)
+	for _, want := range []string{"type: blocks", "from: TST-1"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("inverse .rel missing %q:\n%s", want, content)
+		}
+	}
+}
+
+// TestFixtureIssueMetaRelations: issue.meta renders the relations block for
+// both directions (outgoing "blocks", inverse rendered as "blocked-by").
+func TestFixtureIssueMetaRelations(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode: asserts the seeded synthetic relation")
+	}
+
+	data, err := os.ReadFile(issueMetaPath(testTeamKey, "TST-1"))
+	if err != nil {
+		t.Fatalf("read TST-1 issue.meta: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "relations:") || !strings.Contains(content, "TST-3") {
+		t.Errorf("TST-1 issue.meta missing relations render:\n%s", content)
+	}
+
+	data, err = os.ReadFile(issueMetaPath(testTeamKey, "TST-3"))
+	if err != nil {
+		t.Fatalf("read TST-3 issue.meta: %v", err)
+	}
+	content = string(data)
+	if !strings.Contains(content, "relations:") || !strings.Contains(content, "blocked-by") {
+		t.Errorf("TST-3 issue.meta missing inverse relations render:\n%s", content)
+	}
+}
+
+// TestFixtureMilestoneFile: the seeded milestone lists and reads under
+// projects/<slug>/milestones/.
+func TestFixtureMilestoneFile(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode: asserts the seeded synthetic milestone")
+	}
+
+	path := filepath.Join(projectsPath(testTeamKey), "test-project", "milestones", "Alpha Release.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read milestone: %v", err)
+	}
+	content := string(data)
+	for _, want := range []string{"2024-03-31", "First alpha release"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("milestone file missing %q:\n%s", want, content)
+		}
+	}
+}
+
+// TestFixtureProjectUpdateFile: the seeded project status update lists under
+// projects/<slug>/updates/ and renders the health frontmatter.
+func TestFixtureProjectUpdateFile(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode: asserts the seeded synthetic update")
+	}
+	assertUpdateDirHasHealthyUpdate(t, filepath.Join(projectsPath(testTeamKey), "test-project", "updates"))
+}
+
+// TestFixtureInitiativeUpdateFile: same for initiatives/<slug>/updates/.
+func TestFixtureInitiativeUpdateFile(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode: asserts the seeded synthetic update")
+	}
+	assertUpdateDirHasHealthyUpdate(t, filepath.Join(initiativesPath(), "test-initiative", "updates"))
+}
+
+func assertUpdateDirHasHealthyUpdate(t *testing.T, updatesDir string) {
+	t.Helper()
+	entries, err := os.ReadDir(updatesDir)
+	if err != nil {
+		t.Fatalf("read %s: %v", updatesDir, err)
+	}
+	var updateFile string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".md") && !strings.HasPrefix(e.Name(), "_") {
+			updateFile = e.Name()
+			break
+		}
+	}
+	if updateFile == "" {
+		t.Fatalf("no update .md file in %s (fixture seeded one)", updatesDir)
+	}
+	data, err := os.ReadFile(filepath.Join(updatesDir, updateFile))
+	if err != nil {
+		t.Fatalf("read %s: %v", updateFile, err)
+	}
+	if !strings.Contains(string(data), "health: onTrack") {
+		t.Errorf("update %s missing health frontmatter:\n%s", updateFile, data)
+	}
+}
+
+// TestFixtureAttachmentLinkFile: the seeded external URL attachment surfaces
+// as a .link file alongside the embedded files.
+func TestFixtureAttachmentLinkFile(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode: asserts the seeded synthetic attachment")
+	}
+
+	path := filepath.Join(attachmentsPath(testTeamKey, "TST-1"), "Design Spec.link")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read .link: %v", err)
+	}
+	content := string(data)
+	for _, want := range []string{"title: Design Spec", "url: https://example.com/design-spec"} {
+		if !strings.Contains(content, want) {
+			t.Errorf(".link missing %q:\n%s", want, content)
+		}
+	}
+}
+
+// TestFixtureIssueHistoryRendered: the seeded history cache renders a real
+// change in history.md (not the empty-history placeholder).
+func TestFixtureIssueHistoryRendered(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode: asserts the seeded synthetic history")
+	}
+
+	path := filepath.Join(issueDirPath(testTeamKey, "TST-1"), "history.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read history.md: %v", err)
+	}
+	content := string(data)
+	for _, want := range []string{"Status Changed", "Todo → In Progress", "test@example.com"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("history.md missing %q:\n%s", want, content)
+		}
+	}
+}
+
+// TestFixtureByAssigneeMembers: with team_members populated, by/assignee lists
+// the members' handles alongside "unassigned".
+func TestFixtureByAssigneeMembers(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode: asserts the seeded synthetic membership")
+	}
+
+	entries, err := os.ReadDir(byAssigneePath(testTeamKey))
+	if err != nil {
+		t.Fatalf("read by/assignee: %v", err)
+	}
+	names := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		names[e.Name()] = true
+	}
+	// assigneeHandle prefers DisplayName; see FixtureAPIUsers.
+	for _, want := range []string{"unassigned", "Test User", "Jane", "Bob"} {
+		if !names[want] {
+			t.Errorf("by/assignee missing %q (got %v)", want, names)
+		}
+	}
+}
+
+// TestFixtureMyViewsPopulated: with viewer_cache populated (viewer = user-1,
+// the default fixture assignee), the my/ views resolve offline and are
+// non-empty.
+func TestFixtureMyViewsPopulated(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode: asserts the seeded synthetic viewer")
+	}
+
+	entries, err := os.ReadDir(myAssignedPath())
+	if err != nil {
+		t.Fatalf("read my/assigned: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("my/assigned is empty; viewer fixture (viewer_cache -> user-1) did not resolve")
+	}
+	found := false
+	for _, e := range entries {
+		if e.Name() == "TST-1" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("my/assigned missing TST-1 (assigned to the fixture viewer); got %d entries", len(entries))
+	}
+}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -212,6 +212,18 @@ func populateTestFixtures(ctx context.Context, store *db.Store) error {
 	project := fixtures.FixtureAPIProject()
 	project.LabelIds = []string{"plabel-backend", "plabel-legacy"}
 
+	// One relation both ways: TST-1 blocks TST-3. The issue-embedded copies
+	// back the issue.meta relations render; the issue_relations rows (below)
+	// back the relations/ directory on both endpoints.
+	relation := fixtures.FixtureAPIIssueRelation()
+	inverseRelation := api.IssueRelation{
+		ID:        relation.ID,
+		Type:      relation.Type,
+		Issue:     &api.ParentIssue{ID: "issue-1", Identifier: "TST-1", Title: "Test Issue 1"},
+		CreatedAt: relation.CreatedAt,
+		UpdatedAt: relation.UpdatedAt,
+	}
+
 	// Create issues with various configurations
 	issues := []api.Issue{
 		fixtures.FixtureAPIIssue(
@@ -220,6 +232,7 @@ func populateTestFixtures(ctx context.Context, store *db.Store) error {
 			fixtures.WithDescription("This is test issue 1"),
 			fixtures.WithState(fixtures.FixtureAPIState("started")),
 			fixtures.WithPriority(2),
+			fixtures.WithRelations(relation),
 		),
 		fixtures.FixtureAPIIssue(
 			fixtures.WithIssueID("issue-2", "TST-2"),
@@ -234,6 +247,7 @@ func populateTestFixtures(ctx context.Context, store *db.Store) error {
 			fixtures.WithDescription("This is a high priority issue"),
 			fixtures.WithState(fixtures.FixtureAPIState("backlog")),
 			fixtures.WithPriority(4),
+			fixtures.WithInverseRelations(inverseRelation),
 		),
 		fixtures.FixtureAPIIssue(
 			fixtures.WithIssueID("issue-4", "TST-4"),
@@ -337,6 +351,49 @@ func populateTestFixtures(ctx context.Context, store *db.Store) error {
 	// Populate embedded files for issue-1
 	embeddedFiles := fixtures.FixtureAPIEmbeddedFiles()
 	if err := fixtures.PopulateEmbeddedFiles(ctx, store, "issue-1", embeddedFiles); err != nil {
+		return err
+	}
+
+	// Populate the relation row: TST-1 blocks TST-3 (backs relations/ on both ends)
+	if err := fixtures.PopulateIssueRelations(ctx, store, "issue-1", []api.IssueRelation{relation}); err != nil {
+		return err
+	}
+
+	// Populate milestones and status updates for the project
+	if err := fixtures.PopulateProjectMilestones(ctx, store, project.ID, []api.ProjectMilestone{fixtures.FixtureAPIProjectMilestone()}); err != nil {
+		return err
+	}
+	if err := fixtures.PopulateProjectUpdates(ctx, store, project.ID, []api.ProjectUpdate{fixtures.FixtureAPIProjectUpdate()}); err != nil {
+		return err
+	}
+
+	// Populate a status update for the initiative
+	if err := fixtures.PopulateInitiativeUpdates(ctx, store, initiative.ID, []api.InitiativeUpdate{fixtures.FixtureAPIInitiativeUpdate()}); err != nil {
+		return err
+	}
+
+	// Populate an external URL attachment for issue-1 (a .link file)
+	if err := fixtures.PopulateAttachments(ctx, store, "issue-1", []api.Attachment{fixtures.FixtureAPIAttachment()}); err != nil {
+		return err
+	}
+
+	// Populate cached history for issue-1 (backs the history.md render)
+	if err := fixtures.PopulateIssueHistory(ctx, store, "issue-1", fixtures.FixtureAPIHistoryEntries()); err != nil {
+		return err
+	}
+
+	// Populate team membership (backs the by/assignee value listing)
+	userIDs := make([]string, len(users))
+	for i, u := range users {
+		userIDs[i] = u.ID
+	}
+	if err := fixtures.PopulateTeamMembers(ctx, store, team.ID, userIDs); err != nil {
+		return err
+	}
+
+	// Populate the viewer identity (backs the my/ views; user-1 is the default
+	// fixture assignee, so my/assigned is non-empty)
+	if err := fixtures.PopulateViewer(ctx, store, "user-1"); err != nil {
 		return err
 	}
 

--- a/internal/testutil/fixtures/api.go
+++ b/internal/testutil/fixtures/api.go
@@ -444,3 +444,69 @@ func FixtureAPIProjectMilestone() api.ProjectMilestone {
 		SortOrder:   1.0,
 	}
 }
+
+// WithRelations sets the issue's outgoing relations. They ride the issue's
+// data blob, so issue.meta renders them; the relations/ directory reads the
+// issue_relations table instead (see PopulateIssueRelations).
+func WithRelations(rels ...api.IssueRelation) IssueOption {
+	return func(i *api.Issue) {
+		i.Relations = api.IssueRelations{Nodes: rels}
+	}
+}
+
+// WithInverseRelations sets the issue's incoming relations (see WithRelations).
+func WithInverseRelations(rels ...api.IssueRelation) IssueOption {
+	return func(i *api.Issue) {
+		i.InverseRelations = api.IssueRelations{Nodes: rels}
+	}
+}
+
+// FixtureAPIIssueRelation returns an outgoing relation: TST-1 blocks TST-3.
+// Both endpoints exist in the standard fixture issue set, so the enrichment
+// path (relationView resolving the other end's identifier/title) is exercised.
+func FixtureAPIIssueRelation() api.IssueRelation {
+	return api.IssueRelation{
+		ID:   "rel-1",
+		Type: "blocks",
+		RelatedIssue: &api.ParentIssue{
+			ID:         "issue-3",
+			Identifier: "TST-3",
+			Title:      "Test Issue 3 - High Priority",
+		},
+		CreatedAt: fixtureTime,
+		UpdatedAt: fixtureTime,
+	}
+}
+
+// FixtureAPIAttachment returns an external URL attachment (rendered as a
+// *.link file in the attachments/ directory).
+func FixtureAPIAttachment() api.Attachment {
+	user := FixtureAPIUser()
+	return api.Attachment{
+		ID:         "attachment-1",
+		Title:      "Design Spec",
+		Subtitle:   "example.com",
+		URL:        "https://example.com/design-spec",
+		SourceType: "url",
+		Creator:    &user,
+		CreatedAt:  fixtureTime,
+		UpdatedAt:  fixtureTime,
+	}
+}
+
+// FixtureAPIHistoryEntries returns issue history entries with a describable
+// change (state transition), so HistoryToMarkdown renders a non-empty body.
+func FixtureAPIHistoryEntries() []api.IssueHistoryEntry {
+	actor := FixtureAPIUser()
+	from := FixtureAPIState("unstarted")
+	to := FixtureAPIState("started")
+	return []api.IssueHistoryEntry{
+		{
+			ID:        "history-1",
+			CreatedAt: fixtureTime.Add(time.Hour),
+			Actor:     &actor,
+			FromState: &from,
+			ToState:   &to,
+		},
+	}
+}

--- a/internal/testutil/fixtures/fstest.go
+++ b/internal/testutil/fixtures/fstest.go
@@ -3,6 +3,7 @@ package fixtures
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"path/filepath"
 	"testing"
 	"time"
@@ -319,6 +320,120 @@ func PopulateEmbeddedFiles(ctx context.Context, store *db.Store, issueID string,
 		}
 	}
 	return nil
+}
+
+// PopulateIssueRelations inserts outgoing relations for an issue into the
+// issue_relations table (the store behind the relations/ directory). Each
+// relation must carry RelatedIssue; the row is stored from the owner's
+// perspective, so the target issue's relations/ shows the inverse file.
+func PopulateIssueRelations(ctx context.Context, store *db.Store, issueID string, rels []api.IssueRelation) error {
+	q := store.Queries()
+	for _, rel := range rels {
+		if err := q.UpsertIssueRelation(ctx, db.IssueRelationUpsertParams(rel, issueID, rel.RelatedIssue.ID)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PopulateProjectMilestones inserts milestones for a project into the SQLite store.
+func PopulateProjectMilestones(ctx context.Context, store *db.Store, projectID string, milestones []api.ProjectMilestone) error {
+	q := store.Queries()
+	for _, m := range milestones {
+		params, err := db.APIProjectMilestoneToDBMilestone(m, projectID)
+		if err != nil {
+			return err
+		}
+		if err := q.UpsertProjectMilestone(ctx, params); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PopulateProjectUpdates inserts status updates for a project into the SQLite store.
+func PopulateProjectUpdates(ctx context.Context, store *db.Store, projectID string, updates []api.ProjectUpdate) error {
+	q := store.Queries()
+	for _, u := range updates {
+		params, err := db.APIProjectUpdateToDBUpdate(u, projectID)
+		if err != nil {
+			return err
+		}
+		if err := q.UpsertProjectUpdate(ctx, params); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PopulateInitiativeUpdates inserts status updates for an initiative into the SQLite store.
+func PopulateInitiativeUpdates(ctx context.Context, store *db.Store, initiativeID string, updates []api.InitiativeUpdate) error {
+	q := store.Queries()
+	for _, u := range updates {
+		params, err := db.APIInitiativeUpdateToDBUpdate(u, initiativeID)
+		if err != nil {
+			return err
+		}
+		if err := q.UpsertInitiativeUpdate(ctx, params); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PopulateAttachments inserts external URL attachments for an issue into the
+// SQLite store (rendered as *.link files in attachments/).
+func PopulateAttachments(ctx context.Context, store *db.Store, issueID string, attachments []api.Attachment) error {
+	q := store.Queries()
+	for _, a := range attachments {
+		params, err := db.APIAttachmentToDBAttachment(a, issueID)
+		if err != nil {
+			return err
+		}
+		if err := q.UpsertAttachment(ctx, params); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PopulateIssueHistory caches history entries for an issue (the store behind
+// the history.md render).
+func PopulateIssueHistory(ctx context.Context, store *db.Store, issueID string, entries []api.IssueHistoryEntry) error {
+	data, err := json.Marshal(entries)
+	if err != nil {
+		return err
+	}
+	return store.Queries().UpsertIssueHistoryCache(ctx, db.UpsertIssueHistoryCacheParams{
+		IssueID:  issueID,
+		SyncedAt: time.Now(),
+		Data:     data,
+	})
+}
+
+// PopulateTeamMembers inserts team membership rows (the store behind the
+// by/assignee value listing).
+func PopulateTeamMembers(ctx context.Context, store *db.Store, teamID string, userIDs []string) error {
+	q := store.Queries()
+	for _, uid := range userIDs {
+		if err := q.UpsertTeamMember(ctx, db.UpsertTeamMemberParams{
+			TeamID:   teamID,
+			UserID:   uid,
+			SyncedAt: time.Now(),
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PopulateViewer records the viewer identity (the store behind the my/ views;
+// the user must also be populated via PopulateUsers so the identity resolves).
+func PopulateViewer(ctx context.Context, store *db.Store, userID string) error {
+	return store.Queries().SetViewerUserID(ctx, db.SetViewerUserIDParams{
+		UserID:   userID,
+		SyncedAt: time.Now(),
+	})
 }
 
 // FixtureAPIEmbeddedFiles returns a set of embedded files for testing.


### PR DESCRIPTION
## Why

Round-18 architecture review, card 5 (fixture parity): schema tables without fixture constructors/populators are surfaces only live mode can exercise — which is exactly how render drift escapes CI. Part of the card was already stale (project-labels catalog+symlink and embedded files gained fixtures/tests in earlier rounds); this closes the remaining gaps and pins the invariant so it can't reopen.

## What

**Fixture constructors + populators** (`internal/testutil/fixtures`):
- `FixtureAPIIssueRelation` + `WithRelations`/`WithInverseRelations` + `PopulateIssueRelations` — relations/ dirs (.rel files, both endpoints) and issue.meta relations render
- `PopulateProjectMilestones`, `PopulateProjectUpdates`, `PopulateInitiativeUpdates`
- `FixtureAPIAttachment` + `PopulateAttachments` — external `*.link` files
- `FixtureAPIHistoryEntries` + `PopulateIssueHistory` — history.md render
- `PopulateTeamMembers` — by/assignee value listing
- `PopulateViewer` — viewer_cache; `InjectTestStore` now mirrors `EnableSQLiteCache`'s cached-viewer load (cache read only, never the API refresh goroutine), so my/ views are exercisable offline

**Conformance:** `TestSchemaFixtureCoverage` enumerates the fixture store's tables (schema.sql as applied) and asserts each is populated or on an explicit, commented exclusion list (`sync_meta`, `pending_detail_sync` — sync bookkeeping, no mount-visible render). A new table without a fixture fails CI.

**New fixture-mode tests:** relation .rel files (both directions), issue.meta relations, milestone file, project/initiative update health frontmatter, attachment .link, rendered history, by/assignee members, my/assigned.

## Production bug found (and fixed, first commit)

The new relation test flushed out a real bug: **both endpoints' .rel files for one relation shared `relationIno(rel.ID)`**. go-fuse dedups nodes by ino after the lookup handler returns, and the `refreshExisting` probe (`parent.GetChild`) can't see across directories — so whichever endpoint was looked up first had its node served for BOTH paths: reading B's `blocked-by-A.rel` returned A's outgoing render (`to: B`) instead of `from: A`. Fixed by keying the inverse view's ino as `rel.ID + "/inverse"`.

## Coverage matrix (24 tables)

| Table | Status |
|---|---|
| teams, states, labels, users, issues, cycles, projects, project_teams, comments, documents, initiatives, initiative_projects, project_labels, embedded_files | already populated |
| issue_relations, project_milestones, project_updates, initiative_updates, attachments, issue_history_cache, team_members, viewer_cache | **newly populated** |
| sync_meta, pending_detail_sync | excluded: sync-worker bookkeeping, no mount-visible render |

## Verification

- `make build`, `go vet ./...`, `gofmt -l internal/` clean
- `go test ./...` green (full suite incl. FUSE integration, fixture mode)
- One existing test updated: `TestFixtureAttachmentsDirectoryListing` now expects the third (external .link) attachment

🤖 Generated with [Claude Code](https://claude.com/claude-code)