### PR TITLE
refactor: read fetch core — fetchOne/fetchNodes/fetchConn over one shared walkPath

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -777,6 +777,46 @@ is why stamping the syncing team was wrong). The team prune targets
 `team_id = <team>`, so `NULL` workspace labels are outside every team's prune
 scope.
 
+### Read fetch (`fetchOne`/`fetchNodes`/`fetchConn`)
+The **deep module** owning the read-side response envelope — the third
+sibling completing `execMutation` (the mutation envelope) and
+`paginate` (the connection drain). Every single-shot read on `Client`
+restated the same ritual: declare an anonymous result struct mirroring the
+JSON path from the response root, call `c.query`, unwrap the nested fields —
+copied ~21 times across client.go. The three fronts
+(`internal/api/fetch.go`) own it once over one shared descent, `walkPath`
+(extracted from `walkConn`, which is rebuilt on it — its
+`paginate:`-prefixed error strings are preserved verbatim); call sites keep
+only what genuinely varies: the query constant, the variable map, and the
+path. `fetchOne[T]` decodes the terminal into an entity; `fetchNodes[T]`
+decodes it as the `conn[T]` envelope and returns the nodes; `fetchConn[T]`
+returns the whole envelope for page-shaped callers (`GetTeamIssuesPage`) and
+errors on a nil `PageInfo` — the same "query must select pageInfo" contract
+as `fetchAll`. `GetTeamLabels` walks two connections out of one shared root
+(`connAt`) and keeps its dedup body.
+
+**The null policy is a deliberate behavior change.** A missing or null path
+element — the terminal included — is an error naming the dotted path
+(`fetch: "team.states" missing or null in response`), where the old
+anonymous structs decoded a null terminal as a **silent zero-value entity**
+(`GetIssue` of a nonexistent ID returned an empty `Issue`, nil error;
+`GetIssueDetails` of a vanished issue returned five empty, "complete"
+collections — the same null-reads-as-empty class the details batch had
+already closed for itself). `fetchNodes` also carries a truncation tripwire:
+a response that selects `pageInfo` and reports `hasNextPage` errors — the
+connection must be drained (`fetchAll`), never silently truncated. Inert
+today (no converted query selects `pageInfo`); live for any future query
+that does.
+
+Four read methods stay hand-written, each for cause: `GetTeamMetadata` and
+`GetWorkspace` are combined multi-connection queries already on
+`conn`+`drain`; `GetIssueDetailsBatch` builds dynamic aliases and owns its
+own all-or-nothing contract; `GetTeamDocuments` is an empty stub (Linear has
+no team-level documents). Recorded follow-up, deliberately not done in this
+refactor: ten of the converted list queries set no `first:` and are silently
+50-capped by Linear (and `GetIssueHistory`, which backs `history.md` live,
+caps at `first: 100` with no drain) — the drain audit is queued work.
+
 ### Sync reconcile tail (`syncCollection`)
 The **deep module** owning the invariant tail of every metadata sync — the
 sync-side sibling of the write-path tails (`commitCreate`/`commitWriteBack`/

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -413,33 +413,13 @@ func (c *Client) BudgetSnapshot() (count int, pct float64) {
 
 // GetTeams fetches all teams the user has access to
 func (c *Client) GetTeams(ctx context.Context) ([]Team, error) {
-	var result struct {
-		Teams struct {
-			Nodes []Team `json:"nodes"`
-		} `json:"teams"`
-	}
-
-	err := c.query(ctx, queryTeams, nil, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.Teams.Nodes, nil
+	return fetchNodes[Team](ctx, c, queryTeams, nil, "teams")
 }
 
 // GetTeamIssuesPage fetches a single page of issues ordered by updatedAt DESC.
 // Returns the issues, page info, and any error.
 // Use cursor="" for the first page.
 func (c *Client) GetTeamIssuesPage(ctx context.Context, teamID string, cursor string, pageSize int) ([]Issue, PageInfo, error) {
-	var result struct {
-		Team struct {
-			Issues struct {
-				PageInfo PageInfo `json:"pageInfo"`
-				Nodes    []Issue  `json:"nodes"`
-			} `json:"issues"`
-		} `json:"team"`
-	}
-
 	vars := map[string]any{
 		"teamId": teamID,
 		"first":  pageSize,
@@ -448,48 +428,21 @@ func (c *Client) GetTeamIssuesPage(ctx context.Context, teamID string, cursor st
 		vars["after"] = cursor
 	}
 
-	err := c.query(ctx, queryTeamIssuesByUpdatedAt, vars, &result)
+	cn, err := fetchConn[Issue](ctx, c, queryTeamIssuesByUpdatedAt, vars, "team", "issues")
 	if err != nil {
 		return nil, PageInfo{}, err
 	}
-
-	return result.Team.Issues.Nodes, result.Team.Issues.PageInfo, nil
+	return cn.Nodes, *cn.PageInfo, nil
 }
 
 // GetIssue fetches a single issue by ID
 func (c *Client) GetIssue(ctx context.Context, issueID string) (*Issue, error) {
-	var result struct {
-		Issue Issue `json:"issue"`
-	}
-
-	vars := map[string]any{
-		"id": issueID,
-	}
-
-	err := c.query(ctx, queryIssue, vars, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return &result.Issue, nil
+	return fetchOne[Issue](ctx, c, queryIssue, map[string]any{"id": issueID}, "issue")
 }
 
 // GetProject fetches a single project by ID
 func (c *Client) GetProject(ctx context.Context, projectID string) (*Project, error) {
-	var result struct {
-		Project Project `json:"project"`
-	}
-
-	vars := map[string]any{
-		"id": projectID,
-	}
-
-	err := c.query(ctx, queryProject, vars, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return &result.Project, nil
+	return fetchOne[Project](ctx, c, queryProject, map[string]any{"id": projectID}, "project")
 }
 
 // UpdateIssue updates an existing issue
@@ -638,24 +591,8 @@ func (c *Client) GetWorkspace(ctx context.Context) (*WorkspaceData, error) {
 
 // GetTeamStates fetches workflow states for a team
 func (c *Client) GetTeamStates(ctx context.Context, teamID string) ([]State, error) {
-	var result struct {
-		Team struct {
-			States struct {
-				Nodes []State `json:"nodes"`
-			} `json:"states"`
-		} `json:"team"`
-	}
-
-	vars := map[string]any{
-		"teamId": teamID,
-	}
-
-	err := c.query(ctx, queryTeamStates, vars, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.Team.States.Nodes, nil
+	return fetchNodes[State](ctx, c, queryTeamStates,
+		map[string]any{"teamId": teamID}, "team", "states")
 }
 
 // GetTeamProjects fetches all projects for a team. Paginated: a team's
@@ -676,24 +613,8 @@ func (c *Client) GetProjectLabels(ctx context.Context) ([]ProjectLabel, error) {
 
 // GetProjectMilestones fetches milestones for a project
 func (c *Client) GetProjectMilestones(ctx context.Context, projectID string) ([]ProjectMilestone, error) {
-	var result struct {
-		Project struct {
-			ProjectMilestones struct {
-				Nodes []ProjectMilestone `json:"nodes"`
-			} `json:"projectMilestones"`
-		} `json:"project"`
-	}
-
-	vars := map[string]any{
-		"projectId": projectID,
-	}
-
-	err := c.query(ctx, queryProjectMilestones, vars, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.Project.ProjectMilestones.Nodes, nil
+	return fetchNodes[ProjectMilestone](ctx, c, queryProjectMilestones,
+		map[string]any{"projectId": projectID}, "project", "projectMilestones")
 }
 
 // CreateProjectMilestone creates a new milestone for a project
@@ -730,24 +651,8 @@ func (c *Client) DeleteProjectMilestone(ctx context.Context, milestoneID string)
 
 // GetProjectUpdates fetches status updates for a project
 func (c *Client) GetProjectUpdates(ctx context.Context, projectID string) ([]ProjectUpdate, error) {
-	var result struct {
-		Project struct {
-			ProjectUpdates struct {
-				Nodes []ProjectUpdate `json:"nodes"`
-			} `json:"projectUpdates"`
-		} `json:"project"`
-	}
-
-	vars := map[string]any{
-		"projectId": projectID,
-	}
-
-	err := c.query(ctx, queryProjectUpdates, vars, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.Project.ProjectUpdates.Nodes, nil
+	return fetchNodes[ProjectUpdate](ctx, c, queryProjectUpdates,
+		map[string]any{"projectId": projectID}, "project", "projectUpdates")
 }
 
 // CreateProjectUpdate creates a new status update on a project
@@ -764,24 +669,8 @@ func (c *Client) CreateProjectUpdate(ctx context.Context, projectID, body, healt
 
 // GetInitiativeUpdates fetches status updates for an initiative
 func (c *Client) GetInitiativeUpdates(ctx context.Context, initiativeID string) ([]InitiativeUpdate, error) {
-	var result struct {
-		Initiative struct {
-			InitiativeUpdates struct {
-				Nodes []InitiativeUpdate `json:"nodes"`
-			} `json:"initiativeUpdates"`
-		} `json:"initiative"`
-	}
-
-	vars := map[string]any{
-		"initiativeId": initiativeID,
-	}
-
-	err := c.query(ctx, queryInitiativeUpdates, vars, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.Initiative.InitiativeUpdates.Nodes, nil
+	return fetchNodes[InitiativeUpdate](ctx, c, queryInitiativeUpdates,
+		map[string]any{"initiativeId": initiativeID}, "initiative", "initiativeUpdates")
 }
 
 // CreateInitiativeUpdate creates a new status update on an initiative
@@ -818,44 +707,23 @@ func (c *Client) RemoveProjectFromInitiative(ctx context.Context, projectID, ini
 
 // GetTeamCycles fetches cycles for a team
 func (c *Client) GetTeamCycles(ctx context.Context, teamID string) ([]Cycle, error) {
-	var result struct {
-		Team struct {
-			Cycles struct {
-				Nodes []Cycle `json:"nodes"`
-			} `json:"cycles"`
-		} `json:"team"`
-	}
+	return fetchNodes[Cycle](ctx, c, queryTeamCycles,
+		map[string]any{"teamId": teamID}, "team", "cycles")
+}
 
-	vars := map[string]any{
-		"teamId": teamID,
+// GetTeamLabels fetches labels for a team (team + workspace labels). One
+// query carries two connections, so it walks the shared root twice instead
+// of going through a single-path front.
+func (c *Client) GetTeamLabels(ctx context.Context, teamID string) ([]Label, error) {
+	var root map[string]json.RawMessage
+	if err := c.query(ctx, queryTeamLabels, map[string]any{"teamId": teamID}, &root); err != nil {
+		return nil, err
 	}
-
-	err := c.query(ctx, queryTeamCycles, vars, &result)
+	teamLabels, err := connAt[Label](root, []string{"team", "labels"})
 	if err != nil {
 		return nil, err
 	}
-
-	return result.Team.Cycles.Nodes, nil
-}
-
-// GetTeamLabels fetches labels for a team (team + workspace labels)
-func (c *Client) GetTeamLabels(ctx context.Context, teamID string) ([]Label, error) {
-	var result struct {
-		Team struct {
-			Labels struct {
-				Nodes []Label `json:"nodes"`
-			} `json:"labels"`
-		} `json:"team"`
-		IssueLabels struct {
-			Nodes []Label `json:"nodes"`
-		} `json:"issueLabels"`
-	}
-
-	vars := map[string]any{
-		"teamId": teamID,
-	}
-
-	err := c.query(ctx, queryTeamLabels, vars, &result)
+	workspaceLabels, err := connAt[Label](root, []string{"issueLabels"})
 	if err != nil {
 		return nil, err
 	}
@@ -863,13 +731,13 @@ func (c *Client) GetTeamLabels(ctx context.Context, teamID string) ([]Label, err
 	// Combine team labels and workspace labels, deduplicating by ID
 	seen := make(map[string]bool)
 	var labels []Label
-	for _, l := range result.Team.Labels.Nodes {
+	for _, l := range teamLabels.Nodes {
 		if !seen[l.ID] {
 			seen[l.ID] = true
 			labels = append(labels, l)
 		}
 	}
-	for _, l := range result.IssueLabels.Nodes {
+	for _, l := range workspaceLabels.Nodes {
 		if !seen[l.ID] {
 			seen[l.ID] = true
 			labels = append(labels, l)
@@ -896,54 +764,18 @@ func (c *Client) DeleteLabel(ctx context.Context, id string) error {
 
 // GetUsers fetches all users in the workspace
 func (c *Client) GetUsers(ctx context.Context) ([]User, error) {
-	var result struct {
-		Users struct {
-			Nodes []User `json:"nodes"`
-		} `json:"users"`
-	}
-
-	err := c.query(ctx, queryUsers, nil, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.Users.Nodes, nil
+	return fetchNodes[User](ctx, c, queryUsers, nil, "users")
 }
 
 // GetViewer fetches the currently authenticated user
 func (c *Client) GetViewer(ctx context.Context) (*User, error) {
-	var result struct {
-		Viewer User `json:"viewer"`
-	}
-
-	err := c.query(ctx, queryViewer, nil, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return &result.Viewer, nil
+	return fetchOne[User](ctx, c, queryViewer, nil, "viewer")
 }
 
 // GetTeamMembers fetches members of a specific team
 func (c *Client) GetTeamMembers(ctx context.Context, teamID string) ([]User, error) {
-	var result struct {
-		Team struct {
-			Members struct {
-				Nodes []User `json:"nodes"`
-			} `json:"members"`
-		} `json:"team"`
-	}
-
-	vars := map[string]any{
-		"teamId": teamID,
-	}
-
-	err := c.query(ctx, queryTeamMembers, vars, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.Team.Members.Nodes, nil
+	return fetchNodes[User](ctx, c, queryTeamMembers,
+		map[string]any{"teamId": teamID}, "team", "members")
 }
 
 // CreateIssue creates a new issue
@@ -993,22 +825,15 @@ func (p issueDetailsPayload) toDetails() *IssueDetails {
 }
 
 // GetIssueDetails fetches comments, documents, attachments, and relations for
-// an issue in a single query
+// an issue in a single query. A null issue (not found) is an error, never
+// five empty, "complete" collections — the same contract as the batch.
 func (c *Client) GetIssueDetails(ctx context.Context, issueID string) (*IssueDetails, error) {
-	var result struct {
-		Issue issueDetailsPayload `json:"issue"`
-	}
-
-	vars := map[string]any{
-		"issueId": issueID,
-	}
-
-	err := c.query(ctx, queryIssueDetails, vars, &result)
+	payload, err := fetchOne[issueDetailsPayload](ctx, c, queryIssueDetails,
+		map[string]any{"issueId": issueID}, "issue")
 	if err != nil {
 		return nil, err
 	}
-
-	return result.Issue.toDetails(), nil
+	return payload.toDetails(), nil
 }
 
 // GetIssueDetailsBatch fetches comments, documents, attachments, and relations
@@ -1089,24 +914,8 @@ func (c *Client) GetIssueDetailsBatch(ctx context.Context, issueIDs []string) (m
 
 // GetIssueComments fetches comments for an issue
 func (c *Client) GetIssueComments(ctx context.Context, issueID string) ([]Comment, error) {
-	var result struct {
-		Issue struct {
-			Comments struct {
-				Nodes []Comment `json:"nodes"`
-			} `json:"comments"`
-		} `json:"issue"`
-	}
-
-	vars := map[string]any{
-		"issueId": issueID,
-	}
-
-	err := c.query(ctx, queryIssueComments, vars, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.Issue.Comments.Nodes, nil
+	return fetchNodes[Comment](ctx, c, queryIssueComments,
+		map[string]any{"issueId": issueID}, "issue", "comments")
 }
 
 // CreateComment creates a new comment on an issue
@@ -1126,68 +935,20 @@ func (c *Client) DeleteComment(ctx context.Context, commentID string) error {
 
 // GetIssueDocuments fetches documents attached to an issue
 func (c *Client) GetIssueDocuments(ctx context.Context, issueID string) ([]Document, error) {
-	var result struct {
-		Issue struct {
-			Documents struct {
-				Nodes []Document `json:"nodes"`
-			} `json:"documents"`
-		} `json:"issue"`
-	}
-
-	vars := map[string]any{
-		"issueId": issueID,
-	}
-
-	err := c.query(ctx, queryIssueDocuments, vars, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.Issue.Documents.Nodes, nil
+	return fetchNodes[Document](ctx, c, queryIssueDocuments,
+		map[string]any{"issueId": issueID}, "issue", "documents")
 }
 
 // GetIssueAttachments fetches attachments (external links) for an issue
 func (c *Client) GetIssueAttachments(ctx context.Context, issueID string) ([]Attachment, error) {
-	var result struct {
-		Issue struct {
-			Attachments struct {
-				Nodes []Attachment `json:"nodes"`
-			} `json:"attachments"`
-		} `json:"issue"`
-	}
-
-	vars := map[string]any{
-		"issueId": issueID,
-	}
-
-	err := c.query(ctx, queryIssueAttachments, vars, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.Issue.Attachments.Nodes, nil
+	return fetchNodes[Attachment](ctx, c, queryIssueAttachments,
+		map[string]any{"issueId": issueID}, "issue", "attachments")
 }
 
 // GetIssueHistory fetches the history/audit trail for an issue
 func (c *Client) GetIssueHistory(ctx context.Context, issueID string) ([]IssueHistoryEntry, error) {
-	var result struct {
-		Issue struct {
-			History struct {
-				Nodes []IssueHistoryEntry `json:"nodes"`
-			} `json:"history"`
-		} `json:"issue"`
-	}
-
-	vars := map[string]any{
-		"issueId": issueID,
-	}
-
-	err := c.query(ctx, queryIssueHistory, vars, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.Issue.History.Nodes, nil
+	return fetchNodes[IssueHistoryEntry](ctx, c, queryIssueHistory,
+		map[string]any{"issueId": issueID}, "issue", "history")
 }
 
 // GetTeamDocuments returns an empty list since Linear API doesn't support team-level documents
@@ -1198,42 +959,14 @@ func (c *Client) GetTeamDocuments(ctx context.Context, teamID string) ([]Documen
 
 // GetProjectDocuments fetches documents for a project
 func (c *Client) GetProjectDocuments(ctx context.Context, projectID string) ([]Document, error) {
-	var result struct {
-		Documents struct {
-			Nodes []Document `json:"nodes"`
-		} `json:"documents"`
-	}
-
-	vars := map[string]any{
-		"projectId": projectID,
-	}
-
-	err := c.query(ctx, queryProjectDocuments, vars, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.Documents.Nodes, nil
+	return fetchNodes[Document](ctx, c, queryProjectDocuments,
+		map[string]any{"projectId": projectID}, "documents")
 }
 
 // GetInitiativeDocuments fetches documents for an initiative
 func (c *Client) GetInitiativeDocuments(ctx context.Context, initiativeID string) ([]Document, error) {
-	var result struct {
-		Documents struct {
-			Nodes []Document `json:"nodes"`
-		} `json:"documents"`
-	}
-
-	vars := map[string]any{
-		"initiativeId": initiativeID,
-	}
-
-	err := c.query(ctx, queryInitiativeDocuments, vars, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.Documents.Nodes, nil
+	return fetchNodes[Document](ctx, c, queryInitiativeDocuments,
+		map[string]any{"initiativeId": initiativeID}, "documents")
 }
 
 // CreateDocument creates a new document
@@ -1253,36 +986,12 @@ func (c *Client) DeleteDocument(ctx context.Context, documentID string) error {
 
 // GetInitiatives fetches all initiatives
 func (c *Client) GetInitiatives(ctx context.Context) ([]Initiative, error) {
-	var result struct {
-		Initiatives struct {
-			Nodes []Initiative `json:"nodes"`
-		} `json:"initiatives"`
-	}
-
-	err := c.query(ctx, queryInitiatives, nil, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.Initiatives.Nodes, nil
+	return fetchNodes[Initiative](ctx, c, queryInitiatives, nil, "initiatives")
 }
 
 // GetInitiative fetches a single initiative by ID
 func (c *Client) GetInitiative(ctx context.Context, initiativeID string) (*Initiative, error) {
-	var result struct {
-		Initiative Initiative `json:"initiative"`
-	}
-
-	vars := map[string]any{
-		"id": initiativeID,
-	}
-
-	err := c.query(ctx, queryInitiative, vars, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return &result.Initiative, nil
+	return fetchOne[Initiative](ctx, c, queryInitiative, map[string]any{"id": initiativeID}, "initiative")
 }
 
 // =============================================================================

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -370,14 +370,11 @@ func TestMockReset(t *testing.T) {
 		t.Errorf("expected 0 calls after reset, got %d", len(mock.Calls()))
 	}
 
-	// Should return empty data now
-	teams, err := client.GetTeams(context.Background())
-	if err != nil {
-		t.Fatalf("GetTeams failed: %v", err)
-	}
-
-	if len(teams) != 0 {
-		t.Errorf("expected 0 teams after reset, got %d", len(teams))
+	// The mock now returns empty data — under the fetch null policy that is
+	// a loud error, not a silent empty team list.
+	_, err := client.GetTeams(context.Background())
+	if err == nil || !strings.Contains(err.Error(), `"teams" missing or null`) {
+		t.Fatalf("GetTeams after reset: err = %v, want missing-or-null error", err)
 	}
 }
 

--- a/internal/api/fetch.go
+++ b/internal/api/fetch.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// The read fetch core.
+//
+// Every Linear read answers with the same envelope: a data root whose nested
+// fields path down to one entity or one connection. The per-method
+// declare-anonymous-struct / call / unwrap sequence was copied ~21 times
+// across client.go; these helpers own it once, the way exec.go owns the
+// mutation envelope and paginate.go owns the connection drain. Call sites
+// keep only what genuinely varies: the query constant, the variable map, and
+// the JSON path from the response root to the payload.
+//
+// Null policy — a DELIBERATE behavior change: a missing or null element
+// anywhere on the path, including the terminal, is an error naming the
+// dotted path walked so far, prefixed "fetch:". The old anonymous structs
+// decoded a null terminal as a silent zero-value entity (GetIssue of a
+// nonexistent ID returned an empty Issue with a nil error); these fronts
+// refuse instead.
+//
+// The helpers never mutate the caller's vars map.
+
+// walkPath descends path from the decoded data root and returns the raw
+// terminal value. A missing or null element errors naming the path walked so
+// far. Errors carry no module prefix — callers wrap ("fetch: %w" here,
+// "paginate: %w" in walkConn) so both fronts share one descent.
+func walkPath(root map[string]json.RawMessage, path []string) (json.RawMessage, error) {
+	if len(path) == 0 {
+		return nil, fmt.Errorf("empty path")
+	}
+	cur := root
+	for i, elem := range path {
+		raw, ok := cur[elem]
+		if !ok || string(raw) == "null" {
+			return nil, fmt.Errorf("%q missing or null in response", strings.Join(path[:i+1], "."))
+		}
+		if i == len(path)-1 {
+			return raw, nil
+		}
+		next := make(map[string]json.RawMessage)
+		if err := json.Unmarshal(raw, &next); err != nil {
+			return nil, fmt.Errorf("decode object at %q: %w", strings.Join(path[:i+1], "."), err)
+		}
+		cur = next
+	}
+	// Unreachable: the loop returns on the last element.
+	return nil, fmt.Errorf("empty path")
+}
+
+// fetchPath executes the query and walks path from the data root, returning
+// the raw terminal value with fetch-front error prefixes.
+func fetchPath(ctx context.Context, c *Client, query string, vars map[string]any, path []string) (json.RawMessage, error) {
+	var root map[string]json.RawMessage
+	if err := c.query(ctx, query, vars, &root); err != nil {
+		return nil, err
+	}
+	raw, err := walkPath(root, path)
+	if err != nil {
+		return nil, fmt.Errorf("fetch: %w", err)
+	}
+	return raw, nil
+}
+
+// fetchOne executes the query and decodes the terminal value at path into T.
+// A missing or null terminal is an error (see the null policy above), never
+// a zero-value entity.
+func fetchOne[T any](ctx context.Context, c *Client, query string, vars map[string]any, path ...string) (*T, error) {
+	raw, err := fetchPath(ctx, c, query, vars, path)
+	if err != nil {
+		return nil, err
+	}
+	var entity T
+	if err := json.Unmarshal(raw, &entity); err != nil {
+		return nil, fmt.Errorf("fetch: decode %q: %w", strings.Join(path, "."), err)
+	}
+	return &entity, nil
+}
+
+// connAt walks path from an already-decoded root and decodes the terminal as
+// a connection envelope, with fetch-front error prefixes. It applies no
+// PageInfo policy — that belongs to the front (fetchNodes tolerates an
+// absent pageInfo, fetchConn requires one). Also usable directly against a
+// root a caller decoded itself (GetTeamLabels walks two connections out of
+// one response).
+func connAt[T any](root map[string]json.RawMessage, path []string) (conn[T], error) {
+	raw, err := walkPath(root, path)
+	if err != nil {
+		return conn[T]{}, fmt.Errorf("fetch: %w", err)
+	}
+	var cn conn[T]
+	if err := json.Unmarshal(raw, &cn); err != nil {
+		return conn[T]{}, fmt.Errorf("fetch: decode connection at %q: %w", strings.Join(path, "."), err)
+	}
+	return cn, nil
+}
+
+// fetchNodes executes the query, decodes the connection envelope at path,
+// and returns its nodes.
+//
+// Truncation tripwire: a response that selects pageInfo and reports
+// hasNextPage is an error — the connection has more pages and must be
+// drained (fetchAll), never silently truncated. Inert today (no converted
+// query selects pageInfo), live for any future query that does. An absent
+// pageInfo is fine: single-page queries don't select it.
+func fetchNodes[T any](ctx context.Context, c *Client, query string, vars map[string]any, path ...string) ([]T, error) {
+	var root map[string]json.RawMessage
+	if err := c.query(ctx, query, vars, &root); err != nil {
+		return nil, err
+	}
+	cn, err := connAt[T](root, path)
+	if err != nil {
+		return nil, err
+	}
+	if cn.PageInfo != nil && cn.PageInfo.HasNextPage {
+		return nil, fmt.Errorf("fetch: connection %q has more pages — it must be drained (fetchAll), not fetched single-page", strings.Join(path, "."))
+	}
+	return cn.Nodes, nil
+}
+
+// fetchConn executes the query and returns the whole connection envelope at
+// path. A page-shaped caller needs the PageInfo, so a response missing it is
+// an error — the same contract as fetchAll's "query must select pageInfo".
+func fetchConn[T any](ctx context.Context, c *Client, query string, vars map[string]any, path ...string) (conn[T], error) {
+	var root map[string]json.RawMessage
+	if err := c.query(ctx, query, vars, &root); err != nil {
+		return conn[T]{}, err
+	}
+	cn, err := connAt[T](root, path)
+	if err != nil {
+		return conn[T]{}, err
+	}
+	if cn.PageInfo == nil {
+		return conn[T]{}, fmt.Errorf("fetch: connection %q missing pageInfo (query must select it)", strings.Join(path, "."))
+	}
+	return cn, nil
+}

--- a/internal/api/fetch_test.go
+++ b/internal/api/fetch_test.go
@@ -1,0 +1,241 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jra3/linear-fuse/internal/testutil"
+)
+
+// rawRoot decodes a JSON object literal into the shape walkPath descends.
+func rawRoot(t *testing.T, s string) map[string]json.RawMessage {
+	t.Helper()
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(s), &root); err != nil {
+		t.Fatalf("rawRoot: %v", err)
+	}
+	return root
+}
+
+func TestWalkPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		root    string
+		path    []string
+		want    string // expected raw terminal (exact JSON), "" if error expected
+		wantErr string // substring the error must contain, "" if success expected
+	}{
+		{
+			name: "terminal decode",
+			root: `{"team": {"states": {"nodes": [{"id": "s1"}]}}}`,
+			path: []string{"team", "states"},
+			want: `{"nodes": [{"id": "s1"}]}`,
+		},
+		{
+			name: "deep path",
+			root: `{"a": {"b": {"c": {"d": 42}}}}`,
+			path: []string{"a", "b", "c", "d"},
+			want: `42`,
+		},
+		{
+			name:    "missing key",
+			root:    `{"team": {"labels": {}}}`,
+			path:    []string{"team", "states"},
+			wantErr: `"team.states" missing or null in response`,
+		},
+		{
+			name:    "null value",
+			root:    `{"team": null}`,
+			path:    []string{"team", "states"},
+			wantErr: `"team" missing or null in response`,
+		},
+		{
+			name:    "null terminal",
+			root:    `{"issue": null}`,
+			path:    []string{"issue"},
+			wantErr: `"issue" missing or null in response`,
+		},
+		{
+			name:    "empty path",
+			root:    `{"issue": {}}`,
+			path:    nil,
+			wantErr: "empty path",
+		},
+		{
+			name:    "non-object intermediate",
+			root:    `{"team": [1, 2]}`,
+			path:    []string{"team", "states"},
+			wantErr: `decode object at "team"`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := walkPath(rawRoot(t, tc.root), tc.path)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("walkPath: %v", err)
+			}
+			if string(raw) != tc.want {
+				t.Errorf("terminal = %s, want %s", raw, tc.want)
+			}
+		})
+	}
+}
+
+// fetchTestClient builds a Client pointed at the mock server.
+func fetchTestClient(t *testing.T) (*testutil.MockLinearServer, *Client) {
+	t.Helper()
+	mock := testutil.NewMockLinearServer()
+	t.Cleanup(mock.Close)
+	c := NewClient("test-key")
+	c.SetAPIURL(mock.URL())
+	return mock, c
+}
+
+const fetchTestQuery = `query Things($id: String!) { thing(id: $id) { things { nodes { id } } } }`
+
+func TestFetchNodesTripwire(t *testing.T) {
+	nodes := []map[string]any{{"id": "n1"}, {"id": "n2"}}
+
+	t.Run("hasNextPage true is an error", func(t *testing.T) {
+		mock, c := fetchTestClient(t)
+		mock.SetResponse("Things", map[string]any{
+			"thing": map[string]any{"things": map[string]any{
+				"pageInfo": map[string]any{"hasNextPage": true, "endCursor": "c1"},
+				"nodes":    nodes,
+			}},
+		})
+		_, err := fetchNodes[idNode](context.Background(), c, fetchTestQuery,
+			map[string]any{"id": "t1"}, "thing", "things")
+		if err == nil || !strings.Contains(err.Error(), "more pages") || !strings.Contains(err.Error(), `"thing.things"`) {
+			t.Fatalf("err = %v, want truncation tripwire naming thing.things", err)
+		}
+	})
+
+	t.Run("hasNextPage false is ok", func(t *testing.T) {
+		mock, c := fetchTestClient(t)
+		mock.SetResponse("Things", map[string]any{
+			"thing": map[string]any{"things": map[string]any{
+				"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+				"nodes":    nodes,
+			}},
+		})
+		got, err := fetchNodes[idNode](context.Background(), c, fetchTestQuery,
+			map[string]any{"id": "t1"}, "thing", "things")
+		if err != nil {
+			t.Fatalf("fetchNodes: %v", err)
+		}
+		if len(got) != 2 || got[0].ID != "n1" || got[1].ID != "n2" {
+			t.Errorf("nodes = %v, want [n1 n2]", got)
+		}
+	})
+
+	t.Run("absent pageInfo is ok", func(t *testing.T) {
+		mock, c := fetchTestClient(t)
+		mock.SetResponse("Things", map[string]any{
+			"thing": map[string]any{"things": map[string]any{"nodes": nodes}},
+		})
+		got, err := fetchNodes[idNode](context.Background(), c, fetchTestQuery,
+			map[string]any{"id": "t1"}, "thing", "things")
+		if err != nil {
+			t.Fatalf("fetchNodes: %v", err)
+		}
+		if len(got) != 2 {
+			t.Errorf("nodes = %v, want 2 nodes", got)
+		}
+	})
+}
+
+func TestFetchNodesNullConnectionIsError(t *testing.T) {
+	mock, c := fetchTestClient(t)
+	mock.SetResponse("Things", map[string]any{"thing": map[string]any{"things": nil}})
+	_, err := fetchNodes[idNode](context.Background(), c, fetchTestQuery,
+		map[string]any{"id": "t1"}, "thing", "things")
+	if err == nil || !strings.Contains(err.Error(), `fetch: "thing.things" missing or null in response`) {
+		t.Fatalf("err = %v, want fetch-prefixed missing-or-null error", err)
+	}
+}
+
+func TestFetchOneNullTerminalIsError(t *testing.T) {
+	// The old anonymous structs decoded {"issue": null} as a zero-value
+	// Issue with a nil error; the fetch front refuses (the recorded
+	// null-policy behavior change).
+	mock, c := fetchTestClient(t)
+	mock.SetResponse("Issue", map[string]any{"issue": nil})
+	_, err := fetchOne[Issue](context.Background(), c, queryIssue,
+		map[string]any{"id": "gone"}, "issue")
+	if err == nil || !strings.Contains(err.Error(), `fetch: "issue" missing or null in response`) {
+		t.Fatalf("err = %v, want fetch-prefixed missing-or-null error", err)
+	}
+}
+
+func TestFetchOneDecodesTerminal(t *testing.T) {
+	mock, c := fetchTestClient(t)
+	mock.SetResponse("Issue", map[string]any{
+		"issue": map[string]any{"id": "i1", "identifier": "TST-1", "title": "One"},
+	})
+	got, err := fetchOne[Issue](context.Background(), c, queryIssue,
+		map[string]any{"id": "i1"}, "issue")
+	if err != nil {
+		t.Fatalf("fetchOne: %v", err)
+	}
+	if got.ID != "i1" || got.Identifier != "TST-1" || got.Title != "One" {
+		t.Errorf("issue = %+v, want i1/TST-1/One", got)
+	}
+}
+
+func TestFetchConnMissingPageInfoIsError(t *testing.T) {
+	mock, c := fetchTestClient(t)
+	mock.SetResponse("Things", map[string]any{
+		"thing": map[string]any{"things": map[string]any{
+			"nodes": []map[string]any{{"id": "n1"}},
+		}},
+	})
+	_, err := fetchConn[idNode](context.Background(), c, fetchTestQuery,
+		map[string]any{"id": "t1"}, "thing", "things")
+	if err == nil || !strings.Contains(err.Error(), "missing pageInfo") || !strings.Contains(err.Error(), `"thing.things"`) {
+		t.Fatalf("err = %v, want missing-pageInfo error naming thing.things", err)
+	}
+}
+
+func TestFetchConnReturnsEnvelope(t *testing.T) {
+	mock, c := fetchTestClient(t)
+	mock.SetResponse("Things", map[string]any{
+		"thing": map[string]any{"things": map[string]any{
+			"pageInfo": map[string]any{"hasNextPage": true, "endCursor": "c9"},
+			"nodes":    []map[string]any{{"id": "n1"}},
+		}},
+	})
+	cn, err := fetchConn[idNode](context.Background(), c, fetchTestQuery,
+		map[string]any{"id": "t1"}, "thing", "things")
+	if err != nil {
+		t.Fatalf("fetchConn: %v", err)
+	}
+	if cn.PageInfo == nil || !cn.PageInfo.HasNextPage || cn.PageInfo.EndCursor != "c9" {
+		t.Errorf("pageInfo = %+v, want hasNextPage=true endCursor=c9", cn.PageInfo)
+	}
+	if len(cn.Nodes) != 1 || cn.Nodes[0].ID != "n1" {
+		t.Errorf("nodes = %v, want [n1]", cn.Nodes)
+	}
+}
+
+func TestFetchDoesNotMutateCallerVars(t *testing.T) {
+	mock, c := fetchTestClient(t)
+	mock.SetResponse("Things", map[string]any{
+		"thing": map[string]any{"things": map[string]any{"nodes": []map[string]any{}}},
+	})
+	vars := map[string]any{"id": "t1"}
+	if _, err := fetchNodes[idNode](context.Background(), c, fetchTestQuery, vars, "thing", "things"); err != nil {
+		t.Fatalf("fetchNodes: %v", err)
+	}
+	if len(vars) != 1 || vars["id"] != "t1" {
+		t.Errorf("caller vars mutated: %v", vars)
+	}
+}

--- a/internal/api/paginate.go
+++ b/internal/api/paginate.go
@@ -176,32 +176,20 @@ func connFetch[N any](c *Client, query string, vars map[string]any, path []strin
 	}
 }
 
-// walkConn descends path from the decoded data root and decodes the
-// terminal value as a connection envelope. A missing or null element
-// errors with the path walked so far.
+// walkConn descends path from the decoded data root (the shared walkPath
+// descent, see fetch.go) and decodes the terminal value as a connection
+// envelope. A missing or null element errors with the path walked so far.
 func walkConn[N any](root map[string]json.RawMessage, path []string) (conn[N], error) {
 	if len(path) == 0 {
 		return conn[N]{}, fmt.Errorf("paginate: empty connection path")
 	}
-	cur := root
-	for i, elem := range path {
-		raw, ok := cur[elem]
-		if !ok || string(raw) == "null" {
-			return conn[N]{}, fmt.Errorf("paginate: %q missing or null in response", strings.Join(path[:i+1], "."))
-		}
-		if i == len(path)-1 {
-			var cn conn[N]
-			if err := json.Unmarshal(raw, &cn); err != nil {
-				return conn[N]{}, fmt.Errorf("paginate: decode connection at %q: %w", strings.Join(path, "."), err)
-			}
-			return cn, nil
-		}
-		next := make(map[string]json.RawMessage)
-		if err := json.Unmarshal(raw, &next); err != nil {
-			return conn[N]{}, fmt.Errorf("paginate: decode object at %q: %w", strings.Join(path[:i+1], "."), err)
-		}
-		cur = next
+	raw, err := walkPath(root, path)
+	if err != nil {
+		return conn[N]{}, fmt.Errorf("paginate: %w", err)
 	}
-	// Unreachable: the loop returns on the last element.
-	return conn[N]{}, fmt.Errorf("paginate: empty connection path")
+	var cn conn[N]
+	if err := json.Unmarshal(raw, &cn); err != nil {
+		return conn[N]{}, fmt.Errorf("paginate: decode connection at %q: %w", strings.Join(path, "."), err)
+	}
+	return cn, nil
 }

--- a/internal/repo/sqlite_test.go
+++ b/internal/repo/sqlite_test.go
@@ -1856,9 +1856,13 @@ func TestMaybeRefreshIssueDetails_EmptyFamiliesNoRefetchLoop(t *testing.T) {
 
 	mock := testutil.NewMockLinearServer()
 	defer mock.Close()
-	// No IssueDetails response configured: the mock returns empty data, which
-	// decodes as an issue with all five detail families empty — exactly the
-	// zero-docs/zero-comments shape that drove the loop.
+	// An issue that exists but has all five detail families empty — exactly
+	// the zero-docs/zero-comments shape that drove the loop. (The issue
+	// object must be present: the api fetch front now errors on a missing or
+	// null issue instead of decoding it as empty families.)
+	mock.SetResponse("IssueDetails", map[string]any{
+		"issue": map[string]any{},
+	})
 
 	client := api.NewClient("test-key")
 	client.SetAPIURL(mock.URL())


### PR DESCRIPTION
Round-21 top pick: the read-side response envelope, the third sibling completing exec.go (mutation envelope) and paginate.go (connection drain).

## What

- **New `internal/api/fetch.go`**: `fetchOne[T]` / `fetchNodes[T]` / `fetchConn[T]` over a shared `walkPath` descent, extracted from `walkConn` (which is rebuilt on it — its `paginate:`-prefixed error strings preserved verbatim).
- **21 read methods converted** from ~15-line anonymous-struct bodies to 1–3-line calls (client.go net −352): 15 list reads → `fetchNodes`, 5 entity reads → `fetchOne` (incl. `GetIssueDetails` via its payload type + `toDetails()`), `GetTeamIssuesPage` → `fetchConn`. `GetTeamLabels` keeps its dedup body but walks its two connections out of one shared root (`connAt`).
- **Left hand-written, each for cause**: `GetTeamMetadata`/`GetWorkspace` (combined multi-connection, already on `conn`+`drain`), `GetIssueDetailsBatch` (dynamic aliases, own all-or-nothing contract), `GetTeamDocuments` (stub).

## Deliberate behavior change: error-on-null

A missing or null path element — terminal included — is now an error naming the dotted path, where the old anonymous structs decoded a null terminal as a **silent zero-value entity** (`GetIssue` of a nonexistent ID returned an empty `Issue` with a nil error; `GetIssueDetails` of a vanished issue returned five empty "complete" collections — the null-reads-as-empty class the details batch had already closed for itself). Two tests updated for this, intent preserved: `TestMockReset` (client_test.go), `TestMaybeRefreshIssueDetails_EmptyFamiliesNoRefetchLoop` (sqlite_test.go).

## Truncation tripwire

`fetchNodes` decodes the `conn[T]` envelope; a response that selects `pageInfo` and reports `hasNextPage` errors instead of silently truncating. Inert today (no converted query selects pageInfo), live for any future query that does. Recorded follow-up (CONTEXT.md): ten converted list queries set no `first:` and are silently 50-capped by Linear — the drain audit is queued work, deliberately not in this PR.

## Verification

- `go vet`, `make staticcheck`, `make fmt` clean
- Full unit suites green (api/fs/repo/sync/marshal/db/reconcile), incl. new `fetch_test.go` (walkPath table, tripwire, null policies, vars non-mutation)
- Integration suite green in fixture mode (63.9s)
- CONTEXT.md entry added after "Connection drain"

🤖 Generated with [Claude Code](https://claude.com/claude-code)