### PR TITLE
chore: prune three tiers of dead methods (−3,102 lines)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -548,7 +548,7 @@ relation's `createdAt`/`updatedAt` end-to-end, which nothing did. The
 took them — the gap was above the DB: `api.IssueRelation` gained the two fields,
 the `CreateIssueRelation` mutation (and the issue fragment) now select
 `createdAt`/`updatedAt`, the create-persist writes the server's times (not
-`now()`), and `GetIssueRelations`/`GetIssueInverseRelations`/`GetIssueRelationByID`
+`now()`), and `GetIssueRelations`/`GetIssueInverseRelations`
 map them back onto the struct. (The orthogonal gap noted here at the time —
 relations populated **only** by the local create handler, so UI-made relations
 never appeared as `.rel` files — was closed in round 14: relations are now the

--- a/internal/db/delete_test.go
+++ b/internal/db/delete_test.go
@@ -34,9 +34,9 @@ func TestDeleteComment(t *testing.T) {
 	}
 
 	// Verify it exists
-	_, err = store.Queries().GetComment(ctx, "comment-1")
-	if err != nil {
-		t.Fatalf("Comment should exist: %v", err)
+	comments, err := store.Queries().ListIssueComments(ctx, "issue-1")
+	if err != nil || len(comments) != 1 {
+		t.Fatalf("Comment should exist: err=%v n=%d", err, len(comments))
 	}
 
 	// Delete it
@@ -45,8 +45,8 @@ func TestDeleteComment(t *testing.T) {
 	}
 
 	// Verify it's gone
-	_, err = store.Queries().GetComment(ctx, "comment-1")
-	if err == nil {
+	comments, _ = store.Queries().ListIssueComments(ctx, "issue-1")
+	if len(comments) != 0 {
 		t.Error("Comment should be deleted")
 	}
 }
@@ -63,42 +63,6 @@ func TestDeleteComment_NonExistent(t *testing.T) {
 	}
 }
 
-func TestDeleteCycle(t *testing.T) {
-	t.Parallel()
-	store := openTestStore(t)
-	defer store.Close()
-	ctx := context.Background()
-
-	now := time.Now()
-	err := store.Queries().UpsertCycle(ctx, UpsertCycleParams{
-		ID:       "cycle-1",
-		TeamID:   "team-1",
-		Number:   1,
-		SyncedAt: now,
-		Data:     json.RawMessage("{}"),
-	})
-	if err != nil {
-		t.Fatalf("UpsertCycle failed: %v", err)
-	}
-
-	// Verify it exists
-	_, err = store.Queries().GetCycle(ctx, "cycle-1")
-	if err != nil {
-		t.Fatalf("Cycle should exist: %v", err)
-	}
-
-	// Delete it
-	if err := store.Queries().DeleteCycle(ctx, "cycle-1"); err != nil {
-		t.Fatalf("DeleteCycle failed: %v", err)
-	}
-
-	// Verify it's gone
-	_, err = store.Queries().GetCycle(ctx, "cycle-1")
-	if err == nil {
-		t.Error("Cycle should be deleted")
-	}
-}
-
 func TestDeleteDocument(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
@@ -106,10 +70,12 @@ func TestDeleteDocument(t *testing.T) {
 	ctx := context.Background()
 
 	now := time.Now()
+	issueID := sql.NullString{String: "issue-1", Valid: true}
 	err := store.Queries().UpsertDocument(ctx, UpsertDocumentParams{
 		ID:       "doc-1",
 		SlugID:   "test-doc",
 		Title:    "Test Document",
+		IssueID:  issueID,
 		SyncedAt: now,
 		Data:     json.RawMessage("{}"),
 	})
@@ -118,9 +84,9 @@ func TestDeleteDocument(t *testing.T) {
 	}
 
 	// Verify it exists
-	_, err = store.Queries().GetDocument(ctx, "doc-1")
-	if err != nil {
-		t.Fatalf("Document should exist: %v", err)
+	docs, err := store.Queries().ListIssueDocuments(ctx, issueID)
+	if err != nil || len(docs) != 1 {
+		t.Fatalf("Document should exist: err=%v n=%d", err, len(docs))
 	}
 
 	// Delete it
@@ -129,8 +95,8 @@ func TestDeleteDocument(t *testing.T) {
 	}
 
 	// Verify it's gone
-	_, err = store.Queries().GetDocument(ctx, "doc-1")
-	if err == nil {
+	docs, _ = store.Queries().ListIssueDocuments(ctx, issueID)
+	if len(docs) != 0 {
 		t.Error("Document should be deleted")
 	}
 }
@@ -275,81 +241,6 @@ func TestDeleteProject(t *testing.T) {
 	}
 }
 
-func TestDeleteState(t *testing.T) {
-	t.Parallel()
-	store := openTestStore(t)
-	defer store.Close()
-	ctx := context.Background()
-
-	now := time.Now()
-	err := store.Queries().UpsertState(ctx, UpsertStateParams{
-		ID:       "state-1",
-		TeamID:   "team-1",
-		Name:     "Todo",
-		Type:     "unstarted",
-		SyncedAt: now,
-		Data:     json.RawMessage("{}"),
-	})
-	if err != nil {
-		t.Fatalf("UpsertState failed: %v", err)
-	}
-
-	// Verify it exists
-	_, err = store.Queries().GetState(ctx, "state-1")
-	if err != nil {
-		t.Fatalf("State should exist: %v", err)
-	}
-
-	// Delete it
-	if err := store.Queries().DeleteState(ctx, "state-1"); err != nil {
-		t.Fatalf("DeleteState failed: %v", err)
-	}
-
-	// Verify it's gone
-	_, err = store.Queries().GetState(ctx, "state-1")
-	if err == nil {
-		t.Error("State should be deleted")
-	}
-}
-
-func TestDeleteUser(t *testing.T) {
-	t.Parallel()
-	store := openTestStore(t)
-	defer store.Close()
-	ctx := context.Background()
-
-	now := time.Now()
-	err := store.Queries().UpsertUser(ctx, UpsertUserParams{
-		ID:       "user-1",
-		Email:    "test@example.com",
-		Name:     "Test User",
-		Active:   1,
-		Admin:    0,
-		SyncedAt: now,
-		Data:     json.RawMessage("{}"),
-	})
-	if err != nil {
-		t.Fatalf("UpsertUser failed: %v", err)
-	}
-
-	// Verify it exists
-	_, err = store.Queries().GetUser(ctx, "user-1")
-	if err != nil {
-		t.Fatalf("User should exist: %v", err)
-	}
-
-	// Delete it
-	if err := store.Queries().DeleteUser(ctx, "user-1"); err != nil {
-		t.Fatalf("DeleteUser failed: %v", err)
-	}
-
-	// Verify it's gone
-	_, err = store.Queries().GetUser(ctx, "user-1")
-	if err == nil {
-		t.Error("User should be deleted")
-	}
-}
-
 // =============================================================================
 // Cascade Delete Tests (Parent Entity Deletion)
 // =============================================================================
@@ -429,159 +320,10 @@ func TestDeleteIssueDocuments(t *testing.T) {
 		t.Fatalf("DeleteIssueDocuments failed: %v", err)
 	}
 
-	// Verify documents are gone by trying to get them
-	_, err := store.Queries().GetDocument(ctx, "doc-a")
-	if err == nil {
-		t.Error("Document doc-a should be deleted")
-	}
-}
-
-func TestDeleteTeamIssues(t *testing.T) {
-	t.Parallel()
-	store := openTestStore(t)
-	defer store.Close()
-	ctx := context.Background()
-
-	teamID := "team-to-clear"
-
-	// Insert issues for the team
-	for i := 0; i < 3; i++ {
-		data := &IssueData{
-			ID:         "issue-" + string(rune('a'+i)),
-			Identifier: "TST-" + string(rune('1'+i)),
-			Title:      "Issue " + string(rune('1'+i)),
-			TeamID:     teamID,
-			CreatedAt:  time.Now(),
-			UpdatedAt:  time.Now(),
-			Data:       json.RawMessage("{}"),
-		}
-		if err := store.Queries().UpsertIssue(ctx, data.ToUpsertParams()); err != nil {
-			t.Fatalf("Insert failed: %v", err)
-		}
-	}
-
-	// Verify issues exist
-	issues, _ := store.Queries().ListTeamIssues(ctx, teamID)
-	if len(issues) != 3 {
-		t.Fatalf("Expected 3 issues, got %d", len(issues))
-	}
-
-	// Delete all team issues
-	if err := store.Queries().DeleteTeamIssues(ctx, teamID); err != nil {
-		t.Fatalf("DeleteTeamIssues failed: %v", err)
-	}
-
-	// Verify all gone
-	issues, _ = store.Queries().ListTeamIssues(ctx, teamID)
-	if len(issues) != 0 {
-		t.Errorf("Expected 0 issues after delete, got %d", len(issues))
-	}
-}
-
-func TestDeleteTeamLabels(t *testing.T) {
-	t.Parallel()
-	store := openTestStore(t)
-	defer store.Close()
-	ctx := context.Background()
-
-	teamID := "team-with-labels"
-	now := time.Now()
-
-	// Insert labels for the team
-	for i := 0; i < 3; i++ {
-		err := store.Queries().UpsertLabel(ctx, UpsertLabelParams{
-			ID:       "label-" + string(rune('a'+i)),
-			TeamID:   sql.NullString{String: teamID, Valid: true},
-			Name:     "Label " + string(rune('1'+i)),
-			SyncedAt: now,
-			Data:     json.RawMessage("{}"),
-		})
-		if err != nil {
-			t.Fatalf("UpsertLabel failed: %v", err)
-		}
-	}
-
-	// Delete all team labels
-	if err := store.Queries().DeleteTeamLabels(ctx, sql.NullString{String: teamID, Valid: true}); err != nil {
-		t.Fatalf("DeleteTeamLabels failed: %v", err)
-	}
-
-	// Verify labels are gone
-	labels, _ := store.Queries().ListTeamLabels(ctx, sql.NullString{String: teamID, Valid: true})
-	if len(labels) != 0 {
-		t.Errorf("Expected 0 labels after delete, got %d", len(labels))
-	}
-}
-
-func TestDeleteTeamStates(t *testing.T) {
-	t.Parallel()
-	store := openTestStore(t)
-	defer store.Close()
-	ctx := context.Background()
-
-	teamID := "team-with-states"
-	now := time.Now()
-
-	// Insert states for the team
-	stateTypes := []string{"unstarted", "started", "completed"}
-	for i, st := range stateTypes {
-		err := store.Queries().UpsertState(ctx, UpsertStateParams{
-			ID:       "state-" + string(rune('a'+i)),
-			TeamID:   teamID,
-			Name:     "State " + string(rune('1'+i)),
-			Type:     st,
-			SyncedAt: now,
-			Data:     json.RawMessage("{}"),
-		})
-		if err != nil {
-			t.Fatalf("UpsertState failed: %v", err)
-		}
-	}
-
-	// Delete all team states
-	if err := store.Queries().DeleteTeamStates(ctx, teamID); err != nil {
-		t.Fatalf("DeleteTeamStates failed: %v", err)
-	}
-
-	// Verify states are gone
-	states, _ := store.Queries().ListTeamStates(ctx, teamID)
-	if len(states) != 0 {
-		t.Errorf("Expected 0 states after delete, got %d", len(states))
-	}
-}
-
-func TestDeleteTeamCycles(t *testing.T) {
-	t.Parallel()
-	store := openTestStore(t)
-	defer store.Close()
-	ctx := context.Background()
-
-	teamID := "team-with-cycles"
-	now := time.Now()
-
-	// Insert cycles for the team
-	for i := 0; i < 3; i++ {
-		err := store.Queries().UpsertCycle(ctx, UpsertCycleParams{
-			ID:       "cycle-" + string(rune('a'+i)),
-			TeamID:   teamID,
-			Number:   int64(i + 1),
-			SyncedAt: now,
-			Data:     json.RawMessage("{}"),
-		})
-		if err != nil {
-			t.Fatalf("UpsertCycle failed: %v", err)
-		}
-	}
-
-	// Delete all team cycles
-	if err := store.Queries().DeleteTeamCycles(ctx, teamID); err != nil {
-		t.Fatalf("DeleteTeamCycles failed: %v", err)
-	}
-
-	// Verify cycles are gone
-	cycles, _ := store.Queries().ListTeamCycles(ctx, teamID)
-	if len(cycles) != 0 {
-		t.Errorf("Expected 0 cycles after delete, got %d", len(cycles))
+	// Verify documents are gone
+	docs, _ := store.Queries().ListIssueDocuments(ctx, sql.NullString{String: issueID, Valid: true})
+	if len(docs) != 0 {
+		t.Errorf("Expected 0 documents after delete, got %d", len(docs))
 	}
 }
 
@@ -684,54 +426,6 @@ func TestDeleteInitiativeProjects(t *testing.T) {
 	}
 }
 
-func TestDeleteProjectTeam(t *testing.T) {
-	t.Parallel()
-	store := openTestStore(t)
-	defer store.Close()
-	ctx := context.Background()
-
-	now := time.Now()
-
-	// Create project and team
-	if err := store.Queries().UpsertProject(ctx, UpsertProjectParams{
-		ID:       "proj-pt",
-		SlugID:   "proj-pt",
-		Name:     "Project",
-		SyncedAt: now,
-		Data:     json.RawMessage("{}"),
-	}); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-	if err := store.Queries().UpsertTeam(ctx, UpsertTeamParams{
-		ID:        "team-pt",
-		Key:       "TPT",
-		Name:      "Team",
-		CreatedAt: sql.NullTime{Time: now, Valid: true},
-		UpdatedAt: sql.NullTime{Time: now, Valid: true},
-		SyncedAt:  now,
-	}); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-
-	// Create association
-	if err := store.Queries().UpsertProjectTeam(ctx, UpsertProjectTeamParams{
-		ProjectID: "proj-pt",
-		TeamID:    "team-pt",
-		SyncedAt:  now,
-	}); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-
-	// Delete specific association
-	err := store.Queries().DeleteProjectTeam(ctx, DeleteProjectTeamParams{
-		ProjectID: "proj-pt",
-		TeamID:    "team-pt",
-	})
-	if err != nil {
-		t.Fatalf("DeleteProjectTeam failed: %v", err)
-	}
-}
-
 func TestDeleteProjectTeams(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
@@ -780,152 +474,9 @@ func TestDeleteProjectTeams(t *testing.T) {
 	}
 }
 
-func TestDeleteTeamMember(t *testing.T) {
-	t.Parallel()
-	store := openTestStore(t)
-	defer store.Close()
-	ctx := context.Background()
-
-	now := time.Now()
-
-	// Create team and user
-	if err := store.Queries().UpsertTeam(ctx, UpsertTeamParams{
-		ID:        "team-tm",
-		Key:       "TTM",
-		Name:      "Team",
-		CreatedAt: sql.NullTime{Time: now, Valid: true},
-		UpdatedAt: sql.NullTime{Time: now, Valid: true},
-		SyncedAt:  now,
-	}); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-	if err := store.Queries().UpsertUser(ctx, UpsertUserParams{
-		ID:       "user-tm",
-		Email:    "user@example.com",
-		Name:     "User",
-		Active:   1,
-		SyncedAt: now,
-		Data:     json.RawMessage("{}"),
-	}); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-
-	// Create membership
-	if err := store.Queries().UpsertTeamMember(ctx, UpsertTeamMemberParams{
-		TeamID:   "team-tm",
-		UserID:   "user-tm",
-		SyncedAt: now,
-	}); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-
-	// Delete specific membership
-	err := store.Queries().DeleteTeamMember(ctx, DeleteTeamMemberParams{
-		TeamID: "team-tm",
-		UserID: "user-tm",
-	})
-	if err != nil {
-		t.Fatalf("DeleteTeamMember failed: %v", err)
-	}
-}
-
-func TestDeleteTeamMembers(t *testing.T) {
-	t.Parallel()
-	store := openTestStore(t)
-	defer store.Close()
-	ctx := context.Background()
-
-	now := time.Now()
-	teamID := "team-all-members"
-
-	// Create team
-	if err := store.Queries().UpsertTeam(ctx, UpsertTeamParams{
-		ID:        teamID,
-		Key:       "TAM",
-		Name:      "Team",
-		CreatedAt: sql.NullTime{Time: now, Valid: true},
-		UpdatedAt: sql.NullTime{Time: now, Valid: true},
-		SyncedAt:  now,
-	}); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-
-	// Create users and memberships
-	for i := 0; i < 3; i++ {
-		userID := "user-" + string(rune('a'+i))
-		if err := store.Queries().UpsertUser(ctx, UpsertUserParams{
-			ID:       userID,
-			Email:    "user" + string(rune('1'+i)) + "@example.com",
-			Name:     "User " + string(rune('1'+i)),
-			Active:   1,
-			SyncedAt: now,
-			Data:     json.RawMessage("{}"),
-		}); err != nil {
-			t.Fatalf("setup: %v", err)
-		}
-		if err := store.Queries().UpsertTeamMember(ctx, UpsertTeamMemberParams{
-			TeamID:   teamID,
-			UserID:   userID,
-			SyncedAt: now,
-		}); err != nil {
-			t.Fatalf("setup: %v", err)
-		}
-	}
-
-	// Delete all members for team
-	if err := store.Queries().DeleteTeamMembers(ctx, teamID); err != nil {
-		t.Fatalf("DeleteTeamMembers failed: %v", err)
-	}
-}
-
 // =============================================================================
 // Update/Initiative Delete Tests
 // =============================================================================
-
-func TestDeleteInitiativeUpdate(t *testing.T) {
-	t.Parallel()
-	store := openTestStore(t)
-	defer store.Close()
-	ctx := context.Background()
-
-	now := time.Now()
-
-	// Create initiative first
-	if err := store.Queries().UpsertInitiative(ctx, UpsertInitiativeParams{
-		ID:       "init-update",
-		SlugID:   "init-update",
-		Name:     "Initiative",
-		SyncedAt: now,
-		Data:     json.RawMessage("{}"),
-	}); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-
-	// Create update
-	err := store.Queries().UpsertInitiativeUpdate(ctx, UpsertInitiativeUpdateParams{
-		ID:           "init-upd-1",
-		InitiativeID: "init-update",
-		Body:         "Update body",
-		CreatedAt:    now,
-		UpdatedAt:    now,
-		SyncedAt:     now,
-		Data:         json.RawMessage("{}"),
-	})
-	if err != nil {
-		t.Fatalf("UpsertInitiativeUpdate failed: %v", err)
-	}
-
-	// Delete update
-	if err := store.Queries().DeleteInitiativeUpdate(ctx, "init-upd-1"); err != nil {
-		t.Fatalf("DeleteInitiativeUpdate failed: %v", err)
-	}
-
-	// Verify it's gone
-	_, err = store.Queries().GetInitiativeUpdate(ctx, "init-upd-1")
-	if err == nil {
-		t.Error("Initiative update should be deleted")
-	}
-}
 
 func TestDeleteInitiativeUpdates(t *testing.T) {
 	t.Parallel()
@@ -971,51 +522,6 @@ func TestDeleteInitiativeUpdates(t *testing.T) {
 	updates, _ := store.Queries().ListInitiativeUpdates(ctx, initiativeID)
 	if len(updates) != 0 {
 		t.Errorf("Expected 0 updates after delete, got %d", len(updates))
-	}
-}
-
-func TestDeleteProjectUpdate(t *testing.T) {
-	t.Parallel()
-	store := openTestStore(t)
-	defer store.Close()
-	ctx := context.Background()
-
-	now := time.Now()
-
-	// Create project first
-	if err := store.Queries().UpsertProject(ctx, UpsertProjectParams{
-		ID:       "proj-update",
-		SlugID:   "proj-update",
-		Name:     "Project",
-		SyncedAt: now,
-		Data:     json.RawMessage("{}"),
-	}); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-
-	// Create update
-	err := store.Queries().UpsertProjectUpdate(ctx, UpsertProjectUpdateParams{
-		ID:        "proj-upd-1",
-		ProjectID: "proj-update",
-		Body:      "Update body",
-		CreatedAt: now,
-		UpdatedAt: now,
-		SyncedAt:  now,
-		Data:      json.RawMessage("{}"),
-	})
-	if err != nil {
-		t.Fatalf("UpsertProjectUpdate failed: %v", err)
-	}
-
-	// Delete update
-	if err := store.Queries().DeleteProjectUpdate(ctx, "proj-upd-1"); err != nil {
-		t.Fatalf("DeleteProjectUpdate failed: %v", err)
-	}
-
-	// Verify it's gone
-	_, err = store.Queries().GetProjectUpdate(ctx, "proj-upd-1")
-	if err == nil {
-		t.Error("Project update should be deleted")
 	}
 }
 
@@ -1194,8 +700,8 @@ func TestDeleteProjectDocuments(t *testing.T) {
 	}
 
 	// Verify documents are gone
-	_, err := store.Queries().GetDocument(ctx, "pdoc-a")
-	if err == nil {
-		t.Error("Document pdoc-a should be deleted")
+	docs, _ := store.Queries().ListProjectDocuments(ctx, sql.NullString{String: projectID, Valid: true})
+	if len(docs) != 0 {
+		t.Errorf("Expected 0 documents after delete, got %d", len(docs))
 	}
 }

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -10,35 +10,11 @@ SELECT * FROM issues WHERE team_id = ? ORDER BY updated_at DESC;
 -- name: ListTeamIssuesByState :many
 SELECT * FROM issues WHERE team_id = ? AND state_id = ? ORDER BY updated_at DESC;
 
--- name: ListTeamIssuesByStateName :many
-SELECT * FROM issues WHERE team_id = ? AND state_name = ? ORDER BY updated_at DESC;
-
--- name: ListTeamIssuesByStateType :many
-SELECT * FROM issues WHERE team_id = ? AND state_type = ? ORDER BY updated_at DESC;
-
 -- name: ListTeamIssuesByAssignee :many
 SELECT * FROM issues WHERE team_id = ? AND assignee_id = ? ORDER BY updated_at DESC;
 
--- name: ListTeamIssuesByAssigneeEmail :many
-SELECT * FROM issues WHERE team_id = ? AND assignee_email = ? ORDER BY updated_at DESC;
-
 -- name: ListTeamUnassignedIssues :many
 SELECT * FROM issues WHERE team_id = ? AND assignee_id IS NULL ORDER BY updated_at DESC;
-
--- name: ListTeamIssuesByPriority :many
-SELECT * FROM issues WHERE team_id = ? AND priority = ? ORDER BY updated_at DESC;
-
--- name: ListTeamIssuesByProject :many
-SELECT * FROM issues WHERE team_id = ? AND project_id = ? ORDER BY updated_at DESC;
-
--- name: ListTeamIssuesByProjectName :many
-SELECT * FROM issues WHERE team_id = ? AND project_name = ? ORDER BY updated_at DESC;
-
--- name: ListTeamIssuesByCycle :many
-SELECT * FROM issues WHERE team_id = ? AND cycle_id = ? ORDER BY updated_at DESC;
-
--- name: ListTeamIssuesByCycleName :many
-SELECT * FROM issues WHERE team_id = ? AND cycle_name = ? ORDER BY updated_at DESC;
 
 -- name: ListTeamIssuesByParent :many
 SELECT * FROM issues WHERE parent_id = ? ORDER BY updated_at DESC;
@@ -48,9 +24,6 @@ UPDATE issues SET parent_id = ? WHERE id = ?;
 
 -- name: ListUserAssignedIssues :many
 SELECT * FROM issues WHERE assignee_id = ? ORDER BY updated_at DESC;
-
--- name: ListUserAssignedIssuesByEmail :many
-SELECT * FROM issues WHERE assignee_email = ? ORDER BY updated_at DESC;
 
 -- name: ListUserActiveIssues :many
 SELECT * FROM issues WHERE assignee_id = ? AND state_type NOT IN ('completed', 'canceled') ORDER BY updated_at DESC;
@@ -119,14 +92,8 @@ INSERT INTO issues (
 -- name: DeleteIssue :exec
 DELETE FROM issues WHERE id = ?;
 
--- name: DeleteIssueByIdentifier :exec
-DELETE FROM issues WHERE identifier = ?;
-
 -- name: GetTeamIssueCount :one
 SELECT COUNT(*) FROM issues WHERE team_id = ?;
-
--- name: GetTotalIssueCount :one
-SELECT COUNT(*) FROM issues;
 
 -- name: GetLatestTeamIssueUpdatedAt :one
 SELECT MAX(updated_at) FROM issues WHERE team_id = ?;
@@ -144,16 +111,7 @@ ON CONFLICT(team_id) DO UPDATE SET
     last_issue_updated_at = excluded.last_issue_updated_at,
     issue_count = excluded.issue_count;
 
--- name: ListSyncMeta :many
-SELECT * FROM sync_meta;
-
 -- Teams queries
-
--- name: GetTeam :one
-SELECT * FROM teams WHERE id = ?;
-
--- name: GetTeamByKey :one
-SELECT * FROM teams WHERE key = ?;
 
 -- name: ListTeams :many
 SELECT * FROM teams ORDER BY name;
@@ -194,18 +152,9 @@ DELETE FROM issue_history_cache WHERE issue_id = ?;
 -- name: ListTeamIssueIDs :many
 SELECT id, updated_at FROM issues WHERE team_id = ? ORDER BY updated_at DESC;
 
--- name: DeleteTeamIssues :exec
-DELETE FROM issues WHERE team_id = ?;
-
 -- Label-based queries (labels stored in JSON data column)
 -- These require extracting from JSON - keeping simple queries here,
 -- complex label queries will be done in Go code
-
--- name: ListAllIdentifiers :many
-SELECT identifier, team_id FROM issues ORDER BY identifier;
-
--- name: ListTeamIdentifiers :many
-SELECT identifier FROM issues WHERE team_id = ? ORDER BY identifier;
 
 -- =============================================================================
 -- States queries
@@ -219,9 +168,6 @@ SELECT * FROM states WHERE team_id = ? AND name = ?;
 
 -- name: ListTeamStates :many
 SELECT * FROM states WHERE team_id = ? ORDER BY position;
-
--- name: ListTeamStatesByType :many
-SELECT * FROM states WHERE team_id = ? AND type = ? ORDER BY position;
 
 -- name: UpsertState :exec
 INSERT INTO states (id, team_id, name, type, color, position, created_at, updated_at, synced_at, data)
@@ -237,12 +183,6 @@ ON CONFLICT(id) DO UPDATE SET
     synced_at = excluded.synced_at,
     data = excluded.data;
 
--- name: DeleteState :exec
-DELETE FROM states WHERE id = ?;
-
--- name: DeleteTeamStates :exec
-DELETE FROM states WHERE team_id = ?;
-
 -- =============================================================================
 -- Labels queries
 -- =============================================================================
@@ -255,9 +195,6 @@ SELECT * FROM labels WHERE (team_id = ? OR team_id IS NULL) AND name = ?;
 
 -- name: ListTeamLabels :many
 SELECT * FROM labels WHERE team_id = ? OR team_id IS NULL ORDER BY name;
-
--- name: ListWorkspaceLabels :many
-SELECT * FROM labels WHERE team_id IS NULL ORDER BY name;
 
 -- name: UpsertLabel :exec
 INSERT INTO labels (id, team_id, name, color, description, parent_id, created_at, updated_at, synced_at, data)
@@ -275,9 +212,6 @@ ON CONFLICT(id) DO UPDATE SET
 
 -- name: DeleteLabel :exec
 DELETE FROM labels WHERE id = ?;
-
--- name: DeleteTeamLabels :exec
-DELETE FROM labels WHERE team_id = ?;
 
 -- =============================================================================
 -- Project labels queries (workspace-scoped catalog; see schema.sql)
@@ -315,14 +249,8 @@ DELETE FROM project_labels WHERE synced_at < ?;
 -- name: GetUser :one
 SELECT * FROM users WHERE id = ?;
 
--- name: GetUserByEmail :one
-SELECT * FROM users WHERE email = ?;
-
 -- name: ListUsers :many
 SELECT * FROM users WHERE active = 1 ORDER BY name;
-
--- name: ListAllUsers :many
-SELECT * FROM users ORDER BY name;
 
 -- name: UpsertUser :exec
 INSERT INTO users (id, email, name, display_name, avatar_url, active, admin, created_at, updated_at, synced_at, data)
@@ -338,9 +266,6 @@ ON CONFLICT(id) DO UPDATE SET
     updated_at = excluded.updated_at,
     synced_at = excluded.synced_at,
     data = excluded.data;
-
--- name: DeleteUser :exec
-DELETE FROM users WHERE id = ?;
 
 -- =============================================================================
 -- Team Members queries
@@ -358,30 +283,12 @@ VALUES (?, ?, ?)
 ON CONFLICT(team_id, user_id) DO UPDATE SET
     synced_at = excluded.synced_at;
 
--- name: DeleteTeamMember :exec
-DELETE FROM team_members WHERE team_id = ? AND user_id = ?;
-
--- name: DeleteTeamMembers :exec
-DELETE FROM team_members WHERE team_id = ?;
-
 -- =============================================================================
 -- Cycles queries
 -- =============================================================================
 
--- name: GetCycle :one
-SELECT * FROM cycles WHERE id = ?;
-
--- name: GetCycleByNumber :one
-SELECT * FROM cycles WHERE team_id = ? AND number = ?;
-
--- name: GetCycleByName :one
-SELECT * FROM cycles WHERE team_id = ? AND name = ?;
-
 -- name: ListTeamCycles :many
 SELECT * FROM cycles WHERE team_id = ? ORDER BY number DESC;
-
--- name: ListTeamActiveCycles :many
-SELECT * FROM cycles WHERE team_id = ? AND ends_at > datetime('now') ORDER BY starts_at;
 
 -- name: UpsertCycle :exec
 INSERT INTO cycles (id, team_id, number, name, description, starts_at, ends_at, completed_at, progress, created_at, updated_at, synced_at, data)
@@ -400,12 +307,6 @@ ON CONFLICT(id) DO UPDATE SET
     synced_at = excluded.synced_at,
     data = excluded.data;
 
--- name: DeleteCycle :exec
-DELETE FROM cycles WHERE id = ?;
-
--- name: DeleteTeamCycles :exec
-DELETE FROM cycles WHERE team_id = ?;
-
 -- =============================================================================
 -- Projects queries
 -- =============================================================================
@@ -413,14 +314,8 @@ DELETE FROM cycles WHERE team_id = ?;
 -- name: GetProject :one
 SELECT * FROM projects WHERE id = ?;
 
--- name: GetProjectBySlug :one
-SELECT * FROM projects WHERE slug_id = ?;
-
 -- name: ListProjects :many
 SELECT * FROM projects ORDER BY name;
-
--- name: ListProjectsByState :many
-SELECT * FROM projects WHERE state = ? ORDER BY name;
 
 -- name: ListTeamProjects :many
 SELECT p.* FROM projects p
@@ -482,14 +377,8 @@ DELETE FROM cycles WHERE team_id = ? AND synced_at < ?;
 -- name: PruneTeamMembers :exec
 DELETE FROM team_members WHERE team_id = ? AND synced_at < ?;
 
--- name: DeleteProjectTeam :exec
-DELETE FROM project_teams WHERE project_id = ? AND team_id = ?;
-
 -- name: DeleteProjectTeams :exec
 DELETE FROM project_teams WHERE project_id = ?;
-
--- name: ListProjectTeamIDs :many
-SELECT team_id FROM project_teams WHERE project_id = ?;
 
 -- name: GetProjectPrimaryTeamKey :one
 -- The canonical team for a project that spans teams: first by key order.
@@ -510,9 +399,6 @@ SELECT * FROM project_milestones WHERE id = ?;
 
 -- name: ListProjectMilestones :many
 SELECT * FROM project_milestones WHERE project_id = ? ORDER BY sort_order;
-
--- name: GetMilestoneByName :one
-SELECT * FROM project_milestones WHERE project_id = ? AND name = ?;
 
 -- name: UpsertProjectMilestone :exec
 INSERT INTO project_milestones (id, project_id, name, description, target_date, sort_order, created_at, updated_at, synced_at, data)
@@ -537,9 +423,6 @@ DELETE FROM project_milestones WHERE project_id = ?;
 -- =============================================================================
 -- Comments queries
 -- =============================================================================
-
--- name: GetComment :one
-SELECT * FROM comments WHERE id = ?;
 
 -- name: ListIssueComments :many
 SELECT * FROM comments WHERE issue_id = ? ORDER BY created_at;
@@ -576,12 +459,6 @@ DELETE FROM comments WHERE issue_id = ? AND synced_at < ?;
 -- =============================================================================
 -- Documents queries
 -- =============================================================================
-
--- name: GetDocument :one
-SELECT * FROM documents WHERE id = ?;
-
--- name: GetDocumentBySlug :one
-SELECT * FROM documents WHERE slug_id = ?;
 
 -- name: ListIssueDocuments :many
 SELECT * FROM documents WHERE issue_id = ? ORDER BY title;
@@ -640,9 +517,6 @@ SELECT MAX(synced_at) FROM documents WHERE initiative_id = ?;
 -- name: GetInitiative :one
 SELECT * FROM initiatives WHERE id = ?;
 
--- name: GetInitiativeBySlug :one
-SELECT * FROM initiatives WHERE slug_id = ?;
-
 -- name: ListInitiatives :many
 SELECT * FROM initiatives ORDER BY sort_order, name;
 
@@ -695,24 +569,9 @@ DELETE FROM initiative_projects WHERE initiative_id = ?;
 -- name: DeleteInitiativeProjectsByProject :exec
 DELETE FROM initiative_projects WHERE project_id = ?;
 
--- name: ListInitiativeProjectIDs :many
-SELECT project_id FROM initiative_projects WHERE initiative_id = ?;
-
--- name: ListInitiativeProjects :many
-SELECT p.* FROM projects p
-JOIN initiative_projects ip ON p.id = ip.project_id
-WHERE ip.initiative_id = ?
-ORDER BY p.name;
-
--- name: ListProjectInitiativeIDs :many
-SELECT initiative_id FROM initiative_projects WHERE project_id = ?;
-
 -- =============================================================================
 -- Project Updates queries
 -- =============================================================================
-
--- name: GetProjectUpdate :one
-SELECT * FROM project_updates WHERE id = ?;
 
 -- name: ListProjectUpdates :many
 SELECT * FROM project_updates WHERE project_id = ? ORDER BY created_at DESC;
@@ -734,9 +593,6 @@ ON CONFLICT(id) DO UPDATE SET
     synced_at = excluded.synced_at,
     data = excluded.data;
 
--- name: DeleteProjectUpdate :exec
-DELETE FROM project_updates WHERE id = ?;
-
 -- name: DeleteProjectUpdates :exec
 DELETE FROM project_updates WHERE project_id = ?;
 
@@ -746,9 +602,6 @@ SELECT MAX(synced_at) FROM project_updates WHERE project_id = ?;
 -- =============================================================================
 -- Initiative Updates queries
 -- =============================================================================
-
--- name: GetInitiativeUpdate :one
-SELECT * FROM initiative_updates WHERE id = ?;
 
 -- name: ListInitiativeUpdates :many
 SELECT * FROM initiative_updates WHERE initiative_id = ? ORDER BY created_at DESC;
@@ -770,9 +623,6 @@ ON CONFLICT(id) DO UPDATE SET
     synced_at = excluded.synced_at,
     data = excluded.data;
 
--- name: DeleteInitiativeUpdate :exec
-DELETE FROM initiative_updates WHERE id = ?;
-
 -- name: DeleteInitiativeUpdates :exec
 DELETE FROM initiative_updates WHERE initiative_id = ?;
 
@@ -782,9 +632,6 @@ SELECT MAX(synced_at) FROM initiative_updates WHERE initiative_id = ?;
 -- =============================================================================
 -- Attachments queries (external links: GitHub PRs, Slack, etc.)
 -- =============================================================================
-
--- name: GetAttachment :one
-SELECT * FROM attachments WHERE id = ?;
 
 -- name: ListIssueAttachments :many
 -- The id tiebreaker keeps the order deterministic on equal created_at, so
@@ -822,12 +669,6 @@ DELETE FROM attachments WHERE issue_id = ?;
 -- Embedded Files queries (images, PDFs from Linear CDN)
 -- =============================================================================
 
--- name: GetEmbeddedFile :one
-SELECT * FROM embedded_files WHERE id = ?;
-
--- name: GetEmbeddedFileByURL :one
-SELECT * FROM embedded_files WHERE url = ?;
-
 -- name: ListIssueEmbeddedFiles :many
 -- The id tiebreaker keeps the order deterministic on equal filenames (the
 -- dedup case), so which duplicate gets the (2) suffix stays stable.
@@ -849,27 +690,15 @@ ON CONFLICT(id) DO UPDATE SET
 -- name: UpdateEmbeddedFileCache :exec
 UPDATE embedded_files SET cache_path = ?, file_size = ? WHERE id = ?;
 
--- name: DeleteEmbeddedFile :exec
-DELETE FROM embedded_files WHERE id = ?;
-
 -- name: DeleteIssueEmbeddedFiles :exec
 DELETE FROM embedded_files WHERE issue_id = ?;
-
--- name: ListCachedEmbeddedFiles :many
-SELECT * FROM embedded_files WHERE cache_path IS NOT NULL;
 
 -- =============================================================================
 -- Issue Relations queries
 -- =============================================================================
 
--- name: GetIssueRelation :one
-SELECT * FROM issue_relations WHERE id = ?;
-
 -- name: ListIssueRelations :many
 SELECT * FROM issue_relations WHERE issue_id = ? ORDER BY type, related_issue_id;
-
--- name: ListIssueRelationsByType :many
-SELECT * FROM issue_relations WHERE issue_id = ? AND type = ? ORDER BY related_issue_id;
 
 -- name: ListIssueInverseRelations :many
 SELECT * FROM issue_relations WHERE related_issue_id = ? ORDER BY type, issue_id;
@@ -911,9 +740,6 @@ ON CONFLICT(issue_id) DO UPDATE SET
 -- name: GetIssueHistoryCache :one
 SELECT issue_id, synced_at, data FROM issue_history_cache WHERE issue_id = ?;
 
--- name: GetIssueHistorySyncedAt :one
-SELECT synced_at FROM issue_history_cache WHERE issue_id = ?;
-
 -- =============================================================================
 -- Viewer Cache
 -- =============================================================================
@@ -945,6 +771,3 @@ SELECT issue_id, identifier FROM pending_detail_sync ORDER BY queued_at;
 
 -- name: CountPendingDetailSync :one
 SELECT COUNT(*) FROM pending_detail_sync;
-
--- name: ClearPendingDetailSync :exec
-DELETE FROM pending_detail_sync;

--- a/internal/db/queries.sql.go
+++ b/internal/db/queries.sql.go
@@ -12,15 +12,6 @@ import (
 	"time"
 )
 
-const clearPendingDetailSync = `-- name: ClearPendingDetailSync :exec
-DELETE FROM pending_detail_sync
-`
-
-func (q *Queries) ClearPendingDetailSync(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, clearPendingDetailSync)
-	return err
-}
-
 const countPendingDetailSync = `-- name: CountPendingDetailSync :one
 SELECT COUNT(*) FROM pending_detail_sync
 `
@@ -50,30 +41,12 @@ func (q *Queries) DeleteComment(ctx context.Context, id string) error {
 	return err
 }
 
-const deleteCycle = `-- name: DeleteCycle :exec
-DELETE FROM cycles WHERE id = ?
-`
-
-func (q *Queries) DeleteCycle(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, deleteCycle, id)
-	return err
-}
-
 const deleteDocument = `-- name: DeleteDocument :exec
 DELETE FROM documents WHERE id = ?
 `
 
 func (q *Queries) DeleteDocument(ctx context.Context, id string) error {
 	_, err := q.db.ExecContext(ctx, deleteDocument, id)
-	return err
-}
-
-const deleteEmbeddedFile = `-- name: DeleteEmbeddedFile :exec
-DELETE FROM embedded_files WHERE id = ?
-`
-
-func (q *Queries) DeleteEmbeddedFile(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, deleteEmbeddedFile, id)
 	return err
 }
 
@@ -127,15 +100,6 @@ func (q *Queries) DeleteInitiativeProjectsByProject(ctx context.Context, project
 	return err
 }
 
-const deleteInitiativeUpdate = `-- name: DeleteInitiativeUpdate :exec
-DELETE FROM initiative_updates WHERE id = ?
-`
-
-func (q *Queries) DeleteInitiativeUpdate(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, deleteInitiativeUpdate, id)
-	return err
-}
-
 const deleteInitiativeUpdates = `-- name: DeleteInitiativeUpdates :exec
 DELETE FROM initiative_updates WHERE initiative_id = ?
 `
@@ -160,15 +124,6 @@ DELETE FROM attachments WHERE issue_id = ?
 
 func (q *Queries) DeleteIssueAttachments(ctx context.Context, issueID string) error {
 	_, err := q.db.ExecContext(ctx, deleteIssueAttachments, issueID)
-	return err
-}
-
-const deleteIssueByIdentifier = `-- name: DeleteIssueByIdentifier :exec
-DELETE FROM issues WHERE identifier = ?
-`
-
-func (q *Queries) DeleteIssueByIdentifier(ctx context.Context, identifier string) error {
-	_, err := q.db.ExecContext(ctx, deleteIssueByIdentifier, identifier)
 	return err
 }
 
@@ -280,35 +235,12 @@ func (q *Queries) DeleteProjectMilestones(ctx context.Context, projectID string)
 	return err
 }
 
-const deleteProjectTeam = `-- name: DeleteProjectTeam :exec
-DELETE FROM project_teams WHERE project_id = ? AND team_id = ?
-`
-
-type DeleteProjectTeamParams struct {
-	ProjectID string `json:"project_id"`
-	TeamID    string `json:"team_id"`
-}
-
-func (q *Queries) DeleteProjectTeam(ctx context.Context, arg DeleteProjectTeamParams) error {
-	_, err := q.db.ExecContext(ctx, deleteProjectTeam, arg.ProjectID, arg.TeamID)
-	return err
-}
-
 const deleteProjectTeams = `-- name: DeleteProjectTeams :exec
 DELETE FROM project_teams WHERE project_id = ?
 `
 
 func (q *Queries) DeleteProjectTeams(ctx context.Context, projectID string) error {
 	_, err := q.db.ExecContext(ctx, deleteProjectTeams, projectID)
-	return err
-}
-
-const deleteProjectUpdate = `-- name: DeleteProjectUpdate :exec
-DELETE FROM project_updates WHERE id = ?
-`
-
-func (q *Queries) DeleteProjectUpdate(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, deleteProjectUpdate, id)
 	return err
 }
 
@@ -319,338 +251,6 @@ DELETE FROM project_updates WHERE project_id = ?
 func (q *Queries) DeleteProjectUpdates(ctx context.Context, projectID string) error {
 	_, err := q.db.ExecContext(ctx, deleteProjectUpdates, projectID)
 	return err
-}
-
-const deleteState = `-- name: DeleteState :exec
-DELETE FROM states WHERE id = ?
-`
-
-func (q *Queries) DeleteState(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, deleteState, id)
-	return err
-}
-
-const deleteTeamCycles = `-- name: DeleteTeamCycles :exec
-DELETE FROM cycles WHERE team_id = ?
-`
-
-func (q *Queries) DeleteTeamCycles(ctx context.Context, teamID string) error {
-	_, err := q.db.ExecContext(ctx, deleteTeamCycles, teamID)
-	return err
-}
-
-const deleteTeamIssues = `-- name: DeleteTeamIssues :exec
-DELETE FROM issues WHERE team_id = ?
-`
-
-func (q *Queries) DeleteTeamIssues(ctx context.Context, teamID string) error {
-	_, err := q.db.ExecContext(ctx, deleteTeamIssues, teamID)
-	return err
-}
-
-const deleteTeamLabels = `-- name: DeleteTeamLabels :exec
-DELETE FROM labels WHERE team_id = ?
-`
-
-func (q *Queries) DeleteTeamLabels(ctx context.Context, teamID sql.NullString) error {
-	_, err := q.db.ExecContext(ctx, deleteTeamLabels, teamID)
-	return err
-}
-
-const deleteTeamMember = `-- name: DeleteTeamMember :exec
-DELETE FROM team_members WHERE team_id = ? AND user_id = ?
-`
-
-type DeleteTeamMemberParams struct {
-	TeamID string `json:"team_id"`
-	UserID string `json:"user_id"`
-}
-
-func (q *Queries) DeleteTeamMember(ctx context.Context, arg DeleteTeamMemberParams) error {
-	_, err := q.db.ExecContext(ctx, deleteTeamMember, arg.TeamID, arg.UserID)
-	return err
-}
-
-const deleteTeamMembers = `-- name: DeleteTeamMembers :exec
-DELETE FROM team_members WHERE team_id = ?
-`
-
-func (q *Queries) DeleteTeamMembers(ctx context.Context, teamID string) error {
-	_, err := q.db.ExecContext(ctx, deleteTeamMembers, teamID)
-	return err
-}
-
-const deleteTeamStates = `-- name: DeleteTeamStates :exec
-DELETE FROM states WHERE team_id = ?
-`
-
-func (q *Queries) DeleteTeamStates(ctx context.Context, teamID string) error {
-	_, err := q.db.ExecContext(ctx, deleteTeamStates, teamID)
-	return err
-}
-
-const deleteUser = `-- name: DeleteUser :exec
-DELETE FROM users WHERE id = ?
-`
-
-func (q *Queries) DeleteUser(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, deleteUser, id)
-	return err
-}
-
-const getAttachment = `-- name: GetAttachment :one
-
-SELECT id, issue_id, title, subtitle, url, source_type, metadata, creator_id, creator_name, creator_email, created_at, updated_at, synced_at, data FROM attachments WHERE id = ?
-`
-
-// =============================================================================
-// Attachments queries (external links: GitHub PRs, Slack, etc.)
-// =============================================================================
-func (q *Queries) GetAttachment(ctx context.Context, id string) (Attachment, error) {
-	row := q.db.QueryRowContext(ctx, getAttachment, id)
-	var i Attachment
-	err := row.Scan(
-		&i.ID,
-		&i.IssueID,
-		&i.Title,
-		&i.Subtitle,
-		&i.Url,
-		&i.SourceType,
-		&i.Metadata,
-		&i.CreatorID,
-		&i.CreatorName,
-		&i.CreatorEmail,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.SyncedAt,
-		&i.Data,
-	)
-	return i, err
-}
-
-const getComment = `-- name: GetComment :one
-
-SELECT id, issue_id, body, body_data, user_id, user_name, user_email, edited_at, created_at, updated_at, synced_at, data FROM comments WHERE id = ?
-`
-
-// =============================================================================
-// Comments queries
-// =============================================================================
-func (q *Queries) GetComment(ctx context.Context, id string) (Comment, error) {
-	row := q.db.QueryRowContext(ctx, getComment, id)
-	var i Comment
-	err := row.Scan(
-		&i.ID,
-		&i.IssueID,
-		&i.Body,
-		&i.BodyData,
-		&i.UserID,
-		&i.UserName,
-		&i.UserEmail,
-		&i.EditedAt,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.SyncedAt,
-		&i.Data,
-	)
-	return i, err
-}
-
-const getCycle = `-- name: GetCycle :one
-
-SELECT id, team_id, number, name, description, starts_at, ends_at, completed_at, progress, created_at, updated_at, synced_at, data FROM cycles WHERE id = ?
-`
-
-// =============================================================================
-// Cycles queries
-// =============================================================================
-func (q *Queries) GetCycle(ctx context.Context, id string) (Cycle, error) {
-	row := q.db.QueryRowContext(ctx, getCycle, id)
-	var i Cycle
-	err := row.Scan(
-		&i.ID,
-		&i.TeamID,
-		&i.Number,
-		&i.Name,
-		&i.Description,
-		&i.StartsAt,
-		&i.EndsAt,
-		&i.CompletedAt,
-		&i.Progress,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.SyncedAt,
-		&i.Data,
-	)
-	return i, err
-}
-
-const getCycleByName = `-- name: GetCycleByName :one
-SELECT id, team_id, number, name, description, starts_at, ends_at, completed_at, progress, created_at, updated_at, synced_at, data FROM cycles WHERE team_id = ? AND name = ?
-`
-
-type GetCycleByNameParams struct {
-	TeamID string         `json:"team_id"`
-	Name   sql.NullString `json:"name"`
-}
-
-func (q *Queries) GetCycleByName(ctx context.Context, arg GetCycleByNameParams) (Cycle, error) {
-	row := q.db.QueryRowContext(ctx, getCycleByName, arg.TeamID, arg.Name)
-	var i Cycle
-	err := row.Scan(
-		&i.ID,
-		&i.TeamID,
-		&i.Number,
-		&i.Name,
-		&i.Description,
-		&i.StartsAt,
-		&i.EndsAt,
-		&i.CompletedAt,
-		&i.Progress,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.SyncedAt,
-		&i.Data,
-	)
-	return i, err
-}
-
-const getCycleByNumber = `-- name: GetCycleByNumber :one
-SELECT id, team_id, number, name, description, starts_at, ends_at, completed_at, progress, created_at, updated_at, synced_at, data FROM cycles WHERE team_id = ? AND number = ?
-`
-
-type GetCycleByNumberParams struct {
-	TeamID string `json:"team_id"`
-	Number int64  `json:"number"`
-}
-
-func (q *Queries) GetCycleByNumber(ctx context.Context, arg GetCycleByNumberParams) (Cycle, error) {
-	row := q.db.QueryRowContext(ctx, getCycleByNumber, arg.TeamID, arg.Number)
-	var i Cycle
-	err := row.Scan(
-		&i.ID,
-		&i.TeamID,
-		&i.Number,
-		&i.Name,
-		&i.Description,
-		&i.StartsAt,
-		&i.EndsAt,
-		&i.CompletedAt,
-		&i.Progress,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.SyncedAt,
-		&i.Data,
-	)
-	return i, err
-}
-
-const getDocument = `-- name: GetDocument :one
-
-SELECT id, slug_id, title, icon, color, content, content_data, issue_id, project_id, initiative_id, creator_id, url, created_at, updated_at, synced_at, data FROM documents WHERE id = ?
-`
-
-// =============================================================================
-// Documents queries
-// =============================================================================
-func (q *Queries) GetDocument(ctx context.Context, id string) (Document, error) {
-	row := q.db.QueryRowContext(ctx, getDocument, id)
-	var i Document
-	err := row.Scan(
-		&i.ID,
-		&i.SlugID,
-		&i.Title,
-		&i.Icon,
-		&i.Color,
-		&i.Content,
-		&i.ContentData,
-		&i.IssueID,
-		&i.ProjectID,
-		&i.InitiativeID,
-		&i.CreatorID,
-		&i.Url,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.SyncedAt,
-		&i.Data,
-	)
-	return i, err
-}
-
-const getDocumentBySlug = `-- name: GetDocumentBySlug :one
-SELECT id, slug_id, title, icon, color, content, content_data, issue_id, project_id, initiative_id, creator_id, url, created_at, updated_at, synced_at, data FROM documents WHERE slug_id = ?
-`
-
-func (q *Queries) GetDocumentBySlug(ctx context.Context, slugID string) (Document, error) {
-	row := q.db.QueryRowContext(ctx, getDocumentBySlug, slugID)
-	var i Document
-	err := row.Scan(
-		&i.ID,
-		&i.SlugID,
-		&i.Title,
-		&i.Icon,
-		&i.Color,
-		&i.Content,
-		&i.ContentData,
-		&i.IssueID,
-		&i.ProjectID,
-		&i.InitiativeID,
-		&i.CreatorID,
-		&i.Url,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.SyncedAt,
-		&i.Data,
-	)
-	return i, err
-}
-
-const getEmbeddedFile = `-- name: GetEmbeddedFile :one
-
-SELECT id, issue_id, url, filename, mime_type, file_size, cache_path, source, created_at, synced_at FROM embedded_files WHERE id = ?
-`
-
-// =============================================================================
-// Embedded Files queries (images, PDFs from Linear CDN)
-// =============================================================================
-func (q *Queries) GetEmbeddedFile(ctx context.Context, id string) (EmbeddedFile, error) {
-	row := q.db.QueryRowContext(ctx, getEmbeddedFile, id)
-	var i EmbeddedFile
-	err := row.Scan(
-		&i.ID,
-		&i.IssueID,
-		&i.Url,
-		&i.Filename,
-		&i.MimeType,
-		&i.FileSize,
-		&i.CachePath,
-		&i.Source,
-		&i.CreatedAt,
-		&i.SyncedAt,
-	)
-	return i, err
-}
-
-const getEmbeddedFileByURL = `-- name: GetEmbeddedFileByURL :one
-SELECT id, issue_id, url, filename, mime_type, file_size, cache_path, source, created_at, synced_at FROM embedded_files WHERE url = ?
-`
-
-func (q *Queries) GetEmbeddedFileByURL(ctx context.Context, url string) (EmbeddedFile, error) {
-	row := q.db.QueryRowContext(ctx, getEmbeddedFileByURL, url)
-	var i EmbeddedFile
-	err := row.Scan(
-		&i.ID,
-		&i.IssueID,
-		&i.Url,
-		&i.Filename,
-		&i.MimeType,
-		&i.FileSize,
-		&i.CachePath,
-		&i.Source,
-		&i.CreatedAt,
-		&i.SyncedAt,
-	)
-	return i, err
 }
 
 const getInitiative = `-- name: GetInitiative :one
@@ -684,33 +284,6 @@ func (q *Queries) GetInitiative(ctx context.Context, id string) (Initiative, err
 	return i, err
 }
 
-const getInitiativeBySlug = `-- name: GetInitiativeBySlug :one
-SELECT id, slug_id, name, description, icon, color, status, sort_order, target_date, owner_id, url, created_at, updated_at, synced_at, data FROM initiatives WHERE slug_id = ?
-`
-
-func (q *Queries) GetInitiativeBySlug(ctx context.Context, slugID string) (Initiative, error) {
-	row := q.db.QueryRowContext(ctx, getInitiativeBySlug, slugID)
-	var i Initiative
-	err := row.Scan(
-		&i.ID,
-		&i.SlugID,
-		&i.Name,
-		&i.Description,
-		&i.Icon,
-		&i.Color,
-		&i.Status,
-		&i.SortOrder,
-		&i.TargetDate,
-		&i.OwnerID,
-		&i.Url,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.SyncedAt,
-		&i.Data,
-	)
-	return i, err
-}
-
 const getInitiativeDocumentsSyncedAt = `-- name: GetInitiativeDocumentsSyncedAt :one
 SELECT MAX(synced_at) FROM documents WHERE initiative_id = ?
 `
@@ -720,35 +293,6 @@ func (q *Queries) GetInitiativeDocumentsSyncedAt(ctx context.Context, initiative
 	var max interface{}
 	err := row.Scan(&max)
 	return max, err
-}
-
-const getInitiativeUpdate = `-- name: GetInitiativeUpdate :one
-
-SELECT id, initiative_id, body, body_data, health, user_id, user_name, url, edited_at, created_at, updated_at, synced_at, data FROM initiative_updates WHERE id = ?
-`
-
-// =============================================================================
-// Initiative Updates queries
-// =============================================================================
-func (q *Queries) GetInitiativeUpdate(ctx context.Context, id string) (InitiativeUpdate, error) {
-	row := q.db.QueryRowContext(ctx, getInitiativeUpdate, id)
-	var i InitiativeUpdate
-	err := row.Scan(
-		&i.ID,
-		&i.InitiativeID,
-		&i.Body,
-		&i.BodyData,
-		&i.Health,
-		&i.UserID,
-		&i.UserName,
-		&i.Url,
-		&i.EditedAt,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.SyncedAt,
-		&i.Data,
-	)
-	return i, err
 }
 
 const getInitiativeUpdatesSyncedAt = `-- name: GetInitiativeUpdatesSyncedAt :one
@@ -877,40 +421,6 @@ func (q *Queries) GetIssueHistoryCache(ctx context.Context, issueID string) (Iss
 	return i, err
 }
 
-const getIssueHistorySyncedAt = `-- name: GetIssueHistorySyncedAt :one
-SELECT synced_at FROM issue_history_cache WHERE issue_id = ?
-`
-
-func (q *Queries) GetIssueHistorySyncedAt(ctx context.Context, issueID string) (time.Time, error) {
-	row := q.db.QueryRowContext(ctx, getIssueHistorySyncedAt, issueID)
-	var synced_at time.Time
-	err := row.Scan(&synced_at)
-	return synced_at, err
-}
-
-const getIssueRelation = `-- name: GetIssueRelation :one
-
-SELECT id, issue_id, related_issue_id, type, created_at, updated_at, synced_at FROM issue_relations WHERE id = ?
-`
-
-// =============================================================================
-// Issue Relations queries
-// =============================================================================
-func (q *Queries) GetIssueRelation(ctx context.Context, id string) (IssueRelation, error) {
-	row := q.db.QueryRowContext(ctx, getIssueRelation, id)
-	var i IssueRelation
-	err := row.Scan(
-		&i.ID,
-		&i.IssueID,
-		&i.RelatedIssueID,
-		&i.Type,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.SyncedAt,
-	)
-	return i, err
-}
-
 const getIssueUpdatedAt = `-- name: GetIssueUpdatedAt :one
 
 
@@ -991,33 +501,6 @@ func (q *Queries) GetLatestTeamIssueUpdatedAt(ctx context.Context, teamID string
 	return max, err
 }
 
-const getMilestoneByName = `-- name: GetMilestoneByName :one
-SELECT id, project_id, name, description, target_date, sort_order, created_at, updated_at, synced_at, data FROM project_milestones WHERE project_id = ? AND name = ?
-`
-
-type GetMilestoneByNameParams struct {
-	ProjectID string `json:"project_id"`
-	Name      string `json:"name"`
-}
-
-func (q *Queries) GetMilestoneByName(ctx context.Context, arg GetMilestoneByNameParams) (ProjectMilestone, error) {
-	row := q.db.QueryRowContext(ctx, getMilestoneByName, arg.ProjectID, arg.Name)
-	var i ProjectMilestone
-	err := row.Scan(
-		&i.ID,
-		&i.ProjectID,
-		&i.Name,
-		&i.Description,
-		&i.TargetDate,
-		&i.SortOrder,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.SyncedAt,
-		&i.Data,
-	)
-	return i, err
-}
-
 const getProject = `-- name: GetProject :one
 
 SELECT id, slug_id, name, description, icon, color, state, progress, start_date, target_date, lead_id, url, created_at, updated_at, synced_at, data FROM projects WHERE id = ?
@@ -1028,34 +511,6 @@ SELECT id, slug_id, name, description, icon, color, state, progress, start_date,
 // =============================================================================
 func (q *Queries) GetProject(ctx context.Context, id string) (Project, error) {
 	row := q.db.QueryRowContext(ctx, getProject, id)
-	var i Project
-	err := row.Scan(
-		&i.ID,
-		&i.SlugID,
-		&i.Name,
-		&i.Description,
-		&i.Icon,
-		&i.Color,
-		&i.State,
-		&i.Progress,
-		&i.StartDate,
-		&i.TargetDate,
-		&i.LeadID,
-		&i.Url,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.SyncedAt,
-		&i.Data,
-	)
-	return i, err
-}
-
-const getProjectBySlug = `-- name: GetProjectBySlug :one
-SELECT id, slug_id, name, description, icon, color, state, progress, start_date, target_date, lead_id, url, created_at, updated_at, synced_at, data FROM projects WHERE slug_id = ?
-`
-
-func (q *Queries) GetProjectBySlug(ctx context.Context, slugID string) (Project, error) {
-	row := q.db.QueryRowContext(ctx, getProjectBySlug, slugID)
 	var i Project
 	err := row.Scan(
 		&i.ID,
@@ -1133,35 +588,6 @@ func (q *Queries) GetProjectPrimaryTeamKey(ctx context.Context, projectID string
 	return key, err
 }
 
-const getProjectUpdate = `-- name: GetProjectUpdate :one
-
-SELECT id, project_id, body, body_data, health, user_id, user_name, url, edited_at, created_at, updated_at, synced_at, data FROM project_updates WHERE id = ?
-`
-
-// =============================================================================
-// Project Updates queries
-// =============================================================================
-func (q *Queries) GetProjectUpdate(ctx context.Context, id string) (ProjectUpdate, error) {
-	row := q.db.QueryRowContext(ctx, getProjectUpdate, id)
-	var i ProjectUpdate
-	err := row.Scan(
-		&i.ID,
-		&i.ProjectID,
-		&i.Body,
-		&i.BodyData,
-		&i.Health,
-		&i.UserID,
-		&i.UserName,
-		&i.Url,
-		&i.EditedAt,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.SyncedAt,
-		&i.Data,
-	)
-	return i, err
-}
-
 const getProjectUpdatesSyncedAt = `-- name: GetProjectUpdatesSyncedAt :one
 SELECT MAX(synced_at) FROM project_updates WHERE project_id = ?
 `
@@ -1175,9 +601,13 @@ func (q *Queries) GetProjectUpdatesSyncedAt(ctx context.Context, projectID strin
 
 const getState = `-- name: GetState :one
 
+
 SELECT id, team_id, name, type, color, position, created_at, updated_at, synced_at, data FROM states WHERE id = ?
 `
 
+// Label-based queries (labels stored in JSON data column)
+// These require extracting from JSON - keeping simple queries here,
+// complex label queries will be done in Go code
 // =============================================================================
 // States queries
 // =============================================================================
@@ -1244,63 +674,12 @@ func (q *Queries) GetSyncMeta(ctx context.Context, teamID string) (SyncMetum, er
 	return i, err
 }
 
-const getTeam = `-- name: GetTeam :one
-
-SELECT id, "key", name, icon, created_at, updated_at, synced_at FROM teams WHERE id = ?
-`
-
-// Teams queries
-func (q *Queries) GetTeam(ctx context.Context, id string) (Team, error) {
-	row := q.db.QueryRowContext(ctx, getTeam, id)
-	var i Team
-	err := row.Scan(
-		&i.ID,
-		&i.Key,
-		&i.Name,
-		&i.Icon,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.SyncedAt,
-	)
-	return i, err
-}
-
-const getTeamByKey = `-- name: GetTeamByKey :one
-SELECT id, "key", name, icon, created_at, updated_at, synced_at FROM teams WHERE key = ?
-`
-
-func (q *Queries) GetTeamByKey(ctx context.Context, key string) (Team, error) {
-	row := q.db.QueryRowContext(ctx, getTeamByKey, key)
-	var i Team
-	err := row.Scan(
-		&i.ID,
-		&i.Key,
-		&i.Name,
-		&i.Icon,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.SyncedAt,
-	)
-	return i, err
-}
-
 const getTeamIssueCount = `-- name: GetTeamIssueCount :one
 SELECT COUNT(*) FROM issues WHERE team_id = ?
 `
 
 func (q *Queries) GetTeamIssueCount(ctx context.Context, teamID string) (int64, error) {
 	row := q.db.QueryRowContext(ctx, getTeamIssueCount, teamID)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
-}
-
-const getTotalIssueCount = `-- name: GetTotalIssueCount :one
-SELECT COUNT(*) FROM issues
-`
-
-func (q *Queries) GetTotalIssueCount(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getTotalIssueCount)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -1333,29 +712,6 @@ func (q *Queries) GetUser(ctx context.Context, id string) (User, error) {
 	return i, err
 }
 
-const getUserByEmail = `-- name: GetUserByEmail :one
-SELECT id, email, name, display_name, avatar_url, active, admin, created_at, updated_at, synced_at, data FROM users WHERE email = ?
-`
-
-func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error) {
-	row := q.db.QueryRowContext(ctx, getUserByEmail, email)
-	var i User
-	err := row.Scan(
-		&i.ID,
-		&i.Email,
-		&i.Name,
-		&i.DisplayName,
-		&i.AvatarUrl,
-		&i.Active,
-		&i.Admin,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.SyncedAt,
-		&i.Data,
-	)
-	return i, err
-}
-
 const getViewerUserID = `-- name: GetViewerUserID :one
 
 SELECT user_id FROM viewer_cache LIMIT 1
@@ -1369,119 +725,6 @@ func (q *Queries) GetViewerUserID(ctx context.Context) (string, error) {
 	var user_id string
 	err := row.Scan(&user_id)
 	return user_id, err
-}
-
-const listAllIdentifiers = `-- name: ListAllIdentifiers :many
-
-SELECT identifier, team_id FROM issues ORDER BY identifier
-`
-
-type ListAllIdentifiersRow struct {
-	Identifier string `json:"identifier"`
-	TeamID     string `json:"team_id"`
-}
-
-// Label-based queries (labels stored in JSON data column)
-// These require extracting from JSON - keeping simple queries here,
-// complex label queries will be done in Go code
-func (q *Queries) ListAllIdentifiers(ctx context.Context) ([]ListAllIdentifiersRow, error) {
-	rows, err := q.db.QueryContext(ctx, listAllIdentifiers)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []ListAllIdentifiersRow{}
-	for rows.Next() {
-		var i ListAllIdentifiersRow
-		if err := rows.Scan(&i.Identifier, &i.TeamID); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listAllUsers = `-- name: ListAllUsers :many
-SELECT id, email, name, display_name, avatar_url, active, admin, created_at, updated_at, synced_at, data FROM users ORDER BY name
-`
-
-func (q *Queries) ListAllUsers(ctx context.Context) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, listAllUsers)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []User{}
-	for rows.Next() {
-		var i User
-		if err := rows.Scan(
-			&i.ID,
-			&i.Email,
-			&i.Name,
-			&i.DisplayName,
-			&i.AvatarUrl,
-			&i.Active,
-			&i.Admin,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.SyncedAt,
-			&i.Data,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listCachedEmbeddedFiles = `-- name: ListCachedEmbeddedFiles :many
-SELECT id, issue_id, url, filename, mime_type, file_size, cache_path, source, created_at, synced_at FROM embedded_files WHERE cache_path IS NOT NULL
-`
-
-func (q *Queries) ListCachedEmbeddedFiles(ctx context.Context) ([]EmbeddedFile, error) {
-	rows, err := q.db.QueryContext(ctx, listCachedEmbeddedFiles)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []EmbeddedFile{}
-	for rows.Next() {
-		var i EmbeddedFile
-		if err := rows.Scan(
-			&i.ID,
-			&i.IssueID,
-			&i.Url,
-			&i.Filename,
-			&i.MimeType,
-			&i.FileSize,
-			&i.CachePath,
-			&i.Source,
-			&i.CreatedAt,
-			&i.SyncedAt,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
 }
 
 const listCycleIssues = `-- name: ListCycleIssues :many
@@ -1587,84 +830,14 @@ func (q *Queries) ListInitiativeDocuments(ctx context.Context, initiativeID sql.
 	return items, nil
 }
 
-const listInitiativeProjectIDs = `-- name: ListInitiativeProjectIDs :many
-SELECT project_id FROM initiative_projects WHERE initiative_id = ?
-`
-
-func (q *Queries) ListInitiativeProjectIDs(ctx context.Context, initiativeID string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listInitiativeProjectIDs, initiativeID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []string{}
-	for rows.Next() {
-		var project_id string
-		if err := rows.Scan(&project_id); err != nil {
-			return nil, err
-		}
-		items = append(items, project_id)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listInitiativeProjects = `-- name: ListInitiativeProjects :many
-SELECT p.id, p.slug_id, p.name, p.description, p.icon, p.color, p.state, p.progress, p.start_date, p.target_date, p.lead_id, p.url, p.created_at, p.updated_at, p.synced_at, p.data FROM projects p
-JOIN initiative_projects ip ON p.id = ip.project_id
-WHERE ip.initiative_id = ?
-ORDER BY p.name
-`
-
-func (q *Queries) ListInitiativeProjects(ctx context.Context, initiativeID string) ([]Project, error) {
-	rows, err := q.db.QueryContext(ctx, listInitiativeProjects, initiativeID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []Project{}
-	for rows.Next() {
-		var i Project
-		if err := rows.Scan(
-			&i.ID,
-			&i.SlugID,
-			&i.Name,
-			&i.Description,
-			&i.Icon,
-			&i.Color,
-			&i.State,
-			&i.Progress,
-			&i.StartDate,
-			&i.TargetDate,
-			&i.LeadID,
-			&i.Url,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.SyncedAt,
-			&i.Data,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listInitiativeUpdates = `-- name: ListInitiativeUpdates :many
+
 SELECT id, initiative_id, body, body_data, health, user_id, user_name, url, edited_at, created_at, updated_at, synced_at, data FROM initiative_updates WHERE initiative_id = ? ORDER BY created_at DESC
 `
 
+// =============================================================================
+// Initiative Updates queries
+// =============================================================================
 func (q *Queries) ListInitiativeUpdates(ctx context.Context, initiativeID string) ([]InitiativeUpdate, error) {
 	rows, err := q.db.QueryContext(ctx, listInitiativeUpdates, initiativeID)
 	if err != nil {
@@ -1746,9 +919,13 @@ func (q *Queries) ListInitiatives(ctx context.Context) ([]Initiative, error) {
 }
 
 const listIssueAttachments = `-- name: ListIssueAttachments :many
+
 SELECT id, issue_id, title, subtitle, url, source_type, metadata, creator_id, creator_name, creator_email, created_at, updated_at, synced_at, data FROM attachments WHERE issue_id = ? ORDER BY created_at, id
 `
 
+// =============================================================================
+// Attachments queries (external links: GitHub PRs, Slack, etc.)
+// =============================================================================
 // The id tiebreaker keeps the order deterministic on equal created_at, so
 // attachmentListing dedup suffixes stay stable across calls.
 func (q *Queries) ListIssueAttachments(ctx context.Context, issueID string) ([]Attachment, error) {
@@ -1790,9 +967,13 @@ func (q *Queries) ListIssueAttachments(ctx context.Context, issueID string) ([]A
 }
 
 const listIssueComments = `-- name: ListIssueComments :many
+
 SELECT id, issue_id, body, body_data, user_id, user_name, user_email, edited_at, created_at, updated_at, synced_at, data FROM comments WHERE issue_id = ? ORDER BY created_at
 `
 
+// =============================================================================
+// Comments queries
+// =============================================================================
 func (q *Queries) ListIssueComments(ctx context.Context, issueID string) ([]Comment, error) {
 	rows, err := q.db.QueryContext(ctx, listIssueComments, issueID)
 	if err != nil {
@@ -1830,9 +1011,13 @@ func (q *Queries) ListIssueComments(ctx context.Context, issueID string) ([]Comm
 }
 
 const listIssueDocuments = `-- name: ListIssueDocuments :many
+
 SELECT id, slug_id, title, icon, color, content, content_data, issue_id, project_id, initiative_id, creator_id, url, created_at, updated_at, synced_at, data FROM documents WHERE issue_id = ? ORDER BY title
 `
 
+// =============================================================================
+// Documents queries
+// =============================================================================
 func (q *Queries) ListIssueDocuments(ctx context.Context, issueID sql.NullString) ([]Document, error) {
 	rows, err := q.db.QueryContext(ctx, listIssueDocuments, issueID)
 	if err != nil {
@@ -1874,9 +1059,13 @@ func (q *Queries) ListIssueDocuments(ctx context.Context, issueID sql.NullString
 }
 
 const listIssueEmbeddedFiles = `-- name: ListIssueEmbeddedFiles :many
+
 SELECT id, issue_id, url, filename, mime_type, file_size, cache_path, source, created_at, synced_at FROM embedded_files WHERE issue_id = ? ORDER BY filename, id
 `
 
+// =============================================================================
+// Embedded Files queries (images, PDFs from Linear CDN)
+// =============================================================================
 // The id tiebreaker keeps the order deterministic on equal filenames (the
 // dedup case), so which duplicate gets the (2) suffix stays stable.
 func (q *Queries) ListIssueEmbeddedFiles(ctx context.Context, issueID string) ([]EmbeddedFile, error) {
@@ -1949,51 +1138,15 @@ func (q *Queries) ListIssueInverseRelations(ctx context.Context, relatedIssueID 
 }
 
 const listIssueRelations = `-- name: ListIssueRelations :many
+
 SELECT id, issue_id, related_issue_id, type, created_at, updated_at, synced_at FROM issue_relations WHERE issue_id = ? ORDER BY type, related_issue_id
 `
 
+// =============================================================================
+// Issue Relations queries
+// =============================================================================
 func (q *Queries) ListIssueRelations(ctx context.Context, issueID string) ([]IssueRelation, error) {
 	rows, err := q.db.QueryContext(ctx, listIssueRelations, issueID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []IssueRelation{}
-	for rows.Next() {
-		var i IssueRelation
-		if err := rows.Scan(
-			&i.ID,
-			&i.IssueID,
-			&i.RelatedIssueID,
-			&i.Type,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.SyncedAt,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listIssueRelationsByType = `-- name: ListIssueRelationsByType :many
-SELECT id, issue_id, related_issue_id, type, created_at, updated_at, synced_at FROM issue_relations WHERE issue_id = ? AND type = ? ORDER BY related_issue_id
-`
-
-type ListIssueRelationsByTypeParams struct {
-	IssueID string `json:"issue_id"`
-	Type    string `json:"type"`
-}
-
-func (q *Queries) ListIssueRelationsByType(ctx context.Context, arg ListIssueRelationsByTypeParams) ([]IssueRelation, error) {
-	rows, err := q.db.QueryContext(ctx, listIssueRelationsByType, arg.IssueID, arg.Type)
 	if err != nil {
 		return nil, err
 	}
@@ -2089,33 +1242,6 @@ func (q *Queries) ListProjectDocuments(ctx context.Context, projectID sql.NullSt
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listProjectInitiativeIDs = `-- name: ListProjectInitiativeIDs :many
-SELECT initiative_id FROM initiative_projects WHERE project_id = ?
-`
-
-func (q *Queries) ListProjectInitiativeIDs(ctx context.Context, projectID string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listProjectInitiativeIDs, projectID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []string{}
-	for rows.Next() {
-		var initiative_id string
-		if err := rows.Scan(&initiative_id); err != nil {
-			return nil, err
-		}
-		items = append(items, initiative_id)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -2266,37 +1392,14 @@ func (q *Queries) ListProjectMilestones(ctx context.Context, projectID string) (
 	return items, nil
 }
 
-const listProjectTeamIDs = `-- name: ListProjectTeamIDs :many
-SELECT team_id FROM project_teams WHERE project_id = ?
-`
-
-func (q *Queries) ListProjectTeamIDs(ctx context.Context, projectID string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listProjectTeamIDs, projectID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []string{}
-	for rows.Next() {
-		var team_id string
-		if err := rows.Scan(&team_id); err != nil {
-			return nil, err
-		}
-		items = append(items, team_id)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listProjectUpdates = `-- name: ListProjectUpdates :many
+
 SELECT id, project_id, body, body_data, health, user_id, user_name, url, edited_at, created_at, updated_at, synced_at, data FROM project_updates WHERE project_id = ? ORDER BY created_at DESC
 `
 
+// =============================================================================
+// Project Updates queries
+// =============================================================================
 func (q *Queries) ListProjectUpdates(ctx context.Context, projectID string) ([]ProjectUpdate, error) {
 	rows, err := q.db.QueryContext(ctx, listProjectUpdates, projectID)
 	if err != nil {
@@ -2378,127 +1481,14 @@ func (q *Queries) ListProjects(ctx context.Context) ([]Project, error) {
 	return items, nil
 }
 
-const listProjectsByState = `-- name: ListProjectsByState :many
-SELECT id, slug_id, name, description, icon, color, state, progress, start_date, target_date, lead_id, url, created_at, updated_at, synced_at, data FROM projects WHERE state = ? ORDER BY name
-`
-
-func (q *Queries) ListProjectsByState(ctx context.Context, state sql.NullString) ([]Project, error) {
-	rows, err := q.db.QueryContext(ctx, listProjectsByState, state)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []Project{}
-	for rows.Next() {
-		var i Project
-		if err := rows.Scan(
-			&i.ID,
-			&i.SlugID,
-			&i.Name,
-			&i.Description,
-			&i.Icon,
-			&i.Color,
-			&i.State,
-			&i.Progress,
-			&i.StartDate,
-			&i.TargetDate,
-			&i.LeadID,
-			&i.Url,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.SyncedAt,
-			&i.Data,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listSyncMeta = `-- name: ListSyncMeta :many
-SELECT team_id, last_synced_at, last_issue_updated_at, issue_count FROM sync_meta
-`
-
-func (q *Queries) ListSyncMeta(ctx context.Context) ([]SyncMetum, error) {
-	rows, err := q.db.QueryContext(ctx, listSyncMeta)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []SyncMetum{}
-	for rows.Next() {
-		var i SyncMetum
-		if err := rows.Scan(
-			&i.TeamID,
-			&i.LastSyncedAt,
-			&i.LastIssueUpdatedAt,
-			&i.IssueCount,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listTeamActiveCycles = `-- name: ListTeamActiveCycles :many
-SELECT id, team_id, number, name, description, starts_at, ends_at, completed_at, progress, created_at, updated_at, synced_at, data FROM cycles WHERE team_id = ? AND ends_at > datetime('now') ORDER BY starts_at
-`
-
-func (q *Queries) ListTeamActiveCycles(ctx context.Context, teamID string) ([]Cycle, error) {
-	rows, err := q.db.QueryContext(ctx, listTeamActiveCycles, teamID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []Cycle{}
-	for rows.Next() {
-		var i Cycle
-		if err := rows.Scan(
-			&i.ID,
-			&i.TeamID,
-			&i.Number,
-			&i.Name,
-			&i.Description,
-			&i.StartsAt,
-			&i.EndsAt,
-			&i.CompletedAt,
-			&i.Progress,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.SyncedAt,
-			&i.Data,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listTeamCycles = `-- name: ListTeamCycles :many
+
 SELECT id, team_id, number, name, description, starts_at, ends_at, completed_at, progress, created_at, updated_at, synced_at, data FROM cycles WHERE team_id = ? ORDER BY number DESC
 `
 
+// =============================================================================
+// Cycles queries
+// =============================================================================
 func (q *Queries) ListTeamCycles(ctx context.Context, teamID string) ([]Cycle, error) {
 	rows, err := q.db.QueryContext(ctx, listTeamCycles, teamID)
 	if err != nil {
@@ -2526,33 +1516,6 @@ func (q *Queries) ListTeamCycles(ctx context.Context, teamID string) ([]Cycle, e
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listTeamIdentifiers = `-- name: ListTeamIdentifiers :many
-SELECT identifier FROM issues WHERE team_id = ? ORDER BY identifier
-`
-
-func (q *Queries) ListTeamIdentifiers(ctx context.Context, teamID string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listTeamIdentifiers, teamID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []string{}
-	for rows.Next() {
-		var identifier string
-		if err := rows.Scan(&identifier); err != nil {
-			return nil, err
-		}
-		items = append(items, identifier)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -2718,396 +1681,12 @@ func (q *Queries) ListTeamIssuesByAssignee(ctx context.Context, arg ListTeamIssu
 	return items, nil
 }
 
-const listTeamIssuesByAssigneeEmail = `-- name: ListTeamIssuesByAssigneeEmail :many
-SELECT id, identifier, team_id, title, description, state_id, state_name, state_type, assignee_id, assignee_email, creator_id, creator_email, priority, project_id, project_name, cycle_id, cycle_name, parent_id, due_date, estimate, url, branch_name, created_at, updated_at, started_at, completed_at, canceled_at, archived_at, synced_at, detail_synced_at, data FROM issues WHERE team_id = ? AND assignee_email = ? ORDER BY updated_at DESC
-`
-
-type ListTeamIssuesByAssigneeEmailParams struct {
-	TeamID        string         `json:"team_id"`
-	AssigneeEmail sql.NullString `json:"assignee_email"`
-}
-
-func (q *Queries) ListTeamIssuesByAssigneeEmail(ctx context.Context, arg ListTeamIssuesByAssigneeEmailParams) ([]Issue, error) {
-	rows, err := q.db.QueryContext(ctx, listTeamIssuesByAssigneeEmail, arg.TeamID, arg.AssigneeEmail)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []Issue{}
-	for rows.Next() {
-		var i Issue
-		if err := rows.Scan(
-			&i.ID,
-			&i.Identifier,
-			&i.TeamID,
-			&i.Title,
-			&i.Description,
-			&i.StateID,
-			&i.StateName,
-			&i.StateType,
-			&i.AssigneeID,
-			&i.AssigneeEmail,
-			&i.CreatorID,
-			&i.CreatorEmail,
-			&i.Priority,
-			&i.ProjectID,
-			&i.ProjectName,
-			&i.CycleID,
-			&i.CycleName,
-			&i.ParentID,
-			&i.DueDate,
-			&i.Estimate,
-			&i.Url,
-			&i.BranchName,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.StartedAt,
-			&i.CompletedAt,
-			&i.CanceledAt,
-			&i.ArchivedAt,
-			&i.SyncedAt,
-			&i.DetailSyncedAt,
-			&i.Data,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listTeamIssuesByCycle = `-- name: ListTeamIssuesByCycle :many
-SELECT id, identifier, team_id, title, description, state_id, state_name, state_type, assignee_id, assignee_email, creator_id, creator_email, priority, project_id, project_name, cycle_id, cycle_name, parent_id, due_date, estimate, url, branch_name, created_at, updated_at, started_at, completed_at, canceled_at, archived_at, synced_at, detail_synced_at, data FROM issues WHERE team_id = ? AND cycle_id = ? ORDER BY updated_at DESC
-`
-
-type ListTeamIssuesByCycleParams struct {
-	TeamID  string         `json:"team_id"`
-	CycleID sql.NullString `json:"cycle_id"`
-}
-
-func (q *Queries) ListTeamIssuesByCycle(ctx context.Context, arg ListTeamIssuesByCycleParams) ([]Issue, error) {
-	rows, err := q.db.QueryContext(ctx, listTeamIssuesByCycle, arg.TeamID, arg.CycleID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []Issue{}
-	for rows.Next() {
-		var i Issue
-		if err := rows.Scan(
-			&i.ID,
-			&i.Identifier,
-			&i.TeamID,
-			&i.Title,
-			&i.Description,
-			&i.StateID,
-			&i.StateName,
-			&i.StateType,
-			&i.AssigneeID,
-			&i.AssigneeEmail,
-			&i.CreatorID,
-			&i.CreatorEmail,
-			&i.Priority,
-			&i.ProjectID,
-			&i.ProjectName,
-			&i.CycleID,
-			&i.CycleName,
-			&i.ParentID,
-			&i.DueDate,
-			&i.Estimate,
-			&i.Url,
-			&i.BranchName,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.StartedAt,
-			&i.CompletedAt,
-			&i.CanceledAt,
-			&i.ArchivedAt,
-			&i.SyncedAt,
-			&i.DetailSyncedAt,
-			&i.Data,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listTeamIssuesByCycleName = `-- name: ListTeamIssuesByCycleName :many
-SELECT id, identifier, team_id, title, description, state_id, state_name, state_type, assignee_id, assignee_email, creator_id, creator_email, priority, project_id, project_name, cycle_id, cycle_name, parent_id, due_date, estimate, url, branch_name, created_at, updated_at, started_at, completed_at, canceled_at, archived_at, synced_at, detail_synced_at, data FROM issues WHERE team_id = ? AND cycle_name = ? ORDER BY updated_at DESC
-`
-
-type ListTeamIssuesByCycleNameParams struct {
-	TeamID    string         `json:"team_id"`
-	CycleName sql.NullString `json:"cycle_name"`
-}
-
-func (q *Queries) ListTeamIssuesByCycleName(ctx context.Context, arg ListTeamIssuesByCycleNameParams) ([]Issue, error) {
-	rows, err := q.db.QueryContext(ctx, listTeamIssuesByCycleName, arg.TeamID, arg.CycleName)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []Issue{}
-	for rows.Next() {
-		var i Issue
-		if err := rows.Scan(
-			&i.ID,
-			&i.Identifier,
-			&i.TeamID,
-			&i.Title,
-			&i.Description,
-			&i.StateID,
-			&i.StateName,
-			&i.StateType,
-			&i.AssigneeID,
-			&i.AssigneeEmail,
-			&i.CreatorID,
-			&i.CreatorEmail,
-			&i.Priority,
-			&i.ProjectID,
-			&i.ProjectName,
-			&i.CycleID,
-			&i.CycleName,
-			&i.ParentID,
-			&i.DueDate,
-			&i.Estimate,
-			&i.Url,
-			&i.BranchName,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.StartedAt,
-			&i.CompletedAt,
-			&i.CanceledAt,
-			&i.ArchivedAt,
-			&i.SyncedAt,
-			&i.DetailSyncedAt,
-			&i.Data,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listTeamIssuesByParent = `-- name: ListTeamIssuesByParent :many
 SELECT id, identifier, team_id, title, description, state_id, state_name, state_type, assignee_id, assignee_email, creator_id, creator_email, priority, project_id, project_name, cycle_id, cycle_name, parent_id, due_date, estimate, url, branch_name, created_at, updated_at, started_at, completed_at, canceled_at, archived_at, synced_at, detail_synced_at, data FROM issues WHERE parent_id = ? ORDER BY updated_at DESC
 `
 
 func (q *Queries) ListTeamIssuesByParent(ctx context.Context, parentID sql.NullString) ([]Issue, error) {
 	rows, err := q.db.QueryContext(ctx, listTeamIssuesByParent, parentID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []Issue{}
-	for rows.Next() {
-		var i Issue
-		if err := rows.Scan(
-			&i.ID,
-			&i.Identifier,
-			&i.TeamID,
-			&i.Title,
-			&i.Description,
-			&i.StateID,
-			&i.StateName,
-			&i.StateType,
-			&i.AssigneeID,
-			&i.AssigneeEmail,
-			&i.CreatorID,
-			&i.CreatorEmail,
-			&i.Priority,
-			&i.ProjectID,
-			&i.ProjectName,
-			&i.CycleID,
-			&i.CycleName,
-			&i.ParentID,
-			&i.DueDate,
-			&i.Estimate,
-			&i.Url,
-			&i.BranchName,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.StartedAt,
-			&i.CompletedAt,
-			&i.CanceledAt,
-			&i.ArchivedAt,
-			&i.SyncedAt,
-			&i.DetailSyncedAt,
-			&i.Data,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listTeamIssuesByPriority = `-- name: ListTeamIssuesByPriority :many
-SELECT id, identifier, team_id, title, description, state_id, state_name, state_type, assignee_id, assignee_email, creator_id, creator_email, priority, project_id, project_name, cycle_id, cycle_name, parent_id, due_date, estimate, url, branch_name, created_at, updated_at, started_at, completed_at, canceled_at, archived_at, synced_at, detail_synced_at, data FROM issues WHERE team_id = ? AND priority = ? ORDER BY updated_at DESC
-`
-
-type ListTeamIssuesByPriorityParams struct {
-	TeamID   string        `json:"team_id"`
-	Priority sql.NullInt64 `json:"priority"`
-}
-
-func (q *Queries) ListTeamIssuesByPriority(ctx context.Context, arg ListTeamIssuesByPriorityParams) ([]Issue, error) {
-	rows, err := q.db.QueryContext(ctx, listTeamIssuesByPriority, arg.TeamID, arg.Priority)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []Issue{}
-	for rows.Next() {
-		var i Issue
-		if err := rows.Scan(
-			&i.ID,
-			&i.Identifier,
-			&i.TeamID,
-			&i.Title,
-			&i.Description,
-			&i.StateID,
-			&i.StateName,
-			&i.StateType,
-			&i.AssigneeID,
-			&i.AssigneeEmail,
-			&i.CreatorID,
-			&i.CreatorEmail,
-			&i.Priority,
-			&i.ProjectID,
-			&i.ProjectName,
-			&i.CycleID,
-			&i.CycleName,
-			&i.ParentID,
-			&i.DueDate,
-			&i.Estimate,
-			&i.Url,
-			&i.BranchName,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.StartedAt,
-			&i.CompletedAt,
-			&i.CanceledAt,
-			&i.ArchivedAt,
-			&i.SyncedAt,
-			&i.DetailSyncedAt,
-			&i.Data,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listTeamIssuesByProject = `-- name: ListTeamIssuesByProject :many
-SELECT id, identifier, team_id, title, description, state_id, state_name, state_type, assignee_id, assignee_email, creator_id, creator_email, priority, project_id, project_name, cycle_id, cycle_name, parent_id, due_date, estimate, url, branch_name, created_at, updated_at, started_at, completed_at, canceled_at, archived_at, synced_at, detail_synced_at, data FROM issues WHERE team_id = ? AND project_id = ? ORDER BY updated_at DESC
-`
-
-type ListTeamIssuesByProjectParams struct {
-	TeamID    string         `json:"team_id"`
-	ProjectID sql.NullString `json:"project_id"`
-}
-
-func (q *Queries) ListTeamIssuesByProject(ctx context.Context, arg ListTeamIssuesByProjectParams) ([]Issue, error) {
-	rows, err := q.db.QueryContext(ctx, listTeamIssuesByProject, arg.TeamID, arg.ProjectID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []Issue{}
-	for rows.Next() {
-		var i Issue
-		if err := rows.Scan(
-			&i.ID,
-			&i.Identifier,
-			&i.TeamID,
-			&i.Title,
-			&i.Description,
-			&i.StateID,
-			&i.StateName,
-			&i.StateType,
-			&i.AssigneeID,
-			&i.AssigneeEmail,
-			&i.CreatorID,
-			&i.CreatorEmail,
-			&i.Priority,
-			&i.ProjectID,
-			&i.ProjectName,
-			&i.CycleID,
-			&i.CycleName,
-			&i.ParentID,
-			&i.DueDate,
-			&i.Estimate,
-			&i.Url,
-			&i.BranchName,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.StartedAt,
-			&i.CompletedAt,
-			&i.CanceledAt,
-			&i.ArchivedAt,
-			&i.SyncedAt,
-			&i.DetailSyncedAt,
-			&i.Data,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listTeamIssuesByProjectName = `-- name: ListTeamIssuesByProjectName :many
-SELECT id, identifier, team_id, title, description, state_id, state_name, state_type, assignee_id, assignee_email, creator_id, creator_email, priority, project_id, project_name, cycle_id, cycle_name, parent_id, due_date, estimate, url, branch_name, created_at, updated_at, started_at, completed_at, canceled_at, archived_at, synced_at, detail_synced_at, data FROM issues WHERE team_id = ? AND project_name = ? ORDER BY updated_at DESC
-`
-
-type ListTeamIssuesByProjectNameParams struct {
-	TeamID      string         `json:"team_id"`
-	ProjectName sql.NullString `json:"project_name"`
-}
-
-func (q *Queries) ListTeamIssuesByProjectName(ctx context.Context, arg ListTeamIssuesByProjectNameParams) ([]Issue, error) {
-	rows, err := q.db.QueryContext(ctx, listTeamIssuesByProjectName, arg.TeamID, arg.ProjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -3172,134 +1751,6 @@ type ListTeamIssuesByStateParams struct {
 
 func (q *Queries) ListTeamIssuesByState(ctx context.Context, arg ListTeamIssuesByStateParams) ([]Issue, error) {
 	rows, err := q.db.QueryContext(ctx, listTeamIssuesByState, arg.TeamID, arg.StateID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []Issue{}
-	for rows.Next() {
-		var i Issue
-		if err := rows.Scan(
-			&i.ID,
-			&i.Identifier,
-			&i.TeamID,
-			&i.Title,
-			&i.Description,
-			&i.StateID,
-			&i.StateName,
-			&i.StateType,
-			&i.AssigneeID,
-			&i.AssigneeEmail,
-			&i.CreatorID,
-			&i.CreatorEmail,
-			&i.Priority,
-			&i.ProjectID,
-			&i.ProjectName,
-			&i.CycleID,
-			&i.CycleName,
-			&i.ParentID,
-			&i.DueDate,
-			&i.Estimate,
-			&i.Url,
-			&i.BranchName,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.StartedAt,
-			&i.CompletedAt,
-			&i.CanceledAt,
-			&i.ArchivedAt,
-			&i.SyncedAt,
-			&i.DetailSyncedAt,
-			&i.Data,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listTeamIssuesByStateName = `-- name: ListTeamIssuesByStateName :many
-SELECT id, identifier, team_id, title, description, state_id, state_name, state_type, assignee_id, assignee_email, creator_id, creator_email, priority, project_id, project_name, cycle_id, cycle_name, parent_id, due_date, estimate, url, branch_name, created_at, updated_at, started_at, completed_at, canceled_at, archived_at, synced_at, detail_synced_at, data FROM issues WHERE team_id = ? AND state_name = ? ORDER BY updated_at DESC
-`
-
-type ListTeamIssuesByStateNameParams struct {
-	TeamID    string         `json:"team_id"`
-	StateName sql.NullString `json:"state_name"`
-}
-
-func (q *Queries) ListTeamIssuesByStateName(ctx context.Context, arg ListTeamIssuesByStateNameParams) ([]Issue, error) {
-	rows, err := q.db.QueryContext(ctx, listTeamIssuesByStateName, arg.TeamID, arg.StateName)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []Issue{}
-	for rows.Next() {
-		var i Issue
-		if err := rows.Scan(
-			&i.ID,
-			&i.Identifier,
-			&i.TeamID,
-			&i.Title,
-			&i.Description,
-			&i.StateID,
-			&i.StateName,
-			&i.StateType,
-			&i.AssigneeID,
-			&i.AssigneeEmail,
-			&i.CreatorID,
-			&i.CreatorEmail,
-			&i.Priority,
-			&i.ProjectID,
-			&i.ProjectName,
-			&i.CycleID,
-			&i.CycleName,
-			&i.ParentID,
-			&i.DueDate,
-			&i.Estimate,
-			&i.Url,
-			&i.BranchName,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.StartedAt,
-			&i.CompletedAt,
-			&i.CanceledAt,
-			&i.ArchivedAt,
-			&i.SyncedAt,
-			&i.DetailSyncedAt,
-			&i.Data,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listTeamIssuesByStateType = `-- name: ListTeamIssuesByStateType :many
-SELECT id, identifier, team_id, title, description, state_id, state_name, state_type, assignee_id, assignee_email, creator_id, creator_email, priority, project_id, project_name, cycle_id, cycle_name, parent_id, due_date, estimate, url, branch_name, created_at, updated_at, started_at, completed_at, canceled_at, archived_at, synced_at, detail_synced_at, data FROM issues WHERE team_id = ? AND state_type = ? ORDER BY updated_at DESC
-`
-
-type ListTeamIssuesByStateTypeParams struct {
-	TeamID    string         `json:"team_id"`
-	StateType sql.NullString `json:"state_type"`
-}
-
-func (q *Queries) ListTeamIssuesByStateType(ctx context.Context, arg ListTeamIssuesByStateTypeParams) ([]Issue, error) {
-	rows, err := q.db.QueryContext(ctx, listTeamIssuesByStateType, arg.TeamID, arg.StateType)
 	if err != nil {
 		return nil, err
 	}
@@ -3522,49 +1973,6 @@ func (q *Queries) ListTeamStates(ctx context.Context, teamID string) ([]State, e
 	return items, nil
 }
 
-const listTeamStatesByType = `-- name: ListTeamStatesByType :many
-SELECT id, team_id, name, type, color, position, created_at, updated_at, synced_at, data FROM states WHERE team_id = ? AND type = ? ORDER BY position
-`
-
-type ListTeamStatesByTypeParams struct {
-	TeamID string `json:"team_id"`
-	Type   string `json:"type"`
-}
-
-func (q *Queries) ListTeamStatesByType(ctx context.Context, arg ListTeamStatesByTypeParams) ([]State, error) {
-	rows, err := q.db.QueryContext(ctx, listTeamStatesByType, arg.TeamID, arg.Type)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []State{}
-	for rows.Next() {
-		var i State
-		if err := rows.Scan(
-			&i.ID,
-			&i.TeamID,
-			&i.Name,
-			&i.Type,
-			&i.Color,
-			&i.Position,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.SyncedAt,
-			&i.Data,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listTeamUnassignedIssues = `-- name: ListTeamUnassignedIssues :many
 SELECT id, identifier, team_id, title, description, state_id, state_name, state_type, assignee_id, assignee_email, creator_id, creator_email, priority, project_id, project_name, cycle_id, cycle_name, parent_id, due_date, estimate, url, branch_name, created_at, updated_at, started_at, completed_at, canceled_at, archived_at, synced_at, detail_synced_at, data FROM issues WHERE team_id = ? AND assignee_id IS NULL ORDER BY updated_at DESC
 `
@@ -3625,9 +2033,11 @@ func (q *Queries) ListTeamUnassignedIssues(ctx context.Context, teamID string) (
 }
 
 const listTeams = `-- name: ListTeams :many
+
 SELECT id, "key", name, icon, created_at, updated_at, synced_at FROM teams ORDER BY name
 `
 
+// Teams queries
 func (q *Queries) ListTeams(ctx context.Context) ([]Team, error) {
 	rows, err := q.db.QueryContext(ctx, listTeams)
 	if err != nil {
@@ -3777,65 +2187,6 @@ func (q *Queries) ListUserAssignedIssues(ctx context.Context, assigneeID sql.Nul
 	return items, nil
 }
 
-const listUserAssignedIssuesByEmail = `-- name: ListUserAssignedIssuesByEmail :many
-SELECT id, identifier, team_id, title, description, state_id, state_name, state_type, assignee_id, assignee_email, creator_id, creator_email, priority, project_id, project_name, cycle_id, cycle_name, parent_id, due_date, estimate, url, branch_name, created_at, updated_at, started_at, completed_at, canceled_at, archived_at, synced_at, detail_synced_at, data FROM issues WHERE assignee_email = ? ORDER BY updated_at DESC
-`
-
-func (q *Queries) ListUserAssignedIssuesByEmail(ctx context.Context, assigneeEmail sql.NullString) ([]Issue, error) {
-	rows, err := q.db.QueryContext(ctx, listUserAssignedIssuesByEmail, assigneeEmail)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []Issue{}
-	for rows.Next() {
-		var i Issue
-		if err := rows.Scan(
-			&i.ID,
-			&i.Identifier,
-			&i.TeamID,
-			&i.Title,
-			&i.Description,
-			&i.StateID,
-			&i.StateName,
-			&i.StateType,
-			&i.AssigneeID,
-			&i.AssigneeEmail,
-			&i.CreatorID,
-			&i.CreatorEmail,
-			&i.Priority,
-			&i.ProjectID,
-			&i.ProjectName,
-			&i.CycleID,
-			&i.CycleName,
-			&i.ParentID,
-			&i.DueDate,
-			&i.Estimate,
-			&i.Url,
-			&i.BranchName,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.StartedAt,
-			&i.CompletedAt,
-			&i.CanceledAt,
-			&i.ArchivedAt,
-			&i.SyncedAt,
-			&i.DetailSyncedAt,
-			&i.Data,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listUserCreatedIssues = `-- name: ListUserCreatedIssues :many
 SELECT id, identifier, team_id, title, description, state_id, state_name, state_type, assignee_id, assignee_email, creator_id, creator_email, priority, project_id, project_name, cycle_id, cycle_name, parent_id, due_date, estimate, url, branch_name, created_at, updated_at, started_at, completed_at, canceled_at, archived_at, synced_at, detail_synced_at, data FROM issues WHERE creator_id = ? ORDER BY updated_at DESC
 `
@@ -3916,44 +2267,6 @@ func (q *Queries) ListUsers(ctx context.Context) ([]User, error) {
 			&i.AvatarUrl,
 			&i.Active,
 			&i.Admin,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.SyncedAt,
-			&i.Data,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listWorkspaceLabels = `-- name: ListWorkspaceLabels :many
-SELECT id, team_id, name, color, description, parent_id, created_at, updated_at, synced_at, data FROM labels WHERE team_id IS NULL ORDER BY name
-`
-
-func (q *Queries) ListWorkspaceLabels(ctx context.Context) ([]Label, error) {
-	rows, err := q.db.QueryContext(ctx, listWorkspaceLabels)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []Label{}
-	for rows.Next() {
-		var i Label
-		if err := rows.Scan(
-			&i.ID,
-			&i.TeamID,
-			&i.Name,
-			&i.Color,
-			&i.Description,
-			&i.ParentID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.SyncedAt,

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -149,24 +149,10 @@ func (s *Store) Queries() *Queries {
 	return s.queries
 }
 
-// DB returns the underlying database connection for raw queries
+// DB returns the underlying database connection. Test seam only: no
+// production code calls it — tests and fixture loaders use it for raw SQL.
 func (s *Store) DB() *sql.DB {
 	return s.db
-}
-
-// WithTx executes a function within a transaction
-func (s *Store) WithTx(ctx context.Context, fn func(*Queries) error) error {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	if err := fn(s.queries.WithTx(tx)); err != nil {
-		return err
-	}
-
-	return tx.Commit()
 }
 
 // ListIssuesByLabel returns issues that have a specific label

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -297,38 +297,6 @@ func TestTeams(t *testing.T) {
 	}
 }
 
-func TestWithTransaction(t *testing.T) {
-	t.Parallel()
-	store := openTestStore(t)
-	defer store.Close()
-	ctx := context.Background()
-
-	teamID := "team-1"
-
-	// Successful transaction
-	err := store.WithTx(ctx, func(q *Queries) error {
-		data := &IssueData{
-			ID:         "tx-issue-1",
-			Identifier: "TST-TX1",
-			Title:      "Transaction Test",
-			TeamID:     teamID,
-			CreatedAt:  time.Now(),
-			UpdatedAt:  time.Now(),
-			Data:       json.RawMessage("{}"),
-		}
-		return q.UpsertIssue(ctx, data.ToUpsertParams())
-	})
-	if err != nil {
-		t.Fatalf("Transaction failed: %v", err)
-	}
-
-	// Verify commit
-	_, err = store.Queries().GetIssueByIdentifier(ctx, "TST-TX1")
-	if err != nil {
-		t.Error("Issue not found after commit")
-	}
-}
-
 func TestListTeamIssuesByAssignee(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -283,16 +283,6 @@ func TestTeams(t *testing.T) {
 		t.Fatalf("UpsertTeam failed: %v", err)
 	}
 
-	// Get by key
-	got, err := store.Queries().GetTeamByKey(ctx, "TST")
-	if err != nil {
-		t.Fatalf("GetTeamByKey failed: %v", err)
-	}
-
-	if got.Name != team.Name {
-		t.Errorf("Name mismatch: got %s, want %s", got.Name, team.Name)
-	}
-
 	// List all
 	teams, err := store.Queries().ListTeams(ctx)
 	if err != nil {
@@ -301,6 +291,9 @@ func TestTeams(t *testing.T) {
 
 	if len(teams) != 1 {
 		t.Errorf("Expected 1 team, got %d", len(teams))
+	}
+	if teams[0].Name != team.Name {
+		t.Errorf("Name mismatch: got %s, want %s", teams[0].Name, team.Name)
 	}
 }
 
@@ -379,18 +372,6 @@ func TestListTeamIssuesByAssignee(t *testing.T) {
 	if len(issues) != 2 {
 		t.Errorf("Expected 2 issues for assignee, got %d", len(issues))
 	}
-
-	// Query by assignee email
-	issuesByEmail, err := store.Queries().ListTeamIssuesByAssigneeEmail(ctx, ListTeamIssuesByAssigneeEmailParams{
-		TeamID:        teamID,
-		AssigneeEmail: toNullString(&assigneeEmail),
-	})
-	if err != nil {
-		t.Fatalf("ListTeamIssuesByAssigneeEmail failed: %v", err)
-	}
-	if len(issuesByEmail) != 2 {
-		t.Errorf("Expected 2 issues for assignee email, got %d", len(issuesByEmail))
-	}
 }
 
 func TestListTeamUnassignedIssues(t *testing.T) {
@@ -428,45 +409,6 @@ func TestListTeamUnassignedIssues(t *testing.T) {
 	}
 	if len(issues) != 2 {
 		t.Errorf("Expected 2 unassigned issues, got %d", len(issues))
-	}
-}
-
-func TestListTeamIssuesByPriority(t *testing.T) {
-	t.Parallel()
-	store := openTestStore(t)
-	defer store.Close()
-	ctx := context.Background()
-
-	teamID := "team-1"
-
-	// Insert issues with different priorities
-	priorities := []int{1, 2, 2, 3, 0} // 1=urgent, 2=high, 3=medium, 0=none
-	for i, p := range priorities {
-		data := &IssueData{
-			ID:         "issue-" + string(rune('a'+i)),
-			Identifier: "TST-" + string(rune('1'+i)),
-			Title:      "Issue " + string(rune('1'+i)),
-			TeamID:     teamID,
-			Priority:   p,
-			CreatedAt:  time.Now(),
-			UpdatedAt:  time.Now(),
-			Data:       json.RawMessage("{}"),
-		}
-		if err := store.Queries().UpsertIssue(ctx, data.ToUpsertParams()); err != nil {
-			t.Fatalf("Insert failed: %v", err)
-		}
-	}
-
-	// Query by priority 2 (high)
-	issues, err := store.Queries().ListTeamIssuesByPriority(ctx, ListTeamIssuesByPriorityParams{
-		TeamID:   teamID,
-		Priority: toNullInt64(2),
-	})
-	if err != nil {
-		t.Fatalf("ListTeamIssuesByPriority failed: %v", err)
-	}
-	if len(issues) != 2 {
-		t.Errorf("Expected 2 high priority issues, got %d", len(issues))
 	}
 }
 
@@ -716,44 +658,6 @@ func TestDefaultDBPath(t *testing.T) {
 	}
 }
 
-func TestDeleteIssue(t *testing.T) {
-	t.Parallel()
-	store := openTestStore(t)
-	defer store.Close()
-	ctx := context.Background()
-
-	// Insert an issue
-	data := &IssueData{
-		ID:         "to-delete",
-		Identifier: "TST-DEL",
-		Title:      "To Delete",
-		TeamID:     "team-1",
-		CreatedAt:  time.Now(),
-		UpdatedAt:  time.Now(),
-		Data:       json.RawMessage("{}"),
-	}
-	if err := store.Queries().UpsertIssue(ctx, data.ToUpsertParams()); err != nil {
-		t.Fatalf("Insert failed: %v", err)
-	}
-
-	// Verify it exists
-	_, err := store.Queries().GetIssueByIdentifier(ctx, "TST-DEL")
-	if err != nil {
-		t.Fatalf("Issue should exist: %v", err)
-	}
-
-	// Delete by identifier
-	if err := store.Queries().DeleteIssueByIdentifier(ctx, "TST-DEL"); err != nil {
-		t.Fatalf("DeleteIssueByIdentifier failed: %v", err)
-	}
-
-	// Verify it's gone
-	_, err = store.Queries().GetIssueByIdentifier(ctx, "TST-DEL")
-	if err == nil {
-		t.Error("Issue should be deleted")
-	}
-}
-
 func TestGetTeamIssueCount(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
@@ -978,8 +882,4 @@ func strPtr(s string) *string {
 
 func float64Ptr(f float64) *float64 {
 	return &f
-}
-
-func toNullInt64(i int) sql.NullInt64 {
-	return sql.NullInt64{Int64: int64(i), Valid: true}
 }

--- a/internal/fs/linearfs_test.go
+++ b/internal/fs/linearfs_test.go
@@ -144,13 +144,6 @@ func TestSQLiteFilteredQueries(t *testing.T) {
 			iss.Identifier, iss.StateName, iss.Priority, iss.AssigneeID)
 	}
 
-	// Direct query test to verify SQLite query works
-	directIssues, err := store.Queries().ListTeamIssuesByStateName(ctx, db.ListTeamIssuesByStateNameParams{
-		TeamID:    "team-1",
-		StateName: sql.NullString{String: "Todo", Valid: true},
-	})
-	t.Logf("Direct ListTeamIssuesByStateName 'Todo' result: %d issues, err=%v", len(directIssues), err)
-
 	t.Run("GetFilteredIssuesByStatus", func(t *testing.T) {
 		issues, err := lfs.GetFilteredIssuesByStatus(ctx, "team-1", "Todo")
 		if err != nil {

--- a/internal/repo/sqlite.go
+++ b/internal/repo/sqlite.go
@@ -448,8 +448,7 @@ func (r *SQLiteRepository) GetIssuesByLabel(ctx context.Context, teamID, labelID
 
 // NB: GetIssuesByPriority was deleted (round 19) — it had no production
 // caller (there is no by/priority/ view). Its sqlc query
-// (ListTeamIssuesByPriority) is inert generated code awaiting removal at the
-// next `sqlc generate` (sqlc is not installed on this machine).
+// (ListTeamIssuesByPriority) was removed in the round-20 dead-code prune.
 
 func (r *SQLiteRepository) GetUnassignedIssues(ctx context.Context, teamID string) ([]api.Issue, error) {
 	issues, err := r.store.Queries().ListTeamUnassignedIssues(ctx, teamID)

--- a/internal/repo/sqlite.go
+++ b/internal/repo/sqlite.go
@@ -100,11 +100,6 @@ func NewSQLiteRepository(store *db.Store, client *api.Client) *SQLiteRepository 
 	return r
 }
 
-// SetStalenessThreshold sets how long before on-demand data is considered stale
-func (r *SQLiteRepository) SetStalenessThreshold(d time.Duration) {
-	r.stalenessThreshold = d
-}
-
 // catchUpStaleness is the staleness threshold used during catch-up syncs.
 // Suppresses on-demand refreshes while the sync worker is already fetching the same data.
 const catchUpStaleness = 30 * time.Minute
@@ -375,12 +370,6 @@ func (r *SQLiteRepository) GetTeams(ctx context.Context) ([]api.Team, error) {
 	return db.DBTeamsToAPITeams(teams), nil
 }
 
-func (r *SQLiteRepository) GetTeamByKey(ctx context.Context, key string) (*api.Team, error) {
-	return queryOne("get team by key",
-		func() (db.Team, error) { return r.store.Queries().GetTeamByKey(ctx, key) },
-		pure(db.DBTeamToAPITeam))
-}
-
 // =============================================================================
 // Issues
 // =============================================================================
@@ -623,18 +612,6 @@ func (r *SQLiteRepository) GetUsers(ctx context.Context) ([]api.User, error) {
 	return db.DBUsersToAPIUsers(users), nil
 }
 
-func (r *SQLiteRepository) GetUserByID(ctx context.Context, id string) (*api.User, error) {
-	return queryOne("get user by id",
-		func() (db.User, error) { return r.store.Queries().GetUser(ctx, id) },
-		pure(db.DBUserToAPIUser))
-}
-
-func (r *SQLiteRepository) GetUserByEmail(ctx context.Context, email string) (*api.User, error) {
-	return queryOne("get user by email",
-		func() (db.User, error) { return r.store.Queries().GetUserByEmail(ctx, email) },
-		pure(db.DBUserToAPIUser))
-}
-
 func (r *SQLiteRepository) GetCurrentUser(ctx context.Context) (*api.User, error) {
 	// Return cached user if set (via SetCurrentUser)
 	if r.currentUser != nil {
@@ -666,17 +643,6 @@ func (r *SQLiteRepository) GetTeamCycles(ctx context.Context, teamID string) ([]
 	return db.DBCyclesToAPICycles(cycles), nil
 }
 
-func (r *SQLiteRepository) GetCycleByName(ctx context.Context, teamID, name string) (*api.Cycle, error) {
-	return queryOne("get cycle by name",
-		func() (db.Cycle, error) {
-			return r.store.Queries().GetCycleByName(ctx, db.GetCycleByNameParams{
-				TeamID: teamID,
-				Name:   sql.NullString{String: name, Valid: true},
-			})
-		},
-		pure(db.DBCycleToAPICycle))
-}
-
 // =============================================================================
 // Projects
 // =============================================================================
@@ -687,12 +653,6 @@ func (r *SQLiteRepository) GetTeamProjects(ctx context.Context, teamID string) (
 		return nil, fmt.Errorf("list team projects: %w", err)
 	}
 	return db.DBProjectsToAPIProjects(projects)
-}
-
-func (r *SQLiteRepository) GetProjectBySlug(ctx context.Context, slug string) (*api.Project, error) {
-	return queryOne("get project by slug",
-		func() (db.Project, error) { return r.store.Queries().GetProjectBySlug(ctx, slug) },
-		db.DBProjectToAPIProject)
 }
 
 func (r *SQLiteRepository) GetProjectByID(ctx context.Context, id string) (*api.Project, error) {
@@ -722,89 +682,6 @@ func (r *SQLiteRepository) GetProjectMilestones(ctx context.Context, projectID s
 		return nil, fmt.Errorf("list project milestones: %w", err)
 	}
 	return db.DBMilestonesToAPIProjectMilestones(milestones), nil
-}
-
-func (r *SQLiteRepository) GetMilestoneByName(ctx context.Context, projectID, name string) (*api.ProjectMilestone, error) {
-	return queryOne("get milestone by name",
-		func() (db.ProjectMilestone, error) {
-			return r.store.Queries().GetMilestoneByName(ctx, db.GetMilestoneByNameParams{ProjectID: projectID, Name: name})
-		},
-		pure(db.DBMilestoneToAPIProjectMilestone))
-}
-
-func (r *SQLiteRepository) GetMilestoneByID(ctx context.Context, id string) (*api.ProjectMilestone, error) {
-	return queryOne("get milestone by id",
-		func() (db.ProjectMilestone, error) { return r.store.Queries().GetProjectMilestone(ctx, id) },
-		pure(db.DBMilestoneToAPIProjectMilestone))
-}
-
-func (r *SQLiteRepository) CreateProjectMilestone(ctx context.Context, projectID, name, description string) (*api.ProjectMilestone, error) {
-	if r.client == nil {
-		return nil, fmt.Errorf("API client not available")
-	}
-
-	// Create via API
-	milestone, err := r.client.CreateProjectMilestone(ctx, projectID, name, description)
-	if err != nil {
-		return nil, fmt.Errorf("create milestone: %w", err)
-	}
-
-	// Upsert to SQLite for immediate visibility. Route through the forward
-	// converter so the full milestone lands in `data` — a hand-built params with
-	// Data:"{}" would round-trip to a milestone stripped of any JSON-only field.
-	if params, cerr := db.APIProjectMilestoneToDBMilestone(*milestone, projectID); cerr != nil {
-		log.Printf("[repo] convert milestone %s failed: %v", milestone.ID, cerr)
-	} else if err := r.store.Queries().UpsertProjectMilestone(ctx, params); err != nil {
-		log.Printf("[repo] upsert milestone %s failed: %v", milestone.ID, err)
-	}
-
-	return milestone, nil
-}
-
-func (r *SQLiteRepository) UpdateProjectMilestone(ctx context.Context, milestoneID string, input api.ProjectMilestoneUpdateInput) (*api.ProjectMilestone, error) {
-	if r.client == nil {
-		return nil, fmt.Errorf("API client not available")
-	}
-
-	// Get the current milestone to find the project ID
-	existing, err := r.store.Queries().GetProjectMilestone(ctx, milestoneID)
-	if err != nil {
-		return nil, fmt.Errorf("get milestone: %w", err)
-	}
-
-	// Update via API
-	milestone, err := r.client.UpdateProjectMilestone(ctx, milestoneID, input)
-	if err != nil {
-		return nil, fmt.Errorf("update milestone: %w", err)
-	}
-
-	// Upsert to SQLite for immediate visibility (see CreateProjectMilestone: the
-	// full milestone must land in `data`, not "{}").
-	if params, cerr := db.APIProjectMilestoneToDBMilestone(*milestone, existing.ProjectID); cerr != nil {
-		log.Printf("[repo] convert milestone %s failed: %v", milestone.ID, cerr)
-	} else if err := r.store.Queries().UpsertProjectMilestone(ctx, params); err != nil {
-		log.Printf("[repo] upsert milestone %s failed: %v", milestone.ID, err)
-	}
-
-	return milestone, nil
-}
-
-func (r *SQLiteRepository) DeleteProjectMilestone(ctx context.Context, milestoneID string) error {
-	if r.client == nil {
-		return fmt.Errorf("API client not available")
-	}
-
-	// Delete via API
-	if err := r.client.DeleteProjectMilestone(ctx, milestoneID); err != nil {
-		return fmt.Errorf("delete milestone: %w", err)
-	}
-
-	// Delete from SQLite
-	if err := r.store.Queries().DeleteProjectMilestone(ctx, milestoneID); err != nil {
-		log.Printf("[repo] delete milestone %s from DB failed: %v", milestoneID, err)
-	}
-
-	return nil
 }
 
 // =============================================================================
@@ -1000,12 +877,6 @@ func parseTime(v interface{}) time.Time {
 	return db.ParseSQLiteTimeAny(v)
 }
 
-func (r *SQLiteRepository) GetCommentByID(ctx context.Context, id string) (*api.Comment, error) {
-	return queryOne("get comment by id",
-		func() (db.Comment, error) { return r.store.Queries().GetComment(ctx, id) },
-		db.DBCommentToAPIComment)
-}
-
 // =============================================================================
 // Documents
 // =============================================================================
@@ -1107,12 +978,6 @@ func (r *SQLiteRepository) refreshInitiativeDocuments(ctx context.Context, initi
 	return nil
 }
 
-func (r *SQLiteRepository) GetDocumentBySlug(ctx context.Context, slug string) (*api.Document, error) {
-	return queryOne("get document by slug",
-		func() (db.Document, error) { return r.store.Queries().GetDocumentBySlug(ctx, slug) },
-		db.DBDocumentToAPIDocument)
-}
-
 // =============================================================================
 // Initiatives
 // =============================================================================
@@ -1123,20 +988,6 @@ func (r *SQLiteRepository) GetInitiatives(ctx context.Context) ([]api.Initiative
 		return nil, fmt.Errorf("list initiatives: %w", err)
 	}
 	return db.DBInitiativesToAPIInitiatives(initiatives)
-}
-
-func (r *SQLiteRepository) GetInitiativeBySlug(ctx context.Context, slug string) (*api.Initiative, error) {
-	return queryOne("get initiative by slug",
-		func() (db.Initiative, error) { return r.store.Queries().GetInitiativeBySlug(ctx, slug) },
-		db.DBInitiativeToAPIInitiative)
-}
-
-func (r *SQLiteRepository) GetInitiativeProjects(ctx context.Context, initiativeID string) ([]api.Project, error) {
-	projects, err := r.store.Queries().ListInitiativeProjects(ctx, initiativeID)
-	if err != nil {
-		return nil, fmt.Errorf("list initiative projects: %w", err)
-	}
-	return db.DBProjectsToAPIProjects(projects)
 }
 
 // =============================================================================
@@ -1231,15 +1082,6 @@ func (r *SQLiteRepository) refreshInitiativeUpdates(ctx context.Context, initiat
 	return nil
 }
 
-// =============================================================================
-// Store Access (for sync worker)
-// =============================================================================
-
-// Store returns the underlying database store for direct access (e.g., sync worker)
-func (r *SQLiteRepository) Store() *db.Store {
-	return r.store
-}
-
 // SetCurrentUser sets the cached current user (useful for testing)
 func (r *SQLiteRepository) SetCurrentUser(user *api.User) {
 	r.currentUser = user
@@ -1272,13 +1114,6 @@ func (r *SQLiteRepository) UpdateEmbeddedFileCache(ctx context.Context, id, cach
 		FileSize:  sql.NullInt64{Int64: size, Valid: true},
 		ID:        id,
 	})
-}
-
-// GetAttachmentByID returns an attachment by ID
-func (r *SQLiteRepository) GetAttachmentByID(ctx context.Context, id string) (*api.Attachment, error) {
-	return queryOne("get attachment",
-		func() (db.Attachment, error) { return r.store.Queries().GetAttachment(ctx, id) },
-		db.DBAttachmentToAPIAttachment)
 }
 
 // =============================================================================
@@ -1367,8 +1202,8 @@ const (
 
 // relationView maps one stored db.IssueRelation to an api.IssueRelation, placing
 // the other end in the field the direction dictates and enriching it with the
-// issue's identifier/title. It is the one converter behind all three relation
-// reads (outgoing, inverse, by-id), which were byte-identical but for this
+// issue's identifier/title. It is the one converter behind both relation
+// reads (outgoing, inverse), which were byte-identical but for this
 // direction — so a field added to the mapping now lives in exactly one place.
 func (r *SQLiteRepository) relationView(ctx context.Context, rel db.IssueRelation, dir relationDir) api.IssueRelation {
 	view := api.IssueRelation{
@@ -1417,11 +1252,4 @@ func (r *SQLiteRepository) GetIssueInverseRelations(ctx context.Context, issueID
 		result[i] = r.relationView(ctx, rel, relIncoming)
 	}
 	return result, nil
-}
-
-// GetIssueRelationByID returns a relation by ID
-func (r *SQLiteRepository) GetIssueRelationByID(ctx context.Context, id string) (*api.IssueRelation, error) {
-	return queryOne("get issue relation",
-		func() (db.IssueRelation, error) { return r.store.Queries().GetIssueRelation(ctx, id) },
-		pure(func(rel db.IssueRelation) api.IssueRelation { return r.relationView(ctx, rel, relOutgoing) }))
 }

--- a/internal/repo/sqlite_test.go
+++ b/internal/repo/sqlite_test.go
@@ -53,27 +53,6 @@ func TestSQLiteRepository_Teams(t *testing.T) {
 	if len(teams) != 2 {
 		t.Errorf("Expected 2 teams, got %d", len(teams))
 	}
-
-	// Test GetTeamByKey
-	team, err := repo.GetTeamByKey(ctx, "ENG")
-	if err != nil {
-		t.Fatalf("GetTeamByKey failed: %v", err)
-	}
-	if team == nil {
-		t.Fatal("Expected team, got nil")
-	}
-	if team.Name != "Engineering" {
-		t.Errorf("Expected team name 'Engineering', got %q", team.Name)
-	}
-
-	// Test GetTeamByKey - not found
-	team, err = repo.GetTeamByKey(ctx, "NOTFOUND")
-	if err != nil {
-		t.Fatalf("GetTeamByKey failed: %v", err)
-	}
-	if team != nil {
-		t.Error("Expected nil for non-existent team")
-	}
 }
 
 func TestSQLiteRepository_Issues(t *testing.T) {
@@ -335,30 +314,6 @@ func TestSQLiteRepository_Users(t *testing.T) {
 	if len(result) != 2 {
 		t.Errorf("Expected 2 users, got %d", len(result))
 	}
-
-	// Test GetUserByID
-	user, err := repo.GetUserByID(ctx, "u1")
-	if err != nil {
-		t.Fatalf("GetUserByID failed: %v", err)
-	}
-	if user == nil {
-		t.Fatal("Expected user, got nil")
-	}
-	if user.Name != "Alice" {
-		t.Errorf("Expected name 'Alice', got %q", user.Name)
-	}
-
-	// Test GetUserByEmail
-	user, err = repo.GetUserByEmail(ctx, "bob@example.com")
-	if err != nil {
-		t.Fatalf("GetUserByEmail failed: %v", err)
-	}
-	if user == nil {
-		t.Fatal("Expected user, got nil")
-	}
-	if user.ID != "u2" {
-		t.Errorf("Expected ID 'u2', got %q", user.ID)
-	}
 }
 
 func TestSQLiteRepository_Cycles(t *testing.T) {
@@ -388,18 +343,6 @@ func TestSQLiteRepository_Cycles(t *testing.T) {
 	}
 	if len(result) != 2 {
 		t.Errorf("Expected 2 cycles, got %d", len(result))
-	}
-
-	// Test GetCycleByName
-	cycle, err := repo.GetCycleByName(ctx, "team-1", "Sprint 1")
-	if err != nil {
-		t.Fatalf("GetCycleByName failed: %v", err)
-	}
-	if cycle == nil {
-		t.Fatal("Expected cycle, got nil")
-	}
-	if cycle.Number != 1 {
-		t.Errorf("Expected number 1, got %d", cycle.Number)
 	}
 }
 
@@ -440,20 +383,8 @@ func TestSQLiteRepository_Projects(t *testing.T) {
 		t.Errorf("Expected 2 projects, got %d", len(result))
 	}
 
-	// Test GetProjectBySlug
-	project, err := repo.GetProjectBySlug(ctx, "alpha")
-	if err != nil {
-		t.Fatalf("GetProjectBySlug failed: %v", err)
-	}
-	if project == nil {
-		t.Fatal("Expected project, got nil")
-	}
-	if project.Name != "Project Alpha" {
-		t.Errorf("Expected name 'Project Alpha', got %q", project.Name)
-	}
-
 	// Test GetProjectByID
-	project, err = repo.GetProjectByID(ctx, "p2")
+	project, err := repo.GetProjectByID(ctx, "p2")
 	if err != nil {
 		t.Fatalf("GetProjectByID failed: %v", err)
 	}
@@ -1010,27 +941,6 @@ func TestSQLiteRepository_Milestones(t *testing.T) {
 	if len(milestones) != 2 {
 		t.Errorf("Expected 2 milestones, got %d", len(milestones))
 	}
-
-	// Test GetMilestoneByName
-	milestone, err := repo.GetMilestoneByName(ctx, "project-1", "Alpha")
-	if err != nil {
-		t.Fatalf("GetMilestoneByName failed: %v", err)
-	}
-	if milestone == nil {
-		t.Fatal("Expected milestone, got nil")
-	}
-	if milestone.Name != "Alpha" {
-		t.Errorf("Expected milestone name 'Alpha', got %q", milestone.Name)
-	}
-
-	// Test not found
-	milestone, err = repo.GetMilestoneByName(ctx, "project-1", "NotFound")
-	if err != nil {
-		t.Fatalf("GetMilestoneByName failed: %v", err)
-	}
-	if milestone != nil {
-		t.Error("Expected nil for non-existent milestone")
-	}
 }
 
 func TestSQLiteRepository_Comments(t *testing.T) {
@@ -1082,27 +992,6 @@ func TestSQLiteRepository_Comments(t *testing.T) {
 	}
 	if len(comments) != 2 {
 		t.Errorf("Expected 2 comments, got %d", len(comments))
-	}
-
-	// Test GetCommentByID
-	comment, err := repo.GetCommentByID(ctx, "comment-1")
-	if err != nil {
-		t.Fatalf("GetCommentByID failed: %v", err)
-	}
-	if comment == nil {
-		t.Fatal("Expected comment, got nil")
-	}
-	if comment.Body != "First comment" {
-		t.Errorf("Expected body 'First comment', got %q", comment.Body)
-	}
-
-	// Test not found
-	comment, err = repo.GetCommentByID(ctx, "not-found")
-	if err != nil {
-		t.Fatalf("GetCommentByID failed: %v", err)
-	}
-	if comment != nil {
-		t.Error("Expected nil for non-existent comment")
 	}
 }
 
@@ -1158,18 +1047,6 @@ func TestSQLiteRepository_IssueDocuments(t *testing.T) {
 	}
 	if len(docs) != 1 {
 		t.Errorf("Expected 1 document, got %d", len(docs))
-	}
-
-	// Test GetDocumentBySlug
-	doc2, err := repo.GetDocumentBySlug(ctx, "test-doc")
-	if err != nil {
-		t.Fatalf("GetDocumentBySlug failed: %v", err)
-	}
-	if doc2 == nil {
-		t.Fatal("Expected document, got nil")
-	}
-	if doc2.Title != "Test Doc" {
-		t.Errorf("Expected title 'Test Doc', got %q", doc2.Title)
 	}
 }
 
@@ -1246,75 +1123,6 @@ func TestSQLiteRepository_Initiatives(t *testing.T) {
 	}
 	if len(initiatives) != 1 {
 		t.Errorf("Expected 1 initiative, got %d", len(initiatives))
-	}
-
-	// Test GetInitiativeBySlug
-	init, err := repo.GetInitiativeBySlug(ctx, "test-initiative")
-	if err != nil {
-		t.Fatalf("GetInitiativeBySlug failed: %v", err)
-	}
-	if init == nil {
-		t.Fatal("Expected initiative, got nil")
-	}
-	if init.Name != "Test Initiative" {
-		t.Errorf("Expected name 'Test Initiative', got %q", init.Name)
-	}
-
-	// Test not found
-	init, err = repo.GetInitiativeBySlug(ctx, "not-found")
-	if err != nil {
-		t.Fatalf("GetInitiativeBySlug failed: %v", err)
-	}
-	if init != nil {
-		t.Error("Expected nil for non-existent initiative")
-	}
-}
-
-func TestSQLiteRepository_InitiativeProjects(t *testing.T) {
-	t.Parallel()
-	store, cleanup := setupTestDB(t)
-	defer cleanup()
-
-	repo := NewSQLiteRepository(store, nil)
-	ctx := context.Background()
-
-	// Insert initiative
-	initiative := api.Initiative{
-		ID:        "init-1",
-		Name:      "Test Initiative",
-		Slug:      "test-initiative",
-		Status:    "active",
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
-	}
-	initParams, _ := db.APIInitiativeToDBInitiative(initiative)
-	if err := store.Queries().UpsertInitiative(ctx, initParams); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-
-	// Insert project
-	project := api.Project{ID: "project-1", Name: "Project", Slug: "project", State: "started", CreatedAt: time.Now(), UpdatedAt: time.Now()}
-	projectParams, _ := db.APIProjectToDBProject(project)
-	if err := store.Queries().UpsertProject(ctx, projectParams); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-
-	// Link project to initiative
-	if err := store.Queries().UpsertInitiativeProject(ctx, db.UpsertInitiativeProjectParams{
-		InitiativeID: "init-1",
-		ProjectID:    "project-1",
-		SyncedAt:     time.Now(),
-	}); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-
-	// Test GetInitiativeProjects
-	projects, err := repo.GetInitiativeProjects(ctx, "init-1")
-	if err != nil {
-		t.Fatalf("GetInitiativeProjects failed: %v", err)
-	}
-	if len(projects) != 1 {
-		t.Errorf("Expected 1 project, got %d", len(projects))
 	}
 }
 
@@ -1408,47 +1216,20 @@ func TestSQLiteRepository_InitiativeUpdates(t *testing.T) {
 	}
 }
 
-func TestSQLiteRepository_StoreAndClose(t *testing.T) {
+func TestSQLiteRepository_Close(t *testing.T) {
 	t.Parallel()
 	store, cleanup := setupTestDB(t)
 	defer cleanup()
 
 	repo := NewSQLiteRepository(store, nil)
-
-	// Test Store returns the store
-	s := repo.Store()
-	if s != store {
-		t.Error("Store() should return the underlying store")
-	}
-
-	// Test Close (doesn't return error)
-	repo.Close()
-}
-
-func TestSQLiteRepository_SetStalenessThreshold(t *testing.T) {
-	t.Parallel()
-	store, cleanup := setupTestDB(t)
-	defer cleanup()
-
-	repo := NewSQLiteRepository(store, nil)
-	defer repo.Close()
 
 	// Default threshold should be 5 minutes (2.5× the 2-minute sync interval)
 	if repo.stalenessThreshold != 5*time.Minute {
 		t.Errorf("Expected default threshold of 5m, got %v", repo.stalenessThreshold)
 	}
 
-	// Set custom threshold
-	repo.SetStalenessThreshold(10 * time.Minute)
-	if repo.stalenessThreshold != 10*time.Minute {
-		t.Errorf("Expected threshold of 10m, got %v", repo.stalenessThreshold)
-	}
-
-	// Set to 0
-	repo.SetStalenessThreshold(0)
-	if repo.stalenessThreshold != 0 {
-		t.Errorf("Expected threshold of 0, got %v", repo.stalenessThreshold)
-	}
+	// Test Close (doesn't return error)
+	repo.Close()
 }
 
 func TestSQLiteRepository_ParseTime(t *testing.T) {
@@ -1516,24 +1297,6 @@ func TestSQLiteRepository_GetIssueByIdentifier_NotFound(t *testing.T) {
 	}
 }
 
-func TestSQLiteRepository_GetProjectBySlug_NotFound(t *testing.T) {
-	t.Parallel()
-	store, cleanup := setupTestDB(t)
-	defer cleanup()
-
-	repo := NewSQLiteRepository(store, nil)
-	ctx := context.Background()
-
-	// Test not found
-	project, err := repo.GetProjectBySlug(ctx, "nonexistent")
-	if err != nil {
-		t.Fatalf("GetProjectBySlug should not error on not found: %v", err)
-	}
-	if project != nil {
-		t.Error("Expected nil for non-existent project")
-	}
-}
-
 func TestSQLiteRepository_GetProjectByID_NotFound(t *testing.T) {
 	t.Parallel()
 	store, cleanup := setupTestDB(t)
@@ -1552,24 +1315,6 @@ func TestSQLiteRepository_GetProjectByID_NotFound(t *testing.T) {
 	}
 }
 
-func TestSQLiteRepository_GetDocumentBySlug_NotFound(t *testing.T) {
-	t.Parallel()
-	store, cleanup := setupTestDB(t)
-	defer cleanup()
-
-	repo := NewSQLiteRepository(store, nil)
-	ctx := context.Background()
-
-	// Test not found
-	doc, err := repo.GetDocumentBySlug(ctx, "nonexistent")
-	if err != nil {
-		t.Fatalf("GetDocumentBySlug should not error on not found: %v", err)
-	}
-	if doc != nil {
-		t.Error("Expected nil for non-existent document")
-	}
-}
-
 func TestSQLiteRepository_GetLabelByName_NotFound(t *testing.T) {
 	t.Parallel()
 	store, cleanup := setupTestDB(t)
@@ -1585,60 +1330,6 @@ func TestSQLiteRepository_GetLabelByName_NotFound(t *testing.T) {
 	}
 	if label != nil {
 		t.Error("Expected nil for non-existent label")
-	}
-}
-
-func TestSQLiteRepository_GetUserByID_NotFound(t *testing.T) {
-	t.Parallel()
-	store, cleanup := setupTestDB(t)
-	defer cleanup()
-
-	repo := NewSQLiteRepository(store, nil)
-	ctx := context.Background()
-
-	// Test not found
-	user, err := repo.GetUserByID(ctx, "nonexistent")
-	if err != nil {
-		t.Fatalf("GetUserByID should not error on not found: %v", err)
-	}
-	if user != nil {
-		t.Error("Expected nil for non-existent user")
-	}
-}
-
-func TestSQLiteRepository_GetUserByEmail_NotFound(t *testing.T) {
-	t.Parallel()
-	store, cleanup := setupTestDB(t)
-	defer cleanup()
-
-	repo := NewSQLiteRepository(store, nil)
-	ctx := context.Background()
-
-	// Test not found
-	user, err := repo.GetUserByEmail(ctx, "nonexistent@example.com")
-	if err != nil {
-		t.Fatalf("GetUserByEmail should not error on not found: %v", err)
-	}
-	if user != nil {
-		t.Error("Expected nil for non-existent user")
-	}
-}
-
-func TestSQLiteRepository_GetCycleByName_NotFound(t *testing.T) {
-	t.Parallel()
-	store, cleanup := setupTestDB(t)
-	defer cleanup()
-
-	repo := NewSQLiteRepository(store, nil)
-	ctx := context.Background()
-
-	// Test not found
-	cycle, err := repo.GetCycleByName(ctx, "team-1", "NonexistentCycle")
-	if err != nil {
-		t.Fatalf("GetCycleByName should not error on not found: %v", err)
-	}
-	if cycle != nil {
-		t.Error("Expected nil for non-existent cycle")
 	}
 }
 
@@ -2746,7 +2437,7 @@ func TestReconcileAgainst_LocalQueryErrorDeletesNothing(t *testing.T) {
 	}
 }
 
-// TestIssueRelationView covers the one converter behind all three relation
+// TestIssueRelationView covers the one converter behind both relation
 // reads: outgoing fills RelatedIssue from related_issue_id, inverse fills Issue
 // from issue_id, and both enrich the other end with its identifier/title.
 func TestIssueRelationView(t *testing.T) {
@@ -2820,14 +2511,5 @@ func TestIssueRelationView(t *testing.T) {
 	}
 	if inv[0].Issue.Identifier != "ENG-1" || inv[0].Issue.Title != "Source" {
 		t.Errorf("inverse end not enriched: %+v", inv[0].Issue)
-	}
-
-	// By-id resolves as an outgoing view.
-	byID, err := repo.GetIssueRelationByID(ctx, "rel-1")
-	if err != nil {
-		t.Fatalf("GetIssueRelationByID: %v", err)
-	}
-	if byID == nil || byID.RelatedIssue == nil || byID.RelatedIssue.ID != dst.ID {
-		t.Fatalf("by-id RelatedIssue = %+v, want id %q", byID, dst.ID)
 	}
 }

--- a/internal/repo/sqlite_test.go
+++ b/internal/repo/sqlite_test.go
@@ -2066,6 +2066,17 @@ func TestDeleteOrphanIssue(t *testing.T) {
 	}
 }
 
+// linkCount counts junction-table rows through the raw-SQL test seam
+// (store.DB()) — no production query lists these link IDs.
+func linkCount(t *testing.T, store *db.Store, query, id string) int {
+	t.Helper()
+	var n int
+	if err := store.DB().QueryRow(query, id).Scan(&n); err != nil {
+		t.Fatalf("count links: %v", err)
+	}
+	return n
+}
+
 func TestDeleteOrphanProject(t *testing.T) {
 	t.Parallel()
 	store, cleanup := setupTestDB(t)
@@ -2127,8 +2138,8 @@ func TestDeleteOrphanProject(t *testing.T) {
 	if _, err := q.GetProject(ctx, projectID); err != sql.ErrNoRows {
 		t.Errorf("orphan project not deleted: err=%v", err)
 	}
-	if got, _ := q.ListProjectTeamIDs(ctx, projectID); len(got) != 0 {
-		t.Errorf("orphan project-team links not deleted: %d remain", len(got))
+	if got := linkCount(t, store, "SELECT COUNT(*) FROM project_teams WHERE project_id = ?", projectID); got != 0 {
+		t.Errorf("orphan project-team links not deleted: %d remain", got)
 	}
 	if got, _ := q.ListProjectDocuments(ctx, sql.NullString{String: projectID, Valid: true}); len(got) != 0 {
 		t.Errorf("orphan project docs not deleted: %d remain", len(got))
@@ -2139,8 +2150,8 @@ func TestDeleteOrphanProject(t *testing.T) {
 	if got, _ := q.ListProjectMilestones(ctx, projectID); len(got) != 0 {
 		t.Errorf("orphan milestones not deleted: %d remain", len(got))
 	}
-	if got, _ := q.ListProjectInitiativeIDs(ctx, projectID); len(got) != 0 {
-		t.Errorf("orphan initiative-project links not deleted: %d remain", len(got))
+	if got := linkCount(t, store, "SELECT COUNT(*) FROM initiative_projects WHERE project_id = ?", projectID); got != 0 {
+		t.Errorf("orphan initiative-project links not deleted: %d remain", got)
 	}
 	// Keeper survives.
 	if _, err := q.GetProject(ctx, otherID); err != nil {
@@ -2202,8 +2213,8 @@ func TestDeleteOrphanInitiative(t *testing.T) {
 	if got, _ := q.ListInitiativeUpdates(ctx, initID); len(got) != 0 {
 		t.Errorf("orphan init updates not deleted: %d remain", len(got))
 	}
-	if got, _ := q.ListInitiativeProjectIDs(ctx, initID); len(got) != 0 {
-		t.Errorf("orphan init-project links not deleted: %d remain", len(got))
+	if got := linkCount(t, store, "SELECT COUNT(*) FROM initiative_projects WHERE initiative_id = ?", initID); got != 0 {
+		t.Errorf("orphan init-project links not deleted: %d remain", got)
 	}
 	if _, err := q.GetInitiative(ctx, otherID); err != nil {
 		t.Errorf("keeper initiative was deleted: %v", err)

--- a/internal/sync/metrics_test.go
+++ b/internal/sync/metrics_test.go
@@ -201,8 +201,10 @@ func TestPendingDepthGauge(t *testing.T) {
 	}
 
 	// Draining the queue is visible on the next collect.
-	if err := store.Queries().ClearPendingDetailSync(ctx); err != nil {
-		t.Fatalf("clear pending: %v", err)
+	for _, id := range []string{"issue-1", "issue-2"} {
+		if err := store.Queries().DeletePendingDetailSync(ctx, id); err != nil {
+			t.Fatalf("clear pending %s: %v", id, err)
+		}
 	}
 	rm = collectMetrics(t, reader)
 	m, ok = findMetric(rm, "linearfs.sync.pending_depth")

--- a/internal/sync/prune_test.go
+++ b/internal/sync/prune_test.go
@@ -44,22 +44,36 @@ func seedInitiativeProject(t *testing.T, store *db.Store, initiativeID, projectI
 	}
 }
 
-func projectTeamIDs(t *testing.T, store *db.Store, projectID string) []string {
+// projectTeamIDs and initiativeProjectIDs observe the junction tables through
+// the raw-SQL test seam (store.DB()) — no production query lists these link
+// IDs, and the prune tests only need to see the rows.
+func linkIDs(t *testing.T, store *db.Store, query, id string) []string {
 	t.Helper()
-	ids, err := store.Queries().ListProjectTeamIDs(context.Background(), projectID)
+	rows, err := store.DB().Query(query, id)
 	if err != nil {
-		t.Fatalf("list project teams: %v", err)
+		t.Fatalf("list links: %v", err)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var linked string
+		if err := rows.Scan(&linked); err != nil {
+			t.Fatalf("scan link: %v", err)
+		}
+		ids = append(ids, linked)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate links: %v", err)
 	}
 	return ids
 }
 
+func projectTeamIDs(t *testing.T, store *db.Store, projectID string) []string {
+	return linkIDs(t, store, "SELECT team_id FROM project_teams WHERE project_id = ? ORDER BY team_id", projectID)
+}
+
 func initiativeProjectIDs(t *testing.T, store *db.Store, initiativeID string) []string {
-	t.Helper()
-	ids, err := store.Queries().ListInitiativeProjectIDs(context.Background(), initiativeID)
-	if err != nil {
-		t.Fatalf("list initiative projects: %v", err)
-	}
-	return ids
+	return linkIDs(t, store, "SELECT project_id FROM initiative_projects WHERE initiative_id = ? ORDER BY project_id", initiativeID)
 }
 
 // TestTeamMetadataSyncPrunesStaleProjectTeams: an association the (complete)

--- a/internal/sync/worker_test.go
+++ b/internal/sync/worker_test.go
@@ -1695,17 +1695,19 @@ func TestDetailsSyncPersistsAndPrunesRelations(t *testing.T) {
 	}
 
 	// Inverse: stored from its owner's perspective (issue_id = the other side).
-	inv, err := store.Queries().GetIssueRelation(ctx, "rel-inverse")
-	if err != nil {
-		t.Fatalf("inverse relation not persisted: %v", err)
+	invRels, err := store.Queries().ListIssueRelations(ctx, "issue-3")
+	if err != nil || len(invRels) != 1 {
+		t.Fatalf("inverse relation not persisted: err=%v n=%d", err, len(invRels))
 	}
-	if inv.IssueID != "issue-3" || inv.RelatedIssueID != "issue-1" {
-		t.Errorf("inverse row stored as %s->%s, want issue-3->issue-1", inv.IssueID, inv.RelatedIssueID)
+	if invRels[0].ID != "rel-inverse" || invRels[0].RelatedIssueID != "issue-1" {
+		t.Errorf("inverse row stored as %s (%s->%s), want rel-inverse issue-3->issue-1",
+			invRels[0].ID, invRels[0].IssueID, invRels[0].RelatedIssueID)
 	}
 
 	// The stale row owned by issue-4 is outside issue-1's completeness set.
-	if _, err := store.Queries().GetIssueRelation(ctx, "rel-other"); err != nil {
-		t.Errorf("issue-1's sync pruned a row owned by issue-4: %v", err)
+	otherRels, err := store.Queries().ListIssueRelations(ctx, "issue-4")
+	if err != nil || len(otherRels) != 1 || otherRels[0].ID != "rel-other" {
+		t.Errorf("issue-1's sync pruned a row owned by issue-4: err=%v rels=%v", err, otherRels)
 	}
 }
 
@@ -1734,7 +1736,8 @@ func TestDetailsSyncRelationUpsertFailureSuppressesPrune(t *testing.T) {
 
 	worker.syncDetails(ctx, []issueRef{{ID: "issue-1", Identifier: "TST-1"}})
 
-	if _, err := store.Queries().GetIssueRelation(ctx, "rel-stale"); err != nil {
-		t.Errorf("unclean relation sync must suppress the prune, but rel-stale is gone: %v", err)
+	rels, err := store.Queries().ListIssueRelations(ctx, "issue-1")
+	if err != nil || len(rels) != 1 || rels[0].ID != "rel-stale" {
+		t.Errorf("unclean relation sync must suppress the prune, but rel-stale is gone: err=%v rels=%v", err, rels)
 	}
 }


### PR DESCRIPTION
Dead-code sweep following #220's twin-masking lesson (repo methods shadow api.Client names, so bare-name greps lie about callers). `deadcode ./cmd/linearfs` reports zero dead package-level functions (canary-validated), so the dead mass was all methods — invisible to RTA because every seam converts these types to interfaces. Audited receiver-aware; every deletion re-verified individually before removal.

## Tier 1 — 18 dead `repo.SQLiteRepository` methods (+8/−498)

Thirteen by-name/by-ID getters nothing resolves through anymore (GetTeamByKey, GetCycleByName, GetUserByEmail, …), SetStalenessThreshold, Store(), and a whole vestigial mutation path: `repo.Create/Update/DeleteProjectMilestone` called the API client, but fs has routed milestone mutations through `lfs.mutator()` since the MutationClient seam landed. After this, the repo's client usage is reads + LowBudget/AuthHeader only. `SetCatchUpMode` kept (live via the worker's CatchUpModeToggler). CONTEXT.md's renderFile-precursor paragraph updated to stop citing a deleted method.

## Tier 2 — 58 dead sqlc queries (+121/−2,557)

47 from the audit + 11 orphaned by Tier 1 (cascade iterated to convergence — third pass found nothing). Legacy delete helpers superseded by the reconcile prunes (DeleteTeamCycles, DeleteTeamStates, …), pre-`detail_synced_at` freshness leftovers (GetIssueHistorySyncedAt), unused list variants (ListTeamIssuesByPriority, ListProjectsByState, …). queries.sql pruned, `sqlc generate` re-run (176 → 118 methods); schema and tables untouched. Tests whose sole subject was a dead query deleted (14); live-behavior tests reworked onto live observation seams — including raw SQL via the `store.DB()` test seam for junction-table assertions no production query lists.

## Tier 3 — Store methods (+2/−48)

`WithTx` deleted (transactions entirely unused; the recorded durability story is busy_timeout + single upserts). `DB()` kept and documented as a test seam — zero production callers but load-bearing for pragma tests and fixture loaders.

## Verification

- `go build`, `go vet`, `make fmt`, `make staticcheck` clean
- All unit suites + integration suite (fixture mode, 63.5s) green, re-verified independently post-build
- `deadcode ./cmd/linearfs` still reports nothing

Net −3,102 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)