### PR TITLE
chore: round-19 small cleanups

### DIFF
--- a/docs/plans/2026-07-06-rate-limit-budget-design.md
+++ b/docs/plans/2026-07-06-rate-limit-budget-design.md
@@ -1,0 +1,200 @@
+# Rate-limit management revamp — the `rateBudget` module
+
+**Status:** PR1 built (2026-07-06, working tree): `rateBudget` module + governance
+wired into `Client.query`, plus the decision-2 cold-start probe in the sync worker.
+**Scope:** `internal/api/client.go` rate limiting + `internal/sync/worker.go` cold-start pacing.
+
+## Problem
+
+The client throttles the **wrong meter**. Linear bills two axes per hour —
+**requests** and **complexity points** — and the binding constraint at cold-start
+is complexity. The current client:
+
+1. Shapes only by **request count**, at a hardcoded `rate.NewLimiter(1500/3600, 16)`.
+2. **Ignores complexity entirely** — the axis that actually gets blown.
+3. Parses the reset time from the wrong header (`X-RateLimit-Reset`) as **seconds**,
+   but Linear sends `X-RateLimit-{Requests,Complexity}-Reset` in **epoch milliseconds** —
+   so adaptive backoff is dead and falls back to a fixed 15-min guess.
+4. Keeps the limiter **in-memory**, so a restart resets it to a full tank and
+   **cold-bursts** even though the server remembers the hour's spend.
+5. Syncs **all issue details eagerly** (comments/docs/attachments per issue) — the
+   single largest complexity cost — up front, before anyone views them.
+
+**Failure mode observed (2026-07-06):** a fresh mount's full initial sync + the
+live service together exhausted the 3,000,000-complexity/hr budget, wedging the
+account into `RATELIMITED` (HTTP 400) until the window reset.
+
+## Ground truth
+
+From Linear's docs (<https://linear.app/developers/rate-limiting>) **and a live
+probe** of this workspace's API key (`query { viewer { id } }`, cost 1 point):
+
+```
+x-complexity: 1                              # this query's cost
+x-ratelimit-complexity-limit: 3000000
+x-ratelimit-complexity-remaining: 30713      # real-time remaining
+x-ratelimit-complexity-reset: 1783373283146  # epoch MILLISECONDS
+x-ratelimit-requests-limit: 2500             # NOT 5000 (docs) or 1500 (code)
+x-ratelimit-requests-remaining: 2499
+x-ratelimit-requests-reset: 1783373283146
+```
+
+- Every response carries `X-Complexity` (this query's cost) and
+  `X-RateLimit-Complexity-Remaining` (authoritative remaining) — so we can both
+  **measure** per-op cost and **reconcile** the budget on every round-trip.
+- The request limit is **2,500**, matching neither the docs nor the code:
+  **read every limit from the header; never hardcode.**
+- Complexity formula (for intuition only, not implemented): property 0.1,
+  object 1, connection ×pagination arg (default 50), rounded up. Single-query
+  max 10,000 (already respected by `paginate`'s page-size budgeting).
+- Exceeding → HTTP 400, `extensions.code = "RATELIMITED"`.
+
+## Design decisions (grilled)
+
+1. **Control model — hybrid, server-anchored.** Keep a local predictive budget
+   for pre-send gating; **reconcile to the server's `X-RateLimit-*-Remaining` +
+   actual `X-Complexity` on every response.** The server value is ground truth —
+   snap to it each round-trip, so estimate drift is erased and a restart
+   self-heals on the first response.
+
+2. **Cold-start probe.** On startup, before the sync worker's first cycle, fire
+   one cheap `query { viewer { id } }` (~2 pts, dual-purpose — the viewer is
+   already needed for `/my`) and seed the budget (both axes' limit + remaining +
+   reset) from its headers. The probe *is* the first `observe`; it subsumes the
+   "seed on restart" fix. If the probe itself returns `RATELIMITED`, honor its
+   reset and delay the whole sync start.
+
+   **BUILT (PR1):** `Worker.probeBudget` (`internal/sync/worker.go`) — `run()`
+   calls it synchronously before the initial `syncAllTeams`, via the existing
+   `Client.GetViewer` (added to the worker's `APIClient` interface), so the
+   probe response is observed (budget seeded) strictly before any expensive
+   query is admitted. On a `RATELIMITED` probe it calls `setRateLimited()`
+   (backoff = the budget's server-reported reset, which the probe's own
+   response headers just seeded, +5s; 15-min fallback) and sleeps until the
+   expiry — interruptible by ctx/Stop, in which case `run` exits without
+   firing a post-stop cycle. Any other probe failure logs and proceeds (the
+   same failure repeats in `syncAllTeams` and is handled there). Shape delta
+   from the sketch: the probe lives in the worker (not a separate startup
+   hook) and reuses the full `GetViewer`, so the FS's background viewer
+   refresh in `EnableSQLiteCache` is untouched (one extra ~2-pt query).
+
+3. **Cold-start gentleness — emergent, not a mode.** The worker fetches in
+   **priority tiers** — (1) skeleton (viewer, team metadata, states),
+   (2) issue lists, (3) issue **details** (lowest) — and each request is
+   budget-gated (below). Cold-start isn't special-cased: from empty, a
+   constrained budget delivers the skeleton first and defers details to the
+   existing `pending_detail_sync` queue, trickling them in later cycles / the
+   next window. This also protects a **warm restart on a busy account**, not
+   just a literally-empty DB.
+
+4. **The gate — priority-reserve ladder, two-axis.** Per request, `admit` allows
+   it only if on **both** axes `predictedCost ≤ remaining − reserve(priority)`.
+   Higher priority → lower reserve (spends deeper); details → large reserve (stop
+   first). This ladder is what makes tier-deferral emergent:
+
+   ```
+   mutations / interactive reads   reserve ≈ 0        (flow unless ~empty)
+   skeleton reads                  reserve small
+   list reads                      reserve medium
+   detail reads                    reserve LARGE      (only with ample headroom)
+   ```
+
+   Blocked **read → defer** (return the deferral error; worker queue retries).
+   Blocked **mutation → wait** until reset (user-facing, never silently dropped),
+   unless the wait is absurd. Keep a **right-sized `rate.Limiter`** (limit read
+   from the header) as a thin micro-burst smoother — the budget prevents hourly
+   overshoot, the limiter prevents instantaneous spikes.
+
+5. **Cost prediction — learned per operation.** Predict a query's cost as the
+   last-seen `X-Complexity` for its `opName` (rolling). First-ever call for an
+   unmeasured op uses a conservative default (the 10,000 single-query max, so
+   unknowns are treated as expensive until measured). Self-calibrating: no
+   formula code, auto-tracks page-size/fragment changes (e.g. PR #179).
+
+6. **The seam — a `rateBudget` deep module** (`internal/api/ratebudget.go`)
+   owning both windowed budgets, the per-op predictor, the reserve ladder, and
+   header reconciliation. Small interface:
+   - `admit(opName string, p priority) decision` — allow / defer / wait-until.
+   - `observe(opName string, h http.Header)` — record actual `X-Complexity` for
+     the op; snap remaining/limit/reset (both axes) to the headers; release the
+     in-flight reservation.
+   - injected **clock** (`now func() time.Time`) so window resets are testable.
+
+   `Client.query` calls `admit` before / `observe` after. The scattered logic
+   (`checkRateLimitHeaders`, the inline write-reserve gate, `LowBudget`,
+   `RateLimitResetAt`, and the worker's `setRateLimited`/`isRateLimited`/
+   `rateLimitExpiry`) collapses into these two calls or is deleted.
+
+   **Priority = static base-tier ⊕ caller `interactive` flag.** Base tier from a
+   small `opName → tier` map inside the module (tiers classify *intent*, stable
+   unlike cost). The same op differs by urgency — a background detail-sync vs. a
+   user who just `cat`'d an issue's comments — so **on-demand FS reads and
+   mutations pass `interactive: true`**, promoting them above their base tier;
+   background sync passes false.
+
+7. **Reset mechanics.**
+   - Parse `X-RateLimit-Complexity-Reset` / `-Requests-Reset` **per-axis, as
+     `time.UnixMilli`** (fixes the dead backoff).
+   - **Optimistic refill:** when `now() ≥ resetAt` for an axis, treat it as
+     refilled to its full limit until the next response reports fresh remaining —
+     so the budget believes the clock, not a stale exhausted remaining, and
+     cold-start doesn't wait an extra hour.
+   - **Defensive `RATELIMITED`:** on a 400/`RATELIMITED` response, snap that
+     axis's remaining to 0 and honor the error's reset; `admit` then defers all
+     non-interactive work until reset.
+
+8. **Concurrency — reserve-on-admit / release-on-observe semaphore.** `admit`
+   optimistically `inFlight += predictedCost` when it allows, so concurrent
+   admits see `remaining − inFlight − reserve` and start deferring — no
+   thundering herd. `observe` (and any dropped/errored send) releases the
+   reservation, then snaps remaining to the server value. Mutex-guarded. Net: a
+   semaphore over complexity points.
+
+9. **Rollout.**
+   - **Pre-build live header check — DONE** (probe above; header names/units/limit
+     confirmed).
+   - **PR1 — the `rateBudget` module + correct governance:** admit/observe,
+     predictor, reserve ladder, in-flight semaphore, per-axis ms reset, probe
+     seed; wired into `Client.query`; priority threaded (interactive flag on
+     on-demand reads); delete the scattered old logic. Delivers the correctness
+     fix *and* emergent detail-deferral.
+   - **PR2 — cold-start sequencing polish**, only if PR1's emergent gentleness
+     isn't enough in practice (explicit skeleton-first ordering).
+   - **Testing is unit-heavy** — the point of the seam: `rateBudget` with a fake
+     clock + synthetic headers (reserve ladder defers the right tiers, observe
+     reconciles to server truth, in-flight semaphore under concurrent admits,
+     reset rollover, `RATELIMITED` snap-to-zero). The live probe is the only
+     live dependency.
+
+## Interface sketch (illustrative, not final)
+
+```go
+type priority int // pWrite > pInteractive > pSkeleton > pList > pDetail
+
+type decision struct {
+    allow bool
+    retryAfter time.Duration // when !allow: defer this long (0 = next cycle)
+}
+
+type rateBudget struct {
+    mu       sync.Mutex
+    now      func() time.Time
+    axes     [2]window            // complexity, requests: {limit, remaining, resetAt}
+    inFlight float64              // reserved complexity for in-flight requests
+    cost     map[string]float64   // opName -> last-seen X-Complexity
+}
+
+func (b *rateBudget) admit(op string, p priority) decision
+func (b *rateBudget) observe(op string, h http.Header) // or the RATELIMITED error
+```
+
+## Follow-ups / notes
+
+- On build, add a **CONTEXT.md** concept entry ("Rate budget (`rateBudget`)").
+- Request limit is **per-key and not what any doc says** — the "read from header"
+  rule is load-bearing; the `linearHourlyLimit` constant should go.
+- The existing `deferDetailIssues` + `pending_detail_sync` queue is the deferral
+  substrate PR1 leans on — details tripping their reserve route there.
+- Live validation of a full mount is **budget-hungry** (it exhausted the account
+  today); prefer the cheap direct-probe for any live check, or validate when the
+  account is idle.

--- a/docs/plans/2026-07-07-atime-last-read-design.md
+++ b/docs/plans/2026-07-07-atime-last-read-design.md
@@ -1,0 +1,101 @@
+# atime as persisted last-read tracking
+
+**Status: spec — not built.** Deferred project recorded 2026-07-06 (memory:
+atime-last-read-tracking). Today atime is decorative: `nodeAttr.fill` reports
+`atime = mtime = UpdatedAt` uniformly (nodeattr.go:34), and
+`nodeattr_test.go:50` pins that. The goal: an agent asks "which issues changed
+since I last read them" and the filesystem can answer, across restarts.
+
+## The one query this exists to serve
+
+`mtime > atime` ⇔ "modified since last read" — the classic mail-file idiom
+(`ls -lu`, `find -newerat`). That works only if atime is a *real, persisted*
+last-read time and mtime stays `UpdatedAt` (already true).
+
+## Design
+
+### What counts as a read
+
+A **content read of an entity file** — `Read` on `issue.md` (editBuffer),
+`Read` on a renderFile that represents an entity (`issue.meta` no,
+`history.md` arguably, comments/docs yes), `Read` on an embedded file.
+Explicitly NOT a read: Lookup/Getattr (content is eagerly materialized at
+Lookup for size — editbuffer.go:22 — so construction must not count), readdir,
+and reads by the create/scratch machinery.
+
+Hook points (all exist, all small): `editBuffer.Read`, `renderFile.Read`,
+`EmbeddedFileNode.Read`. Each calls a new `lfs.readTracker.touch(kind, id)`.
+Offset-0 reads only (a sequential read of a big file touches once).
+
+### `readTracker` — the deep module
+
+`internal/fs/readtracker.go`: `{mu, dirty map[key]time.Time}` +
+`touch(kind, id)` + a flush loop. **Write-behind, debounced**: touch records
+in-memory; a background flusher batches rows to SQLite every ~5s (and on
+unmount/Close). A `grep -r` storm costs one map write per file per window,
+not one SQLite write per Read — the write-amplification hazard the survey
+flagged. Injectable clock + store seam; unit-tested with fakes.
+
+Persistence: new table
+```sql
+CREATE TABLE IF NOT EXISTS read_log (
+  kind TEXT NOT NULL, id TEXT NOT NULL, read_at DATETIME NOT NULL,
+  PRIMARY KEY (kind, id));
+```
+Deliberately NOT a column on entity tables: entity rows are owned by the sync
+worker's upsert/prune cycle (a prune would eat the read state; an upsert
+conflict-clause would have to preserve it). A side table is join-cheap and
+survives entity churn. Prune rows older than ~90 days opportunistically.
+
+### Reporting
+
+`nodeAttr`/`fileAttr` construction takes an optional `lastRead` (zero = fall
+back to today's `UpdatedAt`, so files never read report atime == mtime — reads
+as "not modified since last read", the conservative default; see decision 1).
+The entity file nodes and dir nodes pass it from a batched
+`GetLastReads(kind, ids)` repo call during listing/lookup. The kernel attr
+timeouts (60s default / 30s entity tier) bound staleness — acceptable for the
+target query, which is agent-paced, not interactive-precise.
+
+### Constraints honored
+
+- **Cycle symlinks keep atime = EndsAt** (symlink_test.go:72 — semantic
+  encoding, untouched; symlinks aren't entity content files).
+- `nodeattr_test.go:50` (atime == updatedAt) is rewritten to assert the
+  fallback + the override path.
+- The mount must not set `noatime`-style suppression (it doesn't).
+
+## Consumers (same PR or fast-follow)
+
+- `ls -lu` / `find -newerat` just work.
+- Optional: `my/unread/` view (issues where `updated_at > read_at or read_at
+  IS NULL`) — one `namedListing`-style symlink dir; makes the feature legible
+  to agents without stat math. Generated README documents the contract.
+
+## Tests
+
+- Unit: readTracker debounce/flush/Close-flush with fake clock; offset-0
+  gating; attr fallback-vs-override.
+- Integration: read issue.md, remount (restart server), stat shows persisted
+  atime < a subsequent issue update's mtime.
+
+## Effort
+
+Medium. New table + sqlc, one new module, three small hooks, attr plumbing,
+README + tests.
+
+## Decisions to grill
+
+1. **Never-read files**: report atime = UpdatedAt (conservative: "nothing
+   new") or atime = 0/epoch ("never read" is visible but ugly in ls)?
+   Recommendation: UpdatedAt fallback; the `my/unread/` view carries the
+   never-read distinction instead.
+2. Which renderFiles count as entity reads (history.md? .meta? team.md?).
+   Recommendation: only files whose mtime is an entity's UpdatedAt —
+   issue.md, comments, docs, project.md, initiative.md, embedded files —
+   keep sidecars out.
+3. Multi-reader semantics: last-read is per-mount (single-user by design).
+   If a second consumer ever matters, the table gains a reader column — not
+   now.
+4. Does touching atime require bumping `AttrTimeout` down for entity files?
+   Recommendation: no — 30–60s staleness is fine for the target query.

--- a/docs/plans/2026-07-07-attachment-upload-design.md
+++ b/docs/plans/2026-07-07-attachment-upload-design.md
@@ -1,0 +1,111 @@
+# Attachment file uploads through the mount
+
+**Status: spec — not built.** Deferred intention recorded 2026-07-06
+(memory: attachments-future-work). Today `attachments/` supports URL-linking
+(`echo "url title" > _create`) and reading embedded/CDN bytes; you cannot put
+a real file in.
+
+## Goal
+
+```
+cp ./screenshot.png ~/am/linear/teams/ENG/issues/ENG-123/attachments/screenshot.png
+```
+uploads the bytes to Linear's file storage and attaches the resulting asset to
+the issue. `.last` records the created attachment; failures land in `.error`.
+
+## Linear API (verified against docs/linear-schema.graphql)
+
+Three-step flow, standard sign-then-PUT:
+
+1. **`fileUpload(contentType:, filename:, size:, makePublic:, metaData:)
+   → UploadPayload`** (schema :22911). `UploadPayload.uploadFile: UploadFile`
+   carries `uploadUrl` (pre-signed PUT target), `headers: [UploadFileHeader]`
+   (must be echoed on the PUT), and `assetUrl` (the permanent URL the bytes
+   will live at) (schema :45374–45429).
+2. **HTTP PUT** the raw bytes to `uploadUrl` with the returned headers +
+   `Content-Type`. Not GraphQL — a plain HTTP call.
+3. **`attachmentCreate(input: { issueId, url: assetUrl, title })`** — the
+   asset URL is a perfectly ordinary attachment URL (schema :3661); no
+   body-markdown embedding required. Project through `AttachmentFields` per
+   the fragment rule.
+
+## Design
+
+### FUSE surface: named-file `Create` on `AttachmentsNode`
+
+Precedent: `DocsNode.Create` (documents.go:221) — a named create
+(`docs/"Title.md"`) returns a `createFileNode` whose per-open buffer hands the
+complete bytes to an `onFlush` closure. `AttachmentsNode` gains the same
+`Create(name)`:
+
+- Reject names colliding with the trio (`_create`, `.error`, `.last`) and
+  `.link` names (those are the URL-link surface) → `EINVAL` with reason in
+  `.error`.
+- `onFlush(ctx, content)` runs the create tail (`commitCreate`) with a
+  `mutate` closure doing: sniff `contentType` (`http.DetectContentType`,
+  overridable by extension), `fileUpload` → PUT → `attachmentCreate`.
+  Any step's failure classifies through `classifyMutationErr` (rate-limited
+  → `EAGAIN`, etc.); a failed PUT after a successful sign is just an error —
+  nothing was created, retry is safe.
+- `persist`: `UpsertAttachment` (exists). `.last` projection: `WriteResult{
+  URL: assetUrl, Path: <listing name>, Title: filename}`.
+- `entryName`: the attachment lands in the listing as an *external*
+  attachment today (`<title>.link`). See decision 2.
+
+### Client seam
+
+- `api.Client.UploadFile(ctx, filename, contentType string, size int,
+  content []byte) (assetURL string, err error)` — owns steps 1+2 (the
+  GraphQL sign via `execMutation`, then the PUT via an injectable
+  `*http.Client`, the `embeddedFileCache` precedent). Two-step is hidden
+  behind one method: callers can't forget the headers or the PUT.
+- `MutationClient` gains `UploadFile` + reuses existing `CreateAttachment`/
+  `LinkURL` shape for step 3 (check whether `attachmentCreate` with a title
+  needs a new mutation constant vs. reusing `LinkURL` — `attachmentLinkURL`
+  also accepts arbitrary URLs and returns the same fragment; if Linear treats
+  uploads.linear.app URLs identically via linkURL, step 3 collapses into the
+  existing mutation. Verify live.)
+- `fileUpload` runs at **write tier** (it's a mutation) — no budget work.
+
+### Read-your-upload
+
+After create, seed the bytes into `embeddedFileCache` keyed by the new
+attachment/asset so an immediate `cat` doesn't refetch from the CDN
+(`store` + `persist` seams exist). Best-effort.
+
+### Memory bound
+
+`createFileNode` buffers the whole file per open handle (documents already
+accept this). Uploads are bigger: cap at a `maxUploadBytes` (default 50 MiB,
+config-overridable); over-cap writes fail the flush with `EFBIG` + `.error`
+reason. Streaming upload (splice to PUT during Write) is out of scope — FUSE
+gives no reliable "final size" before flush.
+
+## Tests
+
+- Unit: `UploadFile` against `httptest` (sign → PUT echo headers → assetURL),
+  the mockmutation client gains `UploadFile`; onFlush tested with recording
+  closures (name rejection, contentType sniff, cap).
+- Integration (fixture): `cp` a small file, poll `.last`, `cat` it back.
+- Live (write-tests flag): one real small upload against TST.
+
+## Effort
+
+Medium: new client method + mutation constant, `AttachmentsNode.Create`,
+listing integration, cache seed, tests. One PR.
+
+## Decisions to grill
+
+1. **Listing identity of an uploaded file**: it comes back as an external
+   attachment (`foo.png.link`)? That's surprising — the user wrote
+   `foo.png` and should read back `foo.png` bytes. Options: (a) accept the
+   `.link` rename; (b) teach `attachmentListing` that an attachment whose URL
+   is an `uploads.linear.app` asset renders as a byte-file (an
+   `EmbeddedFileNode`-alike) named by its filename, not a `.link`. (b) is the
+   honest surface but touches the listing module. Recommend (b).
+2. `makePublic`: default false (private assets require auth to fetch — the
+   embedded-file reader already sends the auth header). Confirm private
+   assets are fetchable via API key (the CDN reader works for issue-embedded
+   files today — same domain).
+3. Overwrite semantics: `cp` onto an existing uploaded name — reject
+   (`EEXIST`) or new-version upload? Recommend reject in v1.

--- a/docs/plans/2026-07-07-integration-flake-diagnosis.md
+++ b/docs/plans/2026-07-07-integration-flake-diagnosis.md
@@ -1,0 +1,102 @@
+# Integration-suite flake: diagnosis plan
+
+**Status: BUILT — with corrected diagnosis.** H1 (lingering SWR goroutines) was
+WRONG for fixture mode: `InjectTestStore` already wires a nil client and the SWR
+paths guard on it; the fixture-mode 401s are the *mutation-path* tests exercising
+failure branches (they do hit the real API — a follow-up candidate, not the flake).
+The real mechanisms: (a) **the SQLite DB lived inside the mountpoint** — post-mount
+file opens (WAL checkpoints, journals) routed through our own FUSE layer; (b) **an
+intermittent leaked test fd made `server.Unmount` fail EBUSY** and the mount
+silently orphaned at process exit — the next run then died against the dead
+connection (the roaming-EIO signature). Fixes: DB moved to its own temp dir;
+`WaitMount` readiness gate (both modes); TestMain preflight fails loud on a stale
+`linearfs-test-*` mount; cleanup retries then falls back to `fusermount3 -uz`
+(unprivileged `umount2` is EPERM on FUSE — the setuid helper is required) with a
+leaked-fd diagnostic. Verified: 30 consecutive clean full-suite runs, zero orphans
+(one leak occurred and self-healed via lazy detach). The one-at-a-time protocol is
+retired. Original spec below. Confirmed 2026-07-07: full-suite runs of
+`internal/integration` fail nondeterministically — a *different* test each run
+(`TestTeamsListing`, `TestWriteInvalidInputIsLoud`,
+`TestWriteContractAtomicRenameCreateNoEROFS`, `TestWriteContractCreateTrioUniform`,
+cycles/ENOENT tests), always with mount I/O errors (`readdirent: input/output
+error`); every failing test passes in isolation; failed runs often orphan the
+mount. **Reproduces identically at base main@2987b7f** — pre-existing, not a
+round-14 regression. CI passes (it runs a narrower read-only selection and
+carries a `fusermount3 -u /tmp/linearfs-test-*` cleanup hammer —
+.github/workflows/test.yml:60,65 — and runs *without* `-race`).
+
+## Harness facts (surveyed)
+
+- **One shared mount + one process-global LinearFS** for the whole binary
+  (integration_test.go:20–57); cleanup runs once after `m.Run()` — a panic or
+  `os.Exit` path skips unmount → the observed orphans.
+- **No readiness gate** after `MountFS` — tests can hit the mount before the
+  FUSE server serves (integration_test.go:150–157).
+- **The SQLite database file lives inside/alongside the mount temp dir**
+  (integration_test.go:112) — verify whether DB I/O ever crosses the FUSE
+  boundary (it must not).
+- Tests **don't** use `t.Parallel()`, but share process-global state: the
+  injected mockmutation client, `.error`/`.last` sidecars ("the mount is
+  shared, so other tests append too" — t4_create_test.go:115), and the repo's
+  **background goroutines** (`refreshContext` rooted at `context.Background()`,
+  sqlite.go:78–86; refresh/reconcile goroutines outlive the test that
+  triggered them).
+- In fixture mode there is **no API key, yet API calls fire and 401** (seen
+  in every run's logs) — the SWR refresh paths run against the real endpoint
+  and fail. `deleteOrphanIssue` triggers only on "Entity not found", not 401
+  (sqlite.go:929) — verified safe, but the goroutines still contend for the DB.
+- `busy_timeout(5000)` on the DSN — SQLITE_BUSY under contention surfaces as
+  a FUSE handler error (EIO) after a 5s stall, which *is* the observed
+  failure signature.
+
+## Ranked hypotheses
+
+**H1 (primary): lingering background goroutines contend with test I/O.**
+A test triggers SWR refresh/reconcile; those goroutines (rooted in the
+repo's own ctx, not the test's) keep running into later tests, take DB locks
+or churn rows; a later test's FUSE handler hits SQLITE_BUSY/an inconsistent
+row and returns EIO. Explains: different victim each run, isolation always
+passes, timing sensitivity.
+
+**H2: a FUSE handler panic kills the connection.** go-fuse turns an unrecovered
+handler panic into a dead connection → *every* subsequent op returns EIO and
+the mount orphans. One panicking handler anywhere explains total-mount death;
+need panic evidence (nothing in captured logs yet — instrument first).
+
+**H3: shared sidecar state races.** Tests polling `.error`/`.last` while
+others write them — explains assertion-level flakes but not `readdirent: EIO`;
+likely a secondary annoyance, not the mount-killer.
+
+## Diagnosis plan (ordered, cheap → expensive)
+
+1. **Instrument, then reproduce in a loop.** Run the suite 20× with:
+   `-test.v`, go-fuse debug off but a `defer recover()` logging wrapper
+   temporarily around handler entry (or run the server with `Debug` on to a
+   file), SQLite busy/locked errors logged with stack, and `GOTRACEBACK=all`.
+   The first failing run tells us: panic (H2), SQLITE_BUSY (H1), or neither.
+2. **Kill H1 structurally and re-measure**: scope the repo's refresh ctx per
+   test is invasive; instead add a `lfs.QuiesceBackground()` test hook (cancel
+   + wait refresh/reconcile goroutines) called from a `t.Cleanup` helper in
+   tests that trigger refreshes — or globally disable SWR refresh in fixture
+   mode (`stalenessThreshold = ∞` when no API key): fixture tests never want
+   a 401-destined refresh anyway. **This is likely the real fix regardless**:
+   background 401 churn in fixture mode is pure noise.
+3. **Readiness gate**: `WaitMount()` (go-fuse provides it) after MountFS.
+   One line; removes a whole class of early-access races.
+4. **Orphan-proof cleanup**: move unmount into a `defer` + signal handler in
+   TestMain, and have the harness refuse to start if a stale
+   `linearfs-test-*` mount exists (fail loud, print the cleanup command).
+5. Only if flakes persist: per-test-file mount groups (heavier; not the
+   first move).
+
+## Success criteria
+
+`for i in $(seq 20); do go test ./internal/integration/; done` — zero
+failures, zero orphaned mounts, zero 401 log lines in fixture mode. Then
+delete the memory-file protocol note ("run one at a time") and let CI run the
+full suite.
+
+## Effort
+
+Diagnosis: half a day. Likely fix (fixture-mode SWR disable + WaitMount +
+orphan-proof cleanup): small PR. H2, if real, is wherever the panic is.

--- a/docs/plans/2026-07-07-interactive-promotion-threading.md
+++ b/docs/plans/2026-07-07-interactive-promotion-threading.md
@@ -1,0 +1,114 @@
+# Interactive promotion threading (rate-budget PR2)
+
+**Status: BUILT 2026-07-07 — with a corrected inventory.** The build-time
+verification found the spec's call-site table overstated the API surface:
+the 7 render-closure sites (issue.meta, history.md, states.md, labels.md,
+project/initiative meta) are **SQLite-first with background refresh** — they
+never synchronously call the API, so promotion is moot there. Only TWO
+genuinely synchronous user-blocking API calls exist and both now promote:
+`LinearFS.GetTeamDocuments` (team docs listing — the one read that is
+"currently via API as not synced") and the attachment-create authoritative
+re-check (`attachments.go`). The renderFunc ctx-threading was built anyway —
+it is correct hygiene (cancellation; honest ctx; any future synchronous
+source in a render closure can promote) and `TestRenderFileThreadsContext`
+pins the propagation. The never-store rule is documented at
+`WithInteractive`. Original spec below for the record.
+
+**Status (original): spec — not built.** Companion to `2026-07-06-rate-limit-budget-design.md`
+(PR1, built): the `rateBudget` module and its priority ladder (write >
+interactive > skeleton > list > detail) exist and are tested; `WithInteractive(ctx)`
+is the promotion mechanism. **No production call site threads it**, so a human
+waiting on `ls`/`cat` runs at base tier and can queue behind background sync —
+observed live 2026-07-07 when the budget sat below the list-tier reserve and
+everything deferred equally.
+
+## Problem
+
+A FUSE request handler sometimes must call the Linear API synchronously (the
+user is blocked on the answer). Those calls should spend from the interactive
+reserve (2% tier) so they outrank skeleton/list/detail work. Promotion is
+ctx-borne (`tierFor` inspects the ctx), so the fix is plumbing, but the survey
+found the plumbing is **broken upstream of the wrap**: the blocking call sites
+mostly use `context.Background()`, so even a correct `WithInteractive` wrap
+today would be discarded.
+
+## Call-site inventory (verified 2026-07-07)
+
+Synchronous, user-blocking, should promote — **9 sites**:
+
+| # | Site | File | Current tier | ctx reaches query()? |
+|---|------|------|--------------|----------------------|
+| 1 | issue.meta render → `FetchIssueByIdentifier` | issues.go:332 | list | **no — context.Background()** |
+| 2 | issue.meta render → `GetIssueAttachments` | issues.go:335 | detail | no |
+| 3 | history.md render → `GetIssueHistory` | issues.go:347 | detail | no |
+| 4 | states.md render → `GetTeamStates` | teams.go:117 | skeleton | no |
+| 5 | labels.md render → `GetTeamLabels` | teams.go:127 | skeleton | no |
+| 6 | project renders → `GetTeamProjects` | projects.go:240 | skeleton | no |
+| 7 | initiative renders → `GetInitiatives` | initiatives.go:124 | skeleton | no |
+| 8 | attachment create pre-check → `GetIssueAttachments` | attachments.go:233 | detail | yes |
+| 9 | attachment create re-check → `GetIssueAttachments` | attachments.go:268 | detail | yes |
+
+Confirmed correct as-is (do NOT touch):
+- All background goroutines (`MaybeRefreshIssueDetails`, `refreshIssueDetails`,
+  reconcile) deliberately run on `context.Background()` — they must never
+  inherit a promoted ctx (see Hazard below).
+- Mutations already classify as write tier via the query-string intent map.
+- Cache-first repo reads return SQLite data without an API call.
+
+## Design
+
+Two pieces:
+
+### 1. `renderFile.render` gains a ctx (the structural change)
+
+`render func() ([]byte, time.Time, time.Time)` becomes
+`render func(ctx context.Context) ([]byte, time.Time, time.Time)`.
+`renderFile.Read`/`Open`/`Getattr` and `lookupRenderFile`/`newRenderInode`/
+`mountRenderFile` pass the FUSE handler's ctx through. This is a mechanical
+signature change across the ~12 render closures (most ignore the ctx — they
+read SQLite); the 7 API-calling closures switch from `context.Background()`
+to the threaded ctx.
+
+**Getattr/Lookup nuance:** the render closure also runs for size during
+Lookup/Getattr. That is still user-blocking I/O, so promotion is correct
+there too — no special case.
+
+### 2. Wrap the 9 sites
+
+`ctx = api.WithInteractive(ctx)` at each site (or once inside a small helper
+per closure). Sites 8–9 are one-liners today.
+
+### Hazard: promoted-ctx leakage into background work
+
+A promoted ctx must not be handed to anything that outlives the FUSE request
+(a spawned goroutine would spend the interactive reserve on background work).
+Rule, enforced by review + a test: `WithInteractive` is applied at the moment
+of the synchronous call, never stored. The repo's background paths already
+construct their own `context.Background()`-rooted ctx, so today's code is
+safe; add a comment at `WithInteractive` stating the rule.
+
+## Tests
+
+- Unit: a fake-clock `rateBudget` test asserting a `WithInteractive`-wrapped
+  op admits when only the interactive reserve remains while the same op
+  un-wrapped defers (exists in spirit in ratebudget_test.go — add the
+  end-to-end client-level variant via the seeded-headers test harness).
+- Unit: render-closure ctx propagation — a stub render closure asserts it
+  receives the ctx passed to `Read` (extend renderfile_test.go).
+- Live validation: with the budget below the list reserve (reproducible by
+  watching the hourly window), `cat issue.meta` succeeds while sync logs show
+  deferrals.
+
+## Effort
+
+Small-medium: one mechanical signature change (~12 closures), 9 wraps, tests.
+No schema, no API changes. Single PR.
+
+## Decisions to grill
+
+1. Should skeleton-tier files (states.md/labels.md — sites 4–7) promote at
+   all? They're cheap and cached in SQLite; the API call only fires on a cold
+   cache. Recommendation: yes — the tier is about *who waits*, not cost.
+2. Wrap placement: per-site vs. inside `lookupRenderFile` for all render
+   closures uniformly. Recommendation: per-closure (only the API-calling
+   ones), so a future SQLite-only closure doesn't silently spend reserve.

--- a/docs/plans/2026-07-07-project-labels-design.md
+++ b/docs/plans/2026-07-07-project-labels-design.md
@@ -1,0 +1,439 @@
+# Project labels (issue #130) — design
+
+**Status: ACCEPTED — ready to build.** Grilled 2026-07-08: all four live spikes run
+(results in "Grilling outcomes" at the end of this doc) and all six contested
+decisions resolved. Headline deltas from the proposal below: the per-team
+**symlink is now IN scope** (rides `symlinkNode`, zero times — the renderFile
+target reports real times through the link); **`ProjectFields` fragment
+consolidation is IN scope as commit #2** of the same PR; the `retiredBy` fallback
+(L0) and `prune: nil` fallback (L1) are both **dead** — spikes passed; the
+retired-label check is **kept as docs-faithful policy** even though the server
+turned out to accept retired assignment (L3b surprise); delete-the-line-clears,
+targeted clobber guard, and duplicate-name ambiguity error all confirmed as
+proposed.
+**Scope (locked by user): level 2 — READ (catalog file + labels on project.md) and ASSIGN (`labels:` frontmatter → `ProjectUpdateInput.labelIds`). No catalog CRUD; must not foreclose it.**
+**Base architecture: DESIGN UNIFY (panel winner 9 / 8 / 7.5 across the three lenses; the agent-UX lens preferred AGENT-UX 8.5 but its wins are content-level grafts, all absorbed below).**
+**Repo facts re-verified 2026-07-07 against the working tree:** `syncCollection(ctx, spec)` with `upsert func(context.Context, T) error` / `prune func(context.Context) error` (synccollection.go:24-41); `pruneCutoff := db.Now()` already taken at the top of `syncWorkspace` before any fetch (worker.go:473); `TestInodeNamespaceDistinct` is a hand-enumerated map a new kind must join manually (ino_test.go:28-69); converters stamp `SyncedAt: Now()` internally; `DBProjectToAPIProject` is a pure blob unmarshal (convert.go:413); `commitWriteBack`/`writeBackSpec` compare-closure shape (editcommit.go:36-90); `ResolveLabelIDs` is a lowercase name→ID map with **no** ID passthrough (linearfs.go:640-664); team `labels.md` uses a top-level `labels:` frontmatter key (teams.go:257-287); `retiredAt` on `ProjectLabel` is doc-tagged `[Internal]` in the schema (schema line ~32624) while `retiredBy` is public; `opBaseTier` defaults unlisted ops to `pList` (ratebudget.go:101-126); the paginate `drain`/`fetchAll` helpers exist (paginate.go:78,142); `MutationClient.UpdateProject` already exists (mutationclient.go:42).
+
+## Summary
+
+`ProjectLabel` is a **workspace-scoped** entity (organization edge only — no team edge anywhere in the schema, and `type Team` has no `projectLabels` field), with a lifecycle issue labels don't have: **groups** (`isGroup` labels are containers; only one child per group may be applied) and **retirement** (`retiredAt` labels stay on existing projects but can't be newly applied). `Project.labelIds: [String!]!` is a cheap scalar array and `ProjectUpdateInput.labelIds` is an atomic full-set write with no `removedLabelIds` analog.
+
+The slice: a new `project_labels` SQLite table (twin of `labels`, **not** a kind-column extension — see decision record), synced once per cycle in `syncWorkspace` via a `syncCollectionSpec`, rendered as a root-level read-only `project-labels.md` renderFile, and a `labels:` names list in project.md frontmatter that resolves locally against the catalog and rides the **existing single `UpdateProject` call** (scalar-edit territory, explicitly not reconcileLinks). One new pure file, `internal/fs/projectlabels.go`, holds the catalog renderer, the resolver, and the selection-policy validation. No new interfaces, no new node types, no migration machinery (additive `CREATE IF NOT EXISTS`; `labelIds` rides the project `data` blob).
+
+Load-bearing invariant (the panel's consensus depth win): **render unknown label IDs verbatim, and the resolver accepts exact-ID passthrough** — so a cold or stale catalog can never cause an untouched save to strip a label, and agents may assign by ID.
+
+## Decision record
+
+| # | Decision | Choice | Why |
+|---|---|---|---|
+| 1 | **Unify with issue labels?** | **Rejected at table/type/render layers; shared only through the already-generic seams** (renderFile, syncCollection, hydrate-then-overlay, FieldError/writeFeedback, `StringSliceFromYAML`, paginate, ino namespace). | A `kind` column on `labels` breaks on repo-verified facts: `GetLabelByName`'s `(team_id = ? OR team_id IS NULL)` union (queries.sql:250-251) would resolve project-label names as issue labels and hand ProjectLabel IDs to `issueUpdate.labelIds`; `ListTeamLabels` would leak project labels into every team's `labels.md` and `labels/` CRUD dir where `rm` fires `issueLabelDelete` at a ProjectLabel ID. Lifecycles differ (retirement must be *retained* by sync), prune regimes differ (team-scoped vs workspace-wide), and GraphQL fragments cannot span `IssueLabel`/`ProjectLabel` so the only expensive share is forbidden by the wire anyway. Recorded in CONTEXT.md so no future round re-derives the merge. |
+| 2 | **Catalog placement** | **Mount-root `project-labels.md`, single read-only file. No per-team file, no per-team symlink (revisit trigger recorded).** | Schema decides it: no team edge → workspace surface, following the `initiatives/`-at-root precedent (issue `labels.md` is per-team *because* `IssueLabel` has a team edge). A per-team copy misrepresents scope; a symlink is surface-without-information. Discovery = README reference-files line + `<project_frontmatter>` annotation + every `.error` message pointing at the file. If live agent transcripts show root-file misses, a `teams/{KEY}/project-labels.md → ../../project-labels.md` symlink is a ~10-line additive follow-up. |
+| 3 | **File vs directory** | File. | One `Read` gets the whole catalog (the `states.md`/`labels.md` idiom agents already know). The team-level `labels.md`-beside-`labels/` coexistence is the exact precedent for level 3 adding a root `project-labels/` CRUD dir *beside* the file — nothing to undo. |
+| 4 | **Table shape** | New `project_labels` table; columns `is_group`, `parent_id`, `retired_at` earn their keep (read by the validation policy and renderer from day one). **No** `GetProjectLabel :one`, **no** `DeleteProjectLabel`, **no** parent index in this slice (deletion test — nothing reads a single row or filters by parent; validation/render load the whole catalog). | Grafted from MINIMALIST per judge 1; UNIFY's original DDL shipped speculative provisioning it lectured others about. Level 3 adds those queries when a reader exists. |
+| 5 | **Fetch shape** | `Project.labelIds` scalar (one token added to the three project queries), **not** the `labels {nodes{...}}` connection. Names resolve locally against the catalog. Catalog fetched via its own paginated workspace drain, `parent { id }` **only** — no parent name on the wire. | The full catalog is always in hand (SQLite), so parent/group names stitch locally; keeps the complexity-capped 50-page project query flat. `Parent.Name` is hydrated in **one in-memory pass at the repo read** (AGENT-UX graft): the converter keeps `Parent` strictly as `&api.ProjectLabel{ID: parent_id}` from the column, the repo stitches names over the id→row map. |
+| 6 | **Groups/retired rendering** | Retired and group labels are **listed** in the catalog (retirement is lifecycle, not deletion — names on existing projects must keep resolving), flagged with omit-when-false keys in frontmatter and a spelled-out Flags column in the table. The three assignment rules live as prose **in the catalog file itself** (it's the file an agent reads after an `.error`). Empty catalog renders header + rules + "No project labels defined." — **never ENOENT** (stable surface the README can promise; AGENT-UX graft). Catalog frontmatter top key is **`labels:`**, matching the existing `labels.md` idiom (judge-3 fix of UNIFY's off-idiom `projectLabels:`). |
+| 7 | **Groups/retired validation** | Client-side pre-validation for `.error` quality, **before any mutation**; Linear stays authoritative (server errors still land via `classifyMutationErr`). Rules: unknown name; `isGroup` cannot be applied (error **names the assignable children** — AGENT-UX graft); retired cannot be **newly** applied (already-applied retired labels carry through — required, since `labelIds` is a full-set write); at most one child per group among the *selected* set. | Locality: the API's rejection text won't say "pick one of: Platform, Mobile". Live item L3 confirms our policy matches the server's. |
+| 8 | **Write mechanics** | Atomic `ProjectUpdateInput.LabelIds *[]string` on the **existing single `UpdateProject` call** — the scalarEdit fork, explicitly NOT reconcileLinks (labels are one set-semantics input array; reconcileLinks exists for per-pair link mutations). Pointer-or-omit: untouched flush sends nil; clear sends `&[]string{}`. Diff as **ID sets**, order-insensitive. Zero `MutationClient` change. | All three designs and all three judges converged here. |
+| 9 | **Clear semantics** | Delete-the-line clears (key absent + current non-empty → empty set), matching `initiatives:` and issue `labels:`. Gated on live item **L2** (`labelIds: []` accepted — strongly implied by the absence of `removedLabelIds`, unverified). If L2 fails, clear becomes EINVAL-with-explanation, not a workaround. | Uniform mount contract; contested item for grilling (#1). |
+| 10 | **Prune policy** | Full-table prune licensed by the complete workspace drain, cutoff = the `pruneCutoff` **already taken at the top of `syncWorkspace`** (worker.go:473 — earlier-than-fetch is strictly conservative for `synced_at < cutoff`; MINIMALIST graft). Gated on live item **L1**: a retired label must appear in the default drain. Fallback if L1 fails: `prune: nil` (states precedent) — one-line policy swap, pre-agreed. | Schema evidence favors safety (retired ≠ archived; `ProjectLabelFilter` has no retired comparator, i.e. the API doesn't segregate retired labels), but the failure mode — sync eats exactly the rows retirement requires us to keep — is bad enough to verify first. |
+| 11 | **`retiredAt` `[Internal]` hazard** | Live item **L0, run first**: confirm `retiredAt` is selectable by API-key clients. Fallback (MINIMALIST's V1b, grafted by all three judges): fragment selects `retiredBy { id }` instead and retired-ness derives from its presence; the `retired_at` column then stores the sync-observation time and the catalog renders `retired: true` without a date. | This is the one failure mode that bricks the entire catalog query every cycle; only one design planned for it. Decided now (not "decide at that point" — the risk judge's flaw in MINIMALIST) so the column shape is settled either way. |
+| 12 | **Duplicate catalog names** | Deterministic resolver preference instead of map-build-order nondeterminism: on a bare-name tie, prefer **(a) a label already in the project's current `labelIds`, then (b) active over retired, then (c) error listing the candidate IDs**. **No** `Parent/Child` qualified-input grammar (speculative new syntax with no demonstrated need; a label literally named "A/B" would collide with it). | Synthesized from the risk judge's duplicate-name gap + AGENT-UX's prefer-current rule, minus its grammar. (a) guarantees untouched files round-trip; (c) keeps ambiguity loud rather than silently assigning the wrong sibling — the ID-passthrough path is the documented disambiguation. |
+| 13 | **Stale-blob clobber guard** | Before computing the label diff, if the parsed frontmatter changes labels **and** `p.project.LabelIds` is empty, do one `GetProject` fetch to refresh current state first. | Closes the corner all three designs missed (risk-judge graft): a project blob predating the `LabelIds` field reads current as empty; an agent *adding* one label would full-set-write and silently wipe the project's real labels in Linear — undetectable by the WriteBack divergence check (fresh == sent). One cheap fetch, only in the at-risk window (≤1 sync cycle after upgrade). |
+| 14 | **`ProjectFields` fragment consolidation** | **Deferred.** `labelIds` is added by hand to the three inlined project field lists (`queryTeamProjects`, `queryProject`, `mutationCreateProject` echo). | Pre-existing drift site; folding it in smears the slice's diff (both winning judges agreed). Flagged as its own follow-up commit. Grilling item #5. |
+| 15 | **Where the new code lives** | One new pure file `internal/fs/projectlabels.go`: `projectLabelsMarkdown`, `resolveProjectLabels`, `validateProjectLabelSelection`, `sameIDSet`. All unit-testable with a literal catalog slice — no mount, no interface. | Change concentration; the panel penalized MINIMALIST's waffling on this. |
+
+## Architecture
+
+### 1. Schema DDL (`internal/db/schema.sql`)
+
+```sql
+-- Project labels (Linear "ProjectLabel"). WORKSPACE-scoped: the schema has no
+-- team edge, so unlike `labels` there is no team_id column at all. Deliberately
+-- a twin of `labels`, not a kind-column extension of it: scoping, prune regime,
+-- and lifecycle (retirement) all differ -- see CONTEXT.md "Project-label selection".
+-- Retired labels are KEPT (retirement is keep-but-not-newly-assignable, not
+-- deletion) so name resolution on existing projects keeps working.
+CREATE TABLE IF NOT EXISTS project_labels (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    color TEXT,
+    description TEXT,
+    is_group INTEGER NOT NULL DEFAULT 0,   -- groups cannot be applied directly
+    parent_id TEXT,                        -- group parent; NULL = top-level
+    retired_at DATETIME,                   -- NULL = active (see L0 fallback note)
+    created_at DATETIME,
+    updated_at DATETIME,
+    synced_at DATETIME NOT NULL,
+    data JSON NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_project_labels_name ON project_labels(name);
+```
+
+No parent index, per decision #4. Migration for existing DBs: none needed — schema.sql is applied as `CREATE IF NOT EXISTS` at `Open` (store.go), so the table appears on next service start; existing project rows self-heal (see §4).
+
+`internal/db/queries.sql` (then `make sqlc`; no apostrophes in SQL comments — sqlc v1.30):
+
+```sql
+-- name: ListProjectLabels :many
+SELECT * FROM project_labels ORDER BY name COLLATE NOCASE;
+
+-- name: UpsertProjectLabel :exec
+INSERT INTO project_labels (id, name, color, description, is_group, parent_id,
+    retired_at, created_at, updated_at, synced_at, data)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET name=excluded.name, color=excluded.color,
+    description=excluded.description, is_group=excluded.is_group,
+    parent_id=excluded.parent_id, retired_at=excluded.retired_at,
+    created_at=excluded.created_at, updated_at=excluded.updated_at,
+    synced_at=excluded.synced_at, data=excluded.data;
+
+-- Workspace-wide prune, licensed ONLY by a complete drain of Query.projectLabels
+-- that includes retired labels (live-verified, item L1; fallback = nil prune).
+-- name: PruneProjectLabels :exec
+DELETE FROM project_labels WHERE synced_at < ?;
+```
+
+### 2. Conversion (`internal/db/convert.go`)
+
+- `APIProjectLabelToDBProjectLabel(l api.ProjectLabel) (UpsertProjectLabelParams, error)` — marshal the whole struct into `data`; extract columns; `parent_id` from `l.Parent.ID` when non-nil; **`SyncedAt: Now()` stamped internally** per the existing converter convention (no caller-passed timestamp — MINIMALIST's `(l, now)` deviation rejected; internal `Now()` at upsert time is strictly after the pre-fetch prune cutoff, so row survival never depends on timestamp equality).
+- `DBProjectLabelToAPIProjectLabel(l ProjectLabel) api.ProjectLabel` — **hydrate-then-overlay** per the reverse-conversion contract at `DBMilestoneToAPIProjectMilestone`: best-effort blob unmarshal (corrupt blob → zero struct; one bad row can't poison the catalog), then overlay every column; `Parent` **strictly from the `parent_id` column** as `&api.ProjectLabel{ID: ...}` (the `DBLabelToAPILabel` never-trust-the-blob's-relationship rule); timestamps only via `db.ParseSQLiteTime`.
+- `DBProjectLabelsToAPIProjectLabels` slice mapper.
+- **`api.Project.LabelIds` needs zero converter work**: `DBProjectToAPIProject` is a pure blob unmarshal. Known, self-healing consequence: blobs predating the field read as empty `LabelIds` for ≤1 sync cycle — the write-path guard (decision #13) covers the one dangerous window.
+
+### 3. API layer (`internal/api`)
+
+**Types** (`types.go`):
+
+```go
+// ProjectLabel is a WORKSPACE-scoped label applied to projects. Deliberately
+// not unified with Label (IssueLabel): no team edge, group/retirement
+// lifecycle, disjoint mutations. See CONTEXT.md "Project-label selection".
+// IsGroup labels are containers and cannot be applied directly; only one
+// child per group may be applied. RetiredAt != nil (or RetiredBy, per the L0
+// fallback) means not newly assignable but valid on existing projects.
+type ProjectLabel struct {
+    ID          string        `json:"id"`
+    Name        string        `json:"name"`
+    Color       string        `json:"color"`
+    Description string        `json:"description"`
+    IsGroup     bool          `json:"isGroup"`
+    Parent      *ProjectLabel `json:"parent,omitempty"` // id from wire; Name stitched by the repo read
+    RetiredAt   *string       `json:"retiredAt,omitempty"`
+    CreatedAt   string        `json:"createdAt"`
+    UpdatedAt   string        `json:"updatedAt"`
+}
+```
+
+- `Project` gains `LabelIds []string \`json:"labelIds"\``.
+- `ProjectUpdateInput` gains `LabelIds *[]string \`json:"labelIds,omitempty"\`` (pointer-or-omit; `&[]string{}` clears).
+
+**Fragment + query** (`queries.go`) — fragment exists from day one so level-3 mutations project through it (CLAUDE.md rule):
+
+```graphql
+fragment ProjectLabelFields on ProjectLabel {
+  id name color description isGroup retiredAt createdAt updatedAt
+  parent { id }
+}
+
+query ProjectLabelsPage($cursor: String) {
+  projectLabels(first: 250, after: $cursor) {
+    nodes { ...ProjectLabelFields }
+    pageInfo { hasNextPage endCursor }
+  }
+}
+```
+
+(`retiredAt` swaps to `retiredBy { id }` if L0 fails. `lastAppliedAt`/`creator` deliberately unfetched — no reader; blob-first storage makes adding them a fragment edit later.)
+
+- `labelIds` (one scalar token) added by hand to `queryTeamProjects`, `queryProject` (the WriteBack verify fetch — required for the divergence check), and `mutationCreateProject`'s echo.
+- `client.GetProjectLabels(ctx) ([]ProjectLabel, error)` — full drain via the existing `paginate` module (`drainFrom`/`fetchAll` pattern), no `filter:` (the drain must include retired and group labels; completeness licenses the prune).
+- **Rate budget** (`ratebudget.go`): `"ProjectLabelsPage": pSkeleton` in `opBaseTier` — FS-shape metadata beside `WorkspaceLabelsPage`; without the entry it defaults to `pList` and misprices at `defaultPredictedCost` until first measurement.
+- **MutationClient: unchanged.** `UpdateProject(ctx, id, ProjectUpdateInput)` already exists; the input struct grew a field. `mockmutation.UpdateProject`'s `projEdit` overlay extends to record/apply `LabelIds` (test plumbing).
+
+### 4. Sync (`internal/sync/worker.go`)
+
+One new spec at the end of `syncWorkspace` — once per cycle, workspace pass, before the per-team loop; isolated log-and-continue so a catalog failure never blocks users/initiatives (and vice versa). Reuses the existing `pruneCutoff` from the top of the function:
+
+```go
+// Project-label catalog (workspace-scoped; see CONTEXT.md). Reuses pruneCutoff:
+// taken before ANY fetch this pass, so it is strictly conservative for the
+// synced_at < cutoff prune (converter stamps SyncedAt at upsert time, after it).
+plabels, err := w.client.GetProjectLabels(ctx)
+if err != nil {
+    log.Printf("[sync] project labels fetch failed: %v", err) // no prune this pass
+} else {
+    syncCollection(ctx, syncCollectionSpec[api.ProjectLabel]{
+        label: "project-label",
+        items: plabels, // complete drain (retired + groups included) licenses the prune
+        upsert: func(ctx context.Context, l api.ProjectLabel) error {
+            params, err := db.APIProjectLabelToDBProjectLabel(l)
+            if err != nil { return err }
+            return w.store.Queries().UpsertProjectLabel(ctx, params)
+        },
+        prune: func(ctx context.Context) error {
+            return w.store.Queries().PruneProjectLabels(ctx, pruneCutoff)
+        },
+    })
+}
+```
+
+Prune-contract statement for the spec: *clean = every catalog row upserted; the drain is the completeness set; retired labels are members of the drained set every cycle (L1), so retirement never reads as removal — only deletion/archival does.* Fallback if L1 fails: `prune: nil` (states precedent, worker.go:568-580); truly-deleted labels then linger as a documented limitation. `Project.labelIds` freshness needs no sync work — it rides the existing per-team project pass into the blob.
+
+### 5. Repo + LinearFS read/resolve
+
+- `repo/sqlite.go`: `GetProjectLabels(ctx) ([]api.ProjectLabel, error)` = `ListProjectLabels` → converters → **one in-memory pass stitching `Parent.Name`** from the id→row map (concrete method; no interface — round 14 deleted them).
+- `fs/linearfs.go`: `GetProjectLabels(ctx)` passthrough beside `GetInitiatives`; `projectLabelNames(ctx, ids []string) []string` — id→name over one catalog load, **unknown IDs render verbatim as the raw ID, never dropped**.
+- `fs/projectlabels.go` (new, pure):
+  - `resolveProjectLabels(catalog []api.ProjectLabel, names []string, currentIDs map[string]bool) (ids []string, ferr *FieldError)` — per name: case-insensitive name match with the decision-#12 tie-break (prefer current, then active-over-retired, else ambiguity error listing candidate IDs); **exact-ID passthrough** (matches a catalog ID or a current `labelIds` member — the round-trip invariant); else unknown → FieldError with "See project-labels.md for valid project labels."
+  - `validateProjectLabelSelection(selected []api.ProjectLabel, currentIDs map[string]bool, catalog byID) *FieldError` — the three policy rules, with the AGENT-UX error content: group error enumerates children (`"Area" is a label group and cannot be applied directly. Apply one of its children instead: Platform, Mobile. See project-labels.md.`); retired-newly-added error notes existing assignments are unaffected; one-child-per-group names the group and both offenders.
+  - `sameIDSet(a, b []string) bool`.
+  - `projectLabelsMarkdown(labels []api.ProjectLabel) []byte`.
+
+### 6. FS read surfaces
+
+**Catalog** — `RootNode.Readdir` gains `{Name: "project-labels.md", Mode: S_IFREG}`; `RootNode.Lookup` gains a case:
+
+```go
+case "project-labels.md":
+    lfs := r.lfs
+    return r.lookupRenderFile(ctx, out, "project-labels.md",
+        func(ctx context.Context) ([]byte, time.Time, time.Time) {
+            labels, _ := lfs.GetProjectLabels(ctx) // SQLite-only; err → empty render
+            return projectLabelsMarkdown(labels), minCreated(labels), maxUpdated(labels)
+        }, projectLabelsCatalogIno(), inheritTimeout), 0
+```
+
+- Times: mtime = max `UpdatedAt`, ctime = min `CreatedAt`; zero when empty (renderFile's never-fabricate-now() contract). Folding RootNode onto `dirManifest` is noted, not done.
+- `ino.go`: `projectLabelsCatalogIno() uint64 { return ino("project-labels-catalog", "workspace") }` in the Labels section, **manually added to `TestInodeNamespaceDistinct`'s map** (it is a hand-enumerated checklist, not automatic — both non-winning designs got this wrong).
+
+Render shape (top key `labels:` matching the labels.md idiom; omit-when-false flags; rules prose in-file; stable when empty):
+
+```markdown
+---
+labels:
+  - id: aaaa-…
+    name: Area
+    group: true
+  - id: bbbb-…
+    name: Platform
+    color: "#5E6AD2"
+    parent: Area
+  - id: dddd-…
+    name: Legacy-2024
+    retired: true
+---
+# Project Labels (workspace-wide)
+
+Assign in any project.md frontmatter: `labels: [Platform, Q3-Bet]`
+(Names are resolved case-insensitively; a raw label ID is also accepted.)
+
+Rules:
+- Labels marked `group: true` are containers and CANNOT be assigned; assign one
+  of their children instead.
+- At most ONE child from each group may be on a project at a time.
+- Labels marked `retired: true` cannot be newly assigned; existing assignments remain.
+
+| Name | Group | Color | Flags | ID |
+|------|-------|-------|-------|-----|
+| Area | — | — | group (assign a child) | aaaa-… |
+| Platform | Area | #5E6AD2 | | bbbb-… |
+| Legacy-2024 | — | #95A2B3 | retired | dddd-… |
+```
+
+Empty catalog: header + rules + "No project labels defined." — never ENOENT.
+
+**project.md** — `marshal.ProjectToMarkdown(project *api.Project, labelNames []string)` emits `labels:` (flow list of names) beside `initiatives:`, only when non-empty (delete-the-line contract stays uniform). The one non-test caller (projects.go's `generateContent`) computes `labelNames` via `lfs.projectLabelNames(ctx, project.LabelIds)`. `project.meta` and `ProjectMetaToMarkdown` untouched (labels are editable-surface data).
+
+### 7. Write path (`ProjectInfoNode.Flush`, projects.go)
+
+Reordered so **all pure resolution/validation runs before any mutation** (labels introduce the first post-reconcile validation; hoisting closes the partial-application window — the flaw that sank AGENT-UX's flush ordering):
+
+1. **Parse** (unchanged).
+2. **Labels: parse + guard + resolve + validate (pure, no mutation).**
+   - `raw, present := doc.Frontmatter["labels"]`; `desiredNames := marshal.StringSliceFromYAML(raw)`.
+   - **Stale-blob guard (decision #13):** if the write would change labels (`present` with non-empty names, or absent-key-clear per next bullet) and `len(p.project.LabelIds) == 0`, refresh once via `p.lfs.verify().GetProject` and adopt `LabelIds` before diffing.
+   - Key absent + current non-empty → desired = empty set (clear). Key absent + current empty → labels untouched (no-op; the stale-blob no-op corner gets an explicit test).
+   - `resolveProjectLabels` then `validateProjectLabelSelection` → any `*FieldError` → `SetWriteError(p.project.ID, ...)` + `EINVAL`. No API call has happened.
+   - `labelsChanged := !sameIDSet(desiredIDs, p.project.LabelIds)` — **ID sets, order-insensitive** (no name-case flapping; raw-ID round-trip diffs empty → no mutation).
+3. **initiatives: reconcileLinks** (unchanged — per-pair link mutations keep their shape).
+4. **Single UpdateProject:** `input := api.ProjectUpdateInput{Name: edit.name, Description: edit.desc}`; `if labelsChanged { input.LabelIds = &desiredIDs }` (`&[]string{}` for clear); call when `edit.changed() || labelsChanged`; failure → `classifyMutationErr("update project", err)` → `.error` + errno (server remains the policy backstop).
+5. **WriteBack tail:** `compare` closure extended — `edit.divergences(fresh.Name, fresh.Description)` plus, **only when `labelsChanged`** (the guard MINIMALIST omitted, which would have EIO'd every plain rename), a fatal divergence when `!sameIDSet(fresh.LabelIds, desiredIDs)`. `queryProject` now selects `labelIds`; `persist` = existing `UpsertProject` (blob carries them); `p.project = *fresh` adopts server truth.
+6. **Invalidation:** unchanged — existing `InvalidateUpdated(projectInfoIno)` + `InvalidateUpdated(metaIno)` pair. The catalog file is a DIRECT_IO renderFile re-rendered per read: no kernel invalidation surface exists or is needed (proven by test, not asserted — §Test plan). Error keying: existing per-project `.error` via `project.ID`; no new feedback surface.
+
+Project **create** path: out of scope (mkdir creates by name only today); `ProjectCreateInput.labelIds` exists, so a future full-frontmatter project `_create` can take `labels:` with the same resolver — nothing forecloses it.
+
+### 8. Marshal
+
+- `internal/marshal/project.go`: `ProjectToMarkdown` signature grows `labelNames []string`; emits `labels:` when non-empty. Parse side stays in fs (the existing project pattern — marshal renders, Flush reads frontmatter via `StringSliceFromYAML`).
+- `project_test.go`: key-set pins → `["initiatives","labels","name"]` / `["labels","name"]` / `["name"]`; a doc-case pinning "no labels → no key" (the delete-line contract). `TestProjectMetaToMarkdown` untouched.
+
+### 9. Generated README + guard (`generateReadme`, root.go; same change per CLAUDE.md)
+
+- `<directory_structure>`: root gains `project-labels.md  [read-only: workspace project-label catalog (groups, retired)]` near `initiatives/`.
+- **New `<project_frontmatter>` block** (project.md now has three editable fields + body; it has outgrown implication-by-`<operations>`):
+  ```
+  ---
+  name: "API Gateway"                       [editable]
+  initiatives: ["Platform Modernization"]   [names; see initiatives/]
+  labels: [Backend, Q3-Bet]                 [must match project-labels.md; groups
+                                             cannot be applied; max one child per
+                                             group; retired = existing-only; raw
+                                             label IDs also accepted]
+  ---
+  Project description (editable — the body maps to the description)
+  ```
+- `<validation_errors>`: `Validated project fields: initiatives, labels` (**not** `name` — it is sent unvalidated; the docs-lens judge caught MINIMALIST's overclaim) and the Reference-files line gains `project-labels.md (valid project labels)`.
+- `<claude_code_instructions>`: "Check `<mount>/project-labels.md` before editing project `labels:`".
+- `<important_notes>`: one line on group/retired semantics.
+- `TestGeneratedReadmeMatchesBehavior`: want-loop gains `"project-labels.md"` and a rule phrase (`"one child"`); behavior spot-checks: mounted `/project-labels.md` readable, mode 0444, contains `group`.
+
+### 10. CONTEXT.md
+
+New `###` entry **"Project-label selection"** after "Name→ID resolution": the workspace catalog (root renderFile + `project_labels` table + workspace-pass syncCollection with drain-licensed prune and the L1-gated nil-prune fallback); assign-by-set via `ProjectUpdateInput.labelIds` in the single project update; the selection policy as a pure function; the render-unknown-as-ID + resolve-ID-passthrough round-trip invariant; and — explicitly — **the rejected unification with issue labels and its four reasons** (scope axis, prune regime, lifecycle, fragment non-shareability) so no future round re-derives the merge. Plus: "Link reconciliation" entry gains "project labels deliberately do NOT use this (atomic array field)"; "Name→ID resolution" mentions `resolveProjectLabels` as the second multi-name resolver (pure-function-with-catalog-slice, sibling of `ResolveLabelIDs`); "Sync reconcile tail" example list gains `project-label`.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `internal/db/schema.sql` | `project_labels` table + name index (no parent index) |
+| `internal/db/queries.sql` (+ sqlc regen) | `ListProjectLabels` / `UpsertProjectLabel` / `PruneProjectLabels` only |
+| `internal/db/convert.go` | `APIProjectLabelToDBProjectLabel` (internal `SyncedAt: Now()`), `DBProjectLabelToAPIProjectLabel` (hydrate-then-overlay, parent-from-column), slice mapper |
+| `internal/db/convert_test.go` | `TestProjectLabelRoundTrip`; `TestOverlayColumnsWin` project-label subtest |
+| `internal/api/types.go` | `ProjectLabel`; `Project.LabelIds`; `ProjectUpdateInput.LabelIds *[]string` |
+| `internal/api/queries.go` | `ProjectLabelFields` fragment; `ProjectLabelsPage` query; `labelIds` scalar in `queryTeamProjects`, `queryProject`, `mutationCreateProject` echo |
+| `internal/api/client.go` | `GetProjectLabels` paginated drain |
+| `internal/api/ratebudget.go` | `"ProjectLabelsPage": pSkeleton` in `opBaseTier` |
+| `internal/sync/worker.go` | project-label `syncCollection` spec in `syncWorkspace`, reusing `pruneCutoff` |
+| `internal/repo/sqlite.go` | `GetProjectLabels` (+ Parent.Name in-memory stitch) |
+| `internal/fs/linearfs.go` | `GetProjectLabels` passthrough; `projectLabelNames` (unknown → verbatim ID) |
+| `internal/fs/projectlabels.go` (new) | `projectLabelsMarkdown`, `resolveProjectLabels`, `validateProjectLabelSelection`, `sameIDSet` — all pure |
+| `internal/fs/projectlabels_test.go` (new) | unit tables for all of the above |
+| `internal/fs/root.go` | Readdir entry; Lookup case (`lookupRenderFile`); `generateReadme` sections (§9) |
+| `internal/fs/ino.go` + `ino_test.go` | `projectLabelsCatalogIno`; manual addition to `TestInodeNamespaceDistinct` |
+| `internal/fs/projects.go` | Flush: labels guard/resolve/validate hoisted pre-mutation, `LabelIds` on the single UpdateProject, guarded label divergence in the compare closure; `generateContent` passes resolved names |
+| `internal/marshal/project.go` + `project_test.go` | `labels:` render param; key-set pins |
+| `internal/testutil/fixtures/api.go` | `FixtureAPIProjectLabel` (+ `WithGroup`/`WithParent`/`WithRetired`); `FixtureAPIProject` gains `WithLabelIDs` |
+| `internal/testutil/fixtures/fstest.go` | `PopulateProjectLabels`; seed mini-catalog in `populateTestFixtures` |
+| `internal/testutil/mockmutation/mock.go` | `UpdateProject` `projEdit` overlay records/applies `LabelIds` |
+| `internal/integration/projectlabels_test.go` (new) | catalog + assign + validation + round-trip surfaces |
+| `internal/integration/readme_test.go` | guard extensions (§9) |
+| `CONTEXT.md` | new entry + three cross-reference touch-ups (§10) |
+
+## Test plan
+
+**Live spikes FIRST (they gate design decisions; targeted queries only — no temp-mount full sync, per the 3M/hr budget lesson):**
+- **L0** — `retiredAt` selectable by an API-key client despite the `[Internal]` doc tag. Fail → fragment uses `retiredBy { id }`, retired-ness = presence, `retired_at` column stores sync-observation time.
+- **L1** — a retired label appears in the default `projectLabels` drain. Fail → `prune: nil` (one-line swap).
+- **L2** — `projectUpdate` with `labelIds: []` clears. Fail → delete-the-line becomes EINVAL-with-explanation (no fake removal path).
+- **L3** — server rejects a group-label ID on `projectUpdate` (confirms our pre-validation matches server policy; capture the server's message text for comparison).
+
+**Unit (no mount):**
+- convert: round-trip; overlay subtest (every column overlaid + columns-win; blob-only field survives; corrupt blob → columns fallback; parent strictly from column).
+- `projectlabels.go` tables: resolver — case-insensitive hit / unknown / **ID passthrough (catalog ID and current-member ID)** / duplicate-name prefers-current / duplicate-name prefers-active-over-retired / duplicate-name-no-tiebreak → ambiguity error listing IDs / empty catalog; validation — clean / group (error names children) / retired-newly-added / retired-carried-through-OK / two-children-one-group / two-children-different-groups; `sameIDSet` order-insensitivity; renderer — flags, sorted, rules prose, **empty-catalog stable render**.
+- marshal: key-set pins; labels absent when empty.
+- flush-diff logic: set-equal → no-op; key-absent + current-empty → no-op (**the stale-blob no-op corner, explicit test**); key-absent + current-non-empty → `&[]string{}`; untouched write → `LabelIds == nil`; **stale-blob clobber guard fires the refresh fetch when current is empty and labels change**.
+- divergence: guarded on `labelsChanged` (a name-only edit with untouched labels must produce zero label divergence); order difference ≠ divergence; real set mismatch → fatal.
+
+**Fixture integration (default SQLite mode, mockmutation):**
+- Seed: group "Platform" with children "Backend"/"Frontend", standalone "Bug", retired "Legacy"; project-1 pre-labeled `[Backend, Legacy]`.
+- Catalog: readable at mount root, 0444, names + group/retired markers + rules text; **mid-test `testStore.Queries().UpsertProjectLabel` visible on the next read** (DIRECT_IO proof — turns the no-invalidation claim into a tested invariant).
+- project.md: renders `labels: [Backend, Legacy]` (names); edit to `[Backend, Bug]` → mock receives the resolved ID set, re-read reflects it; delete the line → `LabelIds = &[]`; unknown/group/retired-new/two-per-group each → EINVAL + expected `.error` text (group error contains the children's names); retired "Legacy" carried through → success.
+- Stale-ID round trip: project carrying a labelId absent from the catalog renders the verbatim ID; unchanged re-save → **no** `UpdateProject` call.
+- README guard extensions per §9.
+
+**Live end-to-end (gated `LINEARFS_LIVE_API=1 LINEARFS_WRITE_TESTS=1`, TST team):** assign a real label through the mounted file, verify read-back + `GetProject.labelIds`; exercise the empty-array clear; confirm a group-assign server rejection lands legibly in `.error` via `classifyMutationErr`.
+
+## Level-3 forward compatibility
+
+`projectLabelCreate/Update/Delete/Retire` all exist in the schema. Later CRUD is a root `project-labels/` directory **beside** the catalog file (the team-level `labels.md`+`labels/` coexistence precedent), built from `namedListing` + collectionTrio (`_create`/`.error`/`.last`) + the `commitCreate`/`commitWriteBack`/`commitDelete` tails, with four new `MutationClient` methods projecting through the already-defined `ProjectLabelFields` fragment (the CLAUDE.md rule is why the fragment ships now, mutation-less). The table already carries every lifecycle column including `retired_at` for a retire-instead-of-delete surface; `GetProjectLabel :one` / `DeleteProjectLabel` queries are added **then**, when readers exist. `.error`/`.last` key via `collectionErrorKey("project-labels", "workspace")`. Nothing in this slice assumes the catalog file is the only surface, and nothing needs rework.
+
+## Effort estimate
+
+**M — two focused sessions** (~600–800 LOC including tests), plus a short up-front live-spike pass.
+- Spike pass (½ hour): L0/L1/L2/L3 as raw GraphQL against the live API — they settle the fragment shape, prune policy, and clear semantics before any code.
+- Session 1: DB + sqlc + converters + API types/query/client/budget + sync spec + repo/linearfs reads + catalog render + ino (READ complete, fixture-testable).
+- Session 2: write path (guard/resolve/validate/UpdateProject/WriteBack) + mock + marshal + integration tests + README/guard + CONTEXT.md.
+No migration risk (additive table, blob-riding field). Reinstall of the live service after merge is warranted (new surface + sync pass) and needs explicit user authorization per house rule.
+
+## Decisions to grill
+
+1. **Delete-the-line clears labels** (key absent + current non-empty → full clear). *Recommendation: keep* — it matches the mount-wide contract (issue labels, initiatives), the stale-blob no-op corner is tested, and the clobber guard covers the dangerous window. The alternative (absent = no-op, clear only via explicit `labels: []`) is safer against accidental truncation but forks the mount's established semantics for one field.
+2. **One-child-per-group client-side check.** The cheapest rule with the weakest justification: the server enforces it, and our check could false-reject if Linear ever relaxes the rule. *Recommendation: keep* — it is ~10 lines in an already-pure function, L3 verifies parity, and the raw GraphQL error it replaces is genuinely unhelpful; but this is the first check to delete if grilling says "server is the authority, period."
+3. **Stale-blob clobber guard shape** — targeted `GetProject` refresh only when current `LabelIds` is empty and labels change, vs always refreshing before any label diff, vs no guard (accept the ≤2-min window as documented). *Recommendation: targeted guard* — one cheap fetch in exactly the at-risk state; always-refreshing adds a fetch to every labeled save forever to cover a window that only exists for one sync cycle after upgrade.
+4. **No per-team symlink** (`teams/{KEY}/project-labels.md → ../../project-labels.md`). *Recommendation: ship without* — README + `<project_frontmatter>` + every `.error` message point at the root file; the symlink is a cheap additive follow-up with a concrete revisit trigger (live agent transcripts showing root-file misses). But this is the one placement facet the user explicitly never confirmed.
+5. **`ProjectFields` fragment consolidation** — this slice touches all three inlined project field lists to add `labelIds`, widening the known drift site by one field each. *Recommendation: defer to its own follow-up commit* (both winning judges agreed the slice shouldn't smear into it), but if the grilling wants the CLAUDE.md fragment rule executed while the files are open, it is severable and low-risk as commit #2 of the same PR.
+6. **Duplicate-name ambiguity error vs silent pick.** Decision #12 errors (listing candidate IDs) when the prefer-current/prefer-active tie-breaks don't resolve a bare name. *Recommendation: keep the error* — silently picking a sibling is exactly the wrong-label hazard the docs lens flagged; the ID-passthrough path is the documented escape hatch. The alternative (always pick deterministically, never error) is friendlier but can assign a label the agent didn't mean, invisibly.
+
+## Grilling outcomes & live-spike results (2026-07-08)
+
+All spikes ran as raw GraphQL against the live API (script preserved the
+workspace: spike labels deleted, TST project's original label restored after a
+quoting bug in the script's restore step was fixed by hand).
+
+**Spike results:**
+
+- **L0 — PASS.** `retiredAt` IS selectable by an API-key client despite the
+  `[Internal]` doc tag. The fragment uses `retiredAt` directly; the `retiredBy`
+  fallback (decision #11) is dead. `retired_at` column stores the real date.
+- **L1 — PASS.** A retired label appears in the default `projectLabels` drain
+  (verified: retired `zz-spike-plain` present, `retiredAt` populated). The
+  full-table prune is licensed; the `prune: nil` fallback (decision #10) is dead.
+  Bonus: `projectLabelDelete` works directly on a retired label — no
+  restore-then-delete dance for future level-3 CRUD.
+- **L2 — PASS.** `projectUpdate` with `labelIds: []` clears cleanly.
+  Delete-the-line-clears (decision #9) confirmed viable and RESOLVED: keep.
+- **L3a — group rejection confirmed, and the error is structured:**
+  `extensions: {type: "invalid input", code: "INPUT_ERROR", statusCode: 400,
+  userError: true, userPresentableMessage: "The label 'zz-spike-group' is a
+  group and cannot be assigned to projects directly."}` (raw message:
+  "labelIds contain parent labels"). BUILD NOTE: verify `classifyMutationErr`
+  maps `INPUT_ERROR`/`userError` to EINVAL (not EIO) and prefers
+  `userPresentableMessage` over the terse internal message when surfacing to
+  `.error`. Our pre-validation still adds value: the server message does not
+  name the assignable children.
+- **L3b — SURPRISE: the server ACCEPTS assigning a retired label.**
+  `projectUpdate` with a retired label ID succeeded, contradicting the schema
+  docs. Retirement enforcement is evidently UI-level only.
+
+**Grill decisions — all resolved:**
+
+1. **Delete-the-line clears: KEEP** (as proposed). Mount-wide contract
+   consistency wins; the stale-blob guard and the tested no-op corner close the
+   dangerous edges.
+2. **One-child-per-group check: KEEP.** Untested live (only one child was
+   created), but the retired-check decision settled the principle: either the
+   server enforces it (our check = parity + better message) or it does not
+   (our check = docs-faithful policy, same stance as retired).
+3. **Retired-label check: KEEP as docs-faithful POLICY** — this is now
+   deliberately stricter than the API (per L3b). Rationale: both the type docs
+   and the `projectLabelRetire` mutation description state the constraint; API
+   acceptance reads as lax enforcement, not intent; an agent newly assigning a
+   retired label is almost certainly a mistake; the escape hatch is restoring
+   the label in Linear. Validation policy in one sentence: **we enforce what
+   Linear's docs say about label assignment, even where the API is lax.**
+4. **Stale-blob clobber guard: TARGETED shape** (refresh only when the write
+   changes labels AND current `LabelIds` is empty). Pinned: the refresh uses
+   the interactive-promoted context (`api.WithInteractive`) — synchronous read
+   inside a user-blocking flush, same rule as the attachment idempotency
+   re-check (PR #187).
+5. **Per-team symlink: NOW IN SCOPE** (reverses the proposal's deferral, on
+   codebase evidence + user's ergonomics preference). `teams/{KEY}/
+   project-labels.md → ../../project-labels.md` via the existing `symlinkNode`
+   deep module — the established cross-tree idiom (initiative project symlinks,
+   `cycles/current`). Construction passes ZERO times (loading the catalog at
+   team-Lookup to stamp symlink times is overkill; the renderFile target
+   reports real times through the link on stat). Files-touched delta: the team
+   directory's listing/lookup (teams.go / its dirManifest) + one README
+   directory-structure line + one guard-test line.
+6. **`ProjectFields` fragment consolidation: NOW IN SCOPE as commit #2 of the
+   same PR** (reverses the proposal's deferral). Executes the CLAUDE.md
+   fragment rule while the three inlined sites are open; severable commit
+   keeps the slice's diff reviewable.
+7. **Duplicate-name ambiguity error: KEEP** (as proposed). Tie-break ladder
+   prefer-current → prefer-active → loud EINVAL listing candidate IDs;
+   ID-passthrough is the documented disambiguation.
+
+**Workspace facts observed during spikes:** catalog is 11 labels, one page,
+no groups/parents/retired in real data — the sync pass is trivially cheap
+today; group/retired fixtures must be synthetic in tests.

--- a/docs/plans/2026-07-08-collection-meta-split-design.md
+++ b/docs/plans/2026-07-08-collection-meta-split-design.md
@@ -1,0 +1,51 @@
+# Collection .meta split — round-18 candidate 2 (grilling-locked)
+
+Candidate 2 from the 2026-07-08 round-18 review. Grilling-locked with John 2026-07-08.
+
+## The hazard
+
+The four small editable entities render server-managed fields into their
+EDITABLE files, and their parses silently ignore edits to them — a silent
+no-op with no `.error`, violating the documented failure model ("an edit that
+fails or appears to no-op is explained at the sibling `.error`") and the
+editable-only split issue/project/initiative follow:
+
+| entity | read-only fields leaked into editable frontmatter | render seam today |
+|---|---|---|
+| documents | id, url, created, updated, creator, slug | marshal |
+| comments | ALL frontmatter (id, created, updated, edited, author, authorName) | hand-rolled in fs/comments.go (bypasses the marshal seam) |
+| milestones | id | marshal |
+| labels | id (plus a generated BODY that re-prints name/color/ID) | fs, via renderWithFrontmatter |
+
+Comment flush (`extractCommentBody`) discards frontmatter wholesale — any
+frontmatter edit is silently dropped.
+
+## Locked decisions
+
+- **Full .meta split, all four entities** (user's call: extend the established
+  issue/project/initiative pattern; a changed-value guard and a drop-the-fields
+  option were considered and rejected). Editable `.md` carries editable fields
+  only; a read-only `.meta` sidecar (0444, renderFile machinery, same as
+  issue.meta) carries the server-managed fields. The mistake becomes
+  unrepresentable instead of punished.
+- Comment `.md` becomes **pure body** (no frontmatter at all). The lenient
+  strip-leading-frontmatter-on-write behavior stays (an agent pasting
+  old-format content must not break).
+- Accepted costs, eyes open: collection listings double (a `.meta` per item);
+  comment authorship moves out of the read path into the sidecar (file
+  mtime/ctime still carry the times).
+- Every listed `.md` has a listed, openable `.meta` and vice versa — the
+  listed⇔openable guarantee extends to the sidecars, pinned by round-trip
+  tests.
+- Renders join the **marshal seam** (CONTEXT "Entity render"): comments' and
+  labels' renders move from fs into marshal, with Meta variants for all four.
+  Exact frontmatter key-set tests pin editable vs meta key sets (the
+  project/initiative precedent).
+- Labels: frontmatter {name, color, description} (all editable); the
+  generated decorative body (which re-printed ID) moves its facts to
+  label `.meta`; the builder inspects `parseLabelMarkdown` and preserves the
+  parse contract for the body.
+- README (`generateReadme`) + `TestGeneratedReadmeMatchesBehavior` updated in
+  the same change — the split alters documented file shapes.
+- New ino wrappers per sidecar kind, registered in
+  `TestInodeNamespaceDistinct`.

--- a/docs/plans/2026-07-08-detail-outcome-swr-refresh-design.md
+++ b/docs/plans/2026-07-08-detail-outcome-swr-refresh-design.md
@@ -1,0 +1,112 @@
+# detailOutcome + swrRefresh — round-17 design (grilling-locked)
+
+Candidates 1 and 2 from the 2026-07-08 architecture review (report:
+`~/tmp/architecture-review-20260708-130636.html`). Both designed together
+because they share the detail-sync/SWR territory; every decision below was
+grilling-locked with John on 2026-07-08.
+
+## The hazards being closed
+
+1. **Touch/dequeue over the requested set** (worker.go:1040–1051): the sync
+   loop iterates the *returned* `detailsMap`, the touch/dequeue loop iterates
+   the *requested* `issues`. An issue silently dropped by the client is
+   stamped `synced_at = now` (masking staleness from the SWR path) and
+   deleted from `pending_detail_sync` (losing its retry). The comment says
+   "successfully synced"; the code removes all.
+2. **Silent drop in `GetIssueDetailsBatch`** (client.go:1008, 1014): missing
+   alias or decode failure → `continue`. Worse: `toDetails()` never returns
+   nil, so a `null` alias yields an **empty** `IssueDetails` whose five empty
+   collections are each "complete" (0 < page size) → **full prune of a live
+   issue's details**. The `details == nil` guard at worker.go:939 is dead code.
+3. **Lost retry on whole-batch failure** (worker.go:914–915): non-rate-limit
+   fetch failure logs and returns without deferring — team-sync-sourced
+   issues lose their worker-side retry entirely.
+4. **Per-issue masked staleness**: an issue whose comment *upsert* failed
+   (e.g. transient SQLITE_BUSY) still gets touched — prune is suppressed
+   (clean guard) but the stale row is stamped fresh, hiding it from SWR.
+5. **SWR fragmentation** (repo/sqlite.go): two staleness policies in three
+   implementations (`staleSince` TTL — the only one `SetCatchUpMode` reaches;
+   the event-driven `issue.updatedAt > synced_at` hand-copied at :838–840 and
+   :1341–1345); the history fetch closure pasted verbatim at :1316 and :1346;
+   `isEntityNotFound → deleteOrphan*` restated at 7 sites; bare-string dedup
+   keys at 6 sites.
+6. **Duplicated persist**: `refreshIssueDetails` (repo) is a hand-rolled
+   near-copy of the worker's five syncCollection specs, diverging: no prunes,
+   no clean guard, **no embedded-file extraction** (a comment fetched via SWR
+   never gets its `*.png` row until the next worker detail sync), and silent
+   `continue` on convert errors.
+
+## Locked decisions
+
+### Candidate 1 — syncDetails (worker) + all-or-nothing client
+
+- **Client contract: all-or-nothing.** `GetIssueDetailsBatch` returns an
+  error if any alias is missing, `null`, or fails to decode. A nil-error
+  return guarantees an entry for every requested ID — the same contract
+  language as `drainFrom`, and prune callers rely on it. (Per-issue outcome
+  maps and null-means-gone were considered and rejected: decode anomalies
+  indicate systemic schema drift, not per-issue state.)
+- **Defer on any failure.** Non-rate-limit batch failure defers the issues to
+  `pending_detail_sync` like the other gates (fixes hazard 3). No attempt
+  cap (YAGNI — bounded cost, loudly logged, SWR backstops).
+- **Clean gate.** `syncCollection` returns `clean bool` (existing metadata
+  callers may ignore it — zero churn). An issue is clean iff all five of its
+  collections are clean; only clean issues get touched + dequeued; unclean
+  issues are (re-)enqueued to pending.
+- **Shape: one Worker method.** `syncDetails(ctx, issues []issueRef)
+  detailOutcome` merges `syncOrDeferDetailBatch` + `syncIssueDetailsBatch`,
+  owning all gates (budget, rate-limit before/mid, fetch failure).
+  `detailOutcome = {synced, deferred []issueRef, gated bool}`.
+  `drainPendingDetailSync` becomes a thin loop that breaks on `gated`.
+  The anonymous `struct{ID, Identifier}` becomes a named `issueRef`.
+  No separate detailSyncer struct — Worker already has the narrow APIClient
+  seam + fixture store for tests.
+
+### Candidate 2 — internal/reconcile + swrRefresh coordinator
+
+- **Scope: coordinator + shared persist** (John chose the bigger scope).
+- **New package `internal/reconcile`** (repo and sync import it; neither
+  imports the other — verified acyclic):
+  - `syncCollection` moves here (returns `clean bool`).
+  - `PersistIssueDetails(ctx, deps, issueID, details, cutoff) (clean bool)` —
+    the five collection specs + `pruneWhenComplete` written once, called by
+    both the worker batch and the repo SWR refresh.
+  - Embedded-file extraction module: pure parse (already split) + HEAD I/O
+    tail, deps = {queries, `AuthHeader()`, injectable httpClient — the
+    embeddedFileCache precedent}.
+  - Rejected placements: repo-imports-sync (read path depending on the
+    worker package misstates the relationship), internal/db (reconcile
+    POLICY doesn't belong in the schema layer).
+- **Repo SWR behavior changes riding along (all improvements, recorded):**
+  prunes-when-complete, clean guard, embedded-file extraction on the SWR
+  path; convert errors now log-and-mark-unclean instead of silent continue.
+- **swrRefresh coordinator** (repo): one spec-shaped entry point with typed
+  refresh keys (kind + id factory), two staleness flavors — TTL via
+  threshold, event-driven via a `changedAt` closure (nil ⇒ TTL, the
+  nil-prune idiom) — dedup/trigger, and orphan-on-not-found classification
+  (`spec.orphan` closure). The six call sites become one-liners; the pasted
+  history closure exists once.
+- **Catch-up mode stays TTL-only — explicit policy, not accident.** Grilled
+  with full tradeoffs: extending suppression to event-driven surfaces would
+  save duplicate fetches the rateBudget ladder already governs, at the cost
+  of silently-empty `comments/` listings during big syncs — the worst
+  failure mode for an agent-facing filesystem. Flipping later is a one-line
+  policy change.
+
+## Build sequence (4 stacked PRs, background agents build, main loop reviews/merges)
+
+1. **Client hardening** (independent): all-or-nothing `GetIssueDetailsBatch`
+   + synthetic-response tests (missing / null / undecodable alias → error).
+2. **internal/reconcile** (independent of 1): move syncCollection (+clean
+   return), add PersistIssueDetails + Extractor; worker switches over;
+   behavior-preserving (clean value ignored until step 3).
+3. **syncDetails ledger** (needs 2): merge the three methods, clean-gated
+   touch/dequeue, defer-on-failure, thin drain.
+4. **swrRefresh** (needs 2): coordinator + route the repo's six surfaces;
+   `refreshIssueDetails` → `reconcile.PersistIssueDetails`; delete the five
+   hand-rolled tails.
+
+CONTEXT.md updates ride each step: new entries (detail outcome, SWR refresh
+coordinator, detail persist), amendments (sync-reconcile-tail moves package +
+returns clean; the relations paragraph's SWR sentence; catch-up asymmetry as
+recorded policy).

--- a/docs/plans/2026-07-08-detail-synced-at-design.md
+++ b/docs/plans/2026-07-08-detail-synced-at-design.md
@@ -1,0 +1,56 @@
+# detailSyncedAt — round-18 top pick (grilling-locked)
+
+Candidate 1 from the 2026-07-08 round-18 review (report
+`~/tmp/architecture-review-20260708-173409.html`). Grilling-locked with John.
+
+## The hazards being closed
+
+1. **The empty-family refetch loop (nearly universal, live budget leak).**
+   Issue-details staleness = min of three per-family `MAX(synced_at)`s
+   (comments/documents/attachments). The touch pass is an `UPDATE` — it cannot
+   stamp rows that don't exist — so any issue with an empty family (most have
+   zero docs) yields `MAX = NULL` → zero time → `swrStale` event-driven reads
+   "never synced" → **stale forever**. Every browse of `comments/`, `docs/`,
+   or `attachments/` fires a background `GetIssueDetails`; the dedup key only
+   covers the in-flight window and the refresh upserts nothing for the empty
+   family, so the next browse re-triggers. Permanent per-browse complexity
+   leak on the hottest agent path.
+2. **The history-staleness mask.** The touch-on-unchanged block
+   (`syncTeamIssues`, worker.go:371-380) re-stamps ALL four sub-resource
+   families for unchanged issues, including `TouchIssueHistoryCache`. History
+   is never worker-fetched (SWR-only), so an issue whose history was cached
+   before its last update gets the stale cache stamped fresh every cycle —
+   `history.md` serves pre-update history indefinitely.
+3. **Dead code**: `repo.TouchIssueSubResources` has zero callers.
+
+## Locked decisions
+
+- **One freshness fact**: `issues.detail_synced_at` (nullable DATETIME).
+  NULL = genuinely never synced (correct cold semantics). Stamped:
+  - by `syncDetails` for CLEAN issues, exactly where the three touches ran
+    (the stamp inherits the round-17 ledger's honesty — unclean issues stay
+    unstamped and pending);
+  - by the repo's `refreshIssueDetails` on a clean `PersistIssueDetails`
+    (symmetric clean gate).
+  Locally-created issues stay NULL → one harmless fetch on first browse.
+- **Upsert safety**: the column is omitted from `UpsertIssue`'s INSERT list
+  and ON CONFLICT SET clause — NULL on insert, preserved on every sync upsert.
+- **Migration: bootstrap ALTER at store open** (first migration precedent —
+  none existed). Check `pragma table_info(issues)`, `ALTER TABLE ADD COLUMN`
+  if missing; idempotent, ~15 lines + test. Rejected: documented rm+resync
+  (live service would error until manual deletion, and a full resync burns
+  real complexity budget — the 2026-07-06 wedge lesson); a user_version
+  framework (framework-building for one column; extract later when full
+  columnization lands).
+- **Full cleanup** (grilled; the alternative belt-and-suspenders option was
+  rejected as two-freshness-mechanisms drift): delete the three `Touch*`
+  queries, the three `GetIssue*SyncedAt` aggregates (their only consumers
+  were staleness inference), the touch-on-unchanged block INCLUDING its
+  history touch (under event-driven staleness an unchanged issue is fresh by
+  definition — stamp > issue.updatedAt — and never-fetched SHOULD read
+  stale; deleting the history touch FIXES hazard 2, a recorded behavior
+  improvement), and the dead `TouchIssueSubResources`.
+- **SWR spec**: the issue-details `syncedAt` closure becomes one query;
+  builder may merge it with the `changedAt` lookup into a single two-column
+  fetch (`updated_at, detail_synced_at`). NULL → zero → stale, unchanged
+  `swrStale` semantics.

--- a/docs/plans/2026-07-08-otel-metrics-design.md
+++ b/docs/plans/2026-07-08-otel-metrics-design.md
@@ -1,0 +1,67 @@
+# OTEL metrics instrumentation — design (grilling-locked)
+
+Planned 2026-07-08 with John. Tracking: GitHub issue on jra3/linear-fuse (this
+doc is the spec). Motivation: round 18's rate-budget leak was diagnosed via
+journal archaeology + sqlite forensics; the budget/API layer should be
+observable directly. The rateBudget module already holds exactly the state
+worth exporting (two axes × limit/remaining/reset, in-flight reservations,
+per-op cost predictions, ladder decisions) — today visible only as log lines.
+
+## Locked decisions
+
+- **Metrics only — traces never (YAGNI).** No tracer, no span design, no
+  context-propagation work. Revisit only if something concrete demands traces.
+- **Export: stdout/file, backend deferred.** No collector/LGTM stack now. The
+  exporter stays config-pluggable so an OTLP endpoint can drop in later with
+  zero instrumentation change. The value today: machine-readable JSONL an
+  agent can jq during diagnosis.
+- **Default state: meter + journald summary ON; file export OPT-IN.** The
+  in-memory meter always runs (negligible at these rates) and a 5-minute
+  human-readable summary line always goes to journald — preserving exactly
+  today's default observability (APIStats' always-on log) with one data
+  source. The JSONL file exporter is config-gated
+  (`telemetry: {file: {enabled, path, interval, max_size_mb}}`; default path
+  under the state dir, size-capped self-rotation). Rejected: on-by-default
+  file (user wants zero disk footprint by default); fully-dark default (would
+  regress the existing journald summary).
+- **APIStats (internal/api/stats.go, ~290 lines) is DELETED.** It is a
+  hand-rolled metrics SDK duplicating what OTEL instruments own (per-op
+  count/latency/errors, rolling window, rate-limit-wait). The 5-minute human
+  summary survives as a rendering of the same OTEL data (one source, two
+  renderings — JSON for machines, one compact line for journalctl; no drift
+  possible). Rejected: keeping both (two systems counting the same events).
+- **Layers: the full rate-limit causal chain** — api + budget + sync + SWR.
+  FS hot-path ops (per-Read/Lookup) are excluded: volume without diagnostic
+  value for this story. The SWR triggers are literally round 18's leak — this
+  set shows leak AND leaker.
+
+## Instrument sketch (builder refines; naming `linearfs.<layer>.*`)
+
+- `linearfs.api.requests` counter {op, outcome=ok|error|ratelimited}
+- `linearfs.api.duration` histogram {op}; `linearfs.api.complexity` histogram {op} (X-Complexity)
+- `linearfs.budget.remaining` / `.limit` / `.inflight` observable gauges {axis=requests|complexity}
+- `linearfs.budget.reset_seconds` observable gauge {axis}
+- `linearfs.budget.decisions` counter {tier, decision=admit|defer|wait|ratelimited}
+- `linearfs.budget.wait_duration` histogram (rate-limit wait — replaces APIStats' rateLimitWaitNs)
+- `linearfs.sync.cycle_duration` histogram; `linearfs.sync.detail_outcomes` counter {outcome=synced|deferred}
+- `linearfs.sync.prunes` counter {collection}; `linearfs.sync.pending_depth` observable gauge
+- `linearfs.swr.triggers` counter {kind, decision=triggered|fresh|deduped|sem_dropped}
+- `linearfs.swr.refresh_outcomes` counter {kind, outcome=ok|error|orphaned}
+
+Cardinality is tiny (ops ~30, kinds 6, tiers 5). Gauges read rateBudget /
+pending-queue state via snapshot methods under existing locks — no new
+mutexes. Dependencies: `go.opentelemetry.io/otel` + `sdk/metric` (+
+stdoutmetric or a small custom JSONL exporter with a rotation writer).
+
+## Phasing (small PRs, each independently green)
+
+1. **Plumbing**: meter provider wiring in cmd/config (`telemetry` config
+   section), the two renderings (journald summary reader @5min; file JSONL
+   reader @interval, gated), rotation writer. No instruments yet beyond a
+   heartbeat.
+2. **api + budget instruments; APIStats deleted** (the summary rendering
+   takes over its journald role in the same PR — no observability gap).
+3. **sync + SWR instruments** (detail outcomes hook the syncDetails ledger;
+   SWR decisions hook maybeRefreshSWR/triggerBackgroundRefresh).
+
+CONTEXT.md gains a "Telemetry (meter)" entry when phase 1 lands.

--- a/docs/plans/2026-07-08-webhook-feasibility.md
+++ b/docs/plans/2026-07-08-webhook-feasibility.md
@@ -1,0 +1,142 @@
+# Feasibility study: real-time cache invalidation via webhooks (#27)
+
+Date: 2026-07-08
+Status: feasibility assessed — API supports it, but **admin-gated**; see verdict.
+
+## The core question
+
+> Is there a way to register or de-register webhooks via the API?
+
+**Yes — full lifecycle.** Verified against the current schema
+(`docs/linear-schema.graphql`):
+
+| Operation | Mutation / query | Notes |
+|---|---|---|
+| Register | `webhookCreate(input: WebhookCreateInput!)` | `url` + `resourceTypes` required; `teamId` **or** `allPublicTeams`; optional `label`, `secret`, `enabled` |
+| Re-point | `webhookUpdate(id, input)` | **Can change `url` in place** — no delete/recreate churn |
+| De-register | `webhookDelete(id)` | |
+| Rotate secret | `webhookRotateSecret(id)` | Returns new HMAC-SHA256 key, old one immediately invalid |
+| List / inspect | `webhooks(first:…)`, `webhook(id)` | Workspace-scoped; `Webhook` type includes `WebhookFailureEvent` history for delivery debugging |
+
+`webhookUpdate` changing the URL in place is the load-bearing fact for the
+tunnel decision: a **quick tunnel with a random URL per restart is perfectly
+workable** — keep exactly one webhook labeled `linearfs`, and on each mount
+find-by-label and `webhookUpdate` its URL. No stable DNS required, no webhook
+accumulation. ngrok vs cloudflared quick tunnel becomes a pure
+operational-preference choice, not an API constraint.
+
+## The blocker: workspace-admin gate (verified live)
+
+Probed live on 2026-07-08 with the mount's API key:
+
+```
+{"errors":[{... "userPresentableMessage":
+  "You must be a workspace admin to interact with webhooks."}]}
+```
+
+- `viewer` = John Allen, `john@antimetal.com`, workspace **Antimetal**, `admin: false`.
+- The gate covers **all interaction** — even the read-only `webhooks` query
+  403s. Team-scoped webhooks (`teamId` in the create input) do not relax it;
+  the role check is workspace-level.
+- The Linear settings UI has the same gate, so "just create it manually in
+  the UI" also requires an admin.
+
+So auto-registration is technically feasible but **not with this credential**.
+
+## Resource-type coverage (webhooks can't fully replace the sync worker)
+
+`WebhookResourceType` enum covers: Issue, Comment, Document, Project,
+ProjectUpdate, ProjectLabel, IssueLabel, Initiative, InitiativeUpdate, Cycle,
+Attachment, Reaction, User (plus agent/customer/release types we don't use).
+
+**Not in the enum:** Team, WorkflowState, **ProjectMilestone**,
+IssueRelation, ProjectStatus. Changes to states, teams, and milestones will
+never push. Relations *may* arrive as part of an Issue update payload
+(unverified). Conclusion: webhooks are a **latency optimization for the hot
+entities**, layered on top of the existing sync worker — never a replacement.
+That matches the invalidation-only architecture in #27 anyway.
+
+## Deployment modes (design consequence)
+
+The admin gate splits the feature into two independently useful halves:
+
+1. **Webhook receiver (no admin needed at runtime).** Embedded HTTP server:
+   verify `Linear-Signature` (HMAC-SHA256 of raw body), map event → SQLite
+   upsert/invalidate → `InodeNotify`/`EntryNotify`. Config carries the shared
+   secret + port. Registration happened out-of-band (an admin, once, via UI
+   or a one-shot admin-key CLI). Requires a **stable URL** → named Cloudflare
+   tunnel (or any static HTTPS ingress).
+2. **Auto-registration (admin key only).** `linearfs webhook create/list/delete`
+   CLI + on-mount find-or-create-by-label + `webhookUpdate` URL re-point.
+   This is what makes quick tunnels viable. Should degrade gracefully: on
+   403, log "webhook auto-registration requires workspace admin" and fall
+   back to receiver-only or plain polling.
+
+For John's Antimetal deployment specifically:
+- **Path A (recommended):** ask an Antimetal admin to create one webhook
+  (one-time, ~2 min) pointed at a named Cloudflare tunnel URL; John holds the
+  signing secret in `config.yaml`. Only half 1 needs to be built.
+- **Path B:** get admin role → both halves work, quick tunnels included.
+- **Path C (dev/testing):** a personal Linear workspace where John *is*
+  admin exercises the full auto-registration path end-to-end.
+- OAuth-app webhooks exist as a third registration route, but Linear
+  app creation is also admin-gated in workspace settings — no advantage here.
+
+## Can the org be configured to allow non-admin webhook access? (researched 2026-07-08)
+
+**No.** The gate is hard-coded, not a workspace setting. Linear's docs:
+"Only workspace admins, or OAuth applications with the `admin` scope, can
+create or read webhooks." The only API-related permission an admin can
+delegate is **Member API keys** (Settings > Administration > API > Member
+API keys — whether members may create personal keys); nothing equivalent
+exists for webhooks or OAuth-app management. The Dec-2025 "team owners"
+role (Business/Enterprise) grants team settings/labels/templates/membership
+— no webhook or API rights.
+
+**But there is a documented non-admin side door: OAuth-application webhooks.**
+Webhooks can be configured *on an OAuth app itself* (URL + resource types in
+the app's settings), and then "each time a new organization authorizes the
+given application, a webhook will be created for that organization" —
+Linear creates the webhook as part of the authorization flow, not via the
+admin-gated mutation. The recipe for John:
+
+1. Create a free personal Linear workspace (he's admin there) and create an
+   OAuth application in it — Linear itself recommends a dedicated workspace
+   for app management.
+2. Configure the app's webhook URL (named Cloudflare tunnel) + resource types.
+3. Authorize the app into Antimetal via the normal OAuth flow as a regular
+   member (`actor=user`, plain `read` scope — NOT `admin` scope, NOT
+   `actor=app`; both of those require an Antimetal admin).
+4. Linear auto-creates the org webhook pointed at the configured URL.
+
+Caveats / unverified edges:
+- **Third-party app approvals** is an Enterprise opt-in (Settings >
+  Administration > Security). If Antimetal has it enabled, member
+  authorization becomes a request-for-admin-approval flow — back to needing
+  an admin once.
+- The docs never state the authorizing user's role explicitly; "org
+  authorizes → webhook created" with no admin caveat is strong but a live
+  test (app in personal workspace → authorize into Antimetal → watch for
+  events) is cheap and definitive.
+- The app-webhook URL lives in the app console (John's own workspace), so he
+  can re-point it himself — but manually, not via `webhookUpdate` (still
+  admin-gated in Antimetal). So this path wants a **stable URL** (named
+  tunnel), same as receiver-only mode.
+- `admin` scope on a token still acts on behalf of the authorizing user;
+  a non-admin authorizing with `admin` scope does not gain webhook CRUD.
+
+This changes the deployment picture: **Path D (OAuth-app webhook) needs no
+Antimetal admin at all** (unless app approvals are enabled), at the cost of
+a one-time app setup and a static URL. The receiver half of the design is
+identical; only registration differs. Note the payload arrives signed with
+the app's webhook secret exactly like a workspace webhook.
+
+## Verdict
+
+**Feasible, with one external dependency.** The API surface is complete and
+better than the issue assumed (in-place URL update kills the
+dynamic-URL problem). The only hard blocker is organizational, not
+technical: one-time admin involvement in the Antimetal workspace. Build the
+receiver half first — it works today with a manually-registered webhook and a
+named tunnel, and the auto-registration half layers on cleanly whenever an
+admin credential is available.

--- a/docs/plans/2026-07-09-coldstart-observation-plan.md
+++ b/docs/plans/2026-07-09-coldstart-observation-plan.md
@@ -1,0 +1,84 @@
+# Cold-start observation — test plan (grilling-locked)
+
+Locked with John 2026-07-09. Goal: observe a fresh-process, NO-cache-db cold
+start and answer four questions: (1) user-visible latency, (2) bottlenecks —
+what do we wait on, (3) where API complexity is consumed, (4) wasted or
+duplicate fetches.
+
+## Locked decisions
+
+- **Subject: the real service itself.** Stop `linearfs.service`, move
+  `~/.config/linearfs/cache.db` aside (the abort/restore path), start — a true
+  cold start under systemd with production config, telemetry, and mount path.
+  On success no restore: the new db is a warm cache by the end. Scratch-mount
+  variants rejected (same budget cost, less representative; running alongside
+  the live service is the recorded round-10 mistake).
+- **Timing: off-hours, budget-gated, unattended.** Confirmed live: complexity
+  limit 3,000,000/hr; a historical full cold sync can consume a whole window.
+  The runbook self-gates: start only when remaining ≥ ~2.5M (read from
+  metrics.jsonl or response headers). Abort criterion: remaining hits the
+  write-tier reserve floor before sync settles → stop service, restore backup
+  db, record where it died (that datapoint is itself a bottleneck finding).
+  Everything must come from recorded artifacts — nobody is watching.
+- **Two runs, consecutive hourly windows** (~2.5h total, one night):
+  - **Run A (pure)**: unattended cold start until sync settles. Clean baseline
+    for phase timing, complexity attribution, time-to-warm.
+  - **Run B (probed)**: wipe again after the window resets and budget
+    recovers; cold start with a scripted probe loop measuring user-visible
+    latency under sync pressure (SWR/promotion behavior). Kept separate so
+    probe-induced fetches don't contaminate Run A's attribution.
+- **Capture: request-timeline instrument built FIRST** (chosen over
+  debug-log-only capture): a per-request JSONL log — `{ts, op, vars,
+  duration_ms, status/outcome, complexity}` — config-gated
+  (`telemetry.requests.{enabled, path}`, off by default), written by the api
+  client at the one place responses settle. This is an application debug log,
+  not an OTEL signal — the metrics-only/traces-never policy is untouched.
+  Full vars (ids/cursors) are logged deliberately: duplicate-fetch detection
+  needs to see WHICH entity was fetched twice. Complexity comes from the
+  X-Complexity header the budget already reads.
+  Plus for the run window: `telemetry.file.interval` dropped to 10s (restored
+  to 60s after), debug logging on (journald carries `[sync]` phase lines).
+
+## Runbook (scripts/coldstart-observe.sh, `at`-schedulable)
+
+1. Preflight: assert service healthy; read remaining/reset from telemetry;
+   sleep until reset + remaining ≥ 2.5M.
+2. Snapshot: journal cursor, copy current metrics.jsonl aside, `mv cache.db
+   cache.db.pre-coldstart`.
+3. Flip config: telemetry interval 10s, request log on (config edits are
+   scripted + reverted in cleanup).
+4. `systemctl --user restart linearfs.service`; record T0; poll mount-ready
+   (first successful `ls` of the root) and record.
+5. Run A: wait until "settled" — pending_depth == 0 AND two consecutive sync
+   cycles with no detail outcomes AND catch-up mode off (all visible in
+   metrics.jsonl / journal); record T_settled. Collect artifacts.
+6. Gate again on the next window (remaining recovered); repeat 2–4, then
+   Run B: probe loop until settled — every 15s, wall-time each of:
+   `ls teams/`, `ls teams/ENG/issues | head`, `cat` one fixed issue.md,
+   `ls` that issue's `comments/`, `cat` a comment, `ls my/assigned/`,
+   `cat teams/ENG/cycles/current/…` — timestamps + durations to a probe log.
+   The probe set covers: skeleton reads, detail-triggering reads (SWR), and
+   viewer-dependent views.
+7. Cleanup: restore telemetry interval + request-log config, restart.
+   Artifacts per run: metrics.jsonl slice, requests.jsonl, journald slice
+   (from cursor), probe log, timestamps file.
+
+## Analysis (next session, produces docs/plans/…-coldstart-findings.md)
+
+- **Latency**: probe-log percentiles per path class over time-since-T0;
+  mount-ready time; time-to-first-team, time-to-warm (T_settled − T0).
+- **Bottlenecks**: journal phase lines + requests.jsonl waterfall (call
+  ordering, gaps = what we waited on); budget.decisions{decision=defer|wait}
+  and wait_duration during the run; pending_depth drain curve.
+- **Complexity attribution**: api.complexity histogram deltas per op +
+  requests.jsonl sum by op — ranked table of where the 3M goes.
+- **Wasted fetches**: requests.jsonl grouped by (op, vars) — any group with
+  count > 1 inside the run is a candidate duplicate (worker vs SWR races,
+  re-fetches of unchanged data); swr.triggers during catch-up (should the
+  worker's own churn be triggering SWR?); detail_outcomes deferred→retried
+  churn; per-cycle re-fetch of workspace/team metadata that didn't change.
+
+## Pre-work (one PR before the runs)
+
+`feat/request-timeline-log`: the requests.jsonl instrument + the runbook
+script + probe script. Off-by-default; zero cost when disabled.

--- a/docs/plans/2026-07-09-view-dir-attrs-design.md
+++ b/docs/plans/2026-07-09-view-dir-attrs-design.md
@@ -1,0 +1,36 @@
+# View/entity directory normalization — round-18 card 4 (grilling-locked)
+
+Locked with John 2026-07-09. One PR, full normalization.
+
+## Friction
+~10 hand-rolled Lookup attr blocks (root.go ×4, cycles.go, filter.go ×2,
+my.go, teams.go, users.go) stamping `time.Now()` — every `ls -l` of the mount
+root or a view parent reshuffles times, the drift attrNode exists to kill —
+plus the recorded ino-namespace inconsistency: these nodes (and TeamNode /
+UserNode, per the nodeRefresher CONTEXT entry) use auto-assigned inos,
+dodging rather than solving the captured-snapshot staleness bug.
+
+## Locked decisions
+- **Full normalization, everything in one PR** (grilled; the conservative
+  view-dirs-only split and a times-only fix were offered and declined):
+  every directory node currently on auto inos gets a stable ino, routes
+  through `newDirInode` (attrNode mixin ⇒ Lookup==Getattr by construction),
+  and reports honest times.
+- Nodes in scope: TeamsNode, UsersNode, MyNode, InitiativesNode (stateless
+  containers — zero times, no refresh needs), CyclesNode{team},
+  CycleDirNode{team,cycle}, RecentNode{team}, the by/ filter dirs
+  (ByNode/FilterTypeNode/FilterValueNode shapes), my/ subdirs, **TeamNode**
+  (teams/{KEY}) and **UserNode** (users/{name}) — the per-entity dirs, fully
+  erasing the recorded inconsistency.
+- Times: entity times where they exist (team times for TeamNode/CyclesNode/
+  RecentNode; cycle times for CycleDirNode), zero (honest unknown) for
+  stateless containers and UserNode (api.User has no time fields).
+- Snapshot carriers implement the nodeRefresher seam (entity()/setEntity
+  under attrNode.stateMu, refreshFrom re-stamps nodeAttr) so kernel-reused
+  nodes pick up fresh snapshots — the round-15 pattern.
+- New ino wrappers per kind with composite keys where needed (e.g.
+  filter-value dirs key on team+category+value), all registered in
+  TestInodeNamespaceDistinct.
+- Guard: extend the round-15 pinned-fd revalidation test technique to a
+  TeamNode case (remote team change visible after entry-timeout expiry with
+  the inode chain pinned).

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -20,7 +20,8 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/jra3/linear-fuse/internal/telemetry"
 )
 
 // apiMetrics holds the api-layer instruments (meter "linearfs/api"):
@@ -33,9 +34,9 @@ type apiMetrics struct {
 func newAPIMetrics() apiMetrics {
 	m := otel.Meter("linearfs/api")
 	return apiMetrics{
-		requests: mustInt64Counter(m, "linearfs.api.requests",
+		requests: telemetry.MustInt64Counter(m, "linearfs.api.requests",
 			metric.WithDescription("GraphQL requests completed, by operation and outcome (ok|error|ratelimited)")),
-		duration: mustFloat64Histogram(m, "linearfs.api.duration",
+		duration: telemetry.MustFloat64Histogram(m, "linearfs.api.duration",
 			metric.WithUnit("s"),
 			metric.WithDescription("GraphQL request duration by operation")),
 	}
@@ -80,11 +81,11 @@ func newBudgetMetrics() budgetMetrics {
 	apiMeter := otel.Meter("linearfs/api")
 	budgetMeter := otel.Meter("linearfs/budget")
 	return budgetMetrics{
-		complexity: mustFloat64Histogram(apiMeter, "linearfs.api.complexity",
+		complexity: telemetry.MustFloat64Histogram(apiMeter, "linearfs.api.complexity",
 			metric.WithDescription("Actual X-Complexity cost of each response, by operation")),
-		decisions: mustInt64Counter(budgetMeter, "linearfs.budget.decisions",
+		decisions: telemetry.MustInt64Counter(budgetMeter, "linearfs.budget.decisions",
 			metric.WithDescription("Rate-budget ladder verdicts, by tier and decision (admit|defer|wait|ratelimited)")),
-		waitDuration: mustFloat64Histogram(budgetMeter, "linearfs.budget.wait_duration",
+		waitDuration: telemetry.MustFloat64Histogram(budgetMeter, "linearfs.budget.wait_duration",
 			metric.WithUnit("s"),
 			metric.WithDescription("Time spent waiting on rate limiting (limiter smoothing and mutation window waits)")),
 	}
@@ -146,26 +147,4 @@ func registerBudgetGauges(b *rateBudget) {
 	if err != nil {
 		log.Printf("telemetry: budget gauge callback not registered: %v", err)
 	}
-}
-
-// mustInt64Counter / mustFloat64Histogram degrade an instrument-creation
-// failure (invalid name — a programming error) to a logged no-op instead of
-// a nil that would panic at record time. Telemetry must never take the
-// client down.
-func mustInt64Counter(m metric.Meter, name string, opts ...metric.Int64CounterOption) metric.Int64Counter {
-	c, err := m.Int64Counter(name, opts...)
-	if err != nil {
-		log.Printf("telemetry: creating %s: %v", name, err)
-		c, _ = noop.NewMeterProvider().Meter("noop").Int64Counter(name)
-	}
-	return c
-}
-
-func mustFloat64Histogram(m metric.Meter, name string, opts ...metric.Float64HistogramOption) metric.Float64Histogram {
-	h, err := m.Float64Histogram(name, opts...)
-	if err != nil {
-		log.Printf("telemetry: creating %s: %v", name, err)
-		h, _ = noop.NewMeterProvider().Meter("noop").Float64Histogram(name)
-	}
-	return h
 }

--- a/internal/fs/linearfs_test.go
+++ b/internal/fs/linearfs_test.go
@@ -161,19 +161,6 @@ func TestSQLiteFilteredQueries(t *testing.T) {
 		}
 	})
 
-	t.Run("GetFilteredIssuesByPriority", func(t *testing.T) {
-		issues, err := lfs.repo.GetIssuesByPriority(ctx, "team-1", 4)
-		if err != nil {
-			t.Fatalf("GetFilteredIssuesByPriority failed: %v", err)
-		}
-		if len(issues) != 1 {
-			t.Errorf("Expected 1 urgent priority issue, got %d", len(issues))
-		}
-		if len(issues) > 0 && issues[0].Identifier != "TST-1" {
-			t.Errorf("Expected TST-1, got %s", issues[0].Identifier)
-		}
-	})
-
 	t.Run("GetFilteredIssuesByAssignee", func(t *testing.T) {
 		issues, err := lfs.repo.GetIssuesByAssignee(ctx, "team-1", "user-1")
 		if err != nil {

--- a/internal/marshal/metaguard_test.go
+++ b/internal/marshal/metaguard_test.go
@@ -1,0 +1,72 @@
+package marshal
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestEveryEditableRenderHasMetaTwin is the completeness guard for the
+// editable-only split (CONTEXT.md "Entity render" / "Collection meta split"):
+// every editable entity's XToMarkdown must ship with an XMetaToMarkdown, so an
+// eighth editable entity cannot land without its .meta sidecar render. The
+// scan reads this package's source (the fixture-parity precedent of scanning
+// the applied schema), so a new render is caught the moment it is written —
+// not when someone remembers to extend a hand-kept list.
+func TestEveryEditableRenderHasMetaTwin(t *testing.T) {
+	t.Parallel()
+
+	// Read-only generated renders with no editable file — no .meta twin exists
+	// or should. Extending this list is a deliberate act with a reason.
+	readOnly := map[string]string{
+		"History": "history.md is a read-only generated file (renderFile), not an editable entity",
+	}
+
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fn := regexp.MustCompile(`(?m)^func (\w+?)(Meta)?ToMarkdown\(`)
+
+	renders := map[string]bool{} // base name -> has plain render
+	metas := map[string]bool{}   // base name -> has meta render
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, m := range fn.FindAllStringSubmatch(string(src), -1) {
+			if m[2] == "Meta" {
+				metas[m[1]] = true
+			} else {
+				renders[m[1]] = true
+			}
+		}
+	}
+
+	if len(renders) == 0 {
+		t.Fatal("scan found no XToMarkdown functions — the regex or the working directory is wrong")
+	}
+
+	for base := range renders {
+		if readOnly[base] != "" {
+			if metas[base] {
+				t.Errorf("%sToMarkdown is on the read-only exclusion list (%s) but has a Meta twin — remove it from the list", base, readOnly[base])
+			}
+			continue
+		}
+		if !metas[base] {
+			t.Errorf("%sToMarkdown has no %sMetaToMarkdown twin: every editable entity render needs its .meta sidecar render (the editable-only split). If %s is genuinely read-only, add it to this test's exclusion list with a reason.", base, base, base)
+		}
+	}
+	for base := range metas {
+		if !renders[base] {
+			t.Errorf("%sMetaToMarkdown has no %sToMarkdown counterpart — a meta sidecar with no editable file makes no sense", base, base)
+		}
+	}
+}

--- a/internal/repo/sqlite.go
+++ b/internal/repo/sqlite.go
@@ -457,16 +457,10 @@ func (r *SQLiteRepository) GetIssuesByLabel(ctx context.Context, teamID, labelID
 	return db.DBIssuesToAPIIssues(issues)
 }
 
-func (r *SQLiteRepository) GetIssuesByPriority(ctx context.Context, teamID string, priority int) ([]api.Issue, error) {
-	issues, err := r.store.Queries().ListTeamIssuesByPriority(ctx, db.ListTeamIssuesByPriorityParams{
-		TeamID:   teamID,
-		Priority: sql.NullInt64{Int64: int64(priority), Valid: true},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("list issues by priority: %w", err)
-	}
-	return db.DBIssuesToAPIIssues(issues)
-}
+// NB: GetIssuesByPriority was deleted (round 19) — it had no production
+// caller (there is no by/priority/ view). Its sqlc query
+// (ListTeamIssuesByPriority) is inert generated code awaiting removal at the
+// next `sqlc generate` (sqlc is not installed on this machine).
 
 func (r *SQLiteRepository) GetUnassignedIssues(ctx context.Context, teamID string) ([]api.Issue, error) {
 	issues, err := r.store.Queries().ListTeamUnassignedIssues(ctx, teamID)

--- a/internal/repo/sqlite_test.go
+++ b/internal/repo/sqlite_test.go
@@ -201,15 +201,6 @@ func TestSQLiteRepository_FilteredIssues(t *testing.T) {
 		t.Errorf("Expected 2 issues in state-1, got %d", len(stateIssues))
 	}
 
-	// Test GetIssuesByPriority
-	priorityIssues, err := repo.GetIssuesByPriority(ctx, "team-1", 1)
-	if err != nil {
-		t.Fatalf("GetIssuesByPriority failed: %v", err)
-	}
-	if len(priorityIssues) != 2 {
-		t.Errorf("Expected 2 issues with priority 1, got %d", len(priorityIssues))
-	}
-
 	// Test GetUnassignedIssues
 	unassigned, err := repo.GetUnassignedIssues(ctx, "team-1")
 	if err != nil {


### PR DESCRIPTION
The three small-wins items from the round-19 review: dedupe the phase-1 vestigial metric helpers onto telemetry.Must*, add the meta-render-twin completeness guard (source-scan, History excluded with reason), and delete the production-dead GetIssuesByPriority path (found during #215; its sqlc query awaits the next regen). Also commits the 13 accumulated docs/plans design docs (rounds 17-19 + OTEL/cold-start/webhook plans) — docs/plans/ is gitignore-whitelisted and older plans are already tracked. Full suite green including integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)