### PR TITLE
refactor(fs): normalize view/entity dir attrs + inos — honest times, total ino namespace, refresh seam everywhere

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -357,21 +357,34 @@ The seam: construction helpers (`newDirInode`/`newFileInode`/`newRenderInode`/
 the bridge will keep if it dedups — and push the fresh twin's volatile state
 into it via `refreshFrom(fresh)` (`internal/fs/refresh.go`). A nil child means
 the kernel FORGOT it and the fresh node installs — already fresh. Per-type
-rules: the three entity dir nodes swap their entity under `attrNode.stateMu`
+rules: snapshot-carrying dir nodes swap their entity under `attrNode.stateMu`
 (which also guards `nodeAttr`, re-stamped by the seam) and expose
-`entity()/setEntity` snapshots; the seven editBuffer file nodes go through
+`entity()/setEntity` snapshots — the three entity dirs (issue/project/
+initiative) plus, since the view-dir normalization, `TeamNode`, `UserNode`,
+`CycleDirNode` (team+cycle under one lock), and every team-view dir holding a
+team (`IssuesNode`/`ProjectsNode`/`CyclesNode`/`RecentNode`/the three by/
+filter shapes); the seven editBuffer file nodes go through
 `editBuffer.refresh` — **a dirty buffer always wins** (a user's in-flight
 edit is never clobbered by background sync) — with Getattr snapshotting
 size+times under one lock; renderFile swaps its closure under `renderMu`
 (embedders with entity fields shadow `refreshFrom` and reuse that lock);
-`EmbeddedFileNode` swaps its file metadata under its own mu. `TeamNode`/
-`UserNode`/cycle dirs are constructed with auto-assigned inos (fresh node per
-Lookup) and don't need the seam — a pre-existing inconsistency with the inode
-namespace that happens to dodge the bug. Guarded end-to-end by
+`EmbeddedFileNode` swaps its file metadata under its own mu. The old
+exception paragraph is GONE: `TeamNode`/`UserNode`/cycle dirs used to ride
+auto-assigned inos (fresh node per Lookup) and dodge the bug — that
+inconsistency is erased; they are on stable inos with the seam like everyone
+else. Because dirty-buffer-wins means the kept node can refuse a refresh,
+`newFileInode` reports the KEPT node's size in the Lookup answer (an
+`interface{ size() int }` probe after `refreshExisting`), not the fresh
+render's — a fresh-twin size would clamp kernel reads of longer dirty content
+(a real truncation: project.md read back "unclosed" after a rejected save;
+`TestRejectedSaveKeepsDirtyContentReadable` pins it). Guarded end-to-end by
 `TestRemoteUpdateVisibleAfterKernelRevalidation` (remote upsert → pinned
 inode chain so the kernel cannot FORGET → 31s real entry-timeout expiry →
 fresh content and mtime; the pin is what forces the reuse path — without it
-the kernel may forget everything and the test passes vacuously).
+the kernel may forget everything and the test passes vacuously) and its
+`TestRemoteTeamUpdateVisibleAfterKernelRevalidation` twin on the busiest
+reused node (pin the team dir, upsert the team row, expiry, fresh team.md +
+dir mtime).
 
 ### Attr construction (`nodeAttr`/`attrNode`)
 The **deep module** owning how a directory or file node's attributes are
@@ -395,6 +408,22 @@ with the times their parent's Lookup answered. The collapsed contract is the
 issue's times uniformly (`atime/mtime = UpdatedAt`, `ctime = CreatedAt`), which
 forced the directory nodes to become self-describing — carry the times they
 report rather than re-derive them per call.
+
+The view-dir normalization finished the sweep: every directory node now
+routes through `newDirInode` and the mixin — the four stateless root
+containers (`TeamsNode`/`UsersNode`/`MyNode`/`InitiativesNode`, plus the
+mount root's own `Getattr` and the `my/` subdirs) report **zero times, an
+honest unknown**, never a fabricated `now()`; `TeamNode` and the team-view
+dirs (`issues/`, `projects/`, `cycles/`, `recent/`, `by/` and its two nested
+shapes) report the team's times; `CycleDirNode` keeps the cycle tier's
+convention via the one deliberate `nodeAttr.atime` override (atime=EndsAt,
+mtime/ctime=StartsAt — `api.Cycle` has no created/updated; the `current`
+symlink mirrors it); `UserNode` is zero-times (`api.User` has no time
+fields). `newDirInode` accepts `inheritTimeout` (< 0 skips the Set*Timeout
+calls, like the render files) so the view dirs keep the mount default they
+always had. Remaining exception: `LabelFileNode`/`MilestoneFileNode` `Getattr`
+still report `now()` (their API types carry no timestamps — see
+[[edit-buffer]]).
 
 **Directories vs files.** A directory's attributes are wholly static, so it
 gets the mixin and the inherited `Getattr` (true no-drift). A file's `Size` is
@@ -424,6 +453,17 @@ serving as the checklist a new kind must join. `scratchIno` (`atomicwrite.go`)
 is deliberately **not** a wrapper: its key mixes the parent directory inode with
 the name (so concurrent temp files in different dirs don't collide), a different
 shape than `kind:id`.
+
+The namespace is **total for directories** since the view-dir normalization:
+`viewdir:{name}` (the teams/users/my/initiatives containers) and
+`mydir:{name}` (my/ subdirs) key on the fixed directory name; `teamdir`/
+`cyclesdir`/`recentdir` on the team id, `cycledir` on the cycle id, `userdir`
+on the user id; the by/ filter tree uses composite keys joined with `/` (a
+character a FUSE name can never contain): `bydir:{team}`,
+`bycat:{team}/{category}`, `byval:{team}/{category}/{value}`. No directory is
+ever auto-assigned anymore — the only deliberate auto-ino residents are the
+write-only `_create` trigger files (stateless, one node per open-write-close)
+and symlinks.
 
 ### Edit buffer (`editBuffer`)
 The **deep module** owning the read/write byte buffer of every editable file

--- a/internal/fs/cycles.go
+++ b/internal/fs/cycles.go
@@ -22,9 +22,10 @@ func cycleDirName(cycle api.Cycle) string {
 	return strings.ReplaceAll(name, " ", "-")
 }
 
-// CyclesNode represents the /teams/{KEY}/cycles directory
+// CyclesNode represents the /teams/{KEY}/cycles directory. It holds a team
+// snapshot and reports the team's times; Getattr comes from the attrNode mixin.
 type CyclesNode struct {
-	BaseNode
+	attrNode
 	team api.Team
 }
 
@@ -32,16 +33,29 @@ var _ fs.NodeReaddirer = (*CyclesNode)(nil)
 var _ fs.NodeLookuper = (*CyclesNode)(nil)
 var _ fs.NodeGetattrer = (*CyclesNode)(nil)
 
-func (c *CyclesNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0755 | syscall.S_IFDIR
-	c.SetOwner(out)
-	out.SetTimes(&now, &now, &now)
-	return 0
+// entity/setEntity snapshot and swap the directory's team under the node's
+// volatile-state lock; setEntity is written by the nodeRefresher seam
+// (refresh.go).
+func (c *CyclesNode) entity() api.Team {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	return c.team
+}
+
+func (c *CyclesNode) setEntity(team api.Team) {
+	c.stateMu.Lock()
+	c.team = team
+	c.stateMu.Unlock()
+}
+
+func (c *CyclesNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*CyclesNode); ok {
+		c.setEntity(f.team)
+	}
 }
 
 func (c *CyclesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
-	cycles, err := c.lfs.GetTeamCycles(ctx, c.team.ID)
+	cycles, err := c.lfs.GetTeamCycles(ctx, c.entity().ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -71,7 +85,8 @@ func (c *CyclesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) 
 }
 
 func (c *CyclesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	cycles, err := c.lfs.GetTeamCycles(ctx, c.team.ID)
+	team := c.entity()
+	cycles, err := c.lfs.GetTeamCycles(ctx, team.ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -90,12 +105,12 @@ func (c *CyclesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut
 	// Match by cycle directory name
 	for _, cycle := range cycles {
 		if cycleDirName(cycle) == name {
-			node := &CycleDirNode{BaseNode: BaseNode{lfs: c.lfs}, team: c.team, cycle: cycle}
-			out.Attr.Mode = 0755 | syscall.S_IFDIR
-			out.Attr.Uid = c.lfs.uid
-			out.Attr.Gid = c.lfs.gid
-			out.Attr.SetTimes(&cycle.EndsAt, &cycle.StartsAt, &cycle.StartsAt)
-			return c.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
+			node := &CycleDirNode{attrNode: attrNode{BaseNode: BaseNode{lfs: c.lfs}}, team: team, cycle: cycle}
+			// api.Cycle has no created/updated fields; the cycle tier's
+			// convention is mtime/ctime=StartsAt with atime=EndsAt (which the
+			// "current" symlink mirrors) — never now().
+			na := nodeAttr{mode: 0755 | syscall.S_IFDIR, created: cycle.StartsAt, updated: cycle.StartsAt, atime: cycle.EndsAt}
+			return c.newDirInode(ctx, out, name, node, na, cycleDirIno(cycle.ID), inheritTimeout), 0
 		}
 	}
 
@@ -104,7 +119,7 @@ func (c *CyclesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut
 
 // CycleDirNode represents a cycle directory (e.g., /teams/ENG/cycles/71/)
 type CycleDirNode struct {
-	BaseNode
+	attrNode
 	team  api.Team
 	cycle api.Cycle
 }
@@ -113,15 +128,30 @@ var _ fs.NodeReaddirer = (*CycleDirNode)(nil)
 var _ fs.NodeLookuper = (*CycleDirNode)(nil)
 var _ fs.NodeGetattrer = (*CycleDirNode)(nil)
 
-func (c *CycleDirNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	out.Mode = 0755 | syscall.S_IFDIR
-	c.SetOwner(out)
-	out.Attr.SetTimes(&c.cycle.EndsAt, &c.cycle.StartsAt, &c.cycle.StartsAt)
-	return 0
+// entity/setEntity snapshot and swap the directory's team+cycle under the
+// node's volatile-state lock; setEntity is written by the nodeRefresher seam
+// (refresh.go).
+func (c *CycleDirNode) entity() (api.Team, api.Cycle) {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	return c.team, c.cycle
+}
+
+func (c *CycleDirNode) setEntity(team api.Team, cycle api.Cycle) {
+	c.stateMu.Lock()
+	c.team, c.cycle = team, cycle
+	c.stateMu.Unlock()
+}
+
+func (c *CycleDirNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*CycleDirNode); ok {
+		c.setEntity(f.team, f.cycle)
+	}
 }
 
 func (c *CycleDirNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
-	issues, err := c.lfs.GetCycleIssues(ctx, c.cycle.ID)
+	_, cycle := c.entity()
+	issues, err := c.lfs.GetCycleIssues(ctx, cycle.ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -144,17 +174,17 @@ func (c *CycleDirNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno
 }
 
 func (c *CycleDirNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+	team, cycle := c.entity()
 	// Handle cycle.md. A cycle has no updatedAt; report StartsAt as both mtime
 	// and ctime (preserving the previous sort order), never now().
 	if name == "cycle.md" {
-		team, cycle := c.team, c.cycle
 		return c.lookupRenderFile(ctx, out, "cycle.md", func(context.Context) ([]byte, time.Time, time.Time) {
 			return cycleMarkdown(team, cycle), cycle.StartsAt, cycle.StartsAt
 		}, 0, inheritTimeout), 0
 	}
 
 	// Handle issue symlinks (e.g., "ENG-123")
-	issues, err := c.lfs.GetCycleIssues(ctx, c.cycle.ID)
+	issues, err := c.lfs.GetCycleIssues(ctx, cycle.ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}

--- a/internal/fs/filter.go
+++ b/internal/fs/filter.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
@@ -28,9 +27,10 @@ func assigneeHandle(user *api.User) string {
 	return user.Email
 }
 
-// FilterRootNode represents the by/ directory
+// FilterRootNode represents the by/ directory. It holds a team snapshot and
+// reports the team's times; Getattr comes from the attrNode mixin.
 type FilterRootNode struct {
-	BaseNode
+	attrNode
 	team api.Team
 }
 
@@ -40,12 +40,25 @@ var _ fs.NodeGetattrer = (*FilterRootNode)(nil)
 
 var filterCategories = []string{"status", "label", "assignee"}
 
-func (f *FilterRootNode) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0755 | syscall.S_IFDIR
-	f.SetOwner(out)
-	out.SetTimes(&now, &now, &now)
-	return 0
+// entity/setEntity snapshot and swap the directory's team under the node's
+// volatile-state lock; setEntity is written by the nodeRefresher seam
+// (refresh.go).
+func (f *FilterRootNode) entity() api.Team {
+	f.stateMu.Lock()
+	defer f.stateMu.Unlock()
+	return f.team
+}
+
+func (f *FilterRootNode) setEntity(team api.Team) {
+	f.stateMu.Lock()
+	f.team = team
+	f.stateMu.Unlock()
+}
+
+func (f *FilterRootNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if fr, ok := fresh.(*FilterRootNode); ok {
+		f.setEntity(fr.team)
+	}
 }
 
 func (f *FilterRootNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
@@ -60,27 +73,24 @@ func (f *FilterRootNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Err
 }
 
 func (f *FilterRootNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+	team := f.entity()
 	for _, cat := range filterCategories {
 		if cat == name {
-			now := time.Now()
-			out.Attr.Mode = 0755 | syscall.S_IFDIR
-			out.Attr.Uid = f.lfs.uid
-			out.Attr.Gid = f.lfs.gid
-			out.Attr.SetTimes(&now, &now, &now)
 			node := &FilterCategoryNode{
-				BaseNode: BaseNode{lfs: f.lfs},
-				team:     f.team,
+				attrNode: attrNode{BaseNode: BaseNode{lfs: f.lfs}},
+				team:     team,
 				category: name,
 			}
-			return f.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
+			return f.newDirInode(ctx, out, name, node, dirAttr(team.CreatedAt, team.UpdatedAt), byCategoryIno(team.ID, name), inheritTimeout), 0
 		}
 	}
 	return nil, syscall.ENOENT
 }
 
-// FilterCategoryNode represents a filter category directory (e.g., by/status/)
+// FilterCategoryNode represents a filter category directory (e.g., by/status/).
+// The category is immutable identity; the team snapshot is the volatile half.
 type FilterCategoryNode struct {
-	BaseNode
+	attrNode
 	team     api.Team
 	category string
 }
@@ -89,12 +99,22 @@ var _ fs.NodeReaddirer = (*FilterCategoryNode)(nil)
 var _ fs.NodeLookuper = (*FilterCategoryNode)(nil)
 var _ fs.NodeGetattrer = (*FilterCategoryNode)(nil)
 
-func (f *FilterCategoryNode) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0755 | syscall.S_IFDIR
-	f.SetOwner(out)
-	out.SetTimes(&now, &now, &now)
-	return 0
+func (f *FilterCategoryNode) entity() api.Team {
+	f.stateMu.Lock()
+	defer f.stateMu.Unlock()
+	return f.team
+}
+
+func (f *FilterCategoryNode) setEntity(team api.Team) {
+	f.stateMu.Lock()
+	f.team = team
+	f.stateMu.Unlock()
+}
+
+func (f *FilterCategoryNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if fr, ok := fresh.(*FilterCategoryNode); ok {
+		f.setEntity(fr.team)
+	}
 }
 
 func (f *FilterCategoryNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
@@ -119,30 +139,27 @@ func (f *FilterCategoryNode) Lookup(ctx context.Context, name string, out *fuse.
 		return nil, syscall.EIO
 	}
 
+	team := f.entity()
 	for _, val := range values {
 		if val == name {
-			now := time.Now()
-			out.Attr.Mode = 0755 | syscall.S_IFDIR
-			out.Attr.Uid = f.lfs.uid
-			out.Attr.Gid = f.lfs.gid
-			out.Attr.SetTimes(&now, &now, &now)
 			node := &FilterValueNode{
-				BaseNode: BaseNode{lfs: f.lfs},
-				team:     f.team,
+				attrNode: attrNode{BaseNode: BaseNode{lfs: f.lfs}},
+				team:     team,
 				category: f.category,
 				value:    name,
 			}
-			return f.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
+			return f.newDirInode(ctx, out, name, node, dirAttr(team.CreatedAt, team.UpdatedAt), byValueIno(team.ID, f.category, name), inheritTimeout), 0
 		}
 	}
 	return nil, syscall.ENOENT
 }
 
 func (f *FilterCategoryNode) getUniqueValues(ctx context.Context) ([]string, error) {
+	teamID := f.entity().ID
 	switch f.category {
 	case "status":
 		// Use team states from API - much faster than scanning all issues
-		states, err := f.lfs.GetTeamStates(ctx, f.team.ID)
+		states, err := f.lfs.GetTeamStates(ctx, teamID)
 		if err != nil {
 			return nil, err
 		}
@@ -155,7 +172,7 @@ func (f *FilterCategoryNode) getUniqueValues(ctx context.Context) ([]string, err
 
 	case "label":
 		// Use team labels from API - much faster than scanning all issues
-		labels, err := f.lfs.GetTeamLabels(ctx, f.team.ID)
+		labels, err := f.lfs.GetTeamLabels(ctx, teamID)
 		if err != nil {
 			return nil, err
 		}
@@ -168,7 +185,7 @@ func (f *FilterCategoryNode) getUniqueValues(ctx context.Context) ([]string, err
 
 	case "assignee":
 		// Use team members - show only users who are members of this team plus "unassigned"
-		users, err := f.lfs.GetTeamMembers(ctx, f.team.ID)
+		users, err := f.lfs.GetTeamMembers(ctx, teamID)
 		if err != nil {
 			return nil, err
 		}
@@ -184,9 +201,10 @@ func (f *FilterCategoryNode) getUniqueValues(ctx context.Context) ([]string, err
 	return nil, nil
 }
 
-// FilterValueNode represents a filter value directory (e.g., by/status/In Progress/)
+// FilterValueNode represents a filter value directory (e.g., by/status/In Progress/).
+// category/value are immutable identity; the team snapshot is the volatile half.
 type FilterValueNode struct {
-	BaseNode
+	attrNode
 	team     api.Team
 	category string
 	value    string
@@ -196,12 +214,22 @@ var _ fs.NodeReaddirer = (*FilterValueNode)(nil)
 var _ fs.NodeLookuper = (*FilterValueNode)(nil)
 var _ fs.NodeGetattrer = (*FilterValueNode)(nil)
 
-func (f *FilterValueNode) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0755 | syscall.S_IFDIR
-	f.SetOwner(out)
-	out.SetTimes(&now, &now, &now)
-	return 0
+func (f *FilterValueNode) entity() api.Team {
+	f.stateMu.Lock()
+	defer f.stateMu.Unlock()
+	return f.team
+}
+
+func (f *FilterValueNode) setEntity(team api.Team) {
+	f.stateMu.Lock()
+	f.team = team
+	f.stateMu.Unlock()
+}
+
+func (f *FilterValueNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if fr, ok := fresh.(*FilterValueNode); ok {
+		f.setEntity(fr.team)
+	}
 }
 
 func (f *FilterValueNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
@@ -237,22 +265,23 @@ func (f *FilterValueNode) Lookup(ctx context.Context, name string, out *fuse.Ent
 }
 
 func (f *FilterValueNode) getFilteredIssues(ctx context.Context) ([]api.Issue, error) {
+	teamID := f.entity().ID
 	// Use server-side filtering for much better performance
 	switch f.category {
 	case "status":
-		return f.lfs.GetFilteredIssuesByStatus(ctx, f.team.ID, f.value)
+		return f.lfs.GetFilteredIssuesByStatus(ctx, teamID, f.value)
 	case "label":
-		return f.lfs.GetFilteredIssuesByLabel(ctx, f.team.ID, f.value)
+		return f.lfs.GetFilteredIssuesByLabel(ctx, teamID, f.value)
 	case "assignee":
 		if f.value == "unassigned" {
-			return f.lfs.GetFilteredIssuesUnassigned(ctx, f.team.ID)
+			return f.lfs.GetFilteredIssuesUnassigned(ctx, teamID)
 		}
 		// Need to resolve assignee handle to ID
 		assigneeID, err := f.resolveAssigneeID(ctx)
 		if err != nil {
 			return nil, err
 		}
-		return f.lfs.GetFilteredIssuesByAssignee(ctx, f.team.ID, assigneeID)
+		return f.lfs.GetFilteredIssuesByAssignee(ctx, teamID, assigneeID)
 	default:
 		return nil, fmt.Errorf("unknown filter category: %s", f.category)
 	}
@@ -260,7 +289,7 @@ func (f *FilterValueNode) getFilteredIssues(ctx context.Context) ([]api.Issue, e
 
 // resolveAssigneeID converts an assignee handle (display name or email prefix) to user ID
 func (f *FilterValueNode) resolveAssigneeID(ctx context.Context) (string, error) {
-	users, err := f.lfs.GetTeamMembers(ctx, f.team.ID)
+	users, err := f.lfs.GetTeamMembers(ctx, f.entity().ID)
 	if err != nil {
 		return "", err
 	}

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -14,22 +14,15 @@ import (
 	"github.com/jra3/linear-fuse/internal/marshal"
 )
 
-// InitiativesNode represents the /initiatives directory
+// InitiativesNode represents the /initiatives directory. Stateless container:
+// zero times (honest unknown); Getattr comes from the attrNode mixin.
 type InitiativesNode struct {
-	BaseNode
+	attrNode
 }
 
 var _ fs.NodeReaddirer = (*InitiativesNode)(nil)
 var _ fs.NodeLookuper = (*InitiativesNode)(nil)
 var _ fs.NodeGetattrer = (*InitiativesNode)(nil)
-
-func (i *InitiativesNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0755 | syscall.S_IFDIR
-	i.SetOwner(out)
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
 
 func (i *InitiativesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	initiatives, err := i.lfs.GetInitiatives(ctx)

--- a/internal/fs/ino.go
+++ b/internal/fs/ino.go
@@ -90,6 +90,36 @@ func initiativeUpdatesDirIno(initiativeID string) uint64 {
 }
 func initiativeUpdateIno(updateID string) uint64 { return ino("initiative-update", updateID) }
 
+// Root views ----------------------------------------------------------------
+// The stateless top-level containers (teams/, users/, my/, initiatives/) and
+// the my/ subdirs are keyed by their fixed directory name — there is exactly
+// one of each per mount.
+
+func viewDirIno(name string) uint64 { return ino("viewdir", name) }
+func myDirIno(name string) uint64   { return ino("mydir", name) }
+
+// Team tree -----------------------------------------------------------------
+
+func teamDirIno(teamID string) uint64   { return ino("teamdir", teamID) }
+func cyclesDirIno(teamID string) uint64 { return ino("cyclesdir", teamID) }
+func cycleDirIno(cycleID string) uint64 { return ino("cycledir", cycleID) }
+
+// Filter views (by/) ----------------------------------------------------------
+// Composite keys: a category dir is per team+category, a value dir per
+// team+category+value. FUSE names never contain "/", so "/" is a safe joiner.
+
+func byDirIno(teamID string) uint64 { return ino("bydir", teamID) }
+func byCategoryIno(teamID, category string) uint64 {
+	return ino("bycat", teamID+"/"+category)
+}
+func byValueIno(teamID, category, value string) uint64 {
+	return ino("byval", teamID+"/"+category+"/"+value)
+}
+
+// Users ----------------------------------------------------------------------
+
+func userDirIno(userID string) uint64 { return ino("userdir", userID) }
+
 // Team views ---------------------------------------------------------------
 
 func recentDirIno(teamID string) uint64 { return ino("recentdir", teamID) }

--- a/internal/fs/ino_test.go
+++ b/internal/fs/ino_test.go
@@ -66,6 +66,17 @@ func TestInodeNamespaceDistinct(t *testing.T) {
 		"recentDirIno":            recentDirIno(id),
 		"metaIno":                 metaIno(id),
 		"successIno":              successIno(id),
+		// View/entity directory kinds (composite keys get the shared id for
+		// every part — distinctness must hold regardless).
+		"viewDirIno":    viewDirIno(id),
+		"myDirIno":      myDirIno(id),
+		"teamDirIno":    teamDirIno(id),
+		"cyclesDirIno":  cyclesDirIno(id),
+		"cycleDirIno":   cycleDirIno(id),
+		"byDirIno":      byDirIno(id),
+		"byCategoryIno": byCategoryIno(id, id),
+		"byValueIno":    byValueIno(id, id, id),
+		"userDirIno":    userDirIno(id),
 	}
 
 	seen := make(map[uint64]string, len(namespace))

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -71,9 +71,10 @@ func (lfs *LinearFS) issueCreateSpec(teamID, op, key string, dir uint64, mutate 
 	}
 }
 
-// IssuesNode represents the /teams/{KEY}/issues directory
+// IssuesNode represents the /teams/{KEY}/issues directory. It holds a team
+// snapshot and reports the team's times; Getattr comes from the attrNode mixin.
 type IssuesNode struct {
-	BaseNode
+	attrNode
 	team api.Team
 }
 
@@ -83,16 +84,29 @@ var _ fs.NodeMkdirer = (*IssuesNode)(nil)
 var _ fs.NodeRmdirer = (*IssuesNode)(nil)
 var _ fs.NodeGetattrer = (*IssuesNode)(nil)
 
-func (n *IssuesNode) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0755 | syscall.S_IFDIR
-	n.SetOwner(out)
-	out.SetTimes(&now, &now, &now)
-	return 0
+// entity/setEntity snapshot and swap the directory's team under the node's
+// volatile-state lock; setEntity is written by the nodeRefresher seam
+// (refresh.go).
+func (n *IssuesNode) entity() api.Team {
+	n.stateMu.Lock()
+	defer n.stateMu.Unlock()
+	return n.team
+}
+
+func (n *IssuesNode) setEntity(team api.Team) {
+	n.stateMu.Lock()
+	n.team = team
+	n.stateMu.Unlock()
+}
+
+func (n *IssuesNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*IssuesNode); ok {
+		n.setEntity(f.team)
+	}
 }
 
 func (n *IssuesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
-	issues, err := n.lfs.GetTeamIssues(ctx, n.team.ID)
+	issues, err := n.lfs.GetTeamIssues(ctx, n.entity().ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -112,7 +126,7 @@ func (n *IssuesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) 
 // trio declares the issues collection's writable surfaces: _create takes a
 // full issue spec (frontmatter + body).
 func (n *IssuesNode) trio() collectionTrio {
-	return collectionTrio{kind: "issues", parentID: n.team.ID, onFlush: n.createIssue}
+	return collectionTrio{kind: "issues", parentID: n.entity().ID, onFlush: n.createIssue}
 }
 
 func (n *IssuesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
@@ -185,18 +199,19 @@ func retryableCreateErr(err error) bool {
 
 // Mkdir creates a new issue from a directory name
 func (n *IssuesNode) Mkdir(ctx context.Context, name string, mode uint32, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+	team := n.entity()
 	if n.lfs.debug {
-		log.Printf("Mkdir: %s in team %s (creating issue)", name, n.team.Key)
+		log.Printf("Mkdir: %s in team %s (creating issue)", name, team.Key)
 	}
 
 	// Quick path: title-only spec. Full-object creation goes through issues/_create.
 	issue, errno := commitCreate(ctx, n.lfs, n.lfs.issueCreateSpec(
-		n.team.ID,
+		team.ID,
 		`create issue "`+name+`"`,
-		collectionErrorKey("issues", n.team.ID),
-		issuesDirIno(n.team.ID),
+		collectionErrorKey("issues", team.ID),
+		issuesDirIno(team.ID),
 		func(ctx context.Context) (*api.Issue, error) {
-			return n.lfs.createIssueFromSpec(ctx, n.team, map[string]any{"title": name})
+			return n.lfs.createIssueFromSpec(ctx, team, map[string]any{"title": name})
 		},
 	))
 	if errno != 0 {
@@ -211,11 +226,12 @@ func (n *IssuesNode) Mkdir(ctx context.Context, name string, mode uint32, out *f
 // spec (frontmatter + body) creates one issue with all fields set at birth,
 // resolving names to IDs and reporting the new identity to issues/.last (#151).
 func (n *IssuesNode) createIssue(ctx context.Context, content []byte) syscall.Errno {
+	team := n.entity()
 	_, errno := commitCreate(ctx, n.lfs, n.lfs.issueCreateSpec(
-		n.team.ID,
+		team.ID,
 		"create issue from spec",
-		collectionErrorKey("issues", n.team.ID),
-		issuesDirIno(n.team.ID),
+		collectionErrorKey("issues", team.ID),
+		issuesDirIno(team.ID),
 		func(ctx context.Context) (*api.Issue, error) {
 			spec, err := marshal.MarkdownToIssueCreate(content)
 			if err != nil {
@@ -230,7 +246,7 @@ func (n *IssuesNode) createIssue(ctx context.Context, content []byte) syscall.Er
 				}
 				return nil, &FieldError{Field: field, Message: msg}
 			}
-			return n.lfs.createIssueFromSpec(ctx, n.team, spec)
+			return n.lfs.createIssueFromSpec(ctx, team, spec)
 		},
 	))
 	return errno
@@ -238,15 +254,16 @@ func (n *IssuesNode) createIssue(ctx context.Context, content []byte) syscall.Er
 
 // Rmdir archives an issue (soft delete)
 func (n *IssuesNode) Rmdir(ctx context.Context, name string) syscall.Errno {
+	team := n.entity()
 	if n.lfs.debug {
-		log.Printf("Rmdir: %s in team %s (archiving issue)", name, n.team.Key)
+		log.Printf("Rmdir: %s in team %s (archiving issue)", name, team.Key)
 	}
 
 	return commitDelete(ctx, n.lfs, deleteSpec[api.Issue]{
 		op:  `archive issue "` + name + `"`,
-		key: collectionErrorKey("issues", n.team.ID),
+		key: collectionErrorKey("issues", team.ID),
 		find: func(ctx context.Context) (*api.Issue, error) {
-			issues, err := n.lfs.GetTeamIssues(ctx, n.team.ID)
+			issues, err := n.lfs.GetTeamIssues(ctx, team.ID)
 			if err != nil {
 				return nil, err
 			}
@@ -266,12 +283,12 @@ func (n *IssuesNode) Rmdir(ctx context.Context, name string) syscall.Errno {
 		forget: func(ctx context.Context, i *api.Issue) error {
 			return n.lfs.store.Queries().DeleteIssue(ctx, i.ID)
 		},
-		dir:  issuesDirIno(n.team.ID),
+		dir:  issuesDirIno(team.ID),
 		name: name,
 		invalidateExtra: func(i *api.Issue) {
 			// The archived issue must also vanish from recent/ immediately
 			// (symmetric with the create tail's recent/ coherence).
-			n.lfs.InvalidateDeleted(recentDirIno(n.team.ID), name)
+			n.lfs.InvalidateDeleted(recentDirIno(team.ID), name)
 		},
 	})
 }

--- a/internal/fs/my.go
+++ b/internal/fs/my.go
@@ -10,22 +10,15 @@ import (
 	"github.com/jra3/linear-fuse/internal/api"
 )
 
-// MyNode represents the /my directory (personal views)
+// MyNode represents the /my directory (personal views). Stateless container:
+// zero times (honest unknown); Getattr comes from the attrNode mixin.
 type MyNode struct {
-	BaseNode
+	attrNode
 }
 
 var _ fs.NodeReaddirer = (*MyNode)(nil)
 var _ fs.NodeLookuper = (*MyNode)(nil)
 var _ fs.NodeGetattrer = (*MyNode)(nil)
-
-func (m *MyNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0755 | syscall.S_IFDIR
-	m.SetOwner(out)
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
 
 func (m *MyNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	entries := []fuse.DirEntry{
@@ -37,22 +30,12 @@ func (m *MyNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 }
 
 func (m *MyNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	now := time.Now()
-	out.Attr.Mode = 0755 | syscall.S_IFDIR
-	out.Attr.Uid = m.lfs.uid
-	out.Attr.Gid = m.lfs.gid
-	out.Attr.SetTimes(&now, &now, &now)
-
 	switch name {
-	case "assigned":
-		node := &MyIssuesNode{BaseNode: BaseNode{lfs: m.lfs}, issueType: "assigned"}
-		return m.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
-	case "created":
-		node := &MyIssuesNode{BaseNode: BaseNode{lfs: m.lfs}, issueType: "created"}
-		return m.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
-	case "active":
-		node := &MyIssuesNode{BaseNode: BaseNode{lfs: m.lfs}, issueType: "active"}
-		return m.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
+	case "assigned", "created", "active":
+		// Stateless like the parent (the name IS the identity): zero times,
+		// ino keyed on the fixed subdir name.
+		node := &MyIssuesNode{attrNode: attrNode{BaseNode: BaseNode{lfs: m.lfs}}, issueType: name}
+		return m.newDirInode(ctx, out, name, node, dirAttr(time.Time{}, time.Time{}), myDirIno(name), inheritTimeout), 0
 	default:
 		return nil, syscall.ENOENT
 	}
@@ -60,21 +43,13 @@ func (m *MyNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*
 
 // MyIssuesNode represents /my/{assigned,created,active} directories
 type MyIssuesNode struct {
-	BaseNode
+	attrNode
 	issueType string // "assigned", "created", or "active"
 }
 
 var _ fs.NodeReaddirer = (*MyIssuesNode)(nil)
 var _ fs.NodeLookuper = (*MyIssuesNode)(nil)
 var _ fs.NodeGetattrer = (*MyIssuesNode)(nil)
-
-func (m *MyIssuesNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0755 | syscall.S_IFDIR
-	m.SetOwner(out)
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
 
 func (m *MyIssuesNode) getIssues(ctx context.Context) ([]api.Issue, error) {
 	switch m.issueType {

--- a/internal/fs/nodeattr.go
+++ b/internal/fs/nodeattr.go
@@ -22,6 +22,11 @@ type nodeAttr struct {
 	size    uint64
 	created time.Time
 	updated time.Time
+	// atime, when non-zero, overrides the default atime==updated. The lone
+	// deliberate exception is the cycle directory tier (atime=EndsAt,
+	// mtime/ctime=StartsAt — api.Cycle has no created/updated fields), a
+	// pre-existing convention the "current" symlink mirrors.
+	atime time.Time
 }
 
 // fill renders the nodeAttr into a bare fuse.Attr. Both the directory mixin's
@@ -32,7 +37,11 @@ func (na nodeAttr) fill(attr *fuse.Attr, b *BaseNode) {
 	attr.Mode = na.mode
 	b.setOwnerAttr(attr)
 	attr.Size = na.size
-	attr.SetTimes(nonZeroTime(na.updated), nonZeroTime(na.updated), nonZeroTime(na.created))
+	atime := na.updated
+	if !na.atime.IsZero() {
+		atime = na.atime
+	}
+	attr.SetTimes(nonZeroTime(atime), nonZeroTime(na.updated), nonZeroTime(na.created))
 }
 
 // dirAttr is the nodeAttr for a standard 0755 directory reporting an entity's
@@ -99,13 +108,16 @@ type dirChild interface {
 // newDirInode builds a static-attr directory child from a parent's Lookup. It
 // fixes the child's reporting identity, fills the Lookup EntryOut by calling the
 // child's own fillAttr — the exact method its Getattr uses — sets the entry
-// timeout, and returns the inode. A Lookup answer and a later stat therefore
-// render identically by construction.
+// timeout (inheritTimeout leaves the mount default, like the render files), and
+// returns the inode. A Lookup answer and a later stat therefore render
+// identically by construction.
 func (b *BaseNode) newDirInode(ctx context.Context, out *fuse.EntryOut, name string, child dirChild, na nodeAttr, ino uint64, timeout time.Duration) *fs.Inode {
 	child.setAttr(na)
 	child.fillAttr(&out.Attr)
-	out.SetAttrTimeout(timeout)
-	out.SetEntryTimeout(timeout)
+	if timeout >= 0 {
+		out.SetAttrTimeout(timeout)
+		out.SetEntryTimeout(timeout)
+	}
 	// The bridge dedups AFTER this handler returns: if it still knows a node
 	// under this name, that one will serve — push the freshly-fetched times
 	// and entity into it (see refresh.go).
@@ -130,5 +142,18 @@ func (b *BaseNode) newFileInode(ctx context.Context, out *fuse.EntryOut, name st
 	// The bridge dedups AFTER this handler returns: push fresh content/entity
 	// into the node it will keep (a dirty edit buffer wins — see refresh.go).
 	refreshExisting(b, name, child)
+	// When the bridge keeps an already-known node, the Lookup answer must
+	// report THAT node's size, not the fresh render's. The two can differ in
+	// exactly one case: a dirty edit buffer refused the refresh (the user's
+	// in-flight or rejected-flush content always wins), and a size taken from
+	// the fresh twin would clamp kernel reads of the longer dirty content —
+	// observed as a truncated project.md ("unclosed frontmatter") after a
+	// rejected save.
+	if existing := b.EmbeddedInode().GetChild(name); existing != nil {
+		ops := existing.Operations()
+		if s, ok := ops.(interface{ size() int }); ok && ops != fs.InodeEmbedder(child) {
+			out.Attr.Size = uint64(s.size())
+		}
+	}
 	return b.NewInode(ctx, child, fs.StableAttr{Mode: na.mode & syscall.S_IFMT, Ino: ino})
 }

--- a/internal/fs/nodeattr_test.go
+++ b/internal/fs/nodeattr_test.go
@@ -69,6 +69,28 @@ func TestNodeAttrZeroTimeStaysEpoch(t *testing.T) {
 	}
 }
 
+// TestNodeAttrAtimeOverride pins the one deliberate exception to atime==updated:
+// a non-zero atime field overrides it (the cycle directory tier reports
+// atime=EndsAt with mtime/ctime=StartsAt, since api.Cycle has no
+// created/updated fields), while mtime/ctime stay on updated/created.
+func TestNodeAttrAtimeOverride(t *testing.T) {
+	t.Parallel()
+	lfs := testLFS(t)
+	starts := time.Unix(1_700_000_000, 0)
+	ends := time.Unix(1_700_500_000, 0)
+
+	na := nodeAttr{mode: 0755 | syscall.S_IFDIR, created: starts, updated: starts, atime: ends}
+	var attr fuse.Attr
+	na.fill(&attr, &BaseNode{lfs: lfs})
+
+	if int64(attr.Atime) != ends.Unix() {
+		t.Errorf("atime = %d, want %d (override)", attr.Atime, ends.Unix())
+	}
+	if int64(attr.Mtime) != starts.Unix() || int64(attr.Ctime) != starts.Unix() {
+		t.Errorf("mtime/ctime = %d/%d, want %d (updated/created untouched by the override)", attr.Mtime, attr.Ctime, starts.Unix())
+	}
+}
+
 // dirAttrNode is every constructed directory node: it carries a nodeAttr and
 // reports it through the attrNode mixin's promoted methods. fillAttr is the
 // Lookup-answer path (what newDirInode uses); Getattr is the stat path.
@@ -106,6 +128,24 @@ func TestDirNodeLookupGetattrAgree(t *testing.T) {
 		"issue-dir":      &IssueDirectoryNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
 		"project-dir":    &ProjectNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
 		"initiative-dir": &InitiativeNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		// The view/entity directory kinds normalized onto attrNode: the four
+		// top-level containers, the team/user entity dirs, and the team's view
+		// subdirectories (previously hand-rolled time.Now() blocks).
+		"teams-root":       &TeamsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"users-root":       &UsersNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"my-root":          &MyNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"initiatives-root": &InitiativesNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"team-dir":         &TeamNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"user-dir":         &UserNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"issues":           &IssuesNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"projects":         &ProjectsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"cycles":           &CyclesNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"cycle-dir":        &CycleDirNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"recent":           &RecentNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"by-root":          &FilterRootNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"by-category":      &FilterCategoryNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"by-value":         &FilterValueNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
+		"my-issues":        &MyIssuesNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}},
 	}
 
 	for name, node := range nodes {

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -15,9 +15,10 @@ import (
 	"github.com/jra3/linear-fuse/internal/marshal"
 )
 
-// ProjectsNode represents the /teams/{KEY}/projects directory
+// ProjectsNode represents the /teams/{KEY}/projects directory. It holds a team
+// snapshot and reports the team's times; Getattr comes from the attrNode mixin.
 type ProjectsNode struct {
-	BaseNode
+	attrNode
 	team api.Team
 }
 
@@ -27,16 +28,29 @@ var _ fs.NodeMkdirer = (*ProjectsNode)(nil)
 var _ fs.NodeRmdirer = (*ProjectsNode)(nil)
 var _ fs.NodeGetattrer = (*ProjectsNode)(nil)
 
-func (p *ProjectsNode) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0755 | syscall.S_IFDIR
-	p.SetOwner(out)
-	out.SetTimes(&now, &now, &now)
-	return 0
+// entity/setEntity snapshot and swap the directory's team under the node's
+// volatile-state lock; setEntity is written by the nodeRefresher seam
+// (refresh.go).
+func (p *ProjectsNode) entity() api.Team {
+	p.stateMu.Lock()
+	defer p.stateMu.Unlock()
+	return p.team
+}
+
+func (p *ProjectsNode) setEntity(team api.Team) {
+	p.stateMu.Lock()
+	p.team = team
+	p.stateMu.Unlock()
+}
+
+func (p *ProjectsNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*ProjectsNode); ok {
+		p.setEntity(f.team)
+	}
 }
 
 func (p *ProjectsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
-	projects, err := p.lfs.GetTeamProjects(ctx, p.team.ID)
+	projects, err := p.lfs.GetTeamProjects(ctx, p.entity().ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -57,7 +71,7 @@ func (p *ProjectsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno
 // trio declares the projects collection's feedback surfaces. Projects are
 // created by mkdir rather than a _create trigger, so onFlush stays nil.
 func (p *ProjectsNode) trio() collectionTrio {
-	return collectionTrio{kind: "projects", parentID: p.team.ID}
+	return collectionTrio{kind: "projects", parentID: p.entity().ID}
 }
 
 func (p *ProjectsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
@@ -65,14 +79,15 @@ func (p *ProjectsNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 		return inode, 0
 	}
 
-	projects, err := p.lfs.GetTeamProjects(ctx, p.team.ID)
+	team := p.entity()
+	projects, err := p.lfs.GetTeamProjects(ctx, team.ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
 
 	for _, project := range projects {
 		if projectDirName(project) == name {
-			node := &ProjectNode{attrNode: attrNode{BaseNode: BaseNode{lfs: p.lfs}}, team: p.team, project: project}
+			node := &ProjectNode{attrNode: attrNode{BaseNode: BaseNode{lfs: p.lfs}}, team: team, project: project}
 			return p.newDirInode(ctx, out, name, node, dirAttr(project.CreatedAt, project.UpdatedAt), projectDirIno(project.ID), 30*time.Second), 0
 		}
 	}
@@ -82,17 +97,18 @@ func (p *ProjectsNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 
 // Mkdir creates a new project
 func (p *ProjectsNode) Mkdir(ctx context.Context, name string, mode uint32, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+	team := p.entity()
 	if p.lfs.debug {
-		log.Printf("Mkdir: creating project %s in team %s", name, p.team.Key)
+		log.Printf("Mkdir: creating project %s in team %s", name, team.Key)
 	}
 
 	project, errno := commitCreate(ctx, p.lfs, createSpec[api.Project]{
 		op:  `create project "` + name + `"`,
-		key: collectionErrorKey("projects", p.team.ID),
+		key: collectionErrorKey("projects", team.ID),
 		mutate: func(ctx context.Context) (*api.Project, error) {
 			return p.lfs.mutator().CreateProject(ctx, map[string]any{
 				"name":    name,
-				"teamIds": []string{p.team.ID},
+				"teamIds": []string{team.ID},
 			})
 		},
 		result: func(pr *api.Project) WriteResult {
@@ -104,30 +120,31 @@ func (p *ProjectsNode) Mkdir(ctx context.Context, name string, mode uint32, out 
 			}
 		},
 		persist: func(ctx context.Context, pr *api.Project) error {
-			return p.lfs.UpsertProject(ctx, p.team.ID, *pr)
+			return p.lfs.UpsertProject(ctx, team.ID, *pr)
 		},
-		dir:       projectsDirIno(p.team.ID),
+		dir:       projectsDirIno(team.ID),
 		entryName: func(pr *api.Project) string { return projectDirName(*pr) },
 	})
 	if errno != 0 {
 		return nil, errno
 	}
 
-	node := &ProjectNode{attrNode: attrNode{BaseNode: BaseNode{lfs: p.lfs}}, team: p.team, project: *project}
+	node := &ProjectNode{attrNode: attrNode{BaseNode: BaseNode{lfs: p.lfs}}, team: team, project: *project}
 	return p.newDirInode(ctx, out, projectDirName(*project), node, dirAttr(project.CreatedAt, project.UpdatedAt), projectDirIno(project.ID), 30*time.Second), 0
 }
 
 // Rmdir archives a project (soft delete)
 func (p *ProjectsNode) Rmdir(ctx context.Context, name string) syscall.Errno {
+	team := p.entity()
 	if p.lfs.debug {
-		log.Printf("Rmdir: archiving project %s in team %s", name, p.team.Key)
+		log.Printf("Rmdir: archiving project %s in team %s", name, team.Key)
 	}
 
 	return commitDelete(ctx, p.lfs, deleteSpec[api.Project]{
 		op:  `archive project "` + name + `"`,
-		key: collectionErrorKey("projects", p.team.ID),
+		key: collectionErrorKey("projects", team.ID),
 		find: func(ctx context.Context) (*api.Project, error) {
-			projects, err := p.lfs.GetTeamProjects(ctx, p.team.ID)
+			projects, err := p.lfs.GetTeamProjects(ctx, team.ID)
 			if err != nil {
 				return nil, err
 			}
@@ -147,7 +164,7 @@ func (p *ProjectsNode) Rmdir(ctx context.Context, name string) syscall.Errno {
 		forget: func(ctx context.Context, pr *api.Project) error {
 			return p.lfs.store.Queries().DeleteProject(ctx, pr.ID)
 		},
-		dir:  projectsDirIno(p.team.ID),
+		dir:  projectsDirIno(team.ID),
 		name: name,
 	})
 }

--- a/internal/fs/recent.go
+++ b/internal/fs/recent.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sort"
 	"syscall"
-	"time"
 
 	"github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
@@ -20,7 +19,7 @@ const recentLimit = 50
 // agent a shell-flag-independent "what changed lately" (ls recent/ | head) that
 // doesn't depend on `ls -t` (which failed under eza in the #148 retro).
 type RecentNode struct {
-	BaseNode
+	attrNode
 	team api.Team
 }
 
@@ -28,12 +27,25 @@ var _ fs.NodeReaddirer = (*RecentNode)(nil)
 var _ fs.NodeLookuper = (*RecentNode)(nil)
 var _ fs.NodeGetattrer = (*RecentNode)(nil)
 
-func (n *RecentNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0555 | syscall.S_IFDIR // read-only dir
-	n.SetOwner(out)
-	out.SetTimes(&now, &now, &now)
-	return 0
+// entity/setEntity snapshot and swap the directory's team under the node's
+// volatile-state lock; setEntity is written by the nodeRefresher seam
+// (refresh.go).
+func (n *RecentNode) entity() api.Team {
+	n.stateMu.Lock()
+	defer n.stateMu.Unlock()
+	return n.team
+}
+
+func (n *RecentNode) setEntity(team api.Team) {
+	n.stateMu.Lock()
+	n.team = team
+	n.stateMu.Unlock()
+}
+
+func (n *RecentNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*RecentNode); ok {
+		n.setEntity(f.team)
+	}
 }
 
 // recentIssues returns the team's issues sorted newest-first and capped. SQL
@@ -41,7 +53,7 @@ func (n *RecentNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.Att
 // explicitly — in one place used by both Readdir and Lookup so `ls` and
 // `stat recent/X` agree on membership.
 func (n *RecentNode) recentIssues(ctx context.Context) ([]api.Issue, error) {
-	issues, err := n.lfs.GetTeamIssues(ctx, n.team.ID)
+	issues, err := n.lfs.GetTeamIssues(ctx, n.entity().ID)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +88,7 @@ func (n *RecentNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut
 	// Resolve against ALL team issues, not just the capped window: lookup must be
 	// a superset of readdir so a name that appeared in `ls recent/` never fails
 	// its per-entry stat (the safe direction; the cap lives only in Readdir).
-	issues, err := n.lfs.GetTeamIssues(ctx, n.team.ID)
+	issues, err := n.lfs.GetTeamIssues(ctx, n.entity().ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -20,10 +20,11 @@ var _ fs.NodeLookuper = (*RootNode)(nil)
 var _ fs.NodeGetattrer = (*RootNode)(nil)
 
 func (r *RootNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
+	// The mount root is a stateless container like teams/ or users/: it has no
+	// entity times, so it reports zero (honest unknown) — never a fabricated
+	// now() that reshuffles on every stat.
 	out.Mode = 0755 | syscall.S_IFDIR
 	r.SetOwner(out)
-	out.SetTimes(&now, &now, &now)
 	return 0
 }
 
@@ -40,7 +41,6 @@ func (r *RootNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 }
 
 func (r *RootNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	now := time.Now()
 	switch name {
 	case "README.md":
 		// The generated docs have no natural entity time; report zero (unknown).
@@ -61,37 +61,24 @@ func (r *RootNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 				return projectLabelsMarkdown(labels), mtime, ctime
 			}, projectLabelsCatalogIno(), inheritTimeout), 0
 
+	// The four top-level containers are stateless — no entity backs them, so
+	// they report zero times (honest unknown) and key their inos on the fixed
+	// directory name.
 	case "teams":
-		node := &TeamsNode{BaseNode: BaseNode{lfs: r.lfs}}
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = r.lfs.uid
-		out.Attr.Gid = r.lfs.gid
-		out.Attr.SetTimes(&now, &now, &now)
-		return r.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
+		node := &TeamsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: r.lfs}}}
+		return r.newDirInode(ctx, out, name, node, dirAttr(time.Time{}, time.Time{}), viewDirIno(name), inheritTimeout), 0
 
 	case "users":
-		node := &UsersNode{BaseNode: BaseNode{lfs: r.lfs}}
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = r.lfs.uid
-		out.Attr.Gid = r.lfs.gid
-		out.Attr.SetTimes(&now, &now, &now)
-		return r.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
+		node := &UsersNode{attrNode: attrNode{BaseNode: BaseNode{lfs: r.lfs}}}
+		return r.newDirInode(ctx, out, name, node, dirAttr(time.Time{}, time.Time{}), viewDirIno(name), inheritTimeout), 0
 
 	case "my":
-		node := &MyNode{BaseNode: BaseNode{lfs: r.lfs}}
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = r.lfs.uid
-		out.Attr.Gid = r.lfs.gid
-		out.Attr.SetTimes(&now, &now, &now)
-		return r.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
+		node := &MyNode{attrNode: attrNode{BaseNode: BaseNode{lfs: r.lfs}}}
+		return r.newDirInode(ctx, out, name, node, dirAttr(time.Time{}, time.Time{}), viewDirIno(name), inheritTimeout), 0
 
 	case "initiatives":
-		node := &InitiativesNode{BaseNode: BaseNode{lfs: r.lfs}}
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = r.lfs.uid
-		out.Attr.Gid = r.lfs.gid
-		out.Attr.SetTimes(&now, &now, &now)
-		return r.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
+		node := &InitiativesNode{attrNode: attrNode{BaseNode: BaseNode{lfs: r.lfs}}}
+		return r.newDirInode(ctx, out, name, node, dirAttr(time.Time{}, time.Time{}), viewDirIno(name), inheritTimeout), 0
 
 	default:
 		return nil, syscall.ENOENT

--- a/internal/fs/teams.go
+++ b/internal/fs/teams.go
@@ -11,22 +11,15 @@ import (
 	"github.com/jra3/linear-fuse/internal/api"
 )
 
-// TeamsNode represents the /teams directory
+// TeamsNode represents the /teams directory. Stateless container: zero times
+// (honest unknown), no refresh needs; Getattr comes from the attrNode mixin.
 type TeamsNode struct {
-	BaseNode
+	attrNode
 }
 
 var _ fs.NodeReaddirer = (*TeamsNode)(nil)
 var _ fs.NodeLookuper = (*TeamsNode)(nil)
 var _ fs.NodeGetattrer = (*TeamsNode)(nil)
-
-func (t *TeamsNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0755 | syscall.S_IFDIR
-	t.SetOwner(out)
-	out.SetTimes(&now, &now, &now)
-	return 0
-}
 
 func (t *TeamsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	teams, err := t.lfs.GetTeams(ctx)
@@ -53,12 +46,8 @@ func (t *TeamsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut)
 
 	for _, team := range teams {
 		if team.Key == name {
-			out.Attr.Mode = 0755 | syscall.S_IFDIR
-			out.Attr.Uid = t.lfs.uid
-			out.Attr.Gid = t.lfs.gid
-			out.Attr.SetTimes(&team.UpdatedAt, &team.UpdatedAt, &team.CreatedAt)
-			node := &TeamNode{BaseNode: BaseNode{lfs: t.lfs}, team: team}
-			return t.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
+			node := &TeamNode{attrNode: attrNode{BaseNode: BaseNode{lfs: t.lfs}}, team: team}
+			return t.newDirInode(ctx, out, name, node, dirAttr(team.CreatedAt, team.UpdatedAt), teamDirIno(team.ID), inheritTimeout), 0
 		}
 	}
 
@@ -67,7 +56,7 @@ func (t *TeamsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut)
 
 // TeamNode represents a single team directory (e.g., /teams/ENG)
 type TeamNode struct {
-	BaseNode
+	attrNode
 	team api.Team
 }
 
@@ -75,11 +64,26 @@ var _ fs.NodeReaddirer = (*TeamNode)(nil)
 var _ fs.NodeLookuper = (*TeamNode)(nil)
 var _ fs.NodeGetattrer = (*TeamNode)(nil)
 
-func (t *TeamNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	out.Mode = 0755 | syscall.S_IFDIR
-	t.SetOwner(out)
-	out.SetTimes(&t.team.UpdatedAt, &t.team.UpdatedAt, &t.team.CreatedAt)
-	return 0
+// entity/setEntity snapshot and swap the directory's team under the node's
+// volatile-state lock: setEntity is written by the nodeRefresher seam
+// (refresh.go), which pushes freshly-fetched state into this node when
+// go-fuse dedups a later Lookup onto it.
+func (t *TeamNode) entity() api.Team {
+	t.stateMu.Lock()
+	defer t.stateMu.Unlock()
+	return t.team
+}
+
+func (t *TeamNode) setEntity(team api.Team) {
+	t.stateMu.Lock()
+	t.team = team
+	t.stateMu.Unlock()
+}
+
+func (t *TeamNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*TeamNode); ok {
+		t.setEntity(f.team)
+	}
 }
 
 func (t *TeamNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
@@ -101,10 +105,9 @@ func (t *TeamNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 }
 
 func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	now := time.Now()
+	team := t.entity() // snapshot captured by the arms and their closures
 	switch name {
 	case "team.md":
-		team := t.team
 		return t.lookupRenderFile(ctx, out, "team.md", func(context.Context) ([]byte, time.Time, time.Time) {
 			return teamMarkdown(team), team.UpdatedAt, team.CreatedAt
 		}, 0, inheritTimeout), 0
@@ -113,7 +116,7 @@ func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 		// states.md has no single mtime (it lists a collection); report the
 		// team's times as a stable proxy — never now(). Content is fetched from
 		// SQLite on each read (cheap), so no node-level cache is needed.
-		lfs, team := t.lfs, t.team
+		lfs := t.lfs
 		return t.lookupRenderFile(ctx, out, "states.md", func(ctx context.Context) ([]byte, time.Time, time.Time) {
 			states, err := lfs.GetTeamStates(ctx, team.ID)
 			if err != nil {
@@ -123,7 +126,7 @@ func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 		}, 0, inheritTimeout), 0
 
 	case "labels.md":
-		lfs, team := t.lfs, t.team
+		lfs := t.lfs
 		return t.lookupRenderFile(ctx, out, "labels.md", func(ctx context.Context) ([]byte, time.Time, time.Time) {
 			labels, err := lfs.GetTeamLabels(ctx, team.ID)
 			if err != nil {
@@ -141,65 +144,40 @@ func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 		// file's real times.
 		return t.newSymlinkInode(ctx, out, "../../project-labels.md", time.Time{}, time.Time{}), 0
 
+	// The team's view subdirectories hold a team snapshot and report the
+	// team's times: they are (or contain) projections of the team's state.
 	case "by":
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = t.lfs.uid
-		out.Attr.Gid = t.lfs.gid
-		out.Attr.SetTimes(&now, &now, &now)
-		node := &FilterRootNode{BaseNode: BaseNode{lfs: t.lfs}, team: t.team}
-		return t.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
+		node := &FilterRootNode{attrNode: attrNode{BaseNode: BaseNode{lfs: t.lfs}}, team: team}
+		return t.newDirInode(ctx, out, name, node, dirAttr(team.CreatedAt, team.UpdatedAt), byDirIno(team.ID), inheritTimeout), 0
 
 	case "cycles":
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = t.lfs.uid
-		out.Attr.Gid = t.lfs.gid
-		out.Attr.SetTimes(&now, &now, &now)
-		node := &CyclesNode{BaseNode: BaseNode{lfs: t.lfs}, team: t.team}
-		return t.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
+		node := &CyclesNode{attrNode: attrNode{BaseNode: BaseNode{lfs: t.lfs}}, team: team}
+		return t.newDirInode(ctx, out, name, node, dirAttr(team.CreatedAt, team.UpdatedAt), cyclesDirIno(team.ID), inheritTimeout), 0
 
 	case "projects":
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = t.lfs.uid
-		out.Attr.Gid = t.lfs.gid
-		out.Attr.SetTimes(&now, &now, &now)
-		node := &ProjectsNode{BaseNode: BaseNode{lfs: t.lfs}, team: t.team}
-		return t.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFDIR,
-			Ino:  projectsDirIno(t.team.ID),
-		}), 0
+		node := &ProjectsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: t.lfs}}, team: team}
+		return t.newDirInode(ctx, out, name, node, dirAttr(team.CreatedAt, team.UpdatedAt), projectsDirIno(team.ID), inheritTimeout), 0
 
 	case "issues":
-		out.Attr.Mode = 0755 | syscall.S_IFDIR
-		out.Attr.Uid = t.lfs.uid
-		out.Attr.Gid = t.lfs.gid
-		out.Attr.SetTimes(&now, &now, &now)
-		node := &IssuesNode{BaseNode: BaseNode{lfs: t.lfs}, team: t.team}
+		node := &IssuesNode{attrNode: attrNode{BaseNode: BaseNode{lfs: t.lfs}}, team: team}
 		// The stable ino is what makes create/delete invalidations against
 		// issuesDirIno reach the kernel; without it InodeNotify targets an
 		// inode the kernel never learned.
-		return t.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFDIR,
-			Ino:  issuesDirIno(t.team.ID),
-		}), 0
+		return t.newDirInode(ctx, out, name, node, dirAttr(team.CreatedAt, team.UpdatedAt), issuesDirIno(team.ID), inheritTimeout), 0
 
 	case "recent":
-		out.Attr.Mode = 0555 | syscall.S_IFDIR // read-only view
-		out.Attr.Uid = t.lfs.uid
-		out.Attr.Gid = t.lfs.gid
-		out.Attr.SetTimes(&now, &now, &now)
-		node := &RecentNode{BaseNode: BaseNode{lfs: t.lfs}, team: t.team}
-		return t.NewInode(ctx, node, fs.StableAttr{
-			Mode: syscall.S_IFDIR,
-			Ino:  recentDirIno(t.team.ID),
-		}), 0
+		node := &RecentNode{attrNode: attrNode{BaseNode: BaseNode{lfs: t.lfs}}, team: team}
+		// 0555: read-only view.
+		na := nodeAttr{mode: 0555 | syscall.S_IFDIR, created: team.CreatedAt, updated: team.UpdatedAt}
+		return t.newDirInode(ctx, out, name, node, na, recentDirIno(team.ID), inheritTimeout), 0
 
 	case "docs":
-		node := &DocsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: t.lfs}}, teamID: t.team.ID}
-		return t.newDirInode(ctx, out, "docs", node, dirAttr(t.team.CreatedAt, t.team.UpdatedAt), docsDirIno(t.team.ID), 0), 0
+		node := &DocsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: t.lfs}}, teamID: team.ID}
+		return t.newDirInode(ctx, out, "docs", node, dirAttr(team.CreatedAt, team.UpdatedAt), docsDirIno(team.ID), 0), 0
 
 	case "labels":
-		node := &LabelsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: t.lfs}}, teamID: t.team.ID}
-		return t.newDirInode(ctx, out, "labels", node, dirAttr(t.team.CreatedAt, t.team.UpdatedAt), labelsDirIno(t.team.ID), 0), 0
+		node := &LabelsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: t.lfs}}, teamID: team.ID}
+		return t.newDirInode(ctx, out, "labels", node, dirAttr(team.CreatedAt, team.UpdatedAt), labelsDirIno(team.ID), 0), 0
 	}
 
 	return nil, syscall.ENOENT

--- a/internal/fs/users.go
+++ b/internal/fs/users.go
@@ -12,20 +12,15 @@ import (
 	"github.com/jra3/linear-fuse/internal/api"
 )
 
-// UsersNode represents the /users directory
+// UsersNode represents the /users directory. Stateless container: zero times
+// (honest unknown), no refresh needs; Getattr comes from the attrNode mixin.
 type UsersNode struct {
-	BaseNode
+	attrNode
 }
 
 var _ fs.NodeReaddirer = (*UsersNode)(nil)
 var _ fs.NodeLookuper = (*UsersNode)(nil)
 var _ fs.NodeGetattrer = (*UsersNode)(nil)
-
-func (u *UsersNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	out.Mode = 0755 | syscall.S_IFDIR
-	u.SetOwner(out)
-	return 0
-}
 
 func (u *UsersNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	users, err := u.lfs.GetUsers(ctx)
@@ -52,13 +47,10 @@ func (u *UsersNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut)
 
 	for _, user := range users {
 		if userDirName(user) == name {
-			now := time.Now()
-			out.Attr.Mode = 0755 | syscall.S_IFDIR
-			out.Attr.Uid = u.lfs.uid
-			out.Attr.Gid = u.lfs.gid
-			out.Attr.SetTimes(&now, &now, &now)
-			node := &UserNode{BaseNode: BaseNode{lfs: u.lfs}, user: user}
-			return u.NewInode(ctx, node, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
+			// api.User carries no time fields; the dir honestly reports zero
+			// (unknown) rather than a fabricated now().
+			node := &UserNode{attrNode: attrNode{BaseNode: BaseNode{lfs: u.lfs}}, user: user}
+			return u.newDirInode(ctx, out, name, node, dirAttr(time.Time{}, time.Time{}), userDirIno(user.ID), inheritTimeout), 0
 		}
 	}
 
@@ -78,9 +70,12 @@ func userDirName(user api.User) string {
 	return user.Email
 }
 
-// UserNode represents a single user's directory (e.g., /users/alice)
+// UserNode represents a single user's directory (e.g., /users/alice).
+// api.User has no time fields, so the dir reports zero times, but it still
+// carries a user snapshot (user.md renders from it) — so it implements the
+// nodeRefresher seam like the other snapshot carriers.
 type UserNode struct {
-	BaseNode
+	attrNode
 	user api.User
 }
 
@@ -88,16 +83,29 @@ var _ fs.NodeReaddirer = (*UserNode)(nil)
 var _ fs.NodeLookuper = (*UserNode)(nil)
 var _ fs.NodeGetattrer = (*UserNode)(nil)
 
-func (u *UserNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	now := time.Now()
-	out.Mode = 0755 | syscall.S_IFDIR
-	u.SetOwner(out)
-	out.SetTimes(&now, &now, &now)
-	return 0
+// entity/setEntity snapshot and swap the directory's user under the node's
+// volatile-state lock; setEntity is written by the nodeRefresher seam
+// (refresh.go).
+func (u *UserNode) entity() api.User {
+	u.stateMu.Lock()
+	defer u.stateMu.Unlock()
+	return u.user
+}
+
+func (u *UserNode) setEntity(user api.User) {
+	u.stateMu.Lock()
+	u.user = user
+	u.stateMu.Unlock()
+}
+
+func (u *UserNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*UserNode); ok {
+		u.setEntity(f.user)
+	}
 }
 
 func (u *UserNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
-	issues, err := u.lfs.GetUserIssues(ctx, u.user.ID)
+	issues, err := u.lfs.GetUserIssues(ctx, u.entity().ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -119,16 +127,16 @@ func (u *UserNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 }
 
 func (u *UserNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+	user := u.entity() // snapshot captured by the closures below
 	// Handle user.md metadata file. api.User carries no created/updated times,
 	// so the file honestly reports zero (unknown) rather than a fabricated now().
 	if name == "user.md" {
-		user := u.user
 		return u.lookupRenderFile(ctx, out, "user.md", func(context.Context) ([]byte, time.Time, time.Time) {
 			return userMarkdown(user), time.Time{}, time.Time{}
 		}, 0, inheritTimeout), 0
 	}
 
-	issues, err := u.lfs.GetUserIssues(ctx, u.user.ID)
+	issues, err := u.lfs.GetUserIssues(ctx, user.ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}

--- a/internal/integration/projectlabels_test.go
+++ b/internal/integration/projectlabels_test.go
@@ -221,11 +221,10 @@ func TestProjectLabelsRetiredNewlyApplied(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read project.md: %v", err)
 	}
-	t.Cleanup(func() { _ = writeProjectMD(t, projectMDPath(), string(orig)) })
 
-	// Step 1: delete the labels block entirely (the key line plus its YAML
-	// list items) — the mount-wide delete-the-line clear contract.
-	var kept []string
+	// The labels-free variant of orig (the key line plus its YAML list items
+	// removed) — used by step 1 and by the cleanup.
+	var keptLines []string
 	inLabels := false
 	for _, line := range strings.Split(string(orig), "\n") {
 		trimmed := strings.TrimSpace(line)
@@ -237,9 +236,33 @@ func TestProjectLabelsRetiredNewlyApplied(t *testing.T) {
 			continue
 		}
 		inLabels = false
-		kept = append(kept, line)
+		keptLines = append(keptLines, line)
 	}
-	if err := writeProjectMD(t, projectMDPath(), strings.Join(kept, "\n")); err != nil {
+	kept := strings.Join(keptLines, "\n")
+
+	t.Cleanup(func() {
+		// A content-only restore of orig is REJECTED here (EINVAL — once the
+		// set was cleared, re-adding the retired Legacy counts as
+		// newly-applied), which used to fail silently and leave the node's
+		// buffer permanently dirty with a size the next Lookup contradicted,
+		// poisoning later reads of project.md for the rest of the suite. So:
+		// first clear the dirty buffer with a save the validator ACCEPTS (the
+		// labels-free content — matches the mock's current cleared state),
+		// then restore the store row; the now-clean buffer adopts the
+		// restored labels on the next lookup's refresh.
+		if err := writeProjectMD(t, projectMDPath(), kept); err != nil {
+			t.Errorf("cleanup save (labels-free) failed: %v", err)
+		}
+		restored := fixtures.FixtureAPIProject()
+		restored.LabelIds = []string{"plabel-backend", "plabel-legacy"}
+		if err := fixtures.PopulateProject(context.Background(), testStore, restored, fixtures.FixtureAPITeam().ID); err != nil {
+			t.Errorf("restore project row: %v", err)
+		}
+	})
+
+	// Step 1: delete the labels block entirely — the mount-wide
+	// delete-the-line clear contract.
+	if err := writeProjectMD(t, projectMDPath(), kept); err != nil {
 		t.Fatalf("delete-the-line clear failed: %v", err)
 	}
 	after, err := readFileWithRetry(projectMDPath(), defaultWaitTime)

--- a/internal/integration/staleness_test.go
+++ b/internal/integration/staleness_test.go
@@ -73,9 +73,10 @@ func TestRemoteUpdateVisibleAfterKernelRevalidation(t *testing.T) {
 	// Let the kernel's caches expire for real — the production freshness
 	// mechanism. The sync worker never notifies the kernel; entry timeouts
 	// (30s) make the next path walk re-Lookup every component, and each
-	// re-Lookup runs the nodeRefresher seam. (Targeted EntryNotify calls
-	// can't stand in for this: several ancestor dirs use auto-assigned inos,
-	// so their kernel ids aren't derivable from the ino namespace.)
+	// re-Lookup runs the nodeRefresher seam. (The ino namespace is total now —
+	// every ancestor dir has a derivable stable ino — but timeout-driven
+	// revalidation remains the production mechanism, so it is what this
+	// exercises.)
 	if testing.Short() {
 		t.Skip("waits out the 30s kernel entry timeout; skipped with -short")
 	}
@@ -113,5 +114,156 @@ func TestRemoteUpdateVisibleAfterKernelRevalidation(t *testing.T) {
 		} else {
 			t.Logf("CONTRAST: issue.meta reflects the remote update (re-fetching closure) while issue.md does not:\n%s", meta)
 		}
+	}
+}
+
+// TestRejectedSaveKeepsDirtyContentReadable pins the size half of the
+// dirty-buffer-wins rule: a rejected save (EINVAL) deliberately leaves the
+// user's content in the edit buffer so it can be corrected and re-saved — and
+// every subsequent Lookup must report THAT buffer's size, not the fresh
+// render's. newFileInode used to fill the Lookup answer from the fresh twin
+// while refreshExisting let the dirty buffer keep its content, so the kernel
+// clamped reads of the longer dirty content mid-file ("unclosed frontmatter"
+// on project.md) — a latent mismatch the view-dir normalization surfaced once
+// the whole directory chain became stably reusable.
+func TestRejectedSaveKeepsDirtyContentReadable(t *testing.T) {
+	if testStore == nil {
+		t.Skip("store-backed simulation requires fixture mode")
+	}
+	enableMockMutations(t)
+	ctx := context.Background()
+
+	// A dedicated project row so the poisoned dirty state cannot leak into
+	// other tests' fixtures.
+	proj := fixtures.FixtureAPIProject()
+	proj.ID, proj.Slug, proj.Name = "project-dirty", "dirty-project", "Dirty Project"
+	if err := fixtures.PopulateProject(ctx, testStore, proj, fixtures.FixtureAPITeam().ID); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testStore.DB().Exec("DELETE FROM projects WHERE id = 'project-dirty'")
+		_, _ = testStore.DB().Exec("DELETE FROM project_teams WHERE project_id = 'project-dirty'")
+	})
+
+	path := mountPoint + "/teams/" + testTeamKey + "/projects/dirty-project/project.md"
+	orig, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read project.md: %v", err)
+	}
+
+	// A save that validation rejects: an unknown label name. The flush returns
+	// EINVAL and the buffer stays dirty with exactly this content.
+	rejected := strings.Replace(string(orig), "name:", "labels: [__no_such_project_label__]\nname:", 1)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		t.Fatalf("open for write: %v", err)
+	}
+	if _, err := f.Write([]byte(rejected)); err != nil {
+		f.Close()
+		t.Fatalf("write: %v", err)
+	}
+	if err := f.Close(); err == nil {
+		t.Fatal("expected the save to be rejected (EINVAL), but close succeeded")
+	}
+
+	// Force fresh Lookups through the whole chain (project children run a 0
+	// entry timeout, so every walk re-Lookups), then read back: the stat size
+	// and the read must both cover the FULL dirty content.
+	if _, err := os.ReadDir(mountPoint + "/teams/" + testTeamKey + "/projects/dirty-project"); err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if int64(len(got)) != st.Size() {
+		t.Errorf("stat size %d != read length %d — Lookup answered a different size than the serving buffer", st.Size(), len(got))
+	}
+	if string(got) != rejected {
+		t.Errorf("dirty content clamped or replaced after rejected save:\nwant %d bytes:\n%s\ngot %d bytes:\n%s", len(rejected), rejected, len(got), got)
+	}
+
+	// The documented retry path: writing corrected content must succeed and
+	// leave the buffer clean again.
+	if err := os.WriteFile(path, orig, 0644); err != nil {
+		t.Errorf("corrected re-save failed: %v", err)
+	}
+}
+
+// TestRemoteTeamUpdateVisibleAfterKernelRevalidation extends the pinned-fd
+// revalidation technique to the busiest reused directory node: teams/{KEY} is
+// now on a stable ino (teamDirIno), so after entry-timeout expiry the kernel's
+// re-Lookup dedups onto the FIRST TeamNode ever mounted. The nodeRefresher
+// seam must push the freshly-fetched team snapshot into that node (and
+// newDirInode must re-stamp its nodeAttr), or the directory would report
+// first-Lookup times and team.md would render the old name for as long as the
+// kernel remembered the inode — the exact hazard the view-dir normalization
+// took on when it moved these nodes off auto-assigned inos.
+func TestRemoteTeamUpdateVisibleAfterKernelRevalidation(t *testing.T) {
+	ctx := context.Background()
+	teamDir := mountPoint + "/teams/" + testTeamKey
+	teamFile := teamDir + "/team.md"
+
+	before, err := os.ReadFile(teamFile)
+	if err != nil {
+		t.Fatalf("first read: %v", err)
+	}
+	if !strings.Contains(string(before), "Test Team") {
+		t.Fatalf("fixture team not served, got:\n%s", before)
+	}
+
+	// Pin the team directory: an open descriptor keeps the kernel from
+	// FORGETting the dir inode and its ancestor dentries, so the post-expiry
+	// re-Lookup of "TST" hits the ALREADY-KNOWN TeamNode — the go-fuse reuse
+	// path this test exists to guard.
+	pin, err := os.Open(teamDir)
+	if err != nil {
+		t.Fatalf("pin open: %v", err)
+	}
+	defer pin.Close()
+
+	if testStore == nil {
+		t.Skip("store-backed staleness simulation requires fixture mode")
+	}
+
+	// Simulate the sync worker landing a remote team edit: same team, new
+	// name, newer updatedAt — written straight to the store, no kernel
+	// notification (faithful to production sync).
+	team := fixtures.FixtureAPITeam()
+	team.Name = "Renamed Team By Remote Sync"
+	team.UpdatedAt = time.Now()
+	if err := testStore.Queries().UpsertTeam(ctx, db.APITeamToDBTeam(team)); err != nil {
+		t.Fatalf("upsert team: %v", err)
+	}
+
+	// Wait out the kernel's entry/attr timeouts for real, as in the issue
+	// variant above: expiry forces the next path walk to re-Lookup every
+	// component, and each re-Lookup runs the nodeRefresher seam.
+	if testing.Short() {
+		t.Skip("waits out the 30s kernel entry timeout; skipped with -short")
+	}
+	time.Sleep(31 * time.Second)
+
+	after, err := os.ReadFile(teamFile)
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if !strings.Contains(string(after), "Renamed Team By Remote Sync") {
+		t.Errorf("STALE: team.md still serves first-Lookup content after remote team update + full kernel revalidation.\ngot:\n%s", after)
+	}
+
+	// The team directory's own attrs must follow: mtime = the team's fresh
+	// updatedAt (the honest-times half of the normalization), not the fixture
+	// base time the first Lookup stamped.
+	st, err := os.Stat(teamDir)
+	if err != nil {
+		t.Fatalf("stat team dir: %v", err)
+	}
+	if age := time.Since(st.ModTime()); age > time.Hour {
+		t.Errorf("STALE ATTRS: team dir mtime %v predates the remote update (age %v)", st.ModTime(), age)
 	}
 }


### PR DESCRIPTION
Round-18 card 4, grilling-locked (docs/plans/2026-07-09-view-dir-attrs-design.md): full normalization of every directory node still on auto-assigned inos and hand-rolled Lookup attr blocks.

## What changed

**Ino namespace is now total for directories.** New kinds (all in `TestInodeNamespaceDistinct`):

| kind | key | nodes |
|------|-----|-------|
| `viewdir` | fixed name | TeamsNode, UsersNode, MyNode, InitiativesNode |
| `mydir` | fixed name | my/assigned, my/created, my/active |
| `teamdir` | team ID | TeamNode |
| `cyclesdir` / `cycledir` | team ID / cycle ID | CyclesNode / CycleDirNode |
| `userdir` | user ID | UserNode |
| `bydir` / `bycat` / `byval` | team / team+"/"+cat / team+"/"+cat+"/"+val | the by/ filter tree |

The only deliberate auto-ino residents left are the write-only `_create` trigger files and symlinks — no directories.

**Honest times, all hand-rolled `time.Now()` dir attr blocks deleted.** Stateless containers (mount root, teams/, users/, my/, initiatives/, my/ subdirs) and UserNode (api.User has no time fields) report zero — honest unknown. TeamNode and the team-view dirs (issues/, projects/, cycles/, recent/, by/*) report team times. The cycle tier keeps its atime=EndsAt, mtime/ctime=StartsAt convention via a new optional `nodeAttr.atime` override (api.Cycle has no created/updated; the `current` symlink already mirrors it). Entry timeouts preserved verbatim: `newDirInode` gained `inheritTimeout` (<0 leaves the mount default) so the converted arms keep the defaults they always had.

**Refresh seam everywhere.** Stable inos mean the kernel now dedups these nodes onto the first instance, so every snapshot carrier implements the round-15 `entity()/setEntity/refreshFrom` pattern under `attrNode.stateMu`: TeamNode, UserNode, CyclesNode, CycleDirNode (team+cycle swap under one lock), RecentNode, IssuesNode, ProjectsNode, FilterRootNode, FilterCategoryNode, FilterValueNode. This erases the recorded nodeRefresher inconsistency (TeamNode/UserNode/cycle dirs dodging the staleness bug via fresh nodes).

## Latent bug surfaced and fixed

Making the whole directory chain stably reusable surfaced a pre-existing seam gap (reproduced at base with the same trio of tests): `newFileInode` filled the Lookup answer's size from the fresh render while `refreshExisting` let the kept node's **dirty** buffer keep its content — after a rejected save (EINVAL leaves the buffer dirty by design, for retry), the kernel clamped reads of the longer dirty content mid-file ("unclosed frontmatter" on project.md). `newFileInode` now reports the kept node's size (`interface{ size() int }` probe). `TestRejectedSaveKeepsDirtyContentReadable` pins it.

Relatedly, `TestProjectLabelsRetiredNewlyApplied`'s cleanup was silently broken (content-only restore is rejected: re-adding retired Legacy to a cleared set counts as newly-applied), leaving that poisoned dirty state for the rest of the suite — previously masked by kernel-forget nondeterminism. The cleanup now saves the labels-free content (accepted → buffer clean) and restores the store row.

## Guards

- `TestInodeNamespaceDistinct`: +9 wrappers.
- Anti-drift Lookup==Getattr equality test: +15 directory kinds.
- `TestRemoteTeamUpdateVisibleAfterKernelRevalidation`: round-15 pinned-fd technique on the busiest reused node — pin the team dir, upsert the team row store-side, wait out the real 31s entry timeout, assert fresh team.md content and dir mtime.
- `TestNodeAttrAtimeOverride`: pins the cycle-tier atime exception.
- CONTEXT.md: nodeRefresher exception paragraph removed, ino entry records the total-for-directories namespace, attr-construction entry updated.

## Verification

- `make build`, `go vet ./...`, `gofmt -l` clean
- Full unit suite green; `go test -race ./internal/fs` green
- Full FUSE integration suite green (including both 31s staleness tests), short-mode suite green 3×
- Base-comparison runs confirmed the truncation trio also failed at origin/main — pre-existing, not a regression from this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)