### PR TITLE
feat(telemetry): per-request JSONL debug log + cold-start observation runbook

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -54,6 +54,9 @@ telemetry:
 Source: `internal/config/config.go` (`TelemetryConfig`,
 `TelemetryFileConfig`, `DefaultTelemetryPath`).
 
+`telemetry.requests.*` (the per-request debug log — not an OTEL signal) is
+documented in its own section below.
+
 ## Instruments
 
 Naming: `linearfs.<layer>.<what>`; meter scopes are `linearfs/process`,
@@ -181,6 +184,67 @@ jq -r '.ScopeMetrics[] | .Metrics[] | select(.Name=="linearfs.swr.triggers")
 jq -r '[(.ScopeMetrics[].Metrics[] | select(.Name=="linearfs.budget.remaining")
   | .Data.DataPoints[] | select(.Attributes[0].Value.Value=="complexity") | .Value)] | first' $M
 ```
+
+## Per-request debug log — `telemetry.requests.*`
+
+**A debug log, not an OTEL signal.** The meter pipeline above is untouched by
+this (metrics only — traces never, still). When enabled, the api client
+appends one JSON line per completed GraphQL request to a separate JSONL file,
+written at the same place in `Client.query` where the response settles (the
+`apiMetrics` record site). Built for the cold-start observation runs
+(`docs/plans/2026-07-09-coldstart-observation-plan.md`): duplicate-fetch
+detection and complexity attribution need per-request granularity with full
+variables, which no bounded-cardinality metric can carry.
+
+```yaml
+telemetry:
+  requests:
+    enabled: true                   # default false
+    path: ~/custom-requests.jsonl   # default: <UserConfigDir>/linearfs/requests.jsonl
+```
+
+One line per request:
+
+```json
+{"ts":"2026-07-09T02:00:01.123456789Z","op":"TeamIssuesByUpdatedAt",
+ "vars":{"teamId":"...","first":50},"duration_ms":312.4,"outcome":"ok","complexity":8231}
+```
+
+- `ts` — RFC3339Nano, UTC, at completion.
+- `op` — the same `extractOpName` value as the `op` metric attribute.
+- `vars` — the request's **full** variables map (ids, cursors), deliberately:
+  grouping lines by `(op, vars)` is the duplicate-fetch detector. This is why
+  the log is off by default — it can carry entity IDs.
+- `duration_ms` — wall time of the request.
+- `outcome` — `ok` | `error` | `ratelimited`, the exact classification of
+  `linearfs.api.requests` (one shared classifier).
+- `complexity` — the response's actual `X-Complexity`, threaded from the
+  budget's reconcile (still the ONE place the header is parsed); **omitted**
+  when the response carried none.
+
+Semantics match `linearfs.api.requests`: only requests actually sent are
+logged — budget deferrals never appear (they land in
+`linearfs.budget.decisions`). Disabled costs nothing (nil writer, one
+branch); the file reuses the metrics export's rotation writer with a fixed
+100 MB cap (disk bounded at ~2×). Sources:
+`internal/api/requestlog.go` (entry + log site),
+`internal/telemetry/requestlog.go` (writer), wired at client construction in
+`internal/fs/linearfs.go`.
+
+### Cold-start observation scripts
+
+`scripts/coldstart-observe.sh` is the unattended runbook that consumes this
+log (budget-gated double cold start of the live service; see the plan doc).
+It refuses to run without `LINEARFS_COLDSTART_CONFIRM=1` and is
+`at`-schedulable:
+
+```bash
+echo "LINEARFS_COLDSTART_CONFIRM=1 ~/jra3/linear-fuse/scripts/coldstart-observe.sh" | at 02:00
+```
+
+`scripts/coldstart-probe.sh` is its Run B companion: a 15s loop wall-timing
+fixed read paths on the mount into a TSV. Both are operator tools for the
+live service — never run by CI or any test.
 
 ## Adding an instrument (the phase-2/3 pattern)
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -45,6 +45,10 @@ type Client struct {
 	// completed request records a count and a duration, per operation.
 	metrics apiMetrics
 
+	// reqLog, when non-nil, receives one JSON line per completed request —
+	// the per-request debug log (requestlog.go). nil = disabled (default).
+	reqLog io.Writer
+
 	// budget is the hourly rate-limit governor (see ratebudget.go): query
 	// admits every request through its priority-reserve ladder and observes
 	// every response's headers back into it.
@@ -206,11 +210,16 @@ func (c *Client) query(ctx context.Context, query string, variables map[string]a
 			opName, rateLimitWait.Round(time.Millisecond), hourly, pct)
 	}
 
-	// Record the request count (by outcome) and duration once it completes.
+	// Record the request count (by outcome) and duration once it completes —
+	// and, when enabled, the request debug log line (same site, same outcome
+	// classification; the admission carries the response's X-Complexity by
+	// the time this defer runs, since observe/rateLimited settle inline).
 	reqStart := time.Now()
 	var queryErr error
 	defer func() {
-		c.metrics.record(ctx, opName, time.Since(reqStart), queryErr)
+		elapsed := time.Since(reqStart)
+		c.metrics.record(ctx, opName, elapsed, queryErr)
+		c.logRequest(opName, variables, elapsed, queryErr, adm)
 	}()
 
 	reqBody := graphQLRequest{

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -41,17 +41,24 @@ func newAPIMetrics() apiMetrics {
 	}
 }
 
+// outcomeFor classifies a completed request's error into the closed outcome
+// enum shared by linearfs.api.requests and the request debug log
+// (requestlog.go) — one classification, two consumers.
+func outcomeFor(err error) string {
+	switch {
+	case err == nil:
+		return "ok"
+	case IsRateLimited(err):
+		return "ratelimited"
+	default:
+		return "error"
+	}
+}
+
 // record counts one completed request (one that was actually sent — budget
 // deferrals never reach here; they land in linearfs.budget.decisions).
 func (am apiMetrics) record(ctx context.Context, op string, elapsed time.Duration, err error) {
-	outcome := "ok"
-	switch {
-	case err == nil:
-	case IsRateLimited(err):
-		outcome = "ratelimited"
-	default:
-		outcome = "error"
-	}
+	outcome := outcomeFor(err)
 	am.requests.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("op", op),
 		attribute.String("outcome", outcome)))

--- a/internal/api/ratebudget.go
+++ b/internal/api/ratebudget.go
@@ -273,6 +273,11 @@ type admission struct {
 	tier    priority
 	cost    float64
 	settled bool // guarded by b.mu
+
+	// The response's parsed X-Complexity, captured when observe/rateLimited
+	// reconciles the headers (guarded by b.mu; see actualComplexity).
+	actual     float64
+	actualSeen bool
 }
 
 // admit gates one request at the given priority. On allow it reserves the
@@ -340,7 +345,19 @@ func (a *admission) observe(h http.Header) {
 	}
 	a.settled = true
 	a.b.releaseLocked(a.cost)
-	a.b.reconcileLocked(a.op, h)
+	a.actual, a.actualSeen = a.b.reconcileLocked(a.op, h)
+}
+
+// actualComplexity reports the response's X-Complexity as parsed by the
+// budget's reconcile — the ONE place the header is parsed; the request debug
+// log (requestlog.go) reads the value from here rather than parsing twice.
+// ok is false until the admission has settled via observe/rateLimited, and
+// stays false when the response carried no X-Complexity header (or the
+// admission was released without a response).
+func (a *admission) actualComplexity() (v float64, ok bool) {
+	a.b.mu.Lock()
+	defer a.b.mu.Unlock()
+	return a.actual, a.actualSeen
 }
 
 // rateLimited settles the admission from a 400/RATELIMITED (or 429)
@@ -356,7 +373,7 @@ func (a *admission) rateLimited(h http.Header) {
 	}
 	a.settled = true
 	a.b.releaseLocked(a.cost)
-	a.b.reconcileLocked(a.op, h)
+	a.actual, a.actualSeen = a.b.reconcileLocked(a.op, h)
 	a.b.snapExhaustedLocked()
 	a.b.metrics.recordDecision(a.tier, "ratelimited")
 }
@@ -388,9 +405,12 @@ func (b *rateBudget) releaseLocked(cost float64) {
 // reconcileLocked snaps both axes to the response headers and records the
 // op's actual cost. Missing headers leave the corresponding fields alone.
 // The reset headers are epoch MILLISECONDS, per-axis (the old code read a
-// header Linear doesn't send, as seconds — dead backoff).
-func (b *rateBudget) reconcileLocked(op string, h http.Header) {
-	if v, ok := headerFloat(h, "X-Complexity"); ok {
+// header Linear doesn't send, as seconds — dead backoff). The parsed
+// X-Complexity is returned (ok=false when the header is absent) so callers
+// can thread it onward without parsing the header a second time.
+func (b *rateBudget) reconcileLocked(op string, h http.Header) (complexity float64, ok bool) {
+	if v, seen := headerFloat(h, "X-Complexity"); seen {
+		complexity, ok = v, true
 		b.cost[op] = v
 		// The one place X-Complexity is parsed also records it.
 		b.metrics.complexity.Record(context.Background(), v,
@@ -406,6 +426,7 @@ func (b *rateBudget) reconcileLocked(op string, h http.Header) {
 				w.remaining, w.limit, w.name, op)
 		}
 	}
+	return complexity, ok
 }
 
 func reconcileAxis(w *window, h http.Header, prefix string) {

--- a/internal/api/requestlog.go
+++ b/internal/api/requestlog.go
@@ -1,0 +1,71 @@
+package api
+
+// The per-request JSONL debug log (telemetry.requests.* in config): one JSON
+// line per completed GraphQL request, written where responses settle in
+// Client.query — the same site that records apiMetrics and where the budget
+// admission observes the response headers. This is an application debug log,
+// NOT an OTEL signal (the metrics-only/traces-never policy is untouched); it
+// exists for offline analysis of observation runs — see
+// docs/plans/2026-07-09-coldstart-observation-plan.md.
+//
+// The full variables map is logged deliberately: duplicate-fetch detection
+// needs to see WHICH entity/cursor was fetched twice, so grouping lines by
+// (op, vars) is the analysis primitive. Complexity is the response's actual
+// X-Complexity, threaded from the budget's reconcile (the one place the
+// header is parsed) via admission.actualComplexity — never parsed twice.
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"time"
+)
+
+// requestLogEntry is one requests.jsonl line.
+type requestLogEntry struct {
+	TS         string         `json:"ts"` // RFC3339Nano, UTC
+	Op         string         `json:"op"`
+	Vars       map[string]any `json:"vars,omitempty"`
+	DurationMS float64        `json:"duration_ms"`
+	Outcome    string         `json:"outcome"` // ok|error|ratelimited — same classification as linearfs.api.requests
+	Complexity *float64       `json:"complexity,omitempty"`
+}
+
+// SetRequestLog enables the per-request JSONL debug log: every completed
+// request (one actually sent — budget deferrals never reach the log, exactly
+// like linearfs.api.requests) appends one line to w. Set it once, before the
+// client issues any requests; the field is read without synchronization. The
+// writer must be safe for concurrent Write calls (telemetry.NewRequestLog's
+// rotating writer is). nil (the default) disables logging — the log site
+// does zero work beyond one branch.
+func (c *Client) SetRequestLog(w io.Writer) {
+	c.reqLog = w
+}
+
+// logRequest writes one request-log line. A debug log must never fail the
+// request it describes: encode/write trouble is logged and dropped.
+func (c *Client) logRequest(op string, vars map[string]any, elapsed time.Duration, err error, adm *admission) {
+	if c.reqLog == nil {
+		return
+	}
+	entry := requestLogEntry{
+		TS:         time.Now().UTC().Format(time.RFC3339Nano),
+		Op:         op,
+		Vars:       vars,
+		DurationMS: float64(elapsed.Microseconds()) / 1000.0,
+		Outcome:    outcomeFor(err),
+	}
+	if adm != nil {
+		if v, ok := adm.actualComplexity(); ok {
+			entry.Complexity = &v
+		}
+	}
+	line, jerr := json.Marshal(entry)
+	if jerr != nil {
+		log.Printf("[requestlog] encode failed for %s: %v", op, jerr)
+		return
+	}
+	if _, werr := c.reqLog.Write(append(line, '\n')); werr != nil {
+		log.Printf("[requestlog] write failed: %v", werr)
+	}
+}

--- a/internal/api/requestlog_test.go
+++ b/internal/api/requestlog_test.go
@@ -1,0 +1,190 @@
+package api
+
+// Tests for the per-request JSONL debug log (requestlog.go): entries carry
+// op/vars/duration/outcome, complexity appears exactly when the response
+// carried X-Complexity, and the outcome classification matches
+// linearfs.api.requests' enum. Rotation is the telemetry rotatingWriter's
+// job (tested there); here the writer is a plain buffer.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// decodeRequestLog splits buf into parsed JSONL entries, failing the test on
+// any malformed line.
+func decodeRequestLog(t *testing.T, buf *bytes.Buffer) []requestLogEntry {
+	t.Helper()
+	var entries []requestLogEntry
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var e requestLogEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("request log line not valid JSON: %v\nline: %s", err, line)
+		}
+		entries = append(entries, e)
+	}
+	return entries
+}
+
+func TestRequestLogEntryFields(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Complexity", "1234")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"data": {"teams": {"nodes": []}}}`)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-api-key")
+	client.SetAPIURL(server.URL)
+	var buf bytes.Buffer
+	client.SetRequestLog(&buf) // sequential queries only; no concurrency here
+
+	var result struct{}
+	err := client.query(context.Background(),
+		`query TestOp($id: String!) { team(id: $id) { id } }`,
+		map[string]any{"id": "team-abc"}, &result)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+
+	entries := decodeRequestLog(t, &buf)
+	if len(entries) != 1 {
+		t.Fatalf("got %d log entries, want 1", len(entries))
+	}
+	e := entries[0]
+	if _, terr := time.Parse(time.RFC3339Nano, e.TS); terr != nil {
+		t.Errorf("ts %q is not RFC3339Nano: %v", e.TS, terr)
+	}
+	if e.Op != "TestOp" {
+		t.Errorf("op = %q, want TestOp", e.Op)
+	}
+	if got := e.Vars["id"]; got != "team-abc" {
+		t.Errorf("vars.id = %v, want team-abc (full vars are the duplicate-fetch key)", got)
+	}
+	if e.DurationMS < 0 {
+		t.Errorf("duration_ms = %v, want >= 0", e.DurationMS)
+	}
+	if e.Outcome != "ok" {
+		t.Errorf("outcome = %q, want ok", e.Outcome)
+	}
+	if e.Complexity == nil || *e.Complexity != 1234 {
+		t.Errorf("complexity = %v, want 1234 (the response's X-Complexity)", e.Complexity)
+	}
+}
+
+// TestRequestLogComplexityOmittedWithoutHeader pins the omit-when-absent
+// contract: a response with no X-Complexity produces a line with NO
+// complexity key at all (not a fabricated zero).
+func TestRequestLogComplexityOmittedWithoutHeader(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"data": {"teams": {"nodes": []}}}`)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-api-key")
+	client.SetAPIURL(server.URL)
+	var buf bytes.Buffer
+	client.SetRequestLog(&buf)
+
+	if _, err := client.GetTeams(context.Background()); err != nil {
+		t.Fatalf("GetTeams failed: %v", err)
+	}
+
+	raw := buf.String()
+	if strings.Contains(raw, "complexity") {
+		t.Errorf("line carries a complexity key without an X-Complexity header:\n%s", raw)
+	}
+	entries := decodeRequestLog(t, &buf)
+	if len(entries) != 1 || entries[0].Outcome != "ok" {
+		t.Fatalf("entries = %+v, want one ok entry", entries)
+	}
+}
+
+// TestRequestLogOutcomes pins the error and ratelimited classifications —
+// the same enum as linearfs.api.requests (outcomeFor is shared).
+func TestRequestLogOutcomes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		outcome string
+	}{
+		{
+			name: "graphql error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(w, `{"errors": [{"message": "boom"}]}`)
+			},
+			outcome: "error",
+		},
+		{
+			name: "rate limited",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusTooManyRequests)
+				fmt.Fprintf(w, `{"errors": [{"message": "RATELIMITED"}]}`)
+			},
+			outcome: "ratelimited",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			client := NewClient("test-api-key")
+			client.SetAPIURL(server.URL)
+			var buf bytes.Buffer
+			client.SetRequestLog(&buf)
+
+			if _, err := client.GetTeams(context.Background()); err == nil {
+				t.Fatal("GetTeams succeeded, want failure")
+			}
+
+			entries := decodeRequestLog(t, &buf)
+			if len(entries) != 1 {
+				t.Fatalf("got %d log entries, want 1", len(entries))
+			}
+			if entries[0].Outcome != tc.outcome {
+				t.Errorf("outcome = %q, want %q", entries[0].Outcome, tc.outcome)
+			}
+		})
+	}
+}
+
+// TestRequestLogDisabledByDefault: with no writer set the log site is a
+// no-op branch — queries run normally and nothing is recorded anywhere.
+func TestRequestLogDisabledByDefault(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"data": {"teams": {"nodes": []}}}`)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-api-key")
+	client.SetAPIURL(server.URL)
+
+	if _, err := client.GetTeams(context.Background()); err != nil {
+		t.Fatalf("GetTeams failed with nil request log: %v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,11 +35,13 @@ type LogConfig struct {
 	File  string `yaml:"file"`
 }
 
-// TelemetryConfig configures the OTEL metrics pipeline (internal/telemetry).
-// The in-memory meter and the journald summary line are always on; only the
-// JSONL file export is configurable here.
+// TelemetryConfig configures the OTEL metrics pipeline (internal/telemetry)
+// plus the per-request debug log. The in-memory meter and the journald
+// summary line are always on; only the JSONL file export and the request log
+// are configurable here.
 type TelemetryConfig struct {
-	File TelemetryFileConfig `yaml:"file"`
+	File     TelemetryFileConfig     `yaml:"file"`
+	Requests TelemetryRequestsConfig `yaml:"requests"`
 }
 
 // TelemetryFileConfig gates the JSONL metrics file export (off by default).
@@ -48,6 +50,18 @@ type TelemetryFileConfig struct {
 	Path      string        `yaml:"path"`
 	Interval  time.Duration `yaml:"interval"`
 	MaxSizeMB int           `yaml:"max_size_mb"`
+}
+
+// TelemetryRequestsConfig gates the per-request JSONL debug log (off by
+// default): one JSON line per completed GraphQL request, written by the api
+// client. This is an application debug log, NOT an OTEL signal — the
+// metrics-only/traces-never policy is untouched. It exists for offline
+// analysis runs (duplicate-fetch detection, complexity attribution; see
+// docs/plans/2026-07-09-coldstart-observation-plan.md), which is why the
+// full variables map is logged.
+type TelemetryRequestsConfig struct {
+	Enabled bool   `yaml:"enabled"`
+	Path    string `yaml:"path"`
 }
 
 func DefaultConfig() *Config {
@@ -70,6 +84,10 @@ func DefaultConfig() *Config {
 				Interval:  60 * time.Second,
 				MaxSizeMB: 50,
 			},
+			Requests: TelemetryRequestsConfig{
+				Enabled: false,
+				Path:    DefaultRequestLogPath(),
+			},
 		},
 	}
 }
@@ -83,6 +101,17 @@ func DefaultTelemetryPath() string {
 		configDir = os.Getenv("HOME")
 	}
 	return filepath.Join(configDir, "linearfs", "metrics.jsonl")
+}
+
+// DefaultRequestLogPath returns the default per-request JSONL debug log
+// path, next to the other linearfs state files (same convention as
+// DefaultTelemetryPath's metrics.jsonl).
+func DefaultRequestLogPath() string {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		configDir = os.Getenv("HOME")
+	}
+	return filepath.Join(configDir, "linearfs", "requests.jsonl")
 }
 
 // Load loads configuration using the real environment.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -155,6 +155,60 @@ telemetry:
 	}
 }
 
+// TestLoadTelemetryRequestsConfig covers the per-request debug log gate
+// (telemetry.requests.*): parsing an explicit config, and the off-by-default
+// with default path when the keys are absent.
+func TestLoadTelemetryRequestsConfig(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "linearfs")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("Failed to create config dir: %v", err)
+	}
+
+	configPath := filepath.Join(configDir, "config.yaml")
+	configContent := `
+telemetry:
+  requests:
+    enabled: true
+    path: /tmp/custom-requests.jsonl
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	env := mockEnv(map[string]string{
+		"XDG_CONFIG_HOME": tmpDir,
+	})
+
+	cfg, err := LoadWithEnv(env)
+	if err != nil {
+		t.Fatalf("LoadWithEnv() error: %v", err)
+	}
+
+	if !cfg.Telemetry.Requests.Enabled {
+		t.Error("LoadWithEnv() Telemetry.Requests.Enabled should be true")
+	}
+	if cfg.Telemetry.Requests.Path != "/tmp/custom-requests.jsonl" {
+		t.Errorf("LoadWithEnv() Telemetry.Requests.Path = %q, want /tmp/custom-requests.jsonl", cfg.Telemetry.Requests.Path)
+	}
+	// The sibling file export keeps its defaults untouched.
+	if cfg.Telemetry.File.Enabled {
+		t.Error("LoadWithEnv() Telemetry.File.Enabled flipped by a requests-only config")
+	}
+}
+
+func TestTelemetryRequestsDefaults(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultConfig()
+	if cfg.Telemetry.Requests.Enabled {
+		t.Error("DefaultConfig() Telemetry.Requests.Enabled should be false (the request log is opt-in)")
+	}
+	if filepath.Base(cfg.Telemetry.Requests.Path) != "requests.jsonl" {
+		t.Errorf("DefaultConfig() Telemetry.Requests.Path = %q, want default requests.jsonl path", cfg.Telemetry.Requests.Path)
+	}
+}
+
 func TestLoadWithConfigFile(t *testing.T) {
 	t.Parallel()
 	// Create a temporary directory for config

--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -17,6 +18,7 @@ import (
 	"github.com/jra3/linear-fuse/internal/db"
 	"github.com/jra3/linear-fuse/internal/repo"
 	"github.com/jra3/linear-fuse/internal/sync"
+	"github.com/jra3/linear-fuse/internal/telemetry"
 )
 
 // IssueError represents a validation error from a failed write operation
@@ -33,6 +35,7 @@ type LinearFS struct {
 	repo       *repo.SQLiteRepository // For all read operations
 	store      *db.Store              // SQLite store (owned by repo, kept for sync worker)
 	syncWorker *sync.Worker           // Background sync worker
+	requestLog io.Closer              // per-request debug log writer (nil when disabled); closed in Close
 	debug      bool
 	uid        uint32 // Owner UID for files/dirs
 	gid        uint32 // Owner GID for files/dirs
@@ -90,6 +93,18 @@ func NewLinearFS(cfg *config.Config, debug bool) (*LinearFS, error) {
 
 	client := api.NewClient(cfg.APIKey)
 
+	// Optional per-request JSONL debug log (telemetry.requests.*, default
+	// off). Wired at client construction — the config lives under telemetry
+	// but the client is born here, not in cmd. Failure to open it must never
+	// block mounting: log and continue without it.
+	var requestLog io.Closer
+	if w, err := telemetry.NewRequestLog(cfg.Telemetry.Requests); err != nil {
+		log.Printf("[linearfs] request log disabled: %v", err)
+	} else if w != nil {
+		client.SetRequestLog(w)
+		requestLog = w
+	}
+
 	// Initialize file cache directory
 	cacheDir := filepath.Join(os.Getenv("HOME"), "Library", "Caches", "linearfs", "files")
 	if err := os.MkdirAll(cacheDir, 0755); err != nil {
@@ -102,6 +117,7 @@ func NewLinearFS(cfg *config.Config, debug bool) (*LinearFS, error) {
 		client:       client,
 		mutatorImpl:  client,
 		verifierImpl: client,
+		requestLog:   requestLog,
 		debug:        debug,
 	}
 	// Wire the feedback store's kernel-cache seam to this instance. The method
@@ -135,6 +151,10 @@ func (lfs *LinearFS) Close() {
 	// Close SQLite store
 	if lfs.store != nil {
 		lfs.store.Close()
+	}
+	// Release the request debug log writer (no more queries after this)
+	if lfs.requestLog != nil {
+		_ = lfs.requestLog.Close()
 	}
 }
 

--- a/internal/telemetry/requestlog.go
+++ b/internal/telemetry/requestlog.go
@@ -1,0 +1,37 @@
+package telemetry
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jra3/linear-fuse/internal/config"
+)
+
+// requestLogMaxBytes caps requests.jsonl before rollover. The cap is fixed
+// (not configurable): the request log is a debug instrument for bounded
+// observation runs, and a generous cap keeps a whole cold-start run in one
+// file. The rotatingWriter bounds disk at ~2x this.
+const requestLogMaxBytes = 100 * 1024 * 1024
+
+// NewRequestLog builds the writer for the per-request JSONL debug log
+// (telemetry.requests.* in config — an application debug log, NOT an OTEL
+// signal; the meter pipeline is untouched). Returns (nil, nil) when
+// disabled: callers skip wiring entirely and the api client does zero work.
+// The writer is the same size-capped rotatingWriter the metrics file export
+// uses; the caller owns Close.
+func NewRequestLog(cfg config.TelemetryRequestsConfig) (io.WriteCloser, error) {
+	if !cfg.Enabled {
+		return nil, nil
+	}
+	path := cfg.Path
+	if path == "" {
+		path = config.DefaultRequestLogPath()
+	}
+	if strings.HasPrefix(path, "~/") {
+		home, _ := os.UserHomeDir()
+		path = filepath.Join(home, path[2:])
+	}
+	return newRotatingWriter(path, requestLogMaxBytes)
+}

--- a/internal/telemetry/requestlog_test.go
+++ b/internal/telemetry/requestlog_test.go
@@ -1,0 +1,59 @@
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jra3/linear-fuse/internal/config"
+)
+
+// TestNewRequestLogDisabled: the off-by-default gate — no writer, no file,
+// zero side effects.
+func TestNewRequestLogDisabled(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "requests.jsonl")
+
+	w, err := NewRequestLog(config.TelemetryRequestsConfig{Enabled: false, Path: path})
+	if err != nil {
+		t.Fatalf("NewRequestLog(disabled) error: %v", err)
+	}
+	if w != nil {
+		t.Fatal("NewRequestLog(disabled) returned a writer, want nil")
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Errorf("disabled request log created a file at %s", path)
+	}
+}
+
+// TestNewRequestLogEnabled: enabled config yields a working writer at the
+// configured path (parent directories created), backed by the same
+// rotatingWriter as the metrics export.
+func TestNewRequestLogEnabled(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "sub", "requests.jsonl")
+
+	w, err := NewRequestLog(config.TelemetryRequestsConfig{Enabled: true, Path: path})
+	if err != nil {
+		t.Fatalf("NewRequestLog(enabled) error: %v", err)
+	}
+	if w == nil {
+		t.Fatal("NewRequestLog(enabled) returned nil writer")
+	}
+
+	line := []byte(`{"op":"TestOp"}` + "\n")
+	if _, err := w.Write(line); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading request log: %v", err)
+	}
+	if string(got) != string(line) {
+		t.Errorf("file content = %q, want %q", got, line)
+	}
+}

--- a/scripts/coldstart-observe.sh
+++ b/scripts/coldstart-observe.sh
@@ -1,0 +1,390 @@
+#!/usr/bin/env bash
+# coldstart-observe.sh — unattended cold-start observation runbook for the
+# LIVE linearfs service. Implements docs/plans/2026-07-09-coldstart-observation-plan.md:
+#
+#   Run A (pure):   budget-gate, snapshot, wipe cache.db, restart, record T0,
+#                   wait until sync settles. Clean baseline for phase timing
+#                   and complexity attribution.
+#   Run B (probed): gate on the next budget window, wipe again, restart, and
+#                   run scripts/coldstart-probe.sh alongside until settled —
+#                   user-visible latency under sync pressure.
+#
+# Artifacts land in a timestamped dir under ~/linearfs-coldstart/ (metrics
+# JSONL slices, requests.jsonl, journald slices from a cursor, the probe TSV,
+# and timestamps.txt with T0/mount-ready/T_settled per run).
+#
+# DANGER: this stops the live service, moves the live cache.db aside, and
+# edits the live config.yaml (a marked backup is taken; config comments are
+# NOT preserved by the flip, which is why the restore is a byte-for-byte copy
+# of the backup). It therefore refuses to run unless
+#
+#   LINEARFS_COLDSTART_CONFIRM=1
+#
+# is set. Abort-safe: on ERR/INT/TERM the config is restored, and if the
+# cold sync had not settled the pre-run cache.db is moved back. On success
+# the new (warm) db is kept and the backup left on disk as
+# cache.db.pre-coldstart.
+#
+# Scheduling example (the intended off-hours use):
+#   echo "LINEARFS_COLDSTART_CONFIRM=1 ~/jra3/linear-fuse/scripts/coldstart-observe.sh" | at 02:00
+#
+# Environment (all optional beyond the confirm gate):
+#   LINEARFS_MOUNT                 mount point (default: from ~/.config/linearfs/env, else ~/am/linear)
+#   LINEARFS_COLDSTART_DIR         artifact root      (default: ~/linearfs-coldstart)
+#   LINEARFS_COLDSTART_BUDGET_MIN  complexity floor to start a run   (default: 2500000)
+#   LINEARFS_COLDSTART_ABORT_FLOOR remaining at which a run aborts   (default: 50000 — write-tier territory)
+#   LINEARFS_COLDSTART_MAX_WAIT    max seconds to wait on a budget gate (default: 10800)
+#   LINEARFS_COLDSTART_SETTLE_TIMEOUT  max seconds for one run to settle (default: 3600)
+#   LINEARFS_PROBE_TEAM / LINEARFS_PROBE_ISSUE  passed through to the probe
+#
+# Requires: jq, systemctl --user, journalctl, and python3 with PyYAML (or
+# mikefarah yq) for the config flip. Never run by CI or any test.
+
+set -euo pipefail
+
+log() { printf '[coldstart] %s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"; }
+die() {
+    log "FATAL: $*"
+    exit 1
+}
+
+# ---------------------------------------------------------------- footgun gate
+[[ "${LINEARFS_COLDSTART_CONFIRM:-}" == "1" ]] ||
+    die "refusing to run: this manipulates the live service and cache.db. Set LINEARFS_COLDSTART_CONFIRM=1 to proceed."
+
+# ---------------------------------------------------------------------- paths
+SERVICE=linearfs.service
+CFG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/linearfs"
+CONFIG="$CFG_DIR/config.yaml"
+CONFIG_BACKUP="$CONFIG.coldstart-backup"
+DB="$CFG_DIR/cache.db"
+DB_BACKUP="$DB.pre-coldstart"
+METRICS="$CFG_DIR/metrics.jsonl"
+REQUESTS="$CFG_DIR/requests.jsonl"
+
+ENV_FILE="$CFG_DIR/env"
+if [[ -z "${LINEARFS_MOUNT:-}" && -f "$ENV_FILE" ]]; then
+    # shellcheck disable=SC1090
+    source "$ENV_FILE"
+fi
+MOUNT="${LINEARFS_MOUNT:-$HOME/am/linear}"
+
+BUDGET_MIN="${LINEARFS_COLDSTART_BUDGET_MIN:-2500000}"
+ABORT_FLOOR="${LINEARFS_COLDSTART_ABORT_FLOOR:-50000}"
+MAX_GATE_WAIT="${LINEARFS_COLDSTART_MAX_WAIT:-10800}"
+SETTLE_TIMEOUT="${LINEARFS_COLDSTART_SETTLE_TIMEOUT:-3600}"
+SETTLE_POLL=30    # seconds between settled-checks
+DETAIL_QUIET=150  # detail_outcomes must be flat this long (>= two sync cycles)
+
+ART_ROOT="${LINEARFS_COLDSTART_DIR:-$HOME/linearfs-coldstart}"
+ART_DIR="$ART_ROOT/$(date +%Y%m%d-%H%M%S)"
+TS_FILE="$ART_DIR/timestamps.txt"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# State the cleanup trap consults.
+SYNC_SETTLED=1 # 1 = current cache.db is a valid warm cache (nothing to restore)
+CLEANED=0
+
+mark() { # key [value…]  → timestamps.txt
+    printf '%s=%s\n' "$1" "${2:-$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)}" >>"$TS_FILE"
+}
+
+# ------------------------------------------------------------- jq extractors
+# Latest-line readers over the metrics JSONL (see docs/telemetry.md).
+metric_axis() { # name axis → value of the latest datapoint with that axis
+    [[ -f "$METRICS" ]] || return 0
+    tail -1 "$METRICS" | jq -r --arg n "$1" --arg ax "$2" '
+        [.ScopeMetrics[]?.Metrics[]? | select(.Name==$n) | .Data.DataPoints[]?
+         | select(any(.Attributes[]?; .Key=="axis" and .Value.Value==$ax)) | .Value]
+        | first // empty' 2>/dev/null || true
+}
+metric_first() { # name → first datapoint value
+    [[ -f "$METRICS" ]] || return 0
+    tail -1 "$METRICS" | jq -r --arg n "$1" '
+        [.ScopeMetrics[]?.Metrics[]? | select(.Name==$n) | .Data.DataPoints[]?.Value]
+        | first // empty' 2>/dev/null || true
+}
+metric_sum() { # name → sum over datapoints (cumulative counter total)
+    [[ -f "$METRICS" ]] || return 0
+    tail -1 "$METRICS" | jq -r --arg n "$1" '
+        [.ScopeMetrics[]?.Metrics[]? | select(.Name==$n) | .Data.DataPoints[]?.Value]
+        | add // 0' 2>/dev/null || true
+}
+
+journal_cursor() {
+    journalctl --user -u "$SERVICE" -n 0 --show-cursor 2>/dev/null | sed -n 's/^-- cursor: //p'
+}
+
+catchup_active() { # cursor → success(0) if the last catch-up line since cursor says enabled
+    local last
+    last=$(journalctl --user -u "$SERVICE" --after-cursor="$1" --no-pager 2>/dev/null |
+        grep -o 'catch-up mode \(enabled\|disabled\)' | tail -1 || true)
+    [[ "$last" == "catch-up mode enabled" ]]
+}
+
+# ---------------------------------------------------------------- config flip
+flip_config() {
+    if python3 -c 'import yaml' 2>/dev/null; then
+        python3 - "$CONFIG" <<'PY'
+import sys, yaml
+p = sys.argv[1]
+with open(p) as f:
+    cfg = yaml.safe_load(f) or {}
+t = cfg.setdefault("telemetry", None) or {}
+cfg["telemetry"] = t
+fl = t.setdefault("file", None) or {}
+t["file"] = fl
+fl["enabled"] = True
+fl["interval"] = "10s"
+rq = t.setdefault("requests", None) or {}
+t["requests"] = rq
+rq["enabled"] = True
+with open(p, "w") as f:
+    yaml.safe_dump(cfg, f, default_flow_style=False, sort_keys=False)
+PY
+    elif command -v yq >/dev/null 2>&1; then
+        yq eval -i '.telemetry.file.enabled = true
+            | .telemetry.file.interval = "10s"
+            | .telemetry.requests.enabled = true' "$CONFIG"
+    else
+        return 1
+    fi
+}
+
+restore_config() {
+    if [[ -f "$CONFIG_BACKUP" ]]; then
+        cp -f "$CONFIG_BACKUP" "$CONFIG"
+        rm -f "$CONFIG_BACKUP"
+        log "config restored from backup"
+    fi
+}
+
+# --------------------------------------------------------------- db handling
+# mv the live db (plus WAL/SHM sidecars, kept consistent with it) aside, and
+# verify the backup exists before considering the wipe done.
+backup_db() {
+    [[ -e "$DB_BACKUP" ]] && die "leftover $DB_BACKUP from a previous run — resolve it manually first"
+    if [[ ! -f "$DB" ]]; then
+        log "no cache.db at $DB (already cold); nothing to back up"
+        return 0
+    fi
+    mv "$DB" "$DB_BACKUP"
+    for side in wal shm; do
+        [[ -f "$DB-$side" ]] && mv "$DB-$side" "$DB_BACKUP-$side"
+    done
+    [[ -f "$DB_BACKUP" && ! -e "$DB" ]] || die "db backup verification failed ($DB_BACKUP missing or $DB still present) — aborting before any further step"
+    log "cache.db moved to $DB_BACKUP"
+}
+
+restore_db() {
+    [[ -f "$DB_BACKUP" ]] || return 0
+    rm -f "$DB" "$DB-wal" "$DB-shm"
+    mv "$DB_BACKUP" "$DB"
+    for side in wal shm; do
+        [[ -f "$DB_BACKUP-$side" ]] && mv "$DB_BACKUP-$side" "$DB-$side"
+    done
+    log "cache.db restored from $DB_BACKUP"
+}
+
+# -------------------------------------------------------------------- cleanup
+cleanup() {
+    local rc=$?
+    [[ "$CLEANED" == 1 ]] && exit "$rc"
+    CLEANED=1
+    trap - ERR EXIT INT TERM
+    log "cleanup (exit=$rc, settled=$SYNC_SETTLED)"
+    systemctl --user stop "$SERVICE" 2>/dev/null || true
+    if [[ "$SYNC_SETTLED" != 1 ]]; then
+        restore_db
+        mark "aborted_unsettled" "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)"
+    fi
+    restore_config
+    systemctl --user start "$SERVICE" 2>/dev/null || true
+    log "service restarted; artifacts (if any) in $ART_DIR"
+    exit "$rc"
+}
+trap cleanup EXIT INT TERM
+trap 'log "ERROR at line $LINENO"' ERR
+
+# ------------------------------------------------------------------ preflight
+command -v jq >/dev/null || die "jq is required"
+command -v journalctl >/dev/null || die "journalctl is required"
+[[ -f "$CONFIG" ]] || die "no config at $CONFIG"
+[[ -f "$CONFIG_BACKUP" ]] && die "leftover $CONFIG_BACKUP from a previous run — restore or remove it manually first"
+python3 -c 'import yaml' 2>/dev/null || command -v yq >/dev/null 2>&1 ||
+    die "config flip needs python3+PyYAML or yq"
+systemctl --user is-active --quiet "$SERVICE" || die "$SERVICE is not active — start it healthy first"
+[[ -f "$METRICS" ]] || die "no $METRICS — enable telemetry.file in config so the budget gate can read it"
+if (($(date +%s) - $(stat -c %Y "$METRICS") > 900)); then
+    die "$METRICS is stale (>15min old) — is the file export enabled on the live service?"
+fi
+
+mkdir -p "$ART_DIR"/{pre,runA,runB}
+mark "script_start"
+log "artifacts: $ART_DIR"
+
+# wait_budget: block until complexity remaining >= BUDGET_MIN (reading the
+# live metrics file), bounded by MAX_GATE_WAIT.
+wait_budget() {
+    local waited=0 remaining reset
+    while :; do
+        remaining=$(metric_axis linearfs.budget.remaining complexity)
+        if [[ -n "$remaining" ]] && awk -v r="$remaining" -v m="$BUDGET_MIN" 'BEGIN{exit !(r>=m)}'; then
+            log "budget gate open: $remaining complexity remaining (>= $BUDGET_MIN)"
+            return 0
+        fi
+        ((waited < MAX_GATE_WAIT)) || die "budget gate timed out after ${waited}s (remaining=${remaining:-unknown})"
+        reset=$(metric_axis linearfs.budget.reset_seconds complexity)
+        local nap=120
+        if [[ -n "$reset" ]]; then
+            nap=$(awk -v r="$reset" 'BEGIN{n=int(r)+60; if(n<60)n=60; if(n>900)n=900; print n}')
+        fi
+        log "budget gate: remaining=${remaining:-unknown} < $BUDGET_MIN; sleeping ${nap}s (reset in ${reset:-unknown}s)"
+        sleep "$nap"
+        waited=$((waited + nap))
+    done
+}
+
+# wait_mount: poll until the mount root lists; records nothing itself.
+wait_mount() {
+    local tries=0
+    until /bin/ls "$MOUNT" >/dev/null 2>&1; do
+        ((tries++ < 600)) || die "mount at $MOUNT not ready after 120s"
+        sleep 0.2
+    done
+}
+
+# wait_settled <cursor> <run-label>: poll the settled predicate —
+# pending_depth == 0 AND detail_outcomes flat for DETAIL_QUIET seconds AND
+# catch-up mode off. Aborts the run when complexity remaining falls to the
+# ABORT_FLOOR (that datapoint is itself a finding — recorded, then die).
+wait_settled() {
+    local cursor="$1" label="$2"
+    local start now last_total="" last_change pending details remaining
+    start=$(date +%s)
+    last_change=$start
+    while :; do
+        sleep "$SETTLE_POLL"
+        now=$(date +%s)
+        ((now - start < SETTLE_TIMEOUT)) || die "$label: not settled after ${SETTLE_TIMEOUT}s"
+
+        remaining=$(metric_axis linearfs.budget.remaining complexity)
+        if [[ -n "$remaining" ]] && awk -v r="$remaining" -v f="$ABORT_FLOOR" 'BEGIN{exit !(r<=f)}'; then
+            mark "${label}_abort_budget_remaining" "$remaining"
+            mark "${label}_abort_pending_depth" "$(metric_first linearfs.sync.pending_depth)"
+            mark "${label}_abort_detail_total" "$(metric_sum linearfs.sync.detail_outcomes)"
+            die "$label: complexity remaining $remaining hit the abort floor $ABORT_FLOOR before settling (recorded)"
+        fi
+
+        pending=$(metric_first linearfs.sync.pending_depth)
+        details=$(metric_sum linearfs.sync.detail_outcomes)
+        if [[ -z "$last_total" || "$details" != "$last_total" ]]; then
+            last_total="$details"
+            last_change=$now
+        fi
+        log "$label: pending_depth=${pending:-?} detail_total=${details:-?} quiet=$((now - last_change))s remaining=${remaining:-?}"
+
+        [[ "$pending" == "0" ]] || continue
+        ((now - last_change >= DETAIL_QUIET)) || continue
+        catchup_active "$cursor" && continue
+        mark "${label}_settled"
+        log "$label: settled"
+        return 0
+    done
+}
+
+collect_run() { # <run-dir> <cursor>
+    local dir="$1" cursor="$2"
+    cp -f "$METRICS" "$dir/metrics.jsonl" 2>/dev/null || true
+    cp -f "$REQUESTS" "$dir/requests.jsonl" 2>/dev/null || true
+    journalctl --user -u "$SERVICE" --after-cursor="$cursor" --no-pager \
+        -o short-iso-precise >"$dir/journal.log" 2>/dev/null || true
+}
+
+# ================================================================== RUN A
+log "preflight: waiting on the budget gate for Run A"
+wait_budget
+mark "runA_budget_remaining" "$(metric_axis linearfs.budget.remaining complexity)"
+
+log "Run A snapshot: stopping $SERVICE"
+systemctl --user stop "$SERVICE"
+CURSOR_A=$(journal_cursor)
+mark "runA_journal_cursor" "$CURSOR_A"
+# Pre-run telemetry moves aside so the run's files carry ONLY run lines.
+[[ -f "$METRICS" ]] && mv "$METRICS" "$ART_DIR/pre/metrics.jsonl"
+[[ -f "$REQUESTS" ]] && mv "$REQUESTS" "$ART_DIR/pre/requests.jsonl"
+backup_db
+SYNC_SETTLED=0
+
+log "flipping config (backup at $CONFIG_BACKUP): telemetry interval 10s + request log on"
+cp -f "$CONFIG" "$CONFIG_BACKUP"
+flip_config || die "config flip failed"
+
+log "starting $SERVICE (Run A cold start)"
+systemctl --user start "$SERVICE"
+mark "runA_T0"
+wait_mount
+mark "runA_mount_ready"
+log "Run A: mount ready; waiting for sync to settle"
+
+wait_settled "$CURSOR_A" runA
+SYNC_SETTLED=1
+collect_run "$ART_DIR/runA" "$CURSOR_A"
+log "Run A artifacts collected"
+
+# ================================================================== RUN B
+log "gating Run B on the next budget window"
+RESET_NOW=$(metric_axis linearfs.budget.reset_seconds complexity)
+if [[ -n "$RESET_NOW" ]]; then
+    NAP=$(awk -v r="$RESET_NOW" 'BEGIN{n=int(r)+120; if(n<60)n=60; print n}')
+    log "sleeping ${NAP}s for the window reset"
+    sleep "$NAP"
+fi
+wait_budget
+mark "runB_budget_remaining" "$(metric_axis linearfs.budget.remaining complexity)"
+
+log "Run B snapshot: stopping $SERVICE"
+systemctl --user stop "$SERVICE"
+# Final (complete) Run A telemetry replaces the settle-time copies.
+[[ -f "$METRICS" ]] && mv "$METRICS" "$ART_DIR/runA/metrics.jsonl"
+[[ -f "$REQUESTS" ]] && mv "$REQUESTS" "$ART_DIR/runA/requests.jsonl"
+# Run A's warm db is an artifact; the pre-coldstart backup stays the restore point.
+[[ -f "$DB" ]] && mv "$DB" "$ART_DIR/runA/cache.db"
+rm -f "$DB-wal" "$DB-shm"
+CURSOR_B=$(journal_cursor)
+mark "runB_journal_cursor" "$CURSOR_B"
+SYNC_SETTLED=0
+
+log "starting $SERVICE (Run B cold start, probed)"
+systemctl --user start "$SERVICE"
+mark "runB_T0"
+wait_mount
+mark "runB_mount_ready"
+
+PROBE_LOG="$ART_DIR/runB/probe.tsv"
+STOP_FILE="$PROBE_LOG.stop"
+log "Run B: launching probe loop ($PROBE_LOG)"
+PROBE_LOG="$PROBE_LOG" STOP_FILE="$STOP_FILE" LINEARFS_MOUNT="$MOUNT" \
+    "$SCRIPT_DIR/coldstart-probe.sh" &
+PROBE_PID=$!
+
+wait_settled "$CURSOR_B" runB
+SYNC_SETTLED=1
+
+touch "$STOP_FILE"
+wait "$PROBE_PID" 2>/dev/null || true
+rm -f "$STOP_FILE"
+collect_run "$ART_DIR/runB" "$CURSOR_B"
+log "Run B artifacts collected"
+
+# ================================================================ CLEANUP
+log "restoring config and restarting with the warm cache"
+systemctl --user stop "$SERVICE"
+# Final Run B telemetry into the artifact dir; the restored config re-creates
+# metrics.jsonl at the normal cadence.
+[[ -f "$METRICS" ]] && mv "$METRICS" "$ART_DIR/runB/metrics.jsonl"
+[[ -f "$REQUESTS" ]] && mv "$REQUESTS" "$ART_DIR/runB/requests.jsonl"
+restore_config
+systemctl --user start "$SERVICE"
+mark "script_end"
+log "done. warm db kept; pre-run db left at $DB_BACKUP; artifacts in $ART_DIR"

--- a/scripts/coldstart-probe.sh
+++ b/scripts/coldstart-probe.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# coldstart-probe.sh — the Run B probe loop of the cold-start observation
+# plan (docs/plans/2026-07-09-coldstart-observation-plan.md, runbook step 6).
+#
+# Every PROBE_INTERVAL (15s) it wall-times a fixed set of filesystem paths —
+# skeleton reads, detail-triggering reads (SWR), and viewer-dependent views —
+# and appends one TSV row per probe to PROBE_LOG:
+#
+#   epoch_ns <TAB> iso_ts <TAB> probe <TAB> duration_ms <TAB> exit_status
+#
+# Failures are data, not errors: a probe that fails (path not yet synced)
+# records its non-zero exit status and the loop continues.
+#
+# Usage (normally invoked by coldstart-observe.sh for Run B):
+#   PROBE_LOG=/tmp/probe.tsv scripts/coldstart-probe.sh
+#
+# Stops when STOP_FILE appears (the runbook's settled signal) or on SIGTERM.
+#
+# Environment:
+#   LINEARFS_MOUNT       mount point       (default: from ~/.config/linearfs/env, else ~/am/linear)
+#   PROBE_LOG            output TSV        (default: ./coldstart-probe.tsv)
+#   STOP_FILE            stop sentinel     (default: $PROBE_LOG.stop)
+#   PROBE_INTERVAL       seconds per round (default: 15)
+#   LINEARFS_PROBE_TEAM  team key          (default: ENG)
+#   LINEARFS_PROBE_ISSUE fixed issue ID    (default: auto-pick first issue seen)
+#
+# This script is an operator tool for a live mount. It is never run by CI or
+# any test.
+
+set -u
+
+ENV_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/linearfs/env"
+if [[ -z "${LINEARFS_MOUNT:-}" && -f "$ENV_FILE" ]]; then
+    # shellcheck disable=SC1090
+    source "$ENV_FILE"
+fi
+MOUNT="${LINEARFS_MOUNT:-$HOME/am/linear}"
+PROBE_LOG="${PROBE_LOG:-./coldstart-probe.tsv}"
+STOP_FILE="${STOP_FILE:-$PROBE_LOG.stop}"
+INTERVAL="${PROBE_INTERVAL:-15}"
+TEAM="${LINEARFS_PROBE_TEAM:-ENG}"
+ISSUE="${LINEARFS_PROBE_ISSUE:-}"
+
+mkdir -p "$(dirname "$PROBE_LOG")"
+
+log_row() { # probe duration_ms status
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+        "$(date +%s%N)" "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)" "$1" "$2" "$3" >>"$PROBE_LOG"
+}
+
+# probe NAME CMD... — wall-time one command, record TSV, never fail the loop.
+probe() {
+    local name="$1"
+    shift
+    local start end rc
+    start=$(date +%s%N)
+    "$@" >/dev/null 2>&1
+    rc=$?
+    end=$(date +%s%N)
+    log_row "$name" "$(((end - start) / 1000000))" "$rc"
+}
+
+# cat of the first comment file under the fixed issue, if any exists yet.
+cat_first_comment() {
+    local dir="$MOUNT/teams/$TEAM/issues/$ISSUE/comments"
+    local first
+    first=$(/bin/ls "$dir" 2>/dev/null | grep '\.md$' | head -1) || true
+    [[ -n "$first" ]] && cat "$dir/$first"
+}
+
+echo "# coldstart-probe start mount=$MOUNT team=$TEAM interval=${INTERVAL}s" >>"$PROBE_LOG"
+trap 'echo "# coldstart-probe stop $(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$PROBE_LOG"; exit 0' TERM INT
+
+while [[ ! -e "$STOP_FILE" ]]; do
+    # Fixed-issue selection: auto-pick the first issue the mount shows and
+    # then keep probing THAT issue every round (a stable detail-read target).
+    if [[ -z "$ISSUE" ]]; then
+        ISSUE=$(/bin/ls "$MOUNT/teams/$TEAM/issues" 2>/dev/null | grep -v '^_' | head -1) || true
+        [[ -n "$ISSUE" ]] && echo "# probe issue selected: $ISSUE" >>"$PROBE_LOG"
+    fi
+
+    probe ls_teams        /bin/ls "$MOUNT/teams/"
+    probe ls_team_issues  /bin/ls "$MOUNT/teams/$TEAM/issues"
+    if [[ -n "$ISSUE" ]]; then
+        probe cat_issue    cat "$MOUNT/teams/$TEAM/issues/$ISSUE/issue.md"
+        probe ls_comments  /bin/ls "$MOUNT/teams/$TEAM/issues/$ISSUE/comments/"
+        probe cat_comment  cat_first_comment
+    fi
+    probe ls_my_assigned  /bin/ls "$MOUNT/my/assigned/"
+    probe ls_cycle_current /bin/ls "$MOUNT/teams/$TEAM/cycles/current/"
+
+    sleep "$INTERVAL"
+done
+echo "# coldstart-probe stopped by $STOP_FILE" >>"$PROBE_LOG"


### PR DESCRIPTION
Pre-work for the cold-start observation plan (`docs/plans/2026-07-09-coldstart-observation-plan.md`, grilling-locked 2026-07-09) — the request-timeline instrument built FIRST, plus the runbook and probe scripts. Off by default; zero cost when disabled.

## Request-timeline log

An **application debug log, not an OTEL signal** — the metrics-only/traces-never policy is untouched; the meter pipeline is not modified.

- **Config**: `telemetry.requests.{enabled (default false), path (default <UserConfigDir>/linearfs/requests.jsonl)}` — new `TelemetryRequestsConfig` under the existing `TelemetryConfig`.
- **One JSON line per completed request**, written in `Client.query` at the same site that records `apiMetrics` (so budget deferrals never appear — identical semantics to `linearfs.api.requests`):
  ```json
  {"ts":"…RFC3339Nano…","op":"TeamIssuesByUpdatedAt","vars":{"teamId":"…"},"duration_ms":312.4,"outcome":"ok","complexity":8231}
  ```
  `vars` is the full variables map, deliberately — grouping by `(op, vars)` is the plan's duplicate-fetch detector. `outcome` uses the exact classifier of `linearfs.api.requests` (factored into shared `outcomeFor`).
- **Complexity is threaded, not re-parsed**: `rateBudget.reconcileLocked` (the ONE place `X-Complexity` is parsed) now returns the parsed value; `observe`/`rateLimited` stash it on the admission, and the log site reads it via `admission.actualComplexity()`. Omitted from the line when the response carried no header.
- **Writer**: reuses the telemetry package's `rotatingWriter` (fixed 100 MB cap, ~2× disk bound) via `telemetry.NewRequestLog`; wired at client construction in `fs.NewLinearFS` (the client is born there, not in cmd), closed in `LinearFS.Close`. Disabled = nil writer, one branch.

## Runbook scripts (operator tools — never run by CI or any test)

- `scripts/coldstart-observe.sh`: the plan's runbook — preflight budget gate (jq over the latest `metrics.jsonl` line for `budget.remaining`/`reset_seconds`, wait loop until ≥2.5M), snapshot (journal cursor via `--show-cursor`, telemetry files moved aside, `cache.db` **mv'd with WAL/SHM sidecars and verified before anything proceeds**), marked config backup + flip (10s exports + request log on), restart + T0 + mount-ready poll, Run A settled detection (`pending_depth==0` + `detail_outcomes` flat ≥150s + catch-up off from the journal), artifact collection under `~/linearfs-coldstart/<ts>/`, window gate, probed Run B, cleanup restoring config + restarting.
  - **Footgun guard**: refuses to run unless `LINEARFS_COLDSTART_CONFIRM=1`.
  - **Abort-safe**: trap on EXIT/INT/TERM (+ERR logging) restores the config backup and, when the cold sync hadn't settled, restores the pre-run db; budget-floor abort (default 50k remaining) records where it died — that datapoint is itself a finding.
  - `at`-schedulable: `echo "LINEARFS_COLDSTART_CONFIRM=1 scripts/coldstart-observe.sh" | at 02:00`
  - Mount/config paths come from `~/.config/linearfs/env` (`LINEARFS_MOUNT`) / XDG, overridable by env.
- `scripts/coldstart-probe.sh`: Run B's 15s probe loop — wall-times (`date +%s%N`) skeleton reads, detail-triggering reads, and viewer-dependent views, appending TSV; probe failures are recorded data, never loop-fatal.

## Docs

`docs/telemetry.md`: new "Per-request debug log" section (explicitly marked *debug log, not an OTEL signal*) with the line schema and jq-ready semantics, plus the scripts' usage.

## Verification

- `make build`, `go vet ./...`, `gofmt -l internal/` clean
- `go test ./...` fully green (including the integration suite, 64s)
- `bash -n` on both scripts (shellcheck not installed on this machine — noted)
- New tests: disabled ⇒ no writer/no file; enabled ⇒ valid JSON lines with op/vars/duration/outcome asserted; complexity present iff header present; error and ratelimited outcome classification; config parse + defaults. Rotation reuse rides the existing `rotate_test.go`.

## Deviations from the letter of the task

- The plan's `systemctl --user restart` is split into `stop → (db/telemetry moves) → start` — moving the live db under a running service is unsafe.
- `MockLinearServer` wasn't extended for headers: the api package's existing tests already use raw `httptest` servers with `X-Complexity`/rate-limit headers, so the new tests follow that pattern (no testutil change needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)