### PR TITLE
fix(cmd): stale-mount self-heal preflight + systemd unit hardening + shutdown ordering

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1159,3 +1159,31 @@ rename (a doc/label title change, `fileIno` 0). Built on a `kernelNotifier` seam
 two primitives, satisfied by `*LinearFS`), so the policy is unit-tested with a recording
 fake — no FUSE server. The raw `InvalidateKernelInode`/`Entry` primitives are now
 **internal-only**: every call site in the package goes through an intent method.
+
+### Mount preflight (`PreflightMountpoint`)
+A crash leaves the FUSE mount wedged ("Transport endpoint is not connected"),
+and a wedged mount at the service's own mountpoint once sent systemd into an
+infinite restart loop — ExecStartPre's mkdir failed on every attempt and
+nothing recovered without a manual `fusermount3 -uz`. The cure lived only in
+the integration harness (the stale-mount preflight from PR #191);
+`fs.PreflightMountpoint` (`internal/fs/preflight.go`) promotes it into the
+product. `runMount` calls it before MkdirAll; the harness's hand-rolled copy
+was deleted in favor of calling the same helper per stale `linearfs-test-*`
+mount.
+
+The policy has exactly three cases: a plain dir or missing path **proceeds**;
+a DEAD mount (statfs `ENOTCONN`, or any statfs failure on a path
+`/proc/self/mounts` still lists) is **healed** — lazy unmount, then a
+verifying re-probe, and a still-wedged mountpoint fails with the manual
+cleanup command; a HEALTHY live mount **refuses loudly** ("already a live
+mount — is another linearfs running?"). Never unmount a live mount: that
+would yank the filesystem out from under a concurrent instance. The heal is
+`fusermount3 -uz` by construction, never `umount2` — unprivileged `umount2`
+is `EPERM` on FUSE (recorded lesson). The three OS touchpoints (statfs,
+mount-table lookup, unmount exec) are seams on `mountPreflight`, so all
+branches are unit-tested without a real mount (`preflight_test.go`). The
+systemd unit carries a belt to these suspenders: an `ExecStartPre` lazy
+unmount ahead of the mkdir (covers old-binary/new-unit skew), `ExecStop -uz`,
+and `StartLimitBurst=5`/`StartLimitIntervalSec=60` so a genuinely broken
+start stops looping; sandboxing directives are deliberately absent (the
+mount lives in `$HOME`, config + cache under `~/.config/linearfs`).

--- a/contrib/systemd/linearfs.service
+++ b/contrib/systemd/linearfs.service
@@ -2,15 +2,29 @@
 Description=LinearFS - Linear issues as a FUSE filesystem
 After=network-online.target
 Wants=network-online.target
+# Stop a genuinely broken start from restart-looping forever (the incident:
+# a wedged FUSE mount made ExecStartPre's mkdir fail on every attempt).
+StartLimitBurst=5
+StartLimitIntervalSec=60
 
 [Service]
 Type=simple
 EnvironmentFile=%h/.config/linearfs/env
+# Belt to the binary's suspenders: the binary preflights the mountpoint
+# itself (heals dead mounts, refuses live ones), but a stale wedged mount
+# would fail the mkdir below before the binary ever runs — and this line
+# also covers old-binary/new-unit skew. Lazy unmount is a no-op when
+# nothing is mounted.
+ExecStartPre=/bin/sh -c 'fusermount3 -uz "${LINEARFS_MOUNT}" 2>/dev/null || true'
 ExecStartPre=/usr/bin/mkdir -p ${LINEARFS_MOUNT}
 ExecStart=%h/.local/bin/linearfs mount -f ${LINEARFS_MOUNT}
-ExecStop=/usr/bin/fusermount3 -u ${LINEARFS_MOUNT}
+ExecStop=/usr/bin/fusermount3 -uz ${LINEARFS_MOUNT}
 Restart=on-failure
 RestartSec=5
+SyslogIdentifier=linearfs
+# Deliberately NO sandboxing directives (ProtectHome/ProtectSystem/
+# PrivateTmp/...): the mount lives in $HOME and the config + SQLite cache
+# live under ~/.config/linearfs — hardening those away breaks the service.
 
 [Install]
 WantedBy=default.target

--- a/internal/cmd/mount.go
+++ b/internal/cmd/mount.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 
 	"time"
@@ -50,6 +51,14 @@ func runMount(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("mountpoint required: linearfs mount /path/to/mount")
 	}
 
+	// Preflight the mountpoint before touching it. Heals the wedged-mount
+	// incident (a dead FUSE mount — "Transport endpoint is not connected" —
+	// left by a crash made mkdir fail and sent systemd into a restart loop);
+	// refuses a healthy live mount rather than kill a concurrent instance.
+	if err := fs.PreflightMountpoint(mountpoint); err != nil {
+		return fmt.Errorf("mountpoint preflight: %w", err)
+	}
+
 	// Ensure mountpoint exists
 	if err := os.MkdirAll(mountpoint, 0755); err != nil {
 		return fmt.Errorf("failed to create mountpoint: %w", err)
@@ -65,16 +74,26 @@ func runMount(cmd *cobra.Command, args []string) error {
 	// Telemetry first, so instruments registered during filesystem/worker
 	// construction land on the real provider. Failure must never block
 	// mounting — log and continue without it.
+	//
+	// flushTelemetry is idempotent (sync.Once): called explicitly after
+	// server.Wait() — BEFORE lfs.Close(), because the final export's
+	// observable callbacks (e.g. sync.pending_depth) read the store — and
+	// kept as a defer so early error returns still flush.
+	flushTelemetry := func() {}
 	if shutdownTelemetry, err := telemetry.Init(cfg.Telemetry, Version, GitCommit); err != nil {
 		fmt.Printf("Warning: telemetry disabled: %v\n", err)
 	} else {
-		defer func() {
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			if err := shutdownTelemetry(shutdownCtx); err != nil {
-				fmt.Printf("Warning: telemetry shutdown failed: %v\n", err)
-			}
-		}()
+		var once sync.Once
+		flushTelemetry = func() {
+			once.Do(func() {
+				shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				if err := shutdownTelemetry(shutdownCtx); err != nil {
+					fmt.Printf("Warning: telemetry shutdown failed: %v\n", err)
+				}
+			})
+		}
+		defer flushTelemetry()
 	}
 
 	// Create LinearFS instance
@@ -110,7 +129,10 @@ func runMount(cmd *cobra.Command, args []string) error {
 	fmt.Println("Filesystem mounted. Press Ctrl+C to unmount.")
 	server.Wait()
 
-	// Stop background cache goroutines
+	// Shutdown ordering matters: flush telemetry while the store is still
+	// open (the final export's observable callbacks collect from it), THEN
+	// stop background goroutines and close the store.
+	flushTelemetry()
 	lfs.Close()
 
 	return nil

--- a/internal/fs/preflight.go
+++ b/internal/fs/preflight.go
@@ -1,0 +1,152 @@
+package fs
+
+// Mountpoint preflight: probe the mountpoint before mounting and self-heal
+// the classic wedged state. Born from a real incident — a dead FUSE mount
+// ("Transport endpoint is not connected") left at the service's own
+// mountpoint made ExecStartPre's mkdir fail, and systemd restart-looped
+// forever because nothing recovered without a manual `fusermount3 -uz`.
+//
+// The policy has exactly three cases:
+//   - not a mountpoint (plain dir or missing)  → proceed normally
+//   - DEAD mount (statfs ENOTCONN, or any statfs failure on a path the
+//     mount table still lists)                 → lazy-unmount, verify, proceed
+//   - HEALTHY live mount                       → refuse loudly; never unmount
+//     a live mount (that would kill a concurrent instance)
+//
+// The unmount is `fusermount3 -uz` by construction, never syscall umount2 —
+// unprivileged umount2 is EPERM on FUSE (recorded lesson).
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// mountPreflight carries the three OS seams so the policy is unit-testable
+// without a real mount: statfs, the mount-table lookup, and the unmount exec.
+type mountPreflight struct {
+	statfs    func(path string) error
+	isMounted func(path string) (bool, error)
+	unmount   func(path string) error
+	logf      func(format string, args ...interface{})
+}
+
+func newMountPreflight() *mountPreflight {
+	return &mountPreflight{
+		statfs: func(path string) error {
+			var st syscall.Statfs_t
+			return syscall.Statfs(path, &st)
+		},
+		isMounted: procMounted,
+		unmount: func(path string) error {
+			out, err := exec.Command("fusermount3", "-uz", path).CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("fusermount3 -uz %s: %v (%s)", path, err, strings.TrimSpace(string(out)))
+			}
+			return nil
+		},
+		logf: log.Printf,
+	}
+}
+
+// PreflightMountpoint probes path before mounting: heals a dead FUSE mount
+// left by a crashed/killed instance (lazy unmount + verify), refuses a
+// healthy live mount, and is a no-op for a plain directory or missing path.
+// Called by `linearfs mount` before creating the mountpoint, and by the
+// integration harness to clean stale test mounts from killed prior runs.
+func PreflightMountpoint(path string) error {
+	return newMountPreflight().run(path)
+}
+
+func (p *mountPreflight) run(path string) error {
+	err := p.statfs(path)
+	switch {
+	case err == nil:
+		mounted, merr := p.isMounted(path)
+		if merr != nil {
+			// Mount table unavailable (non-Linux, unreadable /proc).
+			// statfs succeeded, so nothing is wedged — proceed.
+			return nil
+		}
+		if mounted {
+			// Healthy live mount: refuse, never unmount. A lazy unmount
+			// here would yank the filesystem out from under a concurrently
+			// running instance.
+			return fmt.Errorf("%s is already a live mount — is another linearfs running? (unmount it first: fusermount3 -u %s)", path, path)
+		}
+		return nil // plain directory
+	case errors.Is(err, syscall.ENOENT):
+		return nil // missing; MkdirAll creates it
+	}
+
+	// statfs failed. ENOTCONN is the classic dead-FUSE wedge; any other
+	// errno on a path the mount table still lists gets the same treatment.
+	if !errors.Is(err, syscall.ENOTCONN) {
+		mounted, merr := p.isMounted(path)
+		if merr != nil || !mounted {
+			return fmt.Errorf("statfs %s: %w", path, err)
+		}
+	}
+
+	p.logf("linearfs: dead mount at %s (%v); detaching with fusermount3 -uz", path, err)
+	if uerr := p.unmount(path); uerr != nil {
+		return fmt.Errorf("dead mount at %s and lazy unmount failed: %w (clean manually: fusermount3 -uz %s)", path, uerr, path)
+	}
+
+	// Verify the detach took before letting the mount proceed.
+	if verr := p.statfs(path); verr != nil && !errors.Is(verr, syscall.ENOENT) {
+		return fmt.Errorf("mount at %s still wedged after fusermount3 -uz (statfs: %v); clean manually and retry", path, verr)
+	}
+	if mounted, merr := p.isMounted(path); merr == nil && mounted {
+		return fmt.Errorf("mount at %s still present after fusermount3 -uz; clean manually and retry", path)
+	}
+	return nil
+}
+
+// procMounted reports whether path is a mount point per /proc/self/mounts.
+func procMounted(path string) (bool, error) {
+	f, err := os.Open("/proc/self/mounts")
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	target := filepath.Clean(path)
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) < 2 {
+			continue
+		}
+		if unescapeMountPath(fields[1]) == target {
+			return true, nil
+		}
+	}
+	return false, sc.Err()
+}
+
+// unescapeMountPath decodes the octal escapes /proc/self/mounts applies to
+// mount points (\040 space, \011 tab, \012 newline, \134 backslash).
+func unescapeMountPath(s string) string {
+	if !strings.Contains(s, `\`) {
+		return s
+	}
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+3 < len(s) {
+			if n, err := strconv.ParseUint(s[i+1:i+4], 8, 8); err == nil {
+				b.WriteByte(byte(n))
+				i += 3
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}

--- a/internal/fs/preflight_test.go
+++ b/internal/fs/preflight_test.go
@@ -1,0 +1,180 @@
+package fs
+
+import (
+	"errors"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// fakePreflight builds a mountPreflight with scripted seams and records the
+// unmount calls. statfsErrs is consumed in order (probe, then re-probe after
+// heal); the last entry repeats if the script runs out.
+type fakePreflight struct {
+	pf        *mountPreflight
+	unmounted []string
+}
+
+func newFakePreflight(statfsErrs []error, mountedResults []bool, mountedErr error, unmountErr error) *fakePreflight {
+	f := &fakePreflight{}
+	statfsCall, mountedCall := 0, 0
+	f.pf = &mountPreflight{
+		statfs: func(path string) error {
+			i := statfsCall
+			if i >= len(statfsErrs) {
+				i = len(statfsErrs) - 1
+			}
+			statfsCall++
+			return statfsErrs[i]
+		},
+		isMounted: func(path string) (bool, error) {
+			if mountedErr != nil {
+				return false, mountedErr
+			}
+			i := mountedCall
+			if i >= len(mountedResults) {
+				i = len(mountedResults) - 1
+			}
+			mountedCall++
+			return mountedResults[i], nil
+		},
+		unmount: func(path string) error {
+			f.unmounted = append(f.unmounted, path)
+			return unmountErr
+		},
+		logf: func(format string, args ...interface{}) {},
+	}
+	return f
+}
+
+func TestPreflightPlainDirProceeds(t *testing.T) {
+	f := newFakePreflight([]error{nil}, []bool{false}, nil, nil)
+	if err := f.pf.run("/mnt/x"); err != nil {
+		t.Fatalf("plain dir should proceed, got %v", err)
+	}
+	if len(f.unmounted) != 0 {
+		t.Fatalf("plain dir must not trigger unmount, got %v", f.unmounted)
+	}
+}
+
+func TestPreflightMissingDirProceeds(t *testing.T) {
+	f := newFakePreflight([]error{syscall.ENOENT}, nil, nil, nil)
+	if err := f.pf.run("/mnt/x"); err != nil {
+		t.Fatalf("missing dir should proceed, got %v", err)
+	}
+	if len(f.unmounted) != 0 {
+		t.Fatalf("missing dir must not trigger unmount, got %v", f.unmounted)
+	}
+}
+
+func TestPreflightHealthyMountRefuses(t *testing.T) {
+	f := newFakePreflight([]error{nil}, []bool{true}, nil, nil)
+	err := f.pf.run("/mnt/x")
+	if err == nil {
+		t.Fatal("healthy live mount must refuse")
+	}
+	if !strings.Contains(err.Error(), "already a live mount") {
+		t.Fatalf("want 'already a live mount' error, got %v", err)
+	}
+	if len(f.unmounted) != 0 {
+		t.Fatalf("healthy mount must NEVER be unmounted, got %v", f.unmounted)
+	}
+}
+
+func TestPreflightDeadMountHeals(t *testing.T) {
+	// First statfs: ENOTCONN (wedged). After heal: statfs OK, not mounted.
+	f := newFakePreflight([]error{syscall.ENOTCONN, nil}, []bool{false}, nil, nil)
+	if err := f.pf.run("/mnt/x"); err != nil {
+		t.Fatalf("dead mount should heal and proceed, got %v", err)
+	}
+	if len(f.unmounted) != 1 || f.unmounted[0] != "/mnt/x" {
+		t.Fatalf("expected one lazy unmount of /mnt/x, got %v", f.unmounted)
+	}
+}
+
+func TestPreflightDeadMountUnmountFails(t *testing.T) {
+	f := newFakePreflight([]error{syscall.ENOTCONN}, nil, nil, errors.New("fusermount3 not found"))
+	err := f.pf.run("/mnt/x")
+	if err == nil {
+		t.Fatal("failed unmount must error")
+	}
+	if !strings.Contains(err.Error(), "lazy unmount failed") || !strings.Contains(err.Error(), "fusermount3 -uz") {
+		t.Fatalf("want clear manual-cleanup error, got %v", err)
+	}
+}
+
+func TestPreflightStillWedgedAfterUnmount(t *testing.T) {
+	// Unmount "succeeds" but the re-probe still sees ENOTCONN.
+	f := newFakePreflight([]error{syscall.ENOTCONN, syscall.ENOTCONN}, nil, nil, nil)
+	err := f.pf.run("/mnt/x")
+	if err == nil {
+		t.Fatal("still-wedged re-probe must error")
+	}
+	if !strings.Contains(err.Error(), "still wedged") {
+		t.Fatalf("want 'still wedged' error, got %v", err)
+	}
+}
+
+func TestPreflightStillMountedAfterUnmount(t *testing.T) {
+	// Re-probe statfs succeeds but the mount table still lists the path.
+	f := newFakePreflight([]error{syscall.ENOTCONN, nil}, []bool{true}, nil, nil)
+	err := f.pf.run("/mnt/x")
+	if err == nil {
+		t.Fatal("still-mounted re-probe must error")
+	}
+	if !strings.Contains(err.Error(), "still present") {
+		t.Fatalf("want 'still present' error, got %v", err)
+	}
+}
+
+func TestPreflightOtherStatfsErrorNotMounted(t *testing.T) {
+	// A non-ENOTCONN statfs failure on a path the mount table does NOT list
+	// is not a dead mount — propagate, don't unmount.
+	f := newFakePreflight([]error{syscall.EACCES}, []bool{false}, nil, nil)
+	err := f.pf.run("/mnt/x")
+	if err == nil {
+		t.Fatal("unexplained statfs failure must error")
+	}
+	if len(f.unmounted) != 0 {
+		t.Fatalf("must not unmount an unlisted path, got %v", f.unmounted)
+	}
+	if !errors.Is(err, syscall.EACCES) {
+		t.Fatalf("want wrapped EACCES, got %v", err)
+	}
+}
+
+func TestPreflightOtherStatfsErrorButMountedHeals(t *testing.T) {
+	// Non-ENOTCONN errno but /proc/self/mounts still lists it: treat as dead.
+	f := newFakePreflight([]error{syscall.EIO, nil}, []bool{true, false}, nil, nil)
+	if err := f.pf.run("/mnt/x"); err != nil {
+		t.Fatalf("mounted-but-erroring path should heal, got %v", err)
+	}
+	if len(f.unmounted) != 1 {
+		t.Fatalf("expected one lazy unmount, got %v", f.unmounted)
+	}
+}
+
+func TestPreflightMountTableUnavailableProceeds(t *testing.T) {
+	// statfs OK + no mount table (non-Linux): proceed.
+	f := newFakePreflight([]error{nil}, nil, errors.New("no /proc"), nil)
+	if err := f.pf.run("/mnt/x"); err != nil {
+		t.Fatalf("healthy statfs without mount table should proceed, got %v", err)
+	}
+}
+
+func TestUnescapeMountPath(t *testing.T) {
+	cases := map[string]string{
+		`/tmp/plain`:         "/tmp/plain",
+		`/tmp/with\040space`: "/tmp/with space",
+		`/tmp/tab\011here`:   "/tmp/tab\there",
+		`/tmp/back\134slash`: `/tmp/back\slash`,
+		`/tmp/trailing\04`:   `/tmp/trailing\04`, // truncated escape stays literal
+		`/tmp/not\999octal`:  `/tmp/not\999octal`,
+		`/tmp/a\040b\040c`:   "/tmp/a b c",
+	}
+	for in, want := range cases {
+		if got := unescapeMountPath(in); got != want {
+			t.Errorf("unescapeMountPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -34,13 +34,23 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	// Refuse to run over a stale mount from a killed prior run: its dead FUSE
-	// connection makes this run's kernel I/O fail with roaming EIO errors —
-	// the whole-suite flakiness this preflight exists to prevent. Fail loud
-	// with the cleanup command instead.
-	if mounts, err := os.ReadFile("/proc/mounts"); err == nil && strings.Contains(string(mounts), "linearfs-test-") {
-		log.Fatal("stale linearfs-test-* mount detected; clean it first:\n" +
-			"  fusermount3 -uz <mountpoint> && rm -rf <mountpoint>   (see /proc/mounts)")
+	// Preflight stale mounts from a killed prior run: their dead FUSE
+	// connections make this run's kernel I/O fail with roaming EIO errors —
+	// the whole-suite flakiness this exists to prevent. The product's
+	// fs.PreflightMountpoint carries the policy now: dead test mounts are
+	// self-healed (lazy unmount), a healthy one (concurrent test run) fails
+	// loud rather than getting yanked out from under the other run.
+	if mounts, err := os.ReadFile("/proc/self/mounts"); err == nil {
+		for _, line := range strings.Split(string(mounts), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) < 2 || !strings.Contains(fields[1], "linearfs-test-") {
+				continue
+			}
+			if err := fs.PreflightMountpoint(fields[1]); err != nil {
+				log.Fatalf("stale linearfs-test mount at %s: %v", fields[1], err)
+			}
+			_ = os.RemoveAll(fields[1])
+		}
 	}
 
 	apiKey := os.Getenv("LINEAR_API_KEY")


### PR DESCRIPTION
## The incident

A wedged FUSE mount ("Transport endpoint is not connected") at the service's own mountpoint sent systemd into an infinite restart loop: `ExecStartPre`'s `mkdir -p` failed against the dead mount on every attempt, `Restart=on-failure` spun forever, and nothing self-healed — recovery required a manual `fusermount3 -uz`. The test harness has carried the cure since PR #191 (the stale-mount preflight in `internal/integration/integration_test.go`); this PR promotes it into the product.

## The three-case preflight policy

`fs.PreflightMountpoint` (`internal/fs/preflight.go`), called by `runMount` before `MkdirAll`:

1. **Not a mountpoint** (plain dir or missing path) → proceed normally.
2. **DEAD mount** — statfs returns `ENOTCONN`, or any statfs failure on a path `/proc/self/mounts` still lists → lazy-unmount via exec `fusermount3 -uz` (**never** syscall `umount2`: unprivileged `umount2` is `EPERM` on FUSE, a recorded lesson), then a verifying re-probe; a still-wedged mountpoint fails with the manual cleanup command.
3. **HEALTHY live mount** → fail loudly ("already a live mount — is another linearfs running?"). Never unmount a live mount; that would yank the filesystem out from under a concurrent instance.

The three OS touchpoints (statfs, mount-table lookup, unmount exec) are injectable seams on `mountPreflight`, so every branch — including unmount-failed-still-wedged — is unit-tested without a real mount (`preflight_test.go`, 10 cases + the `/proc/self/mounts` octal-unescape).

The integration harness's hand-rolled copy is **deleted** in favor of the same helper: dead `linearfs-test-*` mounts from killed prior runs now self-heal instead of demanding manual cleanup, while a healthy one (a concurrent test run) still fails loud. (Case 3 fired for real during this PR's test run — a concurrent suite's live mount was correctly refused, not killed.)

## systemd unit hardening (`contrib/systemd/linearfs.service`)

- `ExecStartPre` lazy-unmount **before** the mkdir — belt to the binary's suspenders; covers old-binary/new-unit skew. A lazy unmount is a no-op when nothing is mounted.
- `ExecStop`: `-u` → `-uz` (busy-safe).
- `StartLimitBurst=5` + `StartLimitIntervalSec=60` in `[Unit]` so a genuinely broken start stops looping instead of spinning forever.
- `SyslogIdentifier=linearfs`.
- **Deliberately no sandboxing directives** (`ProtectHome`/`ProtectSystem`/`PrivateTmp`/…): the mount lives in `$HOME` and the config + SQLite cache live under `~/.config/linearfs` — hardening those away would break the service. Noted in a unit comment so it isn't "fixed" later.

`make install-service` copies the unit file verbatim, so no Makefile change needed.

## Shutdown ordering fix (`internal/cmd/mount.go`)

The deferred telemetry shutdown ran **after** `lfs.Close()`, so the final metrics export's observable callbacks (`linearfs.sync.pending_depth` counts rows in `pending_detail_sync`) collected against a closed store. Now: after `server.Wait()`, flush telemetry explicitly (bounded 5s ctx) **first**, then `lfs.Close()`. The flush is wrapped in `sync.Once`, so the defer stays as an idempotent safety net for early error returns.

## Deployment note

Merges now, deploys later — do **not** reinstall the live service from this; a scheduled observation run uses the deployed binary tonight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)