### PR TITLE
refactor(fs): delete 29 repo passthrough methods — call sites use the concrete repo directly

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1135,7 +1135,10 @@ modules) rather than mocking under node methods. If a real second adapter
 ever appears (read-through cache, alternate store), re-extract the interface
 from `SQLiteRepository` mechanically. The SQLite fixture helpers
 (`fixtures.PopulateTestData` et al.) are the surviving, genuinely-used part
-of the old scaffolding.
+of the old scaffolding. Round 19 finished the thought: the 29 pure
+passthrough methods `LinearFS` grew over the repo (`GetTeams` et al. +
+`MaybeRefreshIssueDetails`) are deleted — fs call sites use `lfs.repo.X`
+directly, the same way the write handlers use `lfs.store`.
 
 ### ErrorSink
 The minimal seam the WriteBack tail uses to record validation/divergence messages for

--- a/internal/fs/attachments.go
+++ b/internal/fs/attachments.go
@@ -29,7 +29,7 @@ var _ fs.NodeGetattrer = (*AttachmentsNode)(nil)
 
 func (n *AttachmentsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	// Trigger background refresh of sub-resources if stale
-	n.lfs.MaybeRefreshIssueDetails(n.issueID)
+	n.lfs.repo.MaybeRefreshIssueDetails(n.issueID)
 
 	entries := n.trio().entries()
 
@@ -51,8 +51,8 @@ func (n *AttachmentsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Er
 // records the first error there (Lookup distinguishes "not found" from
 // "couldn't look").
 func (n *AttachmentsNode) listing(ctx context.Context, fetchErr *error) attachmentListing {
-	files, ferr := n.lfs.GetIssueEmbeddedFiles(ctx, n.issueID)
-	attachments, aerr := n.lfs.GetIssueAttachments(ctx, n.issueID)
+	files, ferr := n.lfs.repo.GetIssueEmbeddedFiles(ctx, n.issueID)
+	attachments, aerr := n.lfs.repo.GetIssueAttachments(ctx, n.issueID)
 	if fetchErr != nil {
 		if ferr != nil {
 			*fetchErr = ferr
@@ -278,7 +278,7 @@ func (n *AttachmentsNode) createAttachment(ctx context.Context, raw []byte) sysc
 	// the authoritative post-failure re-check inside mutate treats a stale-cache
 	// miss as the created attachment.
 	if url := strings.SplitN(content, " ", 2)[0]; url != "" {
-		if existing, err := n.lfs.GetIssueAttachments(ctx, n.issueID); err == nil {
+		if existing, err := n.lfs.repo.GetIssueAttachments(ctx, n.issueID); err == nil {
 			for _, att := range existing {
 				if attachmentURLsEqual(att.URL, url) {
 					n.lfs.ClearWriteError(collectionErrorKey("attachments", n.issueID))

--- a/internal/fs/comments.go
+++ b/internal/fs/comments.go
@@ -29,10 +29,10 @@ var _ fs.NodeGetattrer = (*CommentsNode)(nil)
 
 func (n *CommentsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	// Trigger background refresh of sub-resources if stale
-	n.lfs.MaybeRefreshIssueDetails(n.issueID)
+	n.lfs.repo.MaybeRefreshIssueDetails(n.issueID)
 
 	// Fetch comments (uses cache if available)
-	comments, err := n.lfs.GetIssueComments(ctx, n.issueID)
+	comments, err := n.lfs.repo.GetIssueComments(ctx, n.issueID)
 	if err != nil {
 		// On error, still serve the trio
 		return fs.NewListDirStream(n.trio().entries()), 0
@@ -66,7 +66,7 @@ func (n *CommentsNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 		return inode, 0
 	}
 
-	comments, err := n.lfs.GetIssueComments(ctx, n.issueID)
+	comments, err := n.lfs.repo.GetIssueComments(ctx, n.issueID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -103,7 +103,7 @@ func (n *CommentsNode) commentMetaRender(comment api.Comment) renderFunc {
 	lfs, issueID := n.lfs, n.issueID
 	return func(ctx context.Context) ([]byte, time.Time, time.Time) {
 		cur := comment
-		if comments, err := lfs.GetIssueComments(ctx, issueID); err == nil {
+		if comments, err := lfs.repo.GetIssueComments(ctx, issueID); err == nil {
 			for _, c := range comments {
 				if c.ID == comment.ID {
 					cur = c
@@ -139,7 +139,7 @@ func (n *CommentsNode) Unlink(ctx context.Context, name string) syscall.Errno {
 		op:  `delete comment "` + name + `"`,
 		key: collectionErrorKey("comments", n.issueID),
 		find: func(ctx context.Context) (*api.Comment, error) {
-			comments, err := n.lfs.GetIssueComments(ctx, n.issueID)
+			comments, err := n.lfs.repo.GetIssueComments(ctx, n.issueID)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/fs/cycles.go
+++ b/internal/fs/cycles.go
@@ -55,7 +55,7 @@ func (c *CyclesNode) refreshFrom(fresh fs.InodeEmbedder) {
 }
 
 func (c *CyclesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
-	cycles, err := c.lfs.GetTeamCycles(ctx, c.entity().ID)
+	cycles, err := c.lfs.repo.GetTeamCycles(ctx, c.entity().ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -86,7 +86,7 @@ func (c *CyclesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) 
 
 func (c *CyclesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
 	team := c.entity()
-	cycles, err := c.lfs.GetTeamCycles(ctx, team.ID)
+	cycles, err := c.lfs.repo.GetTeamCycles(ctx, team.ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}

--- a/internal/fs/documents.go
+++ b/internal/fs/documents.go
@@ -32,17 +32,17 @@ var _ fs.NodeGetattrer = (*DocsNode)(nil)
 func (n *DocsNode) getDocuments(ctx context.Context) ([]api.Document, error) {
 	if n.issueID != "" {
 		// Trigger background refresh of sub-resources if stale
-		n.lfs.MaybeRefreshIssueDetails(n.issueID)
-		return n.lfs.GetIssueDocuments(ctx, n.issueID)
+		n.lfs.repo.MaybeRefreshIssueDetails(n.issueID)
+		return n.lfs.repo.GetIssueDocuments(ctx, n.issueID)
 	}
 	if n.teamID != "" {
 		return n.lfs.GetTeamDocuments(ctx, n.teamID)
 	}
 	if n.projectID != "" {
-		return n.lfs.GetProjectDocuments(ctx, n.projectID)
+		return n.lfs.repo.GetProjectDocuments(ctx, n.projectID)
 	}
 	if n.initiativeID != "" {
-		return n.lfs.GetInitiativeDocuments(ctx, n.initiativeID)
+		return n.lfs.repo.GetInitiativeDocuments(ctx, n.initiativeID)
 	}
 	return nil, nil
 }

--- a/internal/fs/filter.go
+++ b/internal/fs/filter.go
@@ -159,7 +159,7 @@ func (f *FilterCategoryNode) getUniqueValues(ctx context.Context) ([]string, err
 	switch f.category {
 	case "status":
 		// Use team states from API - much faster than scanning all issues
-		states, err := f.lfs.GetTeamStates(ctx, teamID)
+		states, err := f.lfs.repo.GetTeamStates(ctx, teamID)
 		if err != nil {
 			return nil, err
 		}
@@ -172,7 +172,7 @@ func (f *FilterCategoryNode) getUniqueValues(ctx context.Context) ([]string, err
 
 	case "label":
 		// Use team labels from API - much faster than scanning all issues
-		labels, err := f.lfs.GetTeamLabels(ctx, teamID)
+		labels, err := f.lfs.repo.GetTeamLabels(ctx, teamID)
 		if err != nil {
 			return nil, err
 		}
@@ -185,7 +185,7 @@ func (f *FilterCategoryNode) getUniqueValues(ctx context.Context) ([]string, err
 
 	case "assignee":
 		// Use team members - show only users who are members of this team plus "unassigned"
-		users, err := f.lfs.GetTeamMembers(ctx, teamID)
+		users, err := f.lfs.repo.GetTeamMembers(ctx, teamID)
 		if err != nil {
 			return nil, err
 		}
@@ -274,14 +274,14 @@ func (f *FilterValueNode) getFilteredIssues(ctx context.Context) ([]api.Issue, e
 		return f.lfs.GetFilteredIssuesByLabel(ctx, teamID, f.value)
 	case "assignee":
 		if f.value == "unassigned" {
-			return f.lfs.GetFilteredIssuesUnassigned(ctx, teamID)
+			return f.lfs.repo.GetUnassignedIssues(ctx, teamID)
 		}
 		// Need to resolve assignee handle to ID
 		assigneeID, err := f.resolveAssigneeID(ctx)
 		if err != nil {
 			return nil, err
 		}
-		return f.lfs.GetFilteredIssuesByAssignee(ctx, teamID, assigneeID)
+		return f.lfs.repo.GetIssuesByAssignee(ctx, teamID, assigneeID)
 	default:
 		return nil, fmt.Errorf("unknown filter category: %s", f.category)
 	}
@@ -289,7 +289,7 @@ func (f *FilterValueNode) getFilteredIssues(ctx context.Context) ([]api.Issue, e
 
 // resolveAssigneeID converts an assignee handle (display name or email prefix) to user ID
 func (f *FilterValueNode) resolveAssigneeID(ctx context.Context) (string, error) {
-	users, err := f.lfs.GetTeamMembers(ctx, f.entity().ID)
+	users, err := f.lfs.repo.GetTeamMembers(ctx, f.entity().ID)
 	if err != nil {
 		return "", err
 	}

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -25,7 +25,7 @@ var _ fs.NodeLookuper = (*InitiativesNode)(nil)
 var _ fs.NodeGetattrer = (*InitiativesNode)(nil)
 
 func (i *InitiativesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
-	initiatives, err := i.lfs.GetInitiatives(ctx)
+	initiatives, err := i.lfs.repo.GetInitiatives(ctx)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -42,7 +42,7 @@ func (i *InitiativesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Er
 }
 
 func (i *InitiativesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	initiatives, err := i.lfs.GetInitiatives(ctx)
+	initiatives, err := i.lfs.repo.GetInitiatives(ctx)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -135,7 +135,7 @@ func (i *InitiativeNode) manifest() *dirManifest {
 	// initiative.md is reflected here.
 	m.metaFile("initiative.meta", func(ctx context.Context) ([]byte, time.Time, time.Time) {
 		init := initiative
-		if inits, err := lfs.GetInitiatives(ctx); err == nil {
+		if inits, err := lfs.repo.GetInitiatives(ctx); err == nil {
 			init = freshestByID(inits, initiative.ID, func(i api.Initiative) string { return i.ID }, initiative)
 		}
 		node := &InitiativeInfoNode{BaseNode: BaseNode{lfs: lfs}, initiative: init, initiativeID: init.ID}
@@ -464,7 +464,7 @@ var _ fs.NodeCreater = (*InitiativeUpdatesNode)(nil)
 var _ fs.NodeGetattrer = (*InitiativeUpdatesNode)(nil)
 
 func (n *InitiativeUpdatesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
-	updates, err := n.lfs.GetInitiativeUpdates(ctx, n.initiativeID)
+	updates, err := n.lfs.repo.GetInitiativeUpdates(ctx, n.initiativeID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -493,7 +493,7 @@ func (n *InitiativeUpdatesNode) Lookup(ctx context.Context, name string, out *fu
 		return inode, 0
 	}
 
-	updates, err := n.lfs.GetInitiativeUpdates(ctx, n.initiativeID)
+	updates, err := n.lfs.repo.GetInitiativeUpdates(ctx, n.initiativeID)
 	if err != nil {
 		return nil, syscall.EIO
 	}

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -106,7 +106,7 @@ func (n *IssuesNode) refreshFrom(fresh fs.InodeEmbedder) {
 }
 
 func (n *IssuesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
-	issues, err := n.lfs.GetTeamIssues(ctx, n.entity().ID)
+	issues, err := n.lfs.repo.GetTeamIssues(ctx, n.entity().ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -263,7 +263,7 @@ func (n *IssuesNode) Rmdir(ctx context.Context, name string) syscall.Errno {
 		op:  `archive issue "` + name + `"`,
 		key: collectionErrorKey("issues", team.ID),
 		find: func(ctx context.Context) (*api.Issue, error) {
-			issues, err := n.lfs.GetTeamIssues(ctx, team.ID)
+			issues, err := n.lfs.repo.GetTeamIssues(ctx, team.ID)
 			if err != nil {
 				return nil, err
 			}
@@ -372,7 +372,7 @@ func (n *IssueDirectoryNode) manifest() *dirManifest {
 		if fresh, err := lfs.FetchIssueByIdentifier(ctx, ident); err == nil && fresh != nil {
 			iss = fresh
 		}
-		att, _ := lfs.GetIssueAttachments(ctx, iss.ID)
+		att, _ := lfs.repo.GetIssueAttachments(ctx, iss.ID)
 		b, err := marshal.IssueMetaToMarkdown(iss, att...)
 		if err != nil {
 			return nil, iss.UpdatedAt, iss.CreatedAt
@@ -384,7 +384,7 @@ func (n *IssueDirectoryNode) manifest() *dirManifest {
 	// activity history on each read. It reports the issue's own times; a transient
 	// fetch failure renders an empty file rather than making the entry vanish.
 	m.renderFile("history.md", historyIno(issue.ID), func(ctx context.Context) ([]byte, time.Time, time.Time) {
-		entries, err := lfs.GetIssueHistory(ctx, issue.ID)
+		entries, err := lfs.repo.GetIssueHistory(ctx, issue.ID)
 		if err != nil {
 			log.Printf("Failed to fetch history for %s: %v", issue.Identifier, err)
 			return nil, issue.UpdatedAt, issue.CreatedAt
@@ -598,7 +598,7 @@ var _ fs.NodeMkdirer = (*ChildrenNode)(nil)
 
 func (n *ChildrenNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	// Query children from database by parent_id
-	children, err := n.lfs.GetIssueChildren(ctx, n.issue.ID)
+	children, err := n.lfs.repo.GetIssueChildren(ctx, n.issue.ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -614,7 +614,7 @@ func (n *ChildrenNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno
 
 func (n *ChildrenNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
 	// Query children from database by parent_id
-	children, err := n.lfs.GetIssueChildren(ctx, n.issue.ID)
+	children, err := n.lfs.repo.GetIssueChildren(ctx, n.issue.ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}

--- a/internal/fs/labels.go
+++ b/internal/fs/labels.go
@@ -28,7 +28,7 @@ var _ fs.NodeUnlinker = (*LabelsNode)(nil)
 var _ fs.NodeRenamer = (*LabelsNode)(nil)
 
 func (n *LabelsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
-	labels, err := n.lfs.GetTeamLabels(ctx, n.teamID)
+	labels, err := n.lfs.repo.GetTeamLabels(ctx, n.teamID)
 	if err != nil {
 		log.Printf("Failed to get labels: %v", err)
 		return nil, syscall.EIO
@@ -57,7 +57,7 @@ func (n *LabelsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut
 		return inode, 0
 	}
 
-	labels, err := n.lfs.GetTeamLabels(ctx, n.teamID)
+	labels, err := n.lfs.repo.GetTeamLabels(ctx, n.teamID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -86,7 +86,7 @@ func (n *LabelsNode) labelMetaRender(label api.Label) renderFunc {
 	lfs, teamID := n.lfs, n.teamID
 	return func(ctx context.Context) ([]byte, time.Time, time.Time) {
 		cur := label
-		if labels, err := lfs.GetTeamLabels(ctx, teamID); err == nil {
+		if labels, err := lfs.repo.GetTeamLabels(ctx, teamID); err == nil {
 			for _, l := range labels {
 				if l.ID == label.ID {
 					cur = l
@@ -153,7 +153,7 @@ func (n *LabelsNode) Unlink(ctx context.Context, name string) syscall.Errno {
 		op:  `delete label "` + name + `"`,
 		key: collectionErrorKey("labels", n.teamID),
 		find: func(ctx context.Context) (*api.Label, error) {
-			labels, err := n.lfs.GetTeamLabels(ctx, n.teamID)
+			labels, err := n.lfs.repo.GetTeamLabels(ctx, n.teamID)
 			if err != nil {
 				return nil, err
 			}
@@ -211,7 +211,7 @@ func (n *LabelsNode) Rename(ctx context.Context, name string, newParent fs.Inode
 	newLabelName := strings.TrimSuffix(newName, ".md")
 	newLabelName = strings.ReplaceAll(newLabelName, "-", " ")
 
-	labels, err := n.lfs.GetTeamLabels(ctx, n.teamID)
+	labels, err := n.lfs.repo.GetTeamLabels(ctx, n.teamID)
 	if err != nil {
 		return syscall.EIO
 	}
@@ -256,7 +256,7 @@ func (n *LabelsNode) Create(ctx context.Context, name string, flags uint32, mode
 	// If a label already exists with this name, return its read/write node so an
 	// overwrite (mv/cp/editor save-over) updates it in place instead of binding a
 	// write-only _create node to the name and corrupting it (#137).
-	if labels, err := n.lfs.GetTeamLabels(ctx, n.teamID); err == nil {
+	if labels, err := n.lfs.repo.GetTeamLabels(ctx, n.teamID); err == nil {
 		if label, ok := n.listing(labels).find(name); ok {
 			inode, errno := n.newLabelInode(ctx, name, label, out)
 			if errno != 0 {

--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -239,26 +239,6 @@ func (lfs *LinearFS) HasSQLiteCache() bool {
 	return lfs.repo != nil
 }
 
-func (lfs *LinearFS) GetTeams(ctx context.Context) ([]api.Team, error) {
-	return lfs.repo.GetTeams(ctx)
-}
-
-func (lfs *LinearFS) GetTeamIssues(ctx context.Context, teamID string) ([]api.Issue, error) {
-	return lfs.repo.GetTeamIssues(ctx, teamID)
-}
-
-func (lfs *LinearFS) GetIssueAttachments(ctx context.Context, issueID string) ([]api.Attachment, error) {
-	return lfs.repo.GetIssueAttachments(ctx, issueID)
-}
-
-func (lfs *LinearFS) GetIssueEmbeddedFiles(ctx context.Context, issueID string) ([]api.EmbeddedFile, error) {
-	return lfs.repo.GetIssueEmbeddedFiles(ctx, issueID)
-}
-
-func (lfs *LinearFS) GetIssueHistory(ctx context.Context, issueID string) ([]api.IssueHistoryEntry, error) {
-	return lfs.repo.GetIssueHistory(ctx, issueID)
-}
-
 // MountPoint returns the filesystem mount path
 func (lfs *LinearFS) MountPoint() string {
 	if lfs.mountPoint == "" {
@@ -426,11 +406,6 @@ func (lfs *LinearFS) GetFilteredIssuesByStatus(ctx context.Context, teamID, stat
 	return lfs.repo.GetIssuesByState(ctx, teamID, state.ID)
 }
 
-// GetFilteredIssuesByPriority fetches issues filtered by priority
-func (lfs *LinearFS) GetFilteredIssuesByPriority(ctx context.Context, teamID string, priority int) ([]api.Issue, error) {
-	return lfs.repo.GetIssuesByPriority(ctx, teamID, priority)
-}
-
 // GetFilteredIssuesByLabel fetches issues filtered by label name
 func (lfs *LinearFS) GetFilteredIssuesByLabel(ctx context.Context, teamID, labelName string) ([]api.Issue, error) {
 	label, err := lfs.repo.GetLabelByName(ctx, teamID, labelName)
@@ -441,40 +416,6 @@ func (lfs *LinearFS) GetFilteredIssuesByLabel(ctx context.Context, teamID, label
 		return []api.Issue{}, nil
 	}
 	return lfs.repo.GetIssuesByLabel(ctx, teamID, label.ID)
-}
-
-// GetFilteredIssuesByAssignee fetches issues filtered by assignee
-func (lfs *LinearFS) GetFilteredIssuesByAssignee(ctx context.Context, teamID, assigneeID string) ([]api.Issue, error) {
-	return lfs.repo.GetIssuesByAssignee(ctx, teamID, assigneeID)
-}
-
-// GetFilteredIssuesUnassigned fetches issues with no assignee
-func (lfs *LinearFS) GetFilteredIssuesUnassigned(ctx context.Context, teamID string) ([]api.Issue, error) {
-	return lfs.repo.GetUnassignedIssues(ctx, teamID)
-}
-
-func (lfs *LinearFS) GetMyIssues(ctx context.Context) ([]api.Issue, error) {
-	return lfs.repo.GetMyIssues(ctx)
-}
-
-func (lfs *LinearFS) GetMyCreatedIssues(ctx context.Context) ([]api.Issue, error) {
-	return lfs.repo.GetMyCreatedIssues(ctx)
-}
-
-func (lfs *LinearFS) GetMyActiveIssues(ctx context.Context) ([]api.Issue, error) {
-	return lfs.repo.GetMyActiveIssues(ctx)
-}
-
-func (lfs *LinearFS) GetTeamStates(ctx context.Context, teamID string) ([]api.State, error) {
-	return lfs.repo.GetTeamStates(ctx, teamID)
-}
-
-func (lfs *LinearFS) GetTeamLabels(ctx context.Context, teamID string) ([]api.Label, error) {
-	return lfs.repo.GetTeamLabels(ctx, teamID)
-}
-
-func (lfs *LinearFS) GetTeamCycles(ctx context.Context, teamID string) ([]api.Cycle, error) {
-	return lfs.repo.GetTeamCycles(ctx, teamID)
 }
 
 // GetCycleIssues returns issues in a cycle as CycleIssue
@@ -496,10 +437,6 @@ func (lfs *LinearFS) GetCycleIssues(ctx context.Context, cycleID string) ([]api.
 		}
 	}
 	return result, nil
-}
-
-func (lfs *LinearFS) GetTeamProjects(ctx context.Context, teamID string) ([]api.Project, error) {
-	return lfs.repo.GetTeamProjects(ctx, teamID)
 }
 
 // GetProjectIssues returns issues in a project as ProjectIssue
@@ -524,32 +461,6 @@ func (lfs *LinearFS) GetProjectIssues(ctx context.Context, projectID string) ([]
 	return result, nil
 }
 
-func (lfs *LinearFS) GetUsers(ctx context.Context) ([]api.User, error) {
-	return lfs.repo.GetUsers(ctx)
-}
-
-func (lfs *LinearFS) GetTeamMembers(ctx context.Context, teamID string) ([]api.User, error) {
-	return lfs.repo.GetTeamMembers(ctx, teamID)
-}
-
-// GetUserIssues returns issues assigned to a user across all teams
-func (lfs *LinearFS) GetUserIssues(ctx context.Context, userID string) ([]api.Issue, error) {
-	return lfs.repo.GetUserIssues(ctx, userID)
-}
-
-// GetIssueChildren returns child issues of a parent issue
-func (lfs *LinearFS) GetIssueChildren(ctx context.Context, parentID string) ([]api.Issue, error) {
-	return lfs.repo.GetIssueChildren(ctx, parentID)
-}
-
-func (lfs *LinearFS) MaybeRefreshIssueDetails(issueID string) {
-	lfs.repo.MaybeRefreshIssueDetails(issueID)
-}
-
-func (lfs *LinearFS) GetIssueComments(ctx context.Context, issueID string) ([]api.Comment, error) {
-	return lfs.repo.GetIssueComments(ctx, issueID)
-}
-
 // TryGetCachedComments returns comments from SQLite
 func (lfs *LinearFS) TryGetCachedComments(issueID string) ([]api.Comment, bool) {
 	comments, err := lfs.repo.GetIssueComments(context.Background(), issueID)
@@ -563,25 +474,11 @@ func (lfs *LinearFS) UpdateComment(ctx context.Context, issueID string, commentI
 	return lfs.mutator().UpdateComment(ctx, commentID, body)
 }
 
-// Document methods
-
-func (lfs *LinearFS) GetIssueDocuments(ctx context.Context, issueID string) ([]api.Document, error) {
-	return lfs.repo.GetIssueDocuments(ctx, issueID)
-}
-
 // GetTeamDocuments returns documents for a team (currently via API as not
 // synced). This is a synchronous API call on a live FUSE path — the caller's
 // user is blocked on it — so it promotes to the interactive budget tier.
 func (lfs *LinearFS) GetTeamDocuments(ctx context.Context, teamID string) ([]api.Document, error) {
 	return lfs.client.GetTeamDocuments(api.WithInteractive(ctx), teamID)
-}
-
-func (lfs *LinearFS) GetProjectDocuments(ctx context.Context, projectID string) ([]api.Document, error) {
-	return lfs.repo.GetProjectDocuments(ctx, projectID)
-}
-
-func (lfs *LinearFS) GetInitiativeDocuments(ctx context.Context, initiativeID string) ([]api.Document, error) {
-	return lfs.repo.GetInitiativeDocuments(ctx, initiativeID)
 }
 
 func (lfs *LinearFS) UpdateDocument(ctx context.Context, documentID string, input map[string]any, issueID, teamID, projectID string) (*api.Document, error) {
@@ -590,7 +487,7 @@ func (lfs *LinearFS) UpdateDocument(ctx context.Context, documentID string, inpu
 
 // ResolveUserID converts an email or name to a user ID
 func (lfs *LinearFS) ResolveUserID(ctx context.Context, identifier string) (string, error) {
-	users, err := lfs.GetUsers(ctx)
+	users, err := lfs.repo.GetUsers(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -641,7 +538,7 @@ func (lfs *LinearFS) ResolveIssueID(ctx context.Context, identifier string) (str
 
 // ResolveStateID converts a state name to its ID for a given team
 func (lfs *LinearFS) ResolveStateID(ctx context.Context, teamID string, stateName string) (string, error) {
-	states, err := lfs.GetTeamStates(ctx, teamID)
+	states, err := lfs.repo.GetTeamStates(ctx, teamID)
 	if err != nil {
 		return "", err
 	}
@@ -652,7 +549,7 @@ func (lfs *LinearFS) ResolveStateID(ctx context.Context, teamID string, stateNam
 // ResolveLabelIDs converts label names to their IDs for a given team
 // Returns the list of label IDs and any labels that couldn't be resolved
 func (lfs *LinearFS) ResolveLabelIDs(ctx context.Context, teamID string, labelNames []string) ([]string, []string, error) {
-	labels, err := lfs.GetTeamLabels(ctx, teamID)
+	labels, err := lfs.repo.GetTeamLabels(ctx, teamID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -679,7 +576,7 @@ func (lfs *LinearFS) ResolveLabelIDs(ctx context.Context, teamID string, labelNa
 
 // ResolveProjectID converts a project name to its ID for a given team
 func (lfs *LinearFS) ResolveProjectID(ctx context.Context, teamID string, projectName string) (string, error) {
-	projects, err := lfs.GetTeamProjects(ctx, teamID)
+	projects, err := lfs.repo.GetTeamProjects(ctx, teamID)
 	if err != nil {
 		return "", err
 	}
@@ -690,14 +587,14 @@ func (lfs *LinearFS) ResolveProjectID(ctx context.Context, teamID string, projec
 // ResolveProjectSlugToID converts a project slug to its ID by searching all teams.
 // Used by initiatives which are workspace-level and can link to projects from any team.
 func (lfs *LinearFS) ResolveProjectSlugToID(ctx context.Context, projectSlug string) (string, error) {
-	teams, err := lfs.GetTeams(ctx)
+	teams, err := lfs.repo.GetTeams(ctx)
 	if err != nil {
 		return "", err
 	}
 
 	// Search all teams for a project with this slug
 	for _, team := range teams {
-		projects, err := lfs.GetTeamProjects(ctx, team.ID)
+		projects, err := lfs.repo.GetTeamProjects(ctx, team.ID)
 		if err != nil {
 			continue // Skip teams with errors
 		}
@@ -711,14 +608,9 @@ func (lfs *LinearFS) ResolveProjectSlugToID(ctx context.Context, projectSlug str
 	return "", fmt.Errorf("unknown project slug: %s", projectSlug)
 }
 
-// GetProjectMilestones fetches milestones for a project
-func (lfs *LinearFS) GetProjectMilestones(ctx context.Context, projectID string) ([]api.ProjectMilestone, error) {
-	return lfs.repo.GetProjectMilestones(ctx, projectID)
-}
-
 // ResolveMilestoneID converts a milestone name to its ID for a given project
 func (lfs *LinearFS) ResolveMilestoneID(ctx context.Context, projectID string, milestoneName string) (string, error) {
-	milestones, err := lfs.GetProjectMilestones(ctx, projectID)
+	milestones, err := lfs.repo.GetProjectMilestones(ctx, projectID)
 	if err != nil {
 		return "", err
 	}
@@ -748,7 +640,7 @@ func (lfs *LinearFS) UpdateProjectMilestone(ctx context.Context, milestoneID str
 
 // ResolveCycleID resolves a cycle name to its ID
 func (lfs *LinearFS) ResolveCycleID(ctx context.Context, teamID string, cycleName string) (string, error) {
-	cycles, err := lfs.GetTeamCycles(ctx, teamID)
+	cycles, err := lfs.repo.GetTeamCycles(ctx, teamID)
 	if err != nil {
 		return "", err
 	}
@@ -756,19 +648,9 @@ func (lfs *LinearFS) ResolveCycleID(ctx context.Context, teamID string, cycleNam
 		func(c api.Cycle) string { return c.Name }, func(c api.Cycle) string { return c.ID })
 }
 
-// GetProjectUpdates fetches status updates for a project
-func (lfs *LinearFS) GetProjectUpdates(ctx context.Context, projectID string) ([]api.ProjectUpdate, error) {
-	return lfs.repo.GetProjectUpdates(ctx, projectID)
-}
-
-// GetInitiativeUpdates fetches status updates for an initiative
-func (lfs *LinearFS) GetInitiativeUpdates(ctx context.Context, initiativeID string) ([]api.InitiativeUpdate, error) {
-	return lfs.repo.GetInitiativeUpdates(ctx, initiativeID)
-}
-
 // ResolveInitiativeID converts an initiative name to its ID
 func (lfs *LinearFS) ResolveInitiativeID(ctx context.Context, initiativeName string) (string, error) {
-	initiatives, err := lfs.GetInitiatives(ctx)
+	initiatives, err := lfs.repo.GetInitiatives(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -781,17 +663,6 @@ func (lfs *LinearFS) UpdateLabel(ctx context.Context, labelID string, input map[
 	return lfs.mutator().UpdateLabel(ctx, labelID, input)
 }
 
-// GetInitiatives fetches all initiatives
-func (lfs *LinearFS) GetInitiatives(ctx context.Context) ([]api.Initiative, error) {
-	return lfs.repo.GetInitiatives(ctx)
-}
-
-// GetProjectLabels returns the workspace project-label catalog (Parent names
-// stitched by the repo read).
-func (lfs *LinearFS) GetProjectLabels(ctx context.Context) ([]api.ProjectLabel, error) {
-	return lfs.repo.GetProjectLabels(ctx)
-}
-
 // projectLabelNames maps a project's labelIds to catalog names for rendering.
 // An ID missing from the catalog renders VERBATIM, never dropped — the
 // round-trip invariant: a cold or stale catalog must not cause an untouched
@@ -802,7 +673,7 @@ func (lfs *LinearFS) projectLabelNames(ctx context.Context, ids []string) []stri
 		return nil
 	}
 	byID := make(map[string]string)
-	if catalog, err := lfs.GetProjectLabels(ctx); err == nil {
+	if catalog, err := lfs.repo.GetProjectLabels(ctx); err == nil {
 		for _, l := range catalog {
 			byID[l.ID] = l.Name
 		}

--- a/internal/fs/linearfs_test.go
+++ b/internal/fs/linearfs_test.go
@@ -162,7 +162,7 @@ func TestSQLiteFilteredQueries(t *testing.T) {
 	})
 
 	t.Run("GetFilteredIssuesByPriority", func(t *testing.T) {
-		issues, err := lfs.GetFilteredIssuesByPriority(ctx, "team-1", 4)
+		issues, err := lfs.repo.GetIssuesByPriority(ctx, "team-1", 4)
 		if err != nil {
 			t.Fatalf("GetFilteredIssuesByPriority failed: %v", err)
 		}
@@ -175,7 +175,7 @@ func TestSQLiteFilteredQueries(t *testing.T) {
 	})
 
 	t.Run("GetFilteredIssuesByAssignee", func(t *testing.T) {
-		issues, err := lfs.GetFilteredIssuesByAssignee(ctx, "team-1", "user-1")
+		issues, err := lfs.repo.GetIssuesByAssignee(ctx, "team-1", "user-1")
 		if err != nil {
 			t.Fatalf("GetFilteredIssuesByAssignee failed: %v", err)
 		}
@@ -188,7 +188,7 @@ func TestSQLiteFilteredQueries(t *testing.T) {
 	})
 
 	t.Run("GetFilteredIssuesUnassigned", func(t *testing.T) {
-		issues, err := lfs.GetFilteredIssuesUnassigned(ctx, "team-1")
+		issues, err := lfs.repo.GetUnassignedIssues(ctx, "team-1")
 		if err != nil {
 			t.Fatalf("GetFilteredIssuesUnassigned failed: %v", err)
 		}

--- a/internal/fs/milestones.go
+++ b/internal/fs/milestones.go
@@ -25,7 +25,7 @@ var _ fs.NodeUnlinker = (*MilestonesNode)(nil)
 var _ fs.NodeGetattrer = (*MilestonesNode)(nil)
 
 func (n *MilestonesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
-	milestones, err := n.lfs.GetProjectMilestones(ctx, n.projectID)
+	milestones, err := n.lfs.repo.GetProjectMilestones(ctx, n.projectID)
 	if err != nil {
 		// On error, still serve the trio
 		return fs.NewListDirStream(n.trio().entries()), 0
@@ -54,7 +54,7 @@ func (n *MilestonesNode) Lookup(ctx context.Context, name string, out *fuse.Entr
 		return inode, 0
 	}
 
-	milestones, err := n.lfs.GetProjectMilestones(ctx, n.projectID)
+	milestones, err := n.lfs.repo.GetProjectMilestones(ctx, n.projectID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -109,7 +109,7 @@ func (n *MilestonesNode) milestoneMetaRender(m api.ProjectMilestone) renderFunc 
 	lfs, projectID := n.lfs, n.projectID
 	return func(ctx context.Context) ([]byte, time.Time, time.Time) {
 		cur := m
-		if milestones, err := lfs.GetProjectMilestones(ctx, projectID); err == nil {
+		if milestones, err := lfs.repo.GetProjectMilestones(ctx, projectID); err == nil {
 			for _, mm := range milestones {
 				if mm.ID == m.ID {
 					cur = mm
@@ -145,7 +145,7 @@ func (n *MilestonesNode) Unlink(ctx context.Context, name string) syscall.Errno 
 		op:  `delete milestone "` + name + `"`,
 		key: collectionErrorKey("milestones", n.projectID),
 		find: func(ctx context.Context) (*api.ProjectMilestone, error) {
-			milestones, err := n.lfs.GetProjectMilestones(ctx, n.projectID)
+			milestones, err := n.lfs.repo.GetProjectMilestones(ctx, n.projectID)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/fs/my.go
+++ b/internal/fs/my.go
@@ -54,11 +54,11 @@ var _ fs.NodeGetattrer = (*MyIssuesNode)(nil)
 func (m *MyIssuesNode) getIssues(ctx context.Context) ([]api.Issue, error) {
 	switch m.issueType {
 	case "created":
-		return m.lfs.GetMyCreatedIssues(ctx)
+		return m.lfs.repo.GetMyCreatedIssues(ctx)
 	case "active":
-		return m.lfs.GetMyActiveIssues(ctx)
+		return m.lfs.repo.GetMyActiveIssues(ctx)
 	default:
-		return m.lfs.GetMyIssues(ctx)
+		return m.lfs.repo.GetMyIssues(ctx)
 	}
 }
 

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -50,7 +50,7 @@ func (p *ProjectsNode) refreshFrom(fresh fs.InodeEmbedder) {
 }
 
 func (p *ProjectsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
-	projects, err := p.lfs.GetTeamProjects(ctx, p.entity().ID)
+	projects, err := p.lfs.repo.GetTeamProjects(ctx, p.entity().ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -80,7 +80,7 @@ func (p *ProjectsNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 	}
 
 	team := p.entity()
-	projects, err := p.lfs.GetTeamProjects(ctx, team.ID)
+	projects, err := p.lfs.repo.GetTeamProjects(ctx, team.ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -144,7 +144,7 @@ func (p *ProjectsNode) Rmdir(ctx context.Context, name string) syscall.Errno {
 		op:  `archive project "` + name + `"`,
 		key: collectionErrorKey("projects", team.ID),
 		find: func(ctx context.Context) (*api.Project, error) {
-			projects, err := p.lfs.GetTeamProjects(ctx, team.ID)
+			projects, err := p.lfs.repo.GetTeamProjects(ctx, team.ID)
 			if err != nil {
 				return nil, err
 			}
@@ -278,7 +278,7 @@ func (p *ProjectNode) manifest() *dirManifest {
 	// project.md is reflected here.
 	m.metaFile("project.meta", func(ctx context.Context) ([]byte, time.Time, time.Time) {
 		proj := project
-		if projs, err := lfs.GetTeamProjects(ctx, team.ID); err == nil {
+		if projs, err := lfs.repo.GetTeamProjects(ctx, team.ID); err == nil {
 			proj = freshestByID(projs, project.ID, func(p api.Project) string { return p.ID }, project)
 		}
 		node := &ProjectInfoNode{BaseNode: BaseNode{lfs: lfs}, team: team, project: proj}
@@ -441,7 +441,7 @@ func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Er
 	// user-blocking flush; labelsEdit decides when it fires.
 	rawLabels, labelsPresent := doc.Frontmatter["labels"]
 	labels, ferr := newLabelsEdit(ctx, rawLabels, labelsPresent, p.project.LabelIds,
-		p.lfs.GetProjectLabels,
+		p.lfs.repo.GetProjectLabels,
 		func(ctx context.Context) []string {
 			if fresh, err := p.lfs.verify().GetProject(api.WithInteractive(ctx), p.project.ID); err == nil && fresh != nil {
 				p.project.LabelIds = fresh.LabelIds
@@ -552,7 +552,7 @@ var _ fs.NodeCreater = (*UpdatesNode)(nil)
 var _ fs.NodeGetattrer = (*UpdatesNode)(nil)
 
 func (n *UpdatesNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
-	updates, err := n.lfs.GetProjectUpdates(ctx, n.projectID)
+	updates, err := n.lfs.repo.GetProjectUpdates(ctx, n.projectID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -581,7 +581,7 @@ func (n *UpdatesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOu
 		return inode, 0
 	}
 
-	updates, err := n.lfs.GetProjectUpdates(ctx, n.projectID)
+	updates, err := n.lfs.repo.GetProjectUpdates(ctx, n.projectID)
 	if err != nil {
 		return nil, syscall.EIO
 	}

--- a/internal/fs/recent.go
+++ b/internal/fs/recent.go
@@ -53,7 +53,7 @@ func (n *RecentNode) refreshFrom(fresh fs.InodeEmbedder) {
 // explicitly — in one place used by both Readdir and Lookup so `ls` and
 // `stat recent/X` agree on membership.
 func (n *RecentNode) recentIssues(ctx context.Context) ([]api.Issue, error) {
-	issues, err := n.lfs.GetTeamIssues(ctx, n.entity().ID)
+	issues, err := n.lfs.repo.GetTeamIssues(ctx, n.entity().ID)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (n *RecentNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut
 	// Resolve against ALL team issues, not just the capped window: lookup must be
 	// a superset of readdir so a name that appeared in `ls recent/` never fails
 	// its per-entry stat (the safe direction; the cap lives only in Readdir).
-	issues, err := n.lfs.GetTeamIssues(ctx, n.entity().ID)
+	issues, err := n.lfs.repo.GetTeamIssues(ctx, n.entity().ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -56,7 +56,7 @@ func (r *RootNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 		lfs := r.lfs
 		return r.lookupRenderFile(ctx, out, "project-labels.md",
 			func(ctx context.Context) ([]byte, time.Time, time.Time) {
-				labels, _ := lfs.GetProjectLabels(ctx)
+				labels, _ := lfs.repo.GetProjectLabels(ctx)
 				mtime, ctime := projectLabelCatalogTimes(labels)
 				return projectLabelsMarkdown(labels), mtime, ctime
 			}, projectLabelsCatalogIno(), inheritTimeout), 0

--- a/internal/fs/teams.go
+++ b/internal/fs/teams.go
@@ -22,7 +22,7 @@ var _ fs.NodeLookuper = (*TeamsNode)(nil)
 var _ fs.NodeGetattrer = (*TeamsNode)(nil)
 
 func (t *TeamsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
-	teams, err := t.lfs.GetTeams(ctx)
+	teams, err := t.lfs.repo.GetTeams(ctx)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -39,7 +39,7 @@ func (t *TeamsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 }
 
 func (t *TeamsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	teams, err := t.lfs.GetTeams(ctx)
+	teams, err := t.lfs.repo.GetTeams(ctx)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -118,7 +118,7 @@ func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 		// SQLite on each read (cheap), so no node-level cache is needed.
 		lfs := t.lfs
 		return t.lookupRenderFile(ctx, out, "states.md", func(ctx context.Context) ([]byte, time.Time, time.Time) {
-			states, err := lfs.GetTeamStates(ctx, team.ID)
+			states, err := lfs.repo.GetTeamStates(ctx, team.ID)
 			if err != nil {
 				return []byte("# Error loading states\n"), team.UpdatedAt, team.CreatedAt
 			}
@@ -128,7 +128,7 @@ func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 	case "labels.md":
 		lfs := t.lfs
 		return t.lookupRenderFile(ctx, out, "labels.md", func(ctx context.Context) ([]byte, time.Time, time.Time) {
-			labels, err := lfs.GetTeamLabels(ctx, team.ID)
+			labels, err := lfs.repo.GetTeamLabels(ctx, team.ID)
 			if err != nil {
 				return []byte("# Error loading labels\n"), team.UpdatedAt, team.CreatedAt
 			}

--- a/internal/fs/users.go
+++ b/internal/fs/users.go
@@ -23,7 +23,7 @@ var _ fs.NodeLookuper = (*UsersNode)(nil)
 var _ fs.NodeGetattrer = (*UsersNode)(nil)
 
 func (u *UsersNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
-	users, err := u.lfs.GetUsers(ctx)
+	users, err := u.lfs.repo.GetUsers(ctx)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -40,7 +40,7 @@ func (u *UsersNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 }
 
 func (u *UsersNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	users, err := u.lfs.GetUsers(ctx)
+	users, err := u.lfs.repo.GetUsers(ctx)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -105,7 +105,7 @@ func (u *UserNode) refreshFrom(fresh fs.InodeEmbedder) {
 }
 
 func (u *UserNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
-	issues, err := u.lfs.GetUserIssues(ctx, u.entity().ID)
+	issues, err := u.lfs.repo.GetUserIssues(ctx, u.entity().ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}
@@ -136,7 +136,7 @@ func (u *UserNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 		}, 0, inheritTimeout), 0
 	}
 
-	issues, err := u.lfs.GetUserIssues(ctx, user.ID)
+	issues, err := u.lfs.repo.GetUserIssues(ctx, user.ID)
 	if err != nil {
 		return nil, syscall.EIO
 	}


### PR DESCRIPTION
## Summary

Round-19 architecture review top pick: `LinearFS` carried **29 pure passthrough methods** over `*repo.SQLiteRepository` (28 `Get*` + `MaybeRefreshIssueDetails`) — one-liners delegating to `lfs.repo.X` with zero added locking, transformation, or budget promotion. That was 42% of the struct's method surface, pure indirection noise.

All 29 are deleted **uniformly** (sweep-all over keep-hot-paths — consistency wins; call-site count is irrelevant to a mechanical rename), and every call site is rewritten to `lfs.repo.X` directly. This is the same relationship the write handlers already have with the store: they hit `lfs.store.Queries()` directly at ~24 sites (the round-14 "deliberately concrete repo" decision recorded in CONTEXT.md, which this PR extends by one sentence).

## Details

- **Deleted (29):** GetTeams, GetTeamIssues, GetIssueAttachments, GetIssueEmbeddedFiles, GetIssueHistory, GetFilteredIssuesByPriority, GetFilteredIssuesByAssignee, GetFilteredIssuesUnassigned, GetMyIssues, GetMyCreatedIssues, GetMyActiveIssues, GetTeamStates, GetTeamLabels, GetTeamCycles, GetTeamProjects, GetUsers, GetTeamMembers, GetUserIssues, GetIssueChildren, GetIssueComments, GetIssueDocuments, GetProjectDocuments, GetInitiativeDocuments, GetProjectMilestones, GetProjectUpdates, GetInitiativeUpdates, GetInitiatives, GetProjectLabels, MaybeRefreshIssueDetails
- **Three rename at the repo boundary:** `GetFilteredIssuesByPriority` → `repo.GetIssuesByPriority`, `GetFilteredIssuesByAssignee` → `repo.GetIssuesByAssignee`, `GetFilteredIssuesUnassigned` → `repo.GetUnassignedIssues`
- **Kept (real logic, verified not passthroughs):** `GetIssueByIdentifier` / `FetchIssueByIdentifier` (error shaping), `GetFilteredIssuesByStatus` / `GetFilteredIssuesByLabel` (name→ID two-step), `GetCycleIssues` / `GetProjectIssues` (type conversion), `GetTeamDocuments` (client call + interactive promotion), `TryGetCachedComments` (bool shaping)
- **No accessor added:** every consumer — including `linearfs_test.go` — lives in package `fs`, so the unexported `lfs.repo` field is reachable everywhere. No consumers exist in `internal/integration` or `cmd`.
- One method-value call site (`p.lfs.GetProjectLabels` passed as a func to `newLabelsEdit` in projects.go) rewritten to `p.lfs.repo.GetProjectLabels`.
- Incidental finding: `GetFilteredIssuesByPriority` had **no production caller at all** — only its own unit test.

Net: **−126 lines** (80 insertions, 206 deletions across 18 files).

## Testing

- `make build` clean
- `go vet ./...` clean
- `gofmt -l internal/ cmd/` clean
- `go test ./...` — full suite green, including the integration suite (fixture mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)