### PR TITLE
refactor: mount-lifetime context owns every spawned goroutine

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1239,3 +1239,26 @@ unmount ahead of the mkdir (covers old-binary/new-unit skew), `ExecStop -uz`,
 and `StartLimitBurst=5`/`StartLimitIntervalSec=60` so a genuinely broken
 start stops looping; sandboxing directives are deliberately absent (the
 mount lives in `$HOME`, config + cache under `~/.config/linearfs`).
+
+### Mount lifetime (`lifeCtx`/`spawn`)
+`LinearFS` owns the lifecycle context: `NewLinearFS` mints
+`lifeCtx`/`lifeCancel`, and `spawn(fn)` is the **only** way LinearFS launches
+a background goroutine — fn receives `lifeCtx`, is tracked by a WaitGroup,
+and spawn **declines to start fn once Close has begun** (the closed flag and
+`wg.Add` sit under one mutex, which is exactly what orders Add before Close's
+Wait — the classic WaitGroup Add-vs-Wait race). `Close` is therefore a fixed
+sequence: cancel → wait → `syncWorker.Stop()` → `repo.Close()` →
+`store.Close()` → `requestLog.Close()`, so nothing LinearFS spawned can touch
+the store after it closes. Cancelling *before* Stop is deliberate: the
+worker's ctx now derives from `lifeCtx`, so a mid-flight sync cycle aborts
+promptly instead of Stop waiting it out — a shutdown-latency improvement, not
+an accident of ordering. The worker and repo keep their own tested lifetime
+seams (`stopCh`/`doneCh`, `refreshCancel`) **by design** — they merely receive
+lifeCtx-derived contexts; do not rewire them onto spawn. The bug this
+module fixed: `EnableSQLiteCache`'s viewer-refresh goroutine ran on the
+caller's `context.Background()`, so its `<-ctx.Done()` branch could never
+fire and its 60s backoff ladder could outlive `store.Close()`, retrying
+against a closed store. `EnableSQLiteCache` consequently takes no ctx
+parameter at all — its seed queries and `worker.Start` use `lifeCtx`, because
+the work it starts is bounded by the mount's lifetime, not any caller's.
+`TestCloseWaitsForSpawned` pins the ordering contract without sleeps.

--- a/internal/cmd/mount.go
+++ b/internal/cmd/mount.go
@@ -104,8 +104,7 @@ func runMount(cmd *cobra.Command, args []string) error {
 
 	// Enable SQLite persistent cache and background sync BEFORE mounting
 	// This must complete before the filesystem is accessible to prevent nil repo panics
-	ctx := context.Background()
-	if err := lfs.EnableSQLiteCache(ctx, ""); err != nil {
+	if err := lfs.EnableSQLiteCache(""); err != nil {
 		fmt.Printf("Warning: SQLite cache disabled: %v\n", err)
 	}
 

--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -41,6 +41,15 @@ type LinearFS struct {
 	gid        uint32 // Owner GID for files/dirs
 	mountPoint string // Filesystem mount path (for README generation)
 
+	// Mount lifetime: every background goroutine LinearFS launches derives its
+	// ctx from lifeCtx via spawn, so Close can cancel + wait before tearing
+	// down the store the goroutines read (see spawn / Close).
+	lifeCtx    context.Context
+	lifeCancel context.CancelFunc
+	lifeWG     gosync.WaitGroup
+	lifeMu     gosync.Mutex // guards lifeClosed vs. spawn's wg.Add (Add-vs-Wait race)
+	lifeClosed bool         // set at the start of Close; spawn declines after this
+
 	// The one coupling to the FUSE server: kernel-cache invalidation (see
 	// invalidate.go). Embedded, so lfs.SetServer / lfs.InvalidateCreated / … promote.
 	kernelNotify
@@ -120,6 +129,9 @@ func NewLinearFS(cfg *config.Config, debug bool) (*LinearFS, error) {
 		requestLog:   requestLog,
 		debug:        debug,
 	}
+	// Mint the mount-lifetime context. Background is correct here: the mount's
+	// lifetime is bounded by Close, not by any caller's request ctx.
+	lfs.lifeCtx, lfs.lifeCancel = context.WithCancel(context.Background())
 	// Wire the feedback store's kernel-cache seam to this instance. The method
 	// value binds the pointer, so it is safe to set after lfs exists.
 	lfs.writeFeedback = newWriteFeedback(lfs.InvalidateUpdated)
@@ -138,8 +150,39 @@ func NewLinearFS(cfg *config.Config, debug bool) (*LinearFS, error) {
 	return lfs, nil
 }
 
+// spawn launches fn as a background goroutine bound to the mount lifetime:
+// fn receives lifeCtx (cancelled at the start of Close) and Close waits for it
+// to return before closing the store. Once Close has begun, spawn declines to
+// start fn at all — checking the closed flag and calling wg.Add under the same
+// mutex is what makes Add ordered before Close's Wait (the classic WaitGroup
+// Add-vs-Wait race). This is the ONLY way LinearFS may start a goroutine that
+// outlives its caller.
+func (lfs *LinearFS) spawn(fn func(ctx context.Context)) {
+	lfs.lifeMu.Lock()
+	defer lfs.lifeMu.Unlock()
+	if lfs.lifeClosed || lfs.lifeCtx == nil || lfs.lifeCtx.Err() != nil {
+		return // shutdown has begun; the work would only race the store teardown
+	}
+	lfs.lifeWG.Add(1)
+	go func() {
+		defer lfs.lifeWG.Done()
+		fn(lfs.lifeCtx)
+	}()
+}
+
 // Close stops all background operations and releases resources
 func (lfs *LinearFS) Close() {
+	// Cancel the mount-lifetime ctx and wait for every spawned goroutine.
+	// Cancelling BEFORE syncWorker.Stop is deliberate: the worker's ctx
+	// derives from lifeCtx, so a mid-flight sync cycle aborts promptly
+	// instead of Stop waiting it out.
+	lfs.lifeMu.Lock()
+	lfs.lifeClosed = true
+	if lfs.lifeCancel != nil {
+		lfs.lifeCancel()
+	}
+	lfs.lifeMu.Unlock()
+	lfs.lifeWG.Wait()
 	// Stop sync worker first
 	if lfs.syncWorker != nil {
 		lfs.syncWorker.Stop()
@@ -161,7 +204,10 @@ func (lfs *LinearFS) Close() {
 // EnableSQLiteCache initializes the SQLite backend and starts background sync.
 // This MUST be called after creating LinearFS but before mounting.
 // If dbPath is empty, uses the default path (~/.config/linearfs/cache.db).
-func (lfs *LinearFS) EnableSQLiteCache(ctx context.Context, dbPath string) error {
+// Everything here runs under lifeCtx (the mount lifetime) — a caller ctx would
+// be wrong, since the background work it starts must outlive the caller and
+// die with Close instead.
+func (lfs *LinearFS) EnableSQLiteCache(dbPath string) error {
 	if dbPath == "" {
 		dbPath = db.DefaultDBPath()
 	}
@@ -177,16 +223,19 @@ func (lfs *LinearFS) EnableSQLiteCache(ctx context.Context, dbPath string) error
 	lfs.repo = repo.NewSQLiteRepository(store, lfs.client)
 
 	// H-1: Load viewer from SQLite cache immediately for /my views (no API wait)
-	if cachedViewerID, err := store.Queries().GetViewerUserID(ctx); err == nil {
-		if dbUser, err := store.Queries().GetUser(ctx, cachedViewerID); err == nil {
+	if cachedViewerID, err := store.Queries().GetViewerUserID(lfs.lifeCtx); err == nil {
+		if dbUser, err := store.Queries().GetUser(lfs.lifeCtx, cachedViewerID); err == nil {
 			apiUser := db.DBUserToAPIUser(dbUser)
 			lfs.repo.SetCurrentUser(&apiUser)
 			log.Printf("[sqlite] Loaded cached viewer: %s (%s)", apiUser.Email, apiUser.ID)
 		}
 	}
 
-	// Refresh viewer from API in background to keep cache fresh
-	go func() {
+	// Refresh viewer from API in background to keep cache fresh. Spawned under
+	// the mount lifetime so Close cancels + waits for it — with a bare
+	// Background ctx this loop's 60s backoff could outlive store.Close and
+	// retry against a closed store.
+	lfs.spawn(func(ctx context.Context) {
 		delays := []time.Duration{0, 5 * time.Second, 15 * time.Second, 30 * time.Second, 60 * time.Second}
 		for i := 0; ; i++ {
 			delay := delays[min(i, len(delays)-1)]
@@ -222,13 +271,15 @@ func (lfs *LinearFS) EnableSQLiteCache(ctx context.Context, dbPath string) error
 			}
 			return
 		}
-	}()
+	})
 
-	// Create and start sync worker
+	// Create and start sync worker. The worker keeps its own stop mechanism;
+	// it merely derives its ctx from the mount lifetime now, so Close's
+	// cancel aborts a mid-flight sync cycle before Stop is even called.
 	lfs.syncWorker = sync.NewWorker(lfs.client, store, sync.DefaultConfig())
 	lfs.syncWorker.SetBudgetReporter(lfs.client)
 	lfs.syncWorker.SetCatchUpModeToggler(lfs.repo)
-	lfs.syncWorker.Start(ctx)
+	lfs.syncWorker.Start(lfs.lifeCtx)
 
 	log.Printf("[sqlite] Enabled persistent cache at %s", dbPath)
 	return nil

--- a/internal/fs/linearfs_test.go
+++ b/internal/fs/linearfs_test.go
@@ -320,3 +320,55 @@ func TestFetchIssueByIdentifier(t *testing.T) {
 		}
 	})
 }
+
+// TestCloseWaitsForSpawned proves the mount-lifetime contract: a goroutine
+// launched via spawn sees its ctx cancelled by Close, and Close does not
+// return until the goroutine has. The assertion is pure ordering (no sleeps):
+// completed is written just before the spawned fn returns, and Close's
+// wg.Wait establishes the happens-before that makes the read safe.
+func TestCloseWaitsForSpawned(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{APIKey: "test-key"}
+	lfs, err := NewLinearFS(cfg, false)
+	if err != nil {
+		t.Fatalf("NewLinearFS failed: %v", err)
+	}
+
+	var completed bool
+	started := make(chan struct{})
+	lfs.spawn(func(ctx context.Context) {
+		close(started)
+		<-ctx.Done() // only Close's lifeCancel can fire this
+		completed = true
+	})
+
+	<-started // ensure the goroutine is live and blocked before Close
+	lfs.Close()
+
+	if !completed {
+		t.Error("Close returned before the spawned goroutine completed")
+	}
+}
+
+// TestSpawnAfterCloseDeclines proves the other half of the contract: once
+// Close has begun, spawn refuses to start work at all (this is what prevents
+// a late spawn from racing the store teardown).
+func TestSpawnAfterCloseDeclines(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{APIKey: "test-key"}
+	lfs, err := NewLinearFS(cfg, false)
+	if err != nil {
+		t.Fatalf("NewLinearFS failed: %v", err)
+	}
+
+	lfs.Close()
+
+	var ran bool
+	lfs.spawn(func(ctx context.Context) {
+		ran = true
+	})
+
+	if ran {
+		t.Error("spawn ran fn after Close; it must decline")
+	}
+}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -112,8 +112,7 @@ func setupLiveAPI(apiKey string) error {
 	}
 
 	// Enable SQLite cache for repository access
-	ctx := context.Background()
-	if err := lfs.EnableSQLiteCache(ctx, ""); err != nil {
+	if err := lfs.EnableSQLiteCache(""); err != nil {
 		_ = server.Unmount()
 		os.RemoveAll(mountPoint)
 		return fmt.Errorf("enable sqlite cache: %w", err)


### PR DESCRIPTION
## The bug

`LinearFS.EnableSQLiteCache` spawns a viewer-refresh goroutine whose ctx came from `runMount` as `context.Background()` — its `<-ctx.Done()` branch could never fire. Its backoff ladder reaches 60s, so on shutdown it could outlive `store.Close()` and retry `GetViewer`/`SetViewerUserID` against a closed store.

## The design

- **`LinearFS` owns an internal lifecycle context**: `NewLinearFS` mints `lifeCtx`/`lifeCancel` (plus a WaitGroup and a closed-flag+mutex).
- **`spawn(fn func(ctx context.Context))`** is now the only way LinearFS launches background goroutines: under the mutex, if Close has begun it declines to start `fn` at all; otherwise `wg.Add(1)` and go. Checking the closed flag and doing `Add` under the same mutex is what prevents the classic WaitGroup Add-vs-Wait race.
- **`Close()`** becomes: set closed flag + `lifeCancel()` → `wg.Wait()` → existing chain unchanged (`syncWorker.Stop()` → `repo.Close()` → `store.Close()` → `requestLog.Close()`). Nothing LinearFS spawned can touch the store after it closes.
- The viewer-refresh goroutine goes through `spawn`; its body (backoff ladder, retry semantics, `SetCurrentUser`, `SetViewerUserID` persist) is unchanged.
- **`EnableSQLiteCache(dbPath string)`** loses its ctx parameter — the synchronous seed queries and `worker.Start` use `lifeCtx`, since the work it starts is bounded by the mount's lifetime, not any caller's. Both call sites (`cmd/mount.go`, integration harness) updated.
- The worker and repo keep their own lifetime mechanisms (`stopCh`/`doneCh`, `refreshCancel`) untouched — they merely receive lifeCtx-derived contexts.

## Behavior change

Cancelling **before** `syncWorker.Stop()` is deliberate: the worker's ctx now derives from `lifeCtx`, so a mid-flight sync cycle aborts promptly instead of Stop waiting it out — a shutdown-latency improvement.

## Tests

- `TestCloseWaitsForSpawned`: spawned goroutine blocks on `ctx.Done()`, records completion just before returning; Close must observe it — pure ordering assertion, no sleeps (passes under `-race`).
- `TestSpawnAfterCloseDeclines`: spawn after Close never runs `fn`.
- Full suite green including integration (`go test ./...`), `go vet`, `make staticcheck`, `gofmt` clean.

CONTEXT.md gains a "Mount lifetime (`lifeCtx`/`spawn`)" entry alongside the other seam entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)