### PR TITLE
refactor: drain audit — delete nine dead client reads, drain the six live capped ones

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -811,10 +811,20 @@ Four read methods stay hand-written, each for cause: `GetTeamMetadata` and
 `GetWorkspace` are combined multi-connection queries already on
 `conn`+`drain`; `GetIssueDetailsBatch` builds dynamic aliases and owns its
 own all-or-nothing contract; `GetTeamDocuments` is an empty stub (Linear has
-no team-level documents). Recorded follow-up, deliberately not done in this
-refactor: ten of the converted list queries set no `first:` and are silently
-50-capped by Linear (and `GetIssueHistory`, which backs `history.md` live,
-caps at `first: 100` with no drain) — the drain audit is queued work.
+no team-level documents). The recorded follow-up — Linear silently caps a
+connection without `first:` at 50 nodes — ran as the drain audit. Nine of
+the ten capped queries turned out to be **dead client methods**: every
+production caller was the SQLite repo twin (`lfs.repo.*`), the worker's
+drained metadata sync having superseded them, so they were deleted with
+their single-use query consts (states/cycles/labels/users/members/
+initiatives/milestones/issue-comments/issue-documents). The six live capped
+reads — teams (the sync worker's root fetch), project/initiative updates,
+project/initiative documents, and issue history — are drained via
+`fetchAll`. The attachments re-check keeps its deliberate `first: 100`
+single page: it serves the interactive attachment-create re-check, and
+`fetchAll`'s LowBudget gate must not sit on a write path. The detail-family
+page caps (`pruneWhenComplete`) and the combined queries' nested caps remain
+recorded designs.
 
 ### Sync reconcile tail (`syncCollection`)
 The **deep module** owning the invariant tail of every metadata sync — the

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -792,8 +792,7 @@ path. `fetchOne[T]` decodes the terminal into an entity; `fetchNodes[T]`
 decodes it as the `conn[T]` envelope and returns the nodes; `fetchConn[T]`
 returns the whole envelope for page-shaped callers (`GetTeamIssuesPage`) and
 errors on a nil `PageInfo` — the same "query must select pageInfo" contract
-as `fetchAll`. `GetTeamLabels` walks two connections out of one shared root
-(`connAt`) and keeps its dedup body.
+as `fetchAll`. Both fronts share one connection decode, `connAt`.
 
 **The null policy is a deliberate behavior change.** A missing or null path
 element — the terminal included — is an error naming the dotted path

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -589,12 +589,6 @@ func (c *Client) GetWorkspace(ctx context.Context) (*WorkspaceData, error) {
 	}, nil
 }
 
-// GetTeamStates fetches workflow states for a team
-func (c *Client) GetTeamStates(ctx context.Context, teamID string) ([]State, error) {
-	return fetchNodes[State](ctx, c, queryTeamStates,
-		map[string]any{"teamId": teamID}, "team", "states")
-}
-
 // GetTeamProjects fetches all projects for a team. Paginated: a team's
 // projects connection was the first observed to overflow a page (silently
 // truncating teams/ views and dangling initiative symlinks).
@@ -609,12 +603,6 @@ func (c *Client) GetTeamProjects(ctx context.Context, teamID string) ([]Project,
 // queryProjectLabelsPage).
 func (c *Client) GetProjectLabels(ctx context.Context) ([]ProjectLabel, error) {
 	return fetchAll[ProjectLabel](ctx, c, queryProjectLabelsPage, nil, "projectLabels")
-}
-
-// GetProjectMilestones fetches milestones for a project
-func (c *Client) GetProjectMilestones(ctx context.Context, projectID string) ([]ProjectMilestone, error) {
-	return fetchNodes[ProjectMilestone](ctx, c, queryProjectMilestones,
-		map[string]any{"projectId": projectID}, "project", "projectMilestones")
 }
 
 // CreateProjectMilestone creates a new milestone for a project
@@ -705,48 +693,6 @@ func (c *Client) RemoveProjectFromInitiative(ctx context.Context, projectID, ini
 	return execMutationOK(ctx, c, mutationInitiativeToProjectDelete, map[string]any{"projectId": projectID, "initiativeId": initiativeID}, "initiativeToProjectDelete")
 }
 
-// GetTeamCycles fetches cycles for a team
-func (c *Client) GetTeamCycles(ctx context.Context, teamID string) ([]Cycle, error) {
-	return fetchNodes[Cycle](ctx, c, queryTeamCycles,
-		map[string]any{"teamId": teamID}, "team", "cycles")
-}
-
-// GetTeamLabels fetches labels for a team (team + workspace labels). One
-// query carries two connections, so it walks the shared root twice instead
-// of going through a single-path front.
-func (c *Client) GetTeamLabels(ctx context.Context, teamID string) ([]Label, error) {
-	var root map[string]json.RawMessage
-	if err := c.query(ctx, queryTeamLabels, map[string]any{"teamId": teamID}, &root); err != nil {
-		return nil, err
-	}
-	teamLabels, err := connAt[Label](root, []string{"team", "labels"})
-	if err != nil {
-		return nil, err
-	}
-	workspaceLabels, err := connAt[Label](root, []string{"issueLabels"})
-	if err != nil {
-		return nil, err
-	}
-
-	// Combine team labels and workspace labels, deduplicating by ID
-	seen := make(map[string]bool)
-	var labels []Label
-	for _, l := range teamLabels.Nodes {
-		if !seen[l.ID] {
-			seen[l.ID] = true
-			labels = append(labels, l)
-		}
-	}
-	for _, l := range workspaceLabels.Nodes {
-		if !seen[l.ID] {
-			seen[l.ID] = true
-			labels = append(labels, l)
-		}
-	}
-
-	return labels, nil
-}
-
 // CreateLabel creates a new label
 func (c *Client) CreateLabel(ctx context.Context, input map[string]any) (*Label, error) {
 	return execMutation[Label](ctx, c, mutationCreateLabel, map[string]any{"input": input}, "issueLabelCreate", "issueLabel")
@@ -762,20 +708,9 @@ func (c *Client) DeleteLabel(ctx context.Context, id string) error {
 	return execMutationOK(ctx, c, mutationDeleteLabel, map[string]any{"id": id}, "issueLabelDelete")
 }
 
-// GetUsers fetches all users in the workspace
-func (c *Client) GetUsers(ctx context.Context) ([]User, error) {
-	return fetchNodes[User](ctx, c, queryUsers, nil, "users")
-}
-
 // GetViewer fetches the currently authenticated user
 func (c *Client) GetViewer(ctx context.Context) (*User, error) {
 	return fetchOne[User](ctx, c, queryViewer, nil, "viewer")
-}
-
-// GetTeamMembers fetches members of a specific team
-func (c *Client) GetTeamMembers(ctx context.Context, teamID string) ([]User, error) {
-	return fetchNodes[User](ctx, c, queryTeamMembers,
-		map[string]any{"teamId": teamID}, "team", "members")
 }
 
 // CreateIssue creates a new issue
@@ -912,12 +847,6 @@ func (c *Client) GetIssueDetailsBatch(ctx context.Context, issueIDs []string) (m
 	return result, nil
 }
 
-// GetIssueComments fetches comments for an issue
-func (c *Client) GetIssueComments(ctx context.Context, issueID string) ([]Comment, error) {
-	return fetchNodes[Comment](ctx, c, queryIssueComments,
-		map[string]any{"issueId": issueID}, "issue", "comments")
-}
-
 // CreateComment creates a new comment on an issue
 func (c *Client) CreateComment(ctx context.Context, issueID string, body string) (*Comment, error) {
 	return execMutation[Comment](ctx, c, mutationCreateComment, map[string]any{"issueId": issueID, "body": body}, "commentCreate", "comment")
@@ -931,12 +860,6 @@ func (c *Client) UpdateComment(ctx context.Context, commentID string, body strin
 // DeleteComment deletes a comment
 func (c *Client) DeleteComment(ctx context.Context, commentID string) error {
 	return execMutationOK(ctx, c, mutationDeleteComment, map[string]any{"id": commentID}, "commentDelete")
-}
-
-// GetIssueDocuments fetches documents attached to an issue
-func (c *Client) GetIssueDocuments(ctx context.Context, issueID string) ([]Document, error) {
-	return fetchNodes[Document](ctx, c, queryIssueDocuments,
-		map[string]any{"issueId": issueID}, "issue", "documents")
 }
 
 // GetIssueAttachments fetches attachments (external links) for an issue
@@ -982,11 +905,6 @@ func (c *Client) UpdateDocument(ctx context.Context, documentID string, input ma
 // DeleteDocument deletes a document
 func (c *Client) DeleteDocument(ctx context.Context, documentID string) error {
 	return execMutationOK(ctx, c, mutationDeleteDocument, map[string]any{"id": documentID}, "documentDelete")
-}
-
-// GetInitiatives fetches all initiatives
-func (c *Client) GetInitiatives(ctx context.Context) ([]Initiative, error) {
-	return fetchNodes[Initiative](ctx, c, queryInitiatives, nil, "initiatives")
 }
 
 // GetInitiative fetches a single initiative by ID

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -411,9 +411,13 @@ func (c *Client) BudgetSnapshot() (count int, pct float64) {
 	return int(used), used / rq.limit * 100
 }
 
-// GetTeams fetches all teams the user has access to
+// GetTeams fetches all teams the user has access to, draining the
+// connection to completion — this is the sync worker's root fetch, so a
+// silent 50-team cap would truncate the whole sync. All-or-nothing like
+// every fetchAll caller; a low rate budget defers it (ErrBudget) and the
+// worker retries next cycle.
 func (c *Client) GetTeams(ctx context.Context) ([]Team, error) {
-	return fetchNodes[Team](ctx, c, queryTeams, nil, "teams")
+	return fetchAll[Team](ctx, c, queryTeams, nil, "teams")
 }
 
 // GetTeamIssuesPage fetches a single page of issues ordered by updatedAt DESC.
@@ -637,9 +641,11 @@ func (c *Client) DeleteProjectMilestone(ctx context.Context, milestoneID string)
 	return execMutationOK(ctx, c, mutationDeleteProjectMilestone, map[string]any{"id": milestoneID}, "projectMilestoneDelete")
 }
 
-// GetProjectUpdates fetches status updates for a project
+// GetProjectUpdates fetches status updates for a project, drained — updates
+// accumulate past a page over a project's lifetime, and the SWR refresh is
+// upsert-only, so a capped read silently froze completeness.
 func (c *Client) GetProjectUpdates(ctx context.Context, projectID string) ([]ProjectUpdate, error) {
-	return fetchNodes[ProjectUpdate](ctx, c, queryProjectUpdates,
+	return fetchAll[ProjectUpdate](ctx, c, queryProjectUpdates,
 		map[string]any{"projectId": projectID}, "project", "projectUpdates")
 }
 
@@ -655,9 +661,10 @@ func (c *Client) CreateProjectUpdate(ctx context.Context, projectID, body, healt
 	return execMutation[ProjectUpdate](ctx, c, mutationCreateProjectUpdate, vars, "projectUpdateCreate", "projectUpdate")
 }
 
-// GetInitiativeUpdates fetches status updates for an initiative
+// GetInitiativeUpdates fetches status updates for an initiative, drained
+// (see GetProjectUpdates).
 func (c *Client) GetInitiativeUpdates(ctx context.Context, initiativeID string) ([]InitiativeUpdate, error) {
-	return fetchNodes[InitiativeUpdate](ctx, c, queryInitiativeUpdates,
+	return fetchAll[InitiativeUpdate](ctx, c, queryInitiativeUpdates,
 		map[string]any{"initiativeId": initiativeID}, "initiative", "initiativeUpdates")
 }
 
@@ -868,9 +875,10 @@ func (c *Client) GetIssueAttachments(ctx context.Context, issueID string) ([]Att
 		map[string]any{"issueId": issueID}, "issue", "attachments")
 }
 
-// GetIssueHistory fetches the history/audit trail for an issue
+// GetIssueHistory fetches the history/audit trail for an issue, drained —
+// it backs history.md live and an old issue's trail outgrows a page.
 func (c *Client) GetIssueHistory(ctx context.Context, issueID string) ([]IssueHistoryEntry, error) {
-	return fetchNodes[IssueHistoryEntry](ctx, c, queryIssueHistory,
+	return fetchAll[IssueHistoryEntry](ctx, c, queryIssueHistory,
 		map[string]any{"issueId": issueID}, "issue", "history")
 }
 
@@ -880,15 +888,15 @@ func (c *Client) GetTeamDocuments(ctx context.Context, teamID string) ([]Documen
 	return []Document{}, nil
 }
 
-// GetProjectDocuments fetches documents for a project
+// GetProjectDocuments fetches documents for a project, drained.
 func (c *Client) GetProjectDocuments(ctx context.Context, projectID string) ([]Document, error) {
-	return fetchNodes[Document](ctx, c, queryProjectDocuments,
+	return fetchAll[Document](ctx, c, queryProjectDocuments,
 		map[string]any{"projectId": projectID}, "documents")
 }
 
-// GetInitiativeDocuments fetches documents for an initiative
+// GetInitiativeDocuments fetches documents for an initiative, drained.
 func (c *Client) GetInitiativeDocuments(ctx context.Context, initiativeID string) ([]Document, error) {
-	return fetchNodes[Document](ctx, c, queryInitiativeDocuments,
+	return fetchAll[Document](ctx, c, queryInitiativeDocuments,
 		map[string]any{"initiativeId": initiativeID}, "documents")
 }
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -191,148 +191,20 @@ func TestGraphQLError(t *testing.T) {
 	}
 }
 
-func TestGetTeamStates(t *testing.T) {
-	t.Parallel()
-	mock := testutil.NewMockLinearServer()
-	defer mock.Close()
-
-	mock.SetResponse("TeamStates", testutil.TeamStatesResponse())
-
-	client := NewClient("test-api-key")
-	client.SetAPIURL(mock.URL())
-
-	states, err := client.GetTeamStates(context.Background(), "team-123")
-	if err != nil {
-		t.Fatalf("GetTeamStates failed: %v", err)
-	}
-
-	if len(states) != 5 {
-		t.Errorf("expected 5 states, got %d", len(states))
-	}
-
-	// Verify state types
-	stateTypes := make(map[string]bool)
-	for _, s := range states {
-		stateTypes[s.Type] = true
-	}
-	expected := []string{"backlog", "unstarted", "started", "completed", "canceled"}
-	for _, st := range expected {
-		if !stateTypes[st] {
-			t.Errorf("missing state type %q", st)
-		}
-	}
-}
-
-func TestGetTeamLabels(t *testing.T) {
-	t.Parallel()
-	mock := testutil.NewMockLinearServer()
-	defer mock.Close()
-
-	mock.SetResponse("TeamLabels", testutil.TeamLabelsResponse(
-		testutil.FixtureLabel("Bug"),
-		testutil.FixtureLabel("Feature"),
-	))
-
-	client := NewClient("test-api-key")
-	client.SetAPIURL(mock.URL())
-
-	result, err := client.GetTeamLabels(context.Background(), "team-123")
-	if err != nil {
-		t.Fatalf("GetTeamLabels failed: %v", err)
-	}
-
-	if len(result) != 2 {
-		t.Errorf("expected 2 labels, got %d", len(result))
-	}
-}
-
-func TestGetUsers(t *testing.T) {
-	t.Parallel()
-	mock := testutil.NewMockLinearServer()
-	defer mock.Close()
-
-	mock.SetResponse("Users", testutil.UsersResponse(
-		testutil.FixtureUser(),
-		map[string]any{"id": "user-456", "name": "Other User", "email": "other@example.com", "active": true},
-	))
-
-	client := NewClient("test-api-key")
-	client.SetAPIURL(mock.URL())
-
-	result, err := client.GetUsers(context.Background())
-	if err != nil {
-		t.Fatalf("GetUsers failed: %v", err)
-	}
-
-	if len(result) != 2 {
-		t.Errorf("expected 2 users, got %d", len(result))
-	}
-}
-
-func TestGetIssueComments(t *testing.T) {
-	t.Parallel()
-	mock := testutil.NewMockLinearServer()
-	defer mock.Close()
-
-	comment := testutil.FixtureComment()
-	mock.SetResponse("IssueComments", testutil.IssueCommentsResponse(comment))
-
-	client := NewClient("test-api-key")
-	client.SetAPIURL(mock.URL())
-
-	result, err := client.GetIssueComments(context.Background(), "issue-123")
-	if err != nil {
-		t.Fatalf("GetIssueComments failed: %v", err)
-	}
-
-	if len(result) != 1 {
-		t.Fatalf("expected 1 comment, got %d", len(result))
-	}
-
-	if result[0].Body != "This is a test comment" {
-		t.Errorf("expected body 'This is a test comment', got %q", result[0].Body)
-	}
-}
-
-func TestGetIssueDocuments(t *testing.T) {
-	t.Parallel()
-	mock := testutil.NewMockLinearServer()
-	defer mock.Close()
-
-	doc := testutil.FixtureDocument()
-	mock.SetResponse("IssueDocuments", testutil.IssueDocumentsResponse(doc))
-
-	client := NewClient("test-api-key")
-	client.SetAPIURL(mock.URL())
-
-	result, err := client.GetIssueDocuments(context.Background(), "issue-123")
-	if err != nil {
-		t.Fatalf("GetIssueDocuments failed: %v", err)
-	}
-
-	if len(result) != 1 {
-		t.Fatalf("expected 1 document, got %d", len(result))
-	}
-
-	if result[0].Title != "Test Document" {
-		t.Errorf("expected title 'Test Document', got %q", result[0].Title)
-	}
-}
-
 func TestCallRecording(t *testing.T) {
 	t.Parallel()
 	mock := testutil.NewMockLinearServer()
 	defer mock.Close()
 
 	mock.SetResponse("Teams", testutil.TeamsResponse())
-	mock.SetResponse("Users", testutil.UsersResponse())
+	mock.SetResponse("Viewer", map[string]any{"viewer": testutil.FixtureUser()})
 
 	client := NewClient("test-api-key")
 	client.SetAPIURL(mock.URL())
 
 	// Make multiple calls
 	_, _ = client.GetTeams(context.Background())
-	_, _ = client.GetUsers(context.Background())
+	_, _ = client.GetViewer(context.Background())
 
 	calls := mock.Calls()
 	if len(calls) != 2 {
@@ -343,8 +215,8 @@ func TestCallRecording(t *testing.T) {
 		t.Errorf("expected first operation 'Teams', got %q", calls[0].Operation)
 	}
 
-	if calls[1].Operation != "Users" {
-		t.Errorf("expected second operation 'Users', got %q", calls[1].Operation)
+	if calls[1].Operation != "Viewer" {
+		t.Errorf("expected second operation 'Viewer', got %q", calls[1].Operation)
 	}
 }
 
@@ -464,31 +336,6 @@ func TestGetTeamProjects(t *testing.T) {
 	}
 }
 
-func TestGetProjectMilestones(t *testing.T) {
-	t.Parallel()
-	mock := testutil.NewMockLinearServer()
-	defer mock.Close()
-
-	milestone := testutil.FixtureProjectMilestone()
-	mock.SetResponse("ProjectMilestones", testutil.ProjectMilestonesResponse(milestone))
-
-	client := NewClient("test-api-key")
-	client.SetAPIURL(mock.URL())
-
-	milestones, err := client.GetProjectMilestones(context.Background(), "project-123")
-	if err != nil {
-		t.Fatalf("GetProjectMilestones failed: %v", err)
-	}
-
-	if len(milestones) != 1 {
-		t.Fatalf("expected 1 milestone, got %d", len(milestones))
-	}
-
-	if milestones[0].Name != "Alpha Release" {
-		t.Errorf("expected milestone name 'Alpha Release', got %q", milestones[0].Name)
-	}
-}
-
 func TestGetProjectUpdates(t *testing.T) {
 	t.Parallel()
 	mock := testutil.NewMockLinearServer()
@@ -537,31 +384,6 @@ func TestCreateProjectUpdate(t *testing.T) {
 	call := mock.LastCall()
 	if call.Variables["projectId"] != "project-123" {
 		t.Errorf("expected projectId 'project-123', got %v", call.Variables["projectId"])
-	}
-}
-
-func TestGetTeamCycles(t *testing.T) {
-	t.Parallel()
-	mock := testutil.NewMockLinearServer()
-	defer mock.Close()
-
-	cycle := testutil.FixtureCycle()
-	mock.SetResponse("TeamCycles", testutil.TeamCyclesResponse(cycle))
-
-	client := NewClient("test-api-key")
-	client.SetAPIURL(mock.URL())
-
-	cycles, err := client.GetTeamCycles(context.Background(), "team-123")
-	if err != nil {
-		t.Fatalf("GetTeamCycles failed: %v", err)
-	}
-
-	if len(cycles) != 1 {
-		t.Fatalf("expected 1 cycle, got %d", len(cycles))
-	}
-
-	if cycles[0].Number != 42 {
-		t.Errorf("expected cycle number 42, got %d", cycles[0].Number)
 	}
 }
 
@@ -790,31 +612,6 @@ func TestDeleteDocumentFailure(t *testing.T) {
 	}
 }
 
-func TestGetInitiatives(t *testing.T) {
-	t.Parallel()
-	mock := testutil.NewMockLinearServer()
-	defer mock.Close()
-
-	initiative := testutil.FixtureInitiative()
-	mock.SetResponse("Initiatives", testutil.InitiativesResponse(initiative))
-
-	client := NewClient("test-api-key")
-	client.SetAPIURL(mock.URL())
-
-	initiatives, err := client.GetInitiatives(context.Background())
-	if err != nil {
-		t.Fatalf("GetInitiatives failed: %v", err)
-	}
-
-	if len(initiatives) != 1 {
-		t.Fatalf("expected 1 initiative, got %d", len(initiatives))
-	}
-
-	if initiatives[0].Name != "Test Initiative" {
-		t.Errorf("expected name 'Test Initiative', got %q", initiatives[0].Name)
-	}
-}
-
 func TestGetInitiativeUpdates(t *testing.T) {
 	t.Parallel()
 	mock := testutil.NewMockLinearServer()
@@ -899,31 +696,6 @@ func TestGetTeamDocuments(t *testing.T) {
 
 	if len(docs) != 0 {
 		t.Errorf("expected 0 documents, got %d", len(docs))
-	}
-}
-
-func TestGetTeamMembers(t *testing.T) {
-	t.Parallel()
-	mock := testutil.NewMockLinearServer()
-	defer mock.Close()
-
-	user := testutil.FixtureUser()
-	mock.SetResponse("TeamMembers", testutil.TeamMembersResponse(user))
-
-	client := NewClient("test-api-key")
-	client.SetAPIURL(mock.URL())
-
-	members, err := client.GetTeamMembers(context.Background(), "team-123")
-	if err != nil {
-		t.Fatalf("GetTeamMembers failed: %v", err)
-	}
-
-	if len(members) != 1 {
-		t.Fatalf("expected 1 member, got %d", len(members))
-	}
-
-	if members[0].Email != "test@example.com" {
-		t.Errorf("expected email 'test@example.com', got %q", members[0].Email)
 	}
 }
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -46,6 +46,114 @@ func TestGetTeams(t *testing.T) {
 	}
 }
 
+// TestGetTeamsDrainsPages proves GetTeams drains the teams connection —
+// Linear silently caps a connection without first: at 50 nodes, and this is
+// the sync worker's root fetch, so page 2 must be fetched with page 1's
+// cursor and both pages' nodes returned.
+func TestGetTeamsDrainsPages(t *testing.T) {
+	t.Parallel()
+	mock := testutil.NewMockLinearServer()
+	defer mock.Close()
+
+	teamA := testutil.FixtureTeam()
+	teamB := testutil.FixtureTeam()
+	teamB["id"] = "team-456"
+	teamB["key"] = "SEC"
+	mock.SetResponseSequence("Teams",
+		map[string]any{
+			"teams": map[string]any{
+				"pageInfo": map[string]any{"hasNextPage": true, "endCursor": "cursor-1"},
+				"nodes":    []map[string]any{teamA},
+			},
+		},
+		map[string]any{
+			"teams": map[string]any{
+				"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+				"nodes":    []map[string]any{teamB},
+			},
+		},
+	)
+
+	client := NewClient("test-api-key")
+	client.SetAPIURL(mock.URL())
+
+	teams, err := client.GetTeams(context.Background())
+	if err != nil {
+		t.Fatalf("GetTeams failed: %v", err)
+	}
+
+	if len(teams) != 2 {
+		t.Fatalf("expected 2 teams across 2 pages, got %d", len(teams))
+	}
+	if teams[0].ID != "team-123" || teams[1].ID != "team-456" {
+		t.Errorf("teams out of order: got %q, %q", teams[0].ID, teams[1].ID)
+	}
+
+	calls := mock.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", len(calls))
+	}
+	if got := calls[0].Variables["after"]; got != nil {
+		t.Errorf("page 1 carried after=%v, want none", got)
+	}
+	if got := calls[1].Variables["after"]; got != "cursor-1" {
+		t.Errorf("page 2 fetched with after=%v, want cursor-1", got)
+	}
+}
+
+// TestGetProjectUpdatesDrainsPages proves the updates read drains past the
+// old implicit 50-cap: updates accumulate over a project's lifetime and the
+// SWR refresh is upsert-only, so a capped read silently froze completeness.
+func TestGetProjectUpdatesDrainsPages(t *testing.T) {
+	t.Parallel()
+	mock := testutil.NewMockLinearServer()
+	defer mock.Close()
+
+	updateA := testutil.FixtureProjectUpdate()
+	updateB := testutil.FixtureProjectUpdate()
+	updateB["id"] = "update-456"
+	page := func(pi map[string]any, updates ...map[string]any) map[string]any {
+		return map[string]any{
+			"project": map[string]any{
+				"projectUpdates": map[string]any{
+					"pageInfo": pi,
+					"nodes":    updates,
+				},
+			},
+		}
+	}
+	mock.SetResponseSequence("ProjectUpdates",
+		page(map[string]any{"hasNextPage": true, "endCursor": "cursor-1"}, updateA),
+		page(map[string]any{"hasNextPage": false, "endCursor": ""}, updateB),
+	)
+
+	client := NewClient("test-api-key")
+	client.SetAPIURL(mock.URL())
+
+	updates, err := client.GetProjectUpdates(context.Background(), "project-123")
+	if err != nil {
+		t.Fatalf("GetProjectUpdates failed: %v", err)
+	}
+
+	if len(updates) != 2 {
+		t.Fatalf("expected 2 updates across 2 pages, got %d", len(updates))
+	}
+	if updates[0].ID != "update-123" || updates[1].ID != "update-456" {
+		t.Errorf("updates out of order: got %q, %q", updates[0].ID, updates[1].ID)
+	}
+
+	calls := mock.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", len(calls))
+	}
+	if got := calls[1].Variables["after"]; got != "cursor-1" {
+		t.Errorf("page 2 fetched with after=%v, want cursor-1", got)
+	}
+	if got := calls[1].Variables["projectId"]; got != "project-123" {
+		t.Errorf("page 2 lost projectId: got %v", got)
+	}
+}
+
 func TestGetIssue(t *testing.T) {
 	t.Parallel()
 	mock := testutil.NewMockLinearServer()
@@ -186,8 +294,14 @@ func TestGraphQLError(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 
-	if err.Error() != "GraphQL error: authentication failed" {
+	// GetTeams drains, so the GraphQL error arrives wrapped with page
+	// context; the structured error must survive the wrap.
+	if !strings.Contains(err.Error(), "GraphQL error: authentication failed") {
 		t.Errorf("unexpected error message: %v", err)
+	}
+	var gqlErr *GraphQLError
+	if !errors.As(err, &gqlErr) {
+		t.Errorf("error does not unwrap to *GraphQLError: %v", err)
 	}
 }
 
@@ -711,7 +825,7 @@ func TestRateLimitResetHeaderParsed(t *testing.T) {
 		w.Header().Set("X-RateLimit-Complexity-Reset", strconv.FormatInt(resetMs, 10))
 		w.Header().Set("X-RateLimit-Requests-Reset", strconv.FormatInt(resetMs, 10))
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"data": {"teams": {"nodes": []}}}`)
+		fmt.Fprintf(w, `{"data": {"teams": {"pageInfo": {"hasNextPage": false, "endCursor": ""}, "nodes": []}}}`)
 	}))
 	defer server.Close()
 
@@ -799,7 +913,7 @@ func TestRateLimitResetHeaderMissing(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// No X-RateLimit-Reset header
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"data": {"teams": {"nodes": []}}}`)
+		fmt.Fprintf(w, `{"data": {"teams": {"pageInfo": {"hasNextPage": false, "endCursor": ""}, "nodes": []}}}`)
 	}))
 	defer server.Close()
 
@@ -853,7 +967,7 @@ func TestCircuitBreakerResetsOnSuccess(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"data": {"teams": {"nodes": []}}}`)
+		fmt.Fprintf(w, `{"data": {"teams": {"pageInfo": {"hasNextPage": false, "endCursor": ""}, "nodes": []}}}`)
 	}))
 	defer server.Close()
 
@@ -876,7 +990,7 @@ func TestCircuitBreakerCooldownAllowsProbe(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"data": {"teams": {"nodes": []}}}`)
+		fmt.Fprintf(w, `{"data": {"teams": {"pageInfo": {"hasNextPage": false, "endCursor": ""}, "nodes": []}}}`)
 	}))
 	defer server.Close()
 
@@ -910,7 +1024,7 @@ func TestMutationPriorityReservesBudgetForWrites(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"data": {"teams": {"nodes": []}}}`)
+		fmt.Fprintf(w, `{"data": {"teams": {"pageInfo": {"hasNextPage": false, "endCursor": ""}, "nodes": []}}}`)
 	}))
 	defer server.Close()
 

--- a/internal/api/fetch.go
+++ b/internal/api/fetch.go
@@ -85,9 +85,8 @@ func fetchOne[T any](ctx context.Context, c *Client, query string, vars map[stri
 // connAt walks path from an already-decoded root and decodes the terminal as
 // a connection envelope, with fetch-front error prefixes. It applies no
 // PageInfo policy — that belongs to the front (fetchNodes tolerates an
-// absent pageInfo, fetchConn requires one). Also usable directly against a
-// root a caller decoded itself (GetTeamLabels walks two connections out of
-// one response).
+// absent pageInfo, fetchConn requires one); it is the decode the two fronts
+// share.
 func connAt[T any](root map[string]json.RawMessage, path []string) (conn[T], error) {
 	raw, err := walkPath(root, path)
 	if err != nil {

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -148,7 +148,7 @@ func TestQueryRecordsAPIMetrics(t *testing.T) {
 	defer mock.Close()
 	mock.SetResponse("Viewer", map[string]any{"viewer": map[string]any{"id": "u1", "name": "U"}})
 	mock.SetError("Teams", errors.New("boom"))
-	mock.SetError("Users", errors.New("RATELIMITED: complexity budget exhausted"))
+	mock.SetError("Initiative", errors.New("RATELIMITED: complexity budget exhausted"))
 
 	client := NewClient("test-key")
 	client.SetAPIURL(mock.URL())
@@ -162,8 +162,8 @@ func TestQueryRecordsAPIMetrics(t *testing.T) {
 	}
 	// Rate-limited call LAST: settling it snaps the budget windows to zero,
 	// which would defer any later query.
-	if _, err := client.GetUsers(ctx); err == nil {
-		t.Fatal("GetUsers: want error")
+	if _, err := client.GetInitiative(ctx, "init-1"); err == nil {
+		t.Fatal("GetInitiative: want error")
 	}
 
 	rm := collectMetrics(t, reader)
@@ -173,7 +173,7 @@ func TestQueryRecordsAPIMetrics(t *testing.T) {
 	}{
 		{"Viewer", "ok"},
 		{"Teams", "error"},
-		{"Users", "ratelimited"},
+		{"Initiative", "ratelimited"},
 	} {
 		if got := counterValue(t, rm, "linearfs.api.requests", opAttr(tc.op), outcomeAttr(tc.outcome)); got != 1 {
 			t.Errorf("requests{op=%s,outcome=%s} = %d, want 1", tc.op, tc.outcome, got)

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -193,8 +193,8 @@ fragment AttachmentFields on Attachment {
 `
 
 // ProjectMilestoneFields is the shared projection for a project milestone,
-// used by the nested selections in queryTeamProjects/queryProject, the
-// standalone queryProjectMilestones, and the create/update mutations.
+// used by the nested selections in queryTeamProjects/queryProject and the
+// create/update mutations.
 const projectMilestoneFieldsFragment = `
 fragment ProjectMilestoneFields on ProjectMilestone {
   id
@@ -358,51 +358,6 @@ query ProjectLabelsPage($after: String) {
 }
 ` + projectLabelFieldsFragment
 
-const queryTeamStates = `
-query TeamStates($teamId: String!) {
-  team(id: $teamId) {
-    states {
-      nodes {
-        id
-        name
-        type
-      }
-    }
-  }
-}
-`
-
-var queryTeamLabels = `
-query TeamLabels($teamId: String!) {
-  team(id: $teamId) {
-    labels {
-      nodes { ...LabelFields }
-    }
-  }
-  issueLabels {
-    nodes { ...LabelFields }
-  }
-}
-` + labelFieldsFragment
-
-const queryTeamCycles = `
-query TeamCycles($teamId: String!) {
-  team(id: $teamId) {
-    cycles {
-      nodes {
-        id
-        number
-        name
-        startsAt
-        endsAt
-        completedIssueCountHistory
-        issueCountHistory
-      }
-    }
-  }
-}
-`
-
 // ProjectFields is the shared projection for a project — the team-projects
 // page, the single-project fetch (the WriteBack verify read), and the create
 // mutation's echo all project through it, per the fragment rule: an inlined
@@ -464,16 +419,6 @@ query Project($id: String!) {
   project(id: $id) { ...ProjectFields }
 }
 ` + projectFieldsFragment
-
-var queryProjectMilestones = `
-query ProjectMilestones($projectId: String!) {
-  project(id: $projectId) {
-    projectMilestones {
-      nodes { ...ProjectMilestoneFields }
-    }
-  }
-}
-` + projectMilestoneFieldsFragment
 
 // =============================================================================
 // Project Milestones Mutations
@@ -706,20 +651,6 @@ query InitiativeProjectsPage($id: String!, $after: String) {
 }
 `
 
-const queryUsers = `
-query Users {
-  users {
-    nodes {
-      id
-      name
-      email
-      displayName
-      active
-    }
-  }
-}
-`
-
 const queryViewer = `
 query Viewer {
   viewer {
@@ -728,22 +659,6 @@ query Viewer {
     email
     displayName
     active
-  }
-}
-`
-
-const queryTeamMembers = `
-query TeamMembers($teamId: String!) {
-  team(id: $teamId) {
-    members {
-      nodes {
-        id
-        name
-        email
-        displayName
-        active
-      }
-    }
   }
 }
 `
@@ -824,16 +739,6 @@ query IssueAttachments($issueId: String!) {
 }
 ` + AttachmentFieldsFragment
 
-var queryIssueComments = `
-query IssueComments($issueId: String!) {
-  issue(id: $issueId) {
-    comments(first: 100) {
-      nodes { ...CommentFields }
-    }
-  }
-}
-` + CommentFieldsFragment
-
 var mutationCreateComment = `
 mutation CreateComment($issueId: String!, $body: String!) {
   commentCreate(input: { issueId: $issueId, body: $body }) {
@@ -859,16 +764,6 @@ mutation DeleteComment($id: String!) {
   }
 }
 `
-
-var queryIssueDocuments = `
-query IssueDocuments($issueId: String!) {
-  issue(id: $issueId) {
-    documents(first: 100) {
-      nodes { ...DocumentFields }
-    }
-  }
-}
-` + DocumentFieldsFragment
 
 var queryProjectDocuments = `
 query ProjectDocuments($projectId: ID!) {
@@ -934,40 +829,6 @@ const mutationDeleteLabel = `
 mutation DeleteLabel($id: String!) {
   issueLabelDelete(id: $id) {
     success
-  }
-}
-`
-
-// Filtered team issues queries - server-side filtering for by/ directories
-
-const queryInitiatives = `
-query Initiatives {
-  initiatives {
-    nodes {
-      id
-      name
-      slugId
-      description
-      status
-      color
-      icon
-      targetDate
-      url
-      createdAt
-      updatedAt
-      owner {
-        id
-        name
-        email
-      }
-      projects {
-        nodes {
-          id
-          name
-          slugId
-        }
-      }
-    }
   }
 }
 `

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -2,9 +2,13 @@ package api
 
 import "fmt"
 
+// queryTeams drains: this is the sync worker's root fetch, and Linear
+// silently caps a connection without first: at 50 nodes — a 51st team would
+// have silently truncated the whole sync.
 const queryTeams = `
-query Teams {
-  teams {
+query Teams($after: String) {
+  teams(first: 50, after: $after) {
+    pageInfo { hasNextPage endCursor }
     nodes {
       id
       key
@@ -466,10 +470,14 @@ mutation DeleteProjectMilestone($id: String!) {
 }
 `
 
+// queryProjectUpdates drains: updates accumulate past 50 over a project's
+// lifetime, and the SWR refresh is upsert-only — the implicit 50-cap was
+// silently freezing completeness.
 var queryProjectUpdates = `
-query ProjectUpdates($projectId: String!) {
+query ProjectUpdates($projectId: String!, $after: String) {
   project(id: $projectId) {
-    projectUpdates {
+    projectUpdates(first: 50, after: $after) {
+      pageInfo { hasNextPage endCursor }
       nodes { ...ProjectUpdateFields }
     }
   }
@@ -485,10 +493,12 @@ mutation CreateProjectUpdate($projectId: String!, $body: String!, $health: Proje
 }
 ` + projectUpdateFieldsFragment
 
+// queryInitiativeUpdates drains, for the same reason as queryProjectUpdates.
 var queryInitiativeUpdates = `
-query InitiativeUpdates($initiativeId: String!) {
+query InitiativeUpdates($initiativeId: String!, $after: String) {
   initiative(id: $initiativeId) {
-    initiativeUpdates {
+    initiativeUpdates(first: 50, after: $after) {
+      pageInfo { hasNextPage endCursor }
       nodes { ...InitiativeUpdateFields }
     }
   }
@@ -728,7 +738,13 @@ query IssueDetails($issueId: String!) {
 	CommentFieldsFragment + DocumentFieldsFragment + AttachmentFieldsFragment +
 	issueRelationFieldsFragment + issueInverseRelationFieldsFragment
 
-// queryIssueAttachments fetches only attachments for an issue
+// queryIssueAttachments fetches only attachments for an issue.
+//
+// DELIBERATE cap: first: 100, single page, no drain. This query serves the
+// interactive attachment-create re-check (the authoritative read a user's
+// FUSE write blocks on), and fetchAll's LowBudget gate must never sit on a
+// write path — a low budget would turn a create into a spurious failure. An
+// issue with more than 100 attachments is out of scope.
 var queryIssueAttachments = `
 query IssueAttachments($issueId: String!) {
   issue(id: $issueId) {
@@ -766,16 +782,18 @@ mutation DeleteComment($id: String!) {
 `
 
 var queryProjectDocuments = `
-query ProjectDocuments($projectId: ID!) {
-  documents(first: 100, filter: { project: { id: { eq: $projectId } } }) {
+query ProjectDocuments($projectId: ID!, $after: String) {
+  documents(first: 100, after: $after, filter: { project: { id: { eq: $projectId } } }) {
+    pageInfo { hasNextPage endCursor }
     nodes { ...DocumentFields }
   }
 }
 ` + DocumentFieldsFragment
 
 var queryInitiativeDocuments = `
-query InitiativeDocuments($initiativeId: ID!) {
-  documents(first: 100, filter: { initiative: { id: { eq: $initiativeId } } }) {
+query InitiativeDocuments($initiativeId: ID!, $after: String) {
+  documents(first: 100, after: $after, filter: { initiative: { id: { eq: $initiativeId } } }) {
+    pageInfo { hasNextPage endCursor }
     nodes { ...DocumentFields }
   }
 }
@@ -921,11 +939,13 @@ mutation DeleteAttachment($id: String!) {
 }
 `
 
-// queryIssueHistory fetches the history/audit trail for an issue
+// queryIssueHistory fetches the history/audit trail for an issue, drained —
+// it backs history.md live, and an old issue's audit trail outgrows a page.
 const queryIssueHistory = `
-query IssueHistory($issueId: String!) {
+query IssueHistory($issueId: String!, $after: String) {
   issue(id: $issueId) {
-    history(first: 100) {
+    history(first: 100, after: $after) {
+      pageInfo { hasNextPage endCursor }
       nodes {
         id
         createdAt

--- a/internal/api/ratebudget.go
+++ b/internal/api/ratebudget.go
@@ -110,12 +110,8 @@ var opBaseTier = map[string]priority{
 	"Viewer":                   pSkeleton,
 	"Teams":                    pSkeleton,
 	"TeamMetadata":             pSkeleton,
-	"TeamStates":               pSkeleton,
-	"TeamLabels":               pSkeleton,
 	"TeamLabelsPage":           pSkeleton,
-	"TeamCycles":               pSkeleton,
 	"TeamCyclesPage":           pSkeleton,
-	"TeamMembers":              pSkeleton,
 	"TeamMembersPage":          pSkeleton,
 	"TeamProjects":             pSkeleton,
 	"Workspace":                pSkeleton,
@@ -124,8 +120,6 @@ var opBaseTier = map[string]priority{
 	"WorkspaceUsersPage":       pSkeleton,
 	"WorkspaceInitiativesPage": pSkeleton,
 	"InitiativeProjectsPage":   pSkeleton,
-	"Users":                    pSkeleton,
-	"Initiatives":              pSkeleton,
 	"Initiative":               pSkeleton,
 	"Project":                  pSkeleton,
 
@@ -140,15 +134,12 @@ var opBaseTier = map[string]priority{
 	// complexity spenders, and the first to defer.
 	"IssueDetailsBatch":   pDetail,
 	"IssueDetails":        pDetail,
-	"IssueComments":       pDetail,
-	"IssueDocuments":      pDetail,
 	"IssueAttachments":    pDetail,
 	"IssueHistory":        pDetail,
 	"ProjectDocuments":    pDetail,
 	"InitiativeDocuments": pDetail,
 	"ProjectUpdates":      pDetail,
 	"InitiativeUpdates":   pDetail,
-	"ProjectMilestones":   pDetail,
 }
 
 // interactiveCtxKey marks a context as carrying a live caller (a user

--- a/internal/api/requestlog_test.go
+++ b/internal/api/requestlog_test.go
@@ -42,7 +42,7 @@ func TestRequestLogEntryFields(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Complexity", "1234")
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"data": {"teams": {"nodes": []}}}`)
+		fmt.Fprintf(w, `{"data": {"teams": {"pageInfo": {"hasNextPage": false, "endCursor": ""}, "nodes": []}}}`)
 	}))
 	defer server.Close()
 
@@ -92,7 +92,7 @@ func TestRequestLogComplexityOmittedWithoutHeader(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"data": {"teams": {"nodes": []}}}`)
+		fmt.Fprintf(w, `{"data": {"teams": {"pageInfo": {"hasNextPage": false, "endCursor": ""}, "nodes": []}}}`)
 	}))
 	defer server.Close()
 
@@ -177,7 +177,7 @@ func TestRequestLogDisabledByDefault(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"data": {"teams": {"nodes": []}}}`)
+		fmt.Fprintf(w, `{"data": {"teams": {"pageInfo": {"hasNextPage": false, "endCursor": ""}, "nodes": []}}}`)
 	}))
 	defer server.Close()
 

--- a/internal/integration/testdata_test.go
+++ b/internal/integration/testdata_test.go
@@ -265,12 +265,18 @@ func getIssueFromSQLite(issueID string) (*api.Issue, error) {
 	return issue, nil
 }
 
-// getTeamStates fetches workflow states for the test team
+// getTeamStates fetches workflow states for the test team (via the combined
+// metadata query — the per-collection client read methods were deleted with
+// the drain audit; the drained GetTeamMetadata is the production path).
 func getTeamStates() ([]api.State, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	return apiClient.GetTeamStates(ctx, testTeamID)
+	md, err := apiClient.GetTeamMetadata(ctx, testTeamID)
+	if err != nil {
+		return nil, err
+	}
+	return md.States, nil
 }
 
 // createTestDocument creates a document attached to an issue for testing.
@@ -308,12 +314,17 @@ func createTestDocument(issueID, title, content string) (*api.Document, func(), 
 	return doc, cleanup, nil
 }
 
-// getTeamCycles fetches cycles for the test team
+// getTeamCycles fetches cycles for the test team (see getTeamStates for why
+// this goes through the combined metadata query)
 func getTeamCycles() ([]api.Cycle, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	return apiClient.GetTeamCycles(ctx, testTeamID)
+	md, err := apiClient.GetTeamMetadata(ctx, testTeamID)
+	if err != nil {
+		return nil, err
+	}
+	return md.Cycles, nil
 }
 
 // findFirstActiveCycle finds the first active (current or future) cycle for testing
@@ -352,10 +363,11 @@ func deleteTestIssue(issueID string) error {
 	defer cancel()
 
 	// Find canceled state for the team
-	states, err := apiClient.GetTeamStates(ctx, testTeamID)
+	md, err := apiClient.GetTeamMetadata(ctx, testTeamID)
 	if err != nil {
 		return err
 	}
+	states := md.States
 
 	var canceledID string
 	for _, s := range states {

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -35,12 +35,10 @@ type APIClient interface {
 	// completeness licenses the prune in syncProjectLabels)
 	GetProjectLabels(ctx context.Context) ([]api.ProjectLabel, error)
 
-	// Issue details (comments, documents, attachments)
-	GetIssueDetails(ctx context.Context, issueID string) (*api.IssueDetails, error)
+	// Issue details (comments, documents, attachments, relations), batched —
+	// the worker's only detail fetch; the per-issue variants it once used
+	// were superseded by the batch.
 	GetIssueDetailsBatch(ctx context.Context, issueIDs []string) (map[string]*api.IssueDetails, error)
-	GetIssueComments(ctx context.Context, issueID string) ([]api.Comment, error)
-	GetIssueDocuments(ctx context.Context, issueID string) ([]api.Document, error)
-	GetIssueAttachments(ctx context.Context, issueID string) ([]api.Attachment, error)
 
 	// Auth
 	AuthHeader() string

--- a/internal/sync/worker_test.go
+++ b/internal/sync/worker_test.go
@@ -181,16 +181,6 @@ func (m *mockAPIClient) GetProjectLabels(ctx context.Context) ([]api.ProjectLabe
 
 // GetProjectMilestones removed — milestones now come inline from GetTeamProjects
 
-func (m *mockAPIClient) GetIssueDetails(ctx context.Context, issueID string) (*api.IssueDetails, error) {
-	if m.simulateError != nil {
-		return nil, m.simulateError
-	}
-	return &api.IssueDetails{
-		Comments:  []api.Comment{},
-		Documents: []api.Document{},
-	}, nil
-}
-
 func (m *mockAPIClient) GetIssueDetailsBatch(ctx context.Context, issueIDs []string) (map[string]*api.IssueDetails, error) {
 	atomic.AddInt32(&m.detailsCalls, 1)
 	if m.simulateError != nil {
@@ -211,27 +201,6 @@ func (m *mockAPIClient) GetIssueDetailsBatch(ctx context.Context, issueIDs []str
 		}
 	}
 	return result, nil
-}
-
-func (m *mockAPIClient) GetIssueComments(ctx context.Context, issueID string) ([]api.Comment, error) {
-	if m.simulateError != nil {
-		return nil, m.simulateError
-	}
-	return []api.Comment{}, nil
-}
-
-func (m *mockAPIClient) GetIssueDocuments(ctx context.Context, issueID string) ([]api.Document, error) {
-	if m.simulateError != nil {
-		return nil, m.simulateError
-	}
-	return []api.Document{}, nil
-}
-
-func (m *mockAPIClient) GetIssueAttachments(ctx context.Context, issueID string) ([]api.Attachment, error) {
-	if m.simulateError != nil {
-		return nil, m.simulateError
-	}
-	return []api.Attachment{}, nil
 }
 
 func (m *mockAPIClient) AuthHeader() string {

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -157,39 +157,6 @@ func FixtureProject() map[string]any {
 	}
 }
 
-// FixtureInitiative returns a test initiative as a map.
-func FixtureInitiative() map[string]any {
-	return map[string]any{
-		"id":          "initiative-123",
-		"name":        "Test Initiative",
-		"slugId":      "test-initiative",
-		"description": "A test initiative",
-		"status":      "active",
-		"color":       "#0000ff",
-		"targetDate":  "2024-12-31",
-		"url":         "https://linear.app/test/initiative/test-initiative",
-		"createdAt":   time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
-		"updatedAt":   time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
-		"owner":       FixtureUser(),
-		"projects": map[string]any{
-			"nodes": []map[string]any{
-				{"id": "project-123", "name": "Test Project", "slugId": "test-project"},
-			},
-		},
-	}
-}
-
-// FixtureCycle returns a test cycle as a map.
-func FixtureCycle() map[string]any {
-	return map[string]any{
-		"id":       "cycle-123",
-		"number":   42,
-		"name":     "Sprint 42",
-		"startsAt": time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
-		"endsAt":   time.Date(2024, 1, 14, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
-	}
-}
-
 // FixtureProjectUpdate returns a test project update as a map.
 func FixtureProjectUpdate() map[string]any {
 	return map[string]any{
@@ -242,74 +209,6 @@ func CreateCommentResponse(comment map[string]any) map[string]any {
 	}
 }
 
-// TeamStatesResponse returns a response for GetTeamStates.
-func TeamStatesResponse(states ...map[string]any) map[string]any {
-	if len(states) == 0 {
-		states = []map[string]any{
-			FixtureState("backlog"),
-			FixtureState("unstarted"),
-			FixtureState("started"),
-			FixtureState("completed"),
-			FixtureState("canceled"),
-		}
-	}
-	return map[string]any{
-		"team": map[string]any{
-			"states": map[string]any{
-				"nodes": states,
-			},
-		},
-	}
-}
-
-// TeamLabelsResponse returns a response for GetTeamLabels.
-func TeamLabelsResponse(labels ...map[string]any) map[string]any {
-	return map[string]any{
-		"team": map[string]any{
-			"labels": map[string]any{
-				"nodes": labels,
-			},
-		},
-		"issueLabels": map[string]any{
-			"nodes": []map[string]any{},
-		},
-	}
-}
-
-// UsersResponse returns a response for GetUsers.
-func UsersResponse(users ...map[string]any) map[string]any {
-	if len(users) == 0 {
-		users = []map[string]any{FixtureUser()}
-	}
-	return map[string]any{
-		"users": map[string]any{
-			"nodes": users,
-		},
-	}
-}
-
-// IssueCommentsResponse returns a response for GetIssueComments.
-func IssueCommentsResponse(comments ...map[string]any) map[string]any {
-	return map[string]any{
-		"issue": map[string]any{
-			"comments": map[string]any{
-				"nodes": comments,
-			},
-		},
-	}
-}
-
-// IssueDocumentsResponse returns a response for GetIssueDocuments.
-func IssueDocumentsResponse(docs ...map[string]any) map[string]any {
-	return map[string]any{
-		"issue": map[string]any{
-			"documents": map[string]any{
-				"nodes": docs,
-			},
-		},
-	}
-}
-
 // FilteredIssuesResponse returns a response for filtered issue queries (status, label, assignee, unassigned).
 func FilteredIssuesResponse(issues ...map[string]any) map[string]any {
 	return map[string]any{
@@ -358,28 +257,6 @@ func TeamProjectsResponse(projects ...map[string]any) map[string]any {
 	}
 }
 
-// FixtureProjectMilestone returns a test project milestone as a map.
-func FixtureProjectMilestone() map[string]any {
-	return map[string]any{
-		"id":          "milestone-123",
-		"name":        "Alpha Release",
-		"description": "First alpha release",
-		"targetDate":  "2024-03-31",
-		"sortOrder":   1.0,
-	}
-}
-
-// ProjectMilestonesResponse returns a response for GetProjectMilestones.
-func ProjectMilestonesResponse(milestones ...map[string]any) map[string]any {
-	return map[string]any{
-		"project": map[string]any{
-			"projectMilestones": map[string]any{
-				"nodes": milestones,
-			},
-		},
-	}
-}
-
 // ProjectUpdatesResponse returns a response for GetProjectUpdates.
 func ProjectUpdatesResponse(updates ...map[string]any) map[string]any {
 	return map[string]any{
@@ -397,17 +274,6 @@ func CreateProjectUpdateResponse(update map[string]any) map[string]any {
 		"projectUpdateCreate": map[string]any{
 			"success":       true,
 			"projectUpdate": update,
-		},
-	}
-}
-
-// TeamCyclesResponse returns a response for GetTeamCycles.
-func TeamCyclesResponse(cycles ...map[string]any) map[string]any {
-	return map[string]any{
-		"team": map[string]any{
-			"cycles": map[string]any{
-				"nodes": cycles,
-			},
 		},
 	}
 }
@@ -499,15 +365,6 @@ func DeleteDocumentResponse(success bool) map[string]any {
 	}
 }
 
-// InitiativesResponse returns a response for GetInitiatives.
-func InitiativesResponse(initiatives ...map[string]any) map[string]any {
-	return map[string]any{
-		"initiatives": map[string]any{
-			"nodes": initiatives,
-		},
-	}
-}
-
 // FixtureInitiativeUpdate returns a test initiative update as a map.
 func FixtureInitiativeUpdate() map[string]any {
 	return map[string]any{
@@ -546,17 +403,6 @@ func ProjectDocumentsResponse(docs ...map[string]any) map[string]any {
 	return map[string]any{
 		"documents": map[string]any{
 			"nodes": docs,
-		},
-	}
-}
-
-// TeamMembersResponse returns a response for GetTeamMembers.
-func TeamMembersResponse(users ...map[string]any) map[string]any {
-	return map[string]any{
-		"team": map[string]any{
-			"members": map[string]any{
-				"nodes": users,
-			},
 		},
 	}
 }

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -171,14 +171,17 @@ func FixtureProjectUpdate() map[string]any {
 
 // Response builders for mock server
 
-// TeamsResponse returns a response structure for GetTeams.
+// TeamsResponse returns a response structure for GetTeams. The pageInfo is
+// required: GetTeams drains the connection, and fetchAll errors on a
+// response missing pageInfo.
 func TeamsResponse(teams ...map[string]any) map[string]any {
 	if len(teams) == 0 {
 		teams = []map[string]any{FixtureTeam()}
 	}
 	return map[string]any{
 		"teams": map[string]any{
-			"nodes": teams,
+			"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+			"nodes":    teams,
 		},
 	}
 }
@@ -257,12 +260,14 @@ func TeamProjectsResponse(projects ...map[string]any) map[string]any {
 	}
 }
 
-// ProjectUpdatesResponse returns a response for GetProjectUpdates.
+// ProjectUpdatesResponse returns a response for GetProjectUpdates. The
+// pageInfo is required: the updates connection is drained (fetchAll).
 func ProjectUpdatesResponse(updates ...map[string]any) map[string]any {
 	return map[string]any{
 		"project": map[string]any{
 			"projectUpdates": map[string]any{
-				"nodes": updates,
+				"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+				"nodes":    updates,
 			},
 		},
 	}
@@ -377,12 +382,14 @@ func FixtureInitiativeUpdate() map[string]any {
 	}
 }
 
-// InitiativeUpdatesResponse returns a response for GetInitiativeUpdates.
+// InitiativeUpdatesResponse returns a response for GetInitiativeUpdates. The
+// pageInfo is required: the updates connection is drained (fetchAll).
 func InitiativeUpdatesResponse(updates ...map[string]any) map[string]any {
 	return map[string]any{
 		"initiative": map[string]any{
 			"initiativeUpdates": map[string]any{
-				"nodes": updates,
+				"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+				"nodes":    updates,
 			},
 		},
 	}
@@ -398,11 +405,13 @@ func CreateInitiativeUpdateResponse(update map[string]any) map[string]any {
 	}
 }
 
-// ProjectDocumentsResponse returns a response for GetProjectDocuments.
+// ProjectDocumentsResponse returns a response for GetProjectDocuments. The
+// pageInfo is required: the documents connection is drained (fetchAll).
 func ProjectDocumentsResponse(docs ...map[string]any) map[string]any {
 	return map[string]any{
 		"documents": map[string]any{
-			"nodes": docs,
+			"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+			"nodes":    docs,
 		},
 	}
 }


### PR DESCRIPTION
Follow-up to #219, closing its recorded drain-audit item. Linear silently caps a connection without `first:` at 50 nodes; the audit dispositioned every capped single-shot read by real caller analysis.

## Nine dead methods deleted (+33/−668)

Every production call of GetTeamStates, GetTeamCycles, GetTeamLabels, GetUsers, GetTeamMembers, GetInitiatives, GetProjectMilestones, GetIssueComments, GetIssueDocuments goes through the SQLite repo twins (`lfs.repo.*`) — the api.Client versions had **zero production callers**, superseded by the worker's drained metadata sync. Deleted with their single-use query consts, per-method tests, orphaned fixtures, and their nine dead `opBaseTier` entries. The sync worker's `APIClient` interface also sheds its four vestigial detail methods (the batch superseded them); `GetIssueDetails`/`GetIssueAttachments` stay on the client for their live repo-SWR/fs callers.

## Six live capped reads drained (+208/−47)

`$after` + explicit `first:` + `pageInfo` + `fetchAll` (all-or-nothing, LowBudget-gated):

- **GetTeams** — the sync worker's root fetch; a 51st team would have silently truncated the whole sync (`first: 50`)
- **GetProjectUpdates / GetInitiativeUpdates** — updates accumulate past 50 over a project's lifetime, and the SWR refresh is upsert-only, so the implicit cap silently froze completeness (`first: 50`)
- **GetProjectDocuments / GetInitiativeDocuments** (`first: 100` kept)
- **GetIssueHistory** — backs history.md live; an old issue's audit trail outgrows a page (`first: 100` kept)

Caller tolerance for the new `ErrBudget` gate verified: the worker logs-and-retries next cycle; repo SWR treats it as a failed refresh (stays stale, retriggers).

**Deliberately not drained:** the attachments re-check keeps its single `first: 100` page — it serves the interactive attachment-create re-check, and the LowBudget gate must not sit on a write path (documented at the query). The detail-family page caps (`pruneWhenComplete`) and combined-query nested caps remain recorded designs.

## Verification

- `go vet`, `make staticcheck`, `make fmt` clean
- All unit suites + integration suite (fixture mode) green, re-verified independently post-build
- New `TestGetTeamsDrainsPages` / `TestGetProjectUpdatesDrainsPages` (two-page drains, cursor threading asserted)
- `TestGraphQLError` strengthened: asserts via `errors.As(*GraphQLError)` through the paginate wrap instead of exact-string match
- CONTEXT.md "Read fetch" follow-up paragraph rewritten into this resolution

Net −474 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)