### PR TITLE
refactor: worker clock seam — inject now/timer/ticker

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1067,6 +1067,30 @@ raw `SELECT *` positional scans would misalign on one layout — every issue
 scan uses an explicit column list (sqlc expands `*` itself;
 `ListIssuesByLabel` was made explicit by hand).
 
+### Worker clock seam (`Worker.now`/`newTimer`/`newTicker`)
+The sync worker's timing goes through three unexported function fields on
+`Worker` (`internal/sync/worker.go`) — `now func() time.Time`, `newTimer
+func(d) (<-chan time.Time, func() bool)`, `newTicker func(d) (<-chan
+time.Time, func())` — the worker-side sibling of rateBudget's injected
+`now` (closures, not an interface or a clock library). `NewWorker` defaults
+them to the real clock via `realNow`/`realNewTimer`/`realNewTicker` in
+`clock.go` — deliberately a separate file, because the load-bearing rule is
+**no bare `time.` clock calls in worker.go**: every
+`Now/Since/Until/NewTimer/NewTicker/Sleep/After` goes through the seam
+(`time.Duration` arithmetic and `time.RFC3339` formatting are not clock
+calls and stay), the same greppable discipline as the ino namespace's
+no-bare-hashes rule — `grep 'time\.\(Now\|Since\|Until\|NewTimer\|NewTicker\|Sleep\|After\)'
+internal/sync/worker.go` must return nothing. What the seam bought
+(`worker_test.go`, all with zero real waiting): `isRateLimited` flipping as
+the fake clock crosses expiry, `setRateLimited`'s exact backoff arithmetic
+(no more ±2s tolerance windows), `probeBudget`'s RATELIMITED delay — assert
+the exact requested wait on the fake timer, fire it to resume, or close
+stopCh to interrupt — and the run loop's cadence (feed a tick on the fake
+ticker channel, a sync cycle fires). The fake (`fakeClock` in
+`worker_test.go`) is a mutex'd time plus recorded timer/ticker channels; its
+buffered `timerSet` doubles as the handshake that the worker has parked on
+the timer, which is what replaced the old `time.Sleep` grace periods.
+
 ### Reverse conversion contract (hydrate-then-overlay)
 Every DB→API reverse conversion in `internal/db/convert.go` **starts from the
 `data` blob and overlays its queryable columns** (canonical statement at

--- a/internal/sync/clock.go
+++ b/internal/sync/clock.go
@@ -1,0 +1,33 @@
+package sync
+
+import "time"
+
+// The Worker's clock seam — the worker-side sibling of rateBudget's injected
+// now (internal/api/ratebudget.go) — is three function fields on Worker
+// (now/newTimer/newTicker) that NewWorker defaults to the real clock via the
+// wrappers below. Tests swap in a fake that pins now() and hands out
+// channels they fire explicitly, so backoff arithmetic, the probe delay, and
+// the run-loop cadence are testable without real waiting.
+//
+// These wrappers are deliberately the ONLY place the package's non-test code
+// touches the wall clock's constructors: worker.go must stay free of bare
+// time.Now/Since/Until/NewTimer/NewTicker/Sleep/After calls so the seam
+// discipline is enforceable by grep, not just review (see CONTEXT.md
+// "Worker clock seam").
+
+// realNow is the now seam's default.
+func realNow() time.Time { return time.Now() }
+
+// realNewTimer is the newTimer seam's default: a one-shot channel that fires
+// once after d, plus its Stop.
+func realNewTimer(d time.Duration) (<-chan time.Time, func() bool) {
+	t := time.NewTimer(d)
+	return t.C, t.Stop
+}
+
+// realNewTicker is the newTicker seam's default: a channel that fires every
+// d, plus its Stop.
+func realNewTicker(d time.Duration) (<-chan time.Time, func()) {
+	t := time.NewTicker(d)
+	return t.C, t.Stop
+}

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -90,6 +90,15 @@ type Worker struct {
 	cycle     atomic.Int64       // sync-cycle counter; rotates the team order
 	metrics   syncMetrics        // sync-layer instruments, bound at construction
 
+	// Clock seam: EVERY timing decision in this file goes through these
+	// three fields — no bare time-package clock calls (Now/Since/Until/
+	// NewTimer/NewTicker), the greppable rule; see clock.go and CONTEXT.md
+	// "Worker clock seam". NewWorker defaults them to the real clock; tests
+	// inject a fake.
+	now       func() time.Time
+	newTimer  func(d time.Duration) (<-chan time.Time, func() bool)
+	newTicker func(d time.Duration) (<-chan time.Time, func())
+
 	// Rate limit tracking for issue details sync
 	rateLimitMu     sync.RWMutex
 	rateLimitedAt   time.Time
@@ -128,6 +137,9 @@ func NewWorker(client APIClient, store *db.Store, cfg Config) *Worker {
 		stopCh:    make(chan struct{}),
 		doneCh:    make(chan struct{}),
 		metrics:   newSyncMetrics(),
+		now:       realNow,
+		newTimer:  realNewTimer,
+		newTicker: realNewTicker,
 	}
 }
 
@@ -206,8 +218,8 @@ func (w *Worker) run(ctx context.Context) {
 		log.Printf("[sync] initial sync failed: %v", err)
 	}
 
-	ticker := time.NewTicker(w.interval)
-	defer ticker.Stop()
+	tick, stopTicker := w.newTicker(w.interval)
+	defer stopTicker()
 
 	for {
 		select {
@@ -215,7 +227,7 @@ func (w *Worker) run(ctx context.Context) {
 			return
 		case <-w.stopCh:
 			return
-		case <-ticker.C:
+		case <-tick:
 			if err := w.syncAllTeams(ctx); err != nil {
 				log.Printf("[sync] sync failed: %v", err)
 			}
@@ -228,8 +240,8 @@ func (w *Worker) syncAllTeams(ctx context.Context) error {
 	// invoked it (run's initial sync, the ticker, SyncNow). A budget-skipped
 	// cycle records its ~0s duration too — a burst of near-zero samples IS
 	// the signature of budget-gated skipping.
-	start := time.Now()
-	defer func() { w.metrics.recordCycle(time.Since(start)) }()
+	start := w.now()
+	defer func() { w.metrics.recordCycle(w.now().Sub(start)) }()
 
 	// Skip entire sync cycle when budget is critically high
 	if w.budgetExceeds(budgetSkipSyncPct) {
@@ -290,7 +302,7 @@ func (w *Worker) syncAllTeams(ctx context.Context) error {
 	}
 
 	w.mu.Lock()
-	w.lastSync = time.Now()
+	w.lastSync = w.now()
 	w.mu.Unlock()
 
 	return nil
@@ -306,7 +318,7 @@ type SyncTeamResult struct {
 }
 
 func (w *Worker) syncTeam(ctx context.Context, team api.Team) error {
-	start := time.Now()
+	start := w.now()
 
 	// Get last sync metadata
 	meta, err := w.store.Queries().GetSyncMeta(ctx, team.ID)
@@ -343,7 +355,7 @@ func (w *Worker) syncTeam(ctx context.Context, team api.Team) error {
 		log.Printf("[sync] update sync meta for %s failed: %v", team.Key, err)
 	}
 
-	duration := time.Since(start)
+	duration := w.now().Sub(start)
 	log.Printf("[sync] team %s: added=%d updated=%d pages=%d duration=%s",
 		team.Key, added, updated, pages, duration.Round(time.Millisecond))
 
@@ -770,7 +782,7 @@ func (w *Worker) budgetExceeds(pct float64) bool {
 func (w *Worker) isRateLimited() bool {
 	w.rateLimitMu.RLock()
 	defer w.rateLimitMu.RUnlock()
-	return time.Now().Before(w.rateLimitExpiry)
+	return w.now().Before(w.rateLimitExpiry)
 }
 
 // setRateLimited marks that we've hit a rate limit. The backoff consults
@@ -781,12 +793,12 @@ func (w *Worker) isRateLimited() bool {
 func (w *Worker) setRateLimited() {
 	w.rateLimitMu.Lock()
 	defer w.rateLimitMu.Unlock()
-	w.rateLimitedAt = time.Now()
+	w.rateLimitedAt = w.now()
 
 	// Use the budget's server-provided reset time if it's in the future
 	backoff := 15 * time.Minute
-	if resetAt := w.client.RateLimitResetAt(); !resetAt.IsZero() && resetAt.After(time.Now()) {
-		backoff = time.Until(resetAt) + 5*time.Second // 5s buffer past the reset
+	if resetAt := w.client.RateLimitResetAt(); !resetAt.IsZero() && resetAt.After(w.now()) {
+		backoff = resetAt.Sub(w.now()) + 5*time.Second // 5s buffer past the reset
 	}
 	w.rateLimitExpiry = w.rateLimitedAt.Add(backoff)
 
@@ -834,20 +846,20 @@ func (w *Worker) probeBudget(ctx context.Context) bool {
 	expiry := w.rateLimitExpiry
 	w.rateLimitMu.RUnlock()
 
-	wait := time.Until(expiry)
+	wait := expiry.Sub(w.now())
 	log.Printf("[sync] budget probe RATELIMITED; delaying sync start %s (until %s)",
 		wait.Round(time.Second), expiry.Format(time.RFC3339))
 	if wait <= 0 {
 		return true
 	}
-	timer := time.NewTimer(wait)
-	defer timer.Stop()
+	timer, stopTimer := w.newTimer(wait)
+	defer stopTimer()
 	select {
 	case <-ctx.Done():
 		return false
 	case <-w.stopCh:
 		return false
-	case <-timer.C:
+	case <-timer:
 		return true
 	}
 }

--- a/internal/sync/worker_test.go
+++ b/internal/sync/worker_test.go
@@ -25,6 +25,70 @@ func (m *mockBudgetReporter) BudgetSnapshot() (int, float64) {
 	return m.count, m.pct
 }
 
+// fakeClock drives the Worker's clock seam (now/newTimer/newTicker) in tests
+// — the worker-side analogue of ratebudget_test.go's fakeClock, plus recorded
+// timer/ticker channels the test fires explicitly. The time is mutex'd
+// because the run loop reads now() from its own goroutine.
+type fakeClock struct {
+	mu gosync.Mutex
+	t  time.Time
+
+	timerCh  chan time.Time // handed out by newTimer; the test fires it
+	tickerCh chan time.Time // handed out by newTicker; the test feeds ticks
+	tickerD  time.Duration  // duration requested by the last newTicker call
+
+	// Each newTimer call reports its requested duration here (buffered, so
+	// the worker never blocks on it). A receive doubles as the handshake
+	// that the worker has reached — and parked on — the timer.
+	timerSet chan time.Duration
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{
+		t:        time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC),
+		timerCh:  make(chan time.Time),
+		tickerCh: make(chan time.Time),
+		timerSet: make(chan time.Duration, 4),
+	}
+}
+
+func (f *fakeClock) now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.t
+}
+
+func (f *fakeClock) advance(d time.Duration) {
+	f.mu.Lock()
+	f.t = f.t.Add(d)
+	f.mu.Unlock()
+}
+
+func (f *fakeClock) newTimer(d time.Duration) (<-chan time.Time, func() bool) {
+	f.timerSet <- d
+	return f.timerCh, func() bool { return true }
+}
+
+func (f *fakeClock) newTicker(d time.Duration) (<-chan time.Time, func()) {
+	f.mu.Lock()
+	f.tickerD = d
+	f.mu.Unlock()
+	return f.tickerCh, func() {}
+}
+
+func (f *fakeClock) tickerInterval() time.Duration {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.tickerD
+}
+
+// install wires the fake into a worker's clock seam.
+func (f *fakeClock) install(w *Worker) {
+	w.now = f.now
+	w.newTimer = f.newTimer
+	w.newTicker = f.newTicker
+}
+
 // mockAPIClient implements APIClient for testing
 type mockAPIClient struct {
 	teams            []api.Team
@@ -240,10 +304,9 @@ func TestWorkerStartStop(t *testing.T) {
 		t.Error("Worker should be running after Start()")
 	}
 
-	// Wait for initial sync
-	time.Sleep(50 * time.Millisecond)
-
-	// Stop worker
+	// Stop worker. Stop blocks on run()'s doneCh, and run() always completes
+	// the probe and the initial sync cycle before it can observe stopCh — so
+	// GetTeams has fired by the time Stop returns, no settling sleep needed.
 	worker.Stop()
 	if worker.Running() {
 		t.Error("Worker should not be running after Stop()")
@@ -494,17 +557,13 @@ func TestWorkerContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	worker.Start(ctx)
-	time.Sleep(20 * time.Millisecond)
 
-	// Cancel context should stop worker. Poll with a deadline rather than a
-	// fixed grace: the worker only observes cancellation between sync steps,
-	// and on a loaded CI runner the in-flight initial sync can take well over
-	// the old 100ms (observed flaking on the shared runners).
+	// Cancel context should stop worker. run() closes doneCh on every exit
+	// (after clearing running), so a blocking read is the synchronization
+	// point — the old deadline poll flaked on loaded CI runners where the
+	// in-flight initial sync outlived the grace period.
 	cancel()
-	deadline := time.Now().Add(10 * time.Second)
-	for worker.Running() && time.Now().Before(deadline) {
-		time.Sleep(10 * time.Millisecond)
-	}
+	<-worker.doneCh
 
 	if worker.Running() {
 		t.Error("Worker should stop when context is cancelled")
@@ -1056,58 +1115,86 @@ func TestDetailsSyncPrunesStaleDocsAndAttachments(t *testing.T) {
 }
 
 // TestSetRateLimitedAdaptiveBackoff verifies M-3: when the API client reports a non-zero
-// RateLimitResetAt(), setRateLimited() uses that time (+ 5s buffer) instead of the 15-min default.
+// future RateLimitResetAt(), setRateLimited() uses that time (+ 5s buffer) instead of the
+// 15-min default. The pinned fake clock makes the arithmetic exact — no tolerance window.
 func TestSetRateLimitedAdaptiveBackoff(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
 	defer store.Close()
 
+	clock := newFakeClock()
 	mock := newMockAPIClient()
-	serverResetAt := time.Now().Add(30 * time.Minute)
+	serverResetAt := clock.now().Add(30 * time.Minute)
 	mock.rateLimitResetAt = serverResetAt
 
-	cfg := Config{Interval: time.Hour}
-	worker := NewWorker(mock, store, cfg)
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+	clock.install(worker)
 
 	worker.setRateLimited()
 
-	expected := serverResetAt.Add(5 * time.Second)
-	got := worker.rateLimitExpiry
-
-	diff := got.Sub(expected)
-	if diff < 0 {
-		diff = -diff
-	}
-	if diff > 2*time.Second {
-		t.Errorf("rateLimitExpiry = %v, want ~%v (diff %v)", got, expected, diff)
+	if want := serverResetAt.Add(5 * time.Second); !worker.rateLimitExpiry.Equal(want) {
+		t.Errorf("rateLimitExpiry = %v, want exactly %v (server reset + 5s buffer)", worker.rateLimitExpiry, want)
 	}
 }
 
-// TestSetRateLimitedFallback verifies M-3: when no server reset time is available,
-// setRateLimited() falls back to the 15-minute fixed backoff.
+// TestSetRateLimitedFallback verifies M-3: with no usable server reset —
+// zero (never reported) or already past — setRateLimited() falls back to the
+// 15-minute fixed backoff, exactly, on the pinned fake clock.
 func TestSetRateLimitedFallback(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]func(now time.Time) time.Time{
+		"zero reset": func(time.Time) time.Time { return time.Time{} },
+		"past reset": func(now time.Time) time.Time { return now.Add(-time.Minute) },
+	}
+	for name, resetAt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			store := openTestStore(t)
+			defer store.Close()
+
+			clock := newFakeClock()
+			mock := newMockAPIClient()
+			mock.rateLimitResetAt = resetAt(clock.now())
+
+			worker := NewWorker(mock, store, Config{Interval: time.Hour})
+			clock.install(worker)
+
+			worker.setRateLimited()
+
+			if want := clock.now().Add(15 * time.Minute); !worker.rateLimitExpiry.Equal(want) {
+				t.Errorf("rateLimitExpiry = %v, want exactly %v (the 15-minute fallback)", worker.rateLimitExpiry, want)
+			}
+		})
+	}
+}
+
+// TestIsRateLimitedFlipsWhenClockCrossesExpiry: the seam's most basic win —
+// isRateLimited() is a pure now-vs-expiry comparison, so advancing the fake
+// clock across rateLimitExpiry must flip it false with zero real waiting.
+func TestIsRateLimitedFlipsWhenClockCrossesExpiry(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
 	defer store.Close()
 
-	mock := newMockAPIClient()
-	// rateLimitResetAt is zero (the default)
+	clock := newFakeClock()
+	mock := newMockAPIClient() // zero reset → the 15-minute fallback backoff
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+	clock.install(worker)
 
-	cfg := Config{Interval: time.Hour}
-	worker := NewWorker(mock, store, cfg)
-
-	before := time.Now()
 	worker.setRateLimited()
-
-	expected := before.Add(15 * time.Minute)
-	got := worker.rateLimitExpiry
-
-	diff := got.Sub(expected)
-	if diff < 0 {
-		diff = -diff
+	if !worker.isRateLimited() {
+		t.Fatal("isRateLimited() = false immediately after setRateLimited()")
 	}
-	if diff > 2*time.Second {
-		t.Errorf("rateLimitExpiry = %v, want ~%v (diff %v)", got, expected, diff)
+
+	clock.advance(15*time.Minute - time.Second)
+	if !worker.isRateLimited() {
+		t.Error("isRateLimited() = false one second before expiry, want true")
+	}
+
+	clock.advance(2 * time.Second)
+	if worker.isRateLimited() {
+		t.Error("isRateLimited() = true after the clock crossed expiry, want false")
 	}
 }
 
@@ -1132,15 +1219,13 @@ func TestProbeSeedsBudgetBeforeFirstSync(t *testing.T) {
 	defer cancel()
 
 	worker.Start(ctx)
-	defer worker.Stop()
+	// Stop blocks on run()'s doneCh, and run() completes the probe and the
+	// initial sync cycle before it can observe stopCh — so by the time Stop
+	// returns, GetTeams has fired and the call order is settled (no poll).
+	worker.Stop()
 
-	// Wait for the initial sync cycle to reach GetTeams.
-	deadline := time.Now().Add(5 * time.Second)
-	for atomic.LoadInt32(&mock.getTeamsCalls) == 0 {
-		if time.Now().After(deadline) {
-			t.Fatal("initial sync never called GetTeams")
-		}
-		time.Sleep(5 * time.Millisecond)
+	if atomic.LoadInt32(&mock.getTeamsCalls) == 0 {
+		t.Fatal("initial sync never called GetTeams")
 	}
 
 	order := mock.callOrder()
@@ -1162,21 +1247,28 @@ func TestProbeRateLimitedDelaysSyncStart(t *testing.T) {
 	store := openTestStore(t)
 	defer store.Close()
 
+	clock := newFakeClock()
 	mock := newMockAPIClient()
 	mock.teams = []api.Team{{ID: "team-1", Key: "TST", Name: "Test"}}
 	mock.viewerErr = errors.New("GraphQL error: RATELIMITED: rate limit exceeded")
 	// The budget's server-reported reset (seeded by the probe response's
 	// headers in production) is an hour out.
-	mock.rateLimitResetAt = time.Now().Add(time.Hour)
+	mock.rateLimitResetAt = clock.now().Add(time.Hour)
 
 	worker := NewWorker(mock, store, Config{Interval: 10 * time.Millisecond})
+	clock.install(worker)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	worker.Start(ctx)
 
-	// Give the worker ample time to (incorrectly) start syncing.
-	time.Sleep(200 * time.Millisecond)
+	// The probe parks on the injected delay timer — the handshake that
+	// replaced the old 200ms "ample time to misbehave" sleep. Nothing ever
+	// fires the fake timer, so any sync activity from here IS the bug. With
+	// the clock pinned the requested delay is exact: reset − now + 5s buffer.
+	if got, want := <-clock.timerSet, time.Hour+5*time.Second; got != want {
+		t.Errorf("probe delay = %v, want exactly %v", got, want)
+	}
 
 	if got := atomic.LoadInt32(&mock.getTeamsCalls); got != 0 {
 		t.Errorf("GetTeams calls during rate-limited probe delay = %d, want 0", got)
@@ -1209,17 +1301,108 @@ func TestProbeFailureProceeds(t *testing.T) {
 	defer cancel()
 
 	worker.Start(ctx)
-	defer worker.Stop()
+	// Stop blocks until run() exits; a probe failure that (correctly)
+	// proceeds will have completed the initial sync by then.
+	worker.Stop()
 
-	deadline := time.Now().Add(5 * time.Second)
-	for atomic.LoadInt32(&mock.getTeamsCalls) == 0 {
-		if time.Now().After(deadline) {
-			t.Fatal("sync never proceeded past a non-rate-limit probe failure")
-		}
-		time.Sleep(5 * time.Millisecond)
+	if atomic.LoadInt32(&mock.getTeamsCalls) == 0 {
+		t.Fatal("sync never proceeded past a non-rate-limit probe failure")
 	}
 	if worker.isRateLimited() {
 		t.Error("a non-rate-limit probe failure must not mark the worker rate-limited")
+	}
+}
+
+// TestProbeBudgetRateLimitedWaitAndResume drives probeBudget's RATELIMITED
+// path directly on the fake timer: the requested wait must be exactly the
+// backoff-to-expiry duration, and firing the timer resumes sync (returns
+// true) — zero real waiting.
+func TestProbeBudgetRateLimitedWaitAndResume(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+
+	clock := newFakeClock()
+	mock := newMockAPIClient()
+	mock.viewerErr = errors.New("GraphQL error: RATELIMITED: rate limit exceeded")
+	mock.rateLimitResetAt = clock.now().Add(30 * time.Minute)
+
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+	clock.install(worker)
+
+	result := make(chan bool, 1)
+	go func() { result <- worker.probeBudget(context.Background()) }()
+
+	// The probe parked on the fake timer; the clock is pinned, so the
+	// requested wait is exactly reset − now + 5s buffer.
+	if got, want := <-clock.timerSet, 30*time.Minute+5*time.Second; got != want {
+		t.Errorf("probe wait = %v, want exactly %v", got, want)
+	}
+
+	// Fire the timer: the backoff "elapsed", sync must proceed.
+	clock.timerCh <- time.Time{}
+	if !<-result {
+		t.Error("probeBudget = false after the delay timer fired, want true (sync proceeds)")
+	}
+}
+
+// TestProbeBudgetStopInterruptsWait: Stop (stopCh closing) must interrupt the
+// probe's backoff wait and return false so run() exits without firing a
+// post-stop sync cycle. The fake timer never fires — the only way out is the
+// stop channel.
+func TestProbeBudgetStopInterruptsWait(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+
+	clock := newFakeClock()
+	mock := newMockAPIClient()
+	mock.viewerErr = errors.New("GraphQL error: RATELIMITED: rate limit exceeded")
+	mock.rateLimitResetAt = clock.now().Add(30 * time.Minute)
+
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+	clock.install(worker)
+
+	result := make(chan bool, 1)
+	go func() { result <- worker.probeBudget(context.Background()) }()
+
+	<-clock.timerSet     // the probe is parked on the fake timer
+	close(worker.stopCh) // what Stop() does (in-package; run() isn't live here)
+	if <-result {
+		t.Error("probeBudget = true, want false when Stop interrupts the backoff wait")
+	}
+}
+
+// TestRunLoopTickFiresSyncCycle: the run loop's cadence rides the injected
+// ticker — feeding one tick on the fake channel fires a full sync cycle, no
+// real interval elapses.
+func TestRunLoopTickFiresSyncCycle(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+
+	clock := newFakeClock()
+	mock := newMockAPIClient()
+	mock.teams = []api.Team{{ID: "team-1", Key: "TST", Name: "Test"}}
+
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+	clock.install(worker)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	worker.Start(ctx)
+	// The unbuffered send completes only once the loop is parked in its
+	// select — i.e. after the initial sync — and hands it exactly one tick.
+	clock.tickerCh <- time.Time{}
+	// Stop blocks until run() exits, and the tick's sync cycle runs to
+	// completion before the loop can re-enter the select and observe stopCh.
+	worker.Stop()
+
+	if d := clock.tickerInterval(); d != time.Hour {
+		t.Errorf("run loop ticker constructed with %v, want the configured interval %v", d, time.Hour)
+	}
+	if calls := atomic.LoadInt32(&mock.getTeamsCalls); calls != 2 {
+		t.Errorf("GetTeams calls = %d, want exactly 2 (initial sync + the injected tick)", calls)
 	}
 }
 


### PR DESCRIPTION
## The seam

The sync worker called `time.Now/Since/Until/NewTimer/NewTicker` directly at ~9 sites, making its timing logic slow-testable (six `time.Sleep` sites and a deadline-poll loop in `worker_test.go`). One layer down, `rateBudget` already has the cure — an injected `now func() time.Time` driven by a fake clock in tests. This PR gives the `Worker` the same seam: three unexported function fields (closures, not an interface, not a clock library), defaulted in `NewWorker` to real time:

```go
now       func() time.Time
newTimer  func(d time.Duration) (<-chan time.Time, func() bool)  // wraps time.NewTimer → (t.C, t.Stop)
newTicker func(d time.Duration) (<-chan time.Time, func())       // wraps time.NewTicker → (t.C, t.Stop)
```

The real-time defaults (`realNow`/`realNewTimer`/`realNewTicker`) live in the new `internal/sync/clock.go` — deliberately a separate file, so the uniformity rule below holds against `worker.go` itself.

## The no-bare-time rule

**No bare `time.` clock calls remain in `worker.go`** — the same greppable discipline as the ino namespace's no-bare-hashes rule:

```
$ grep -n 'time\.\(Now\|Since\|Until\|NewTimer\|NewTicker\|Sleep\|After\)' internal/sync/worker.go
(nothing)
```

Every site converted: the run-loop ticker, `probeBudget`'s delay timer, the cycle/team-sync duration metrics, the `lastSync` stamp, `isRateLimited`, and `setRateLimited` (`time.Until(x)` → `x.Sub(w.now())`). `time.Duration` arithmetic and `time.RFC3339` formatting stay — they are not clock calls. CONTEXT.md gains a "Worker clock seam" entry recording the seam and the rule.

## Test conversions (by cause)

- **Probe-delay real waits** (`TestProbeRateLimitedDelaysSyncStart`'s 200ms "ample time to misbehave" sleep): the fake timer records the requested duration on a buffered `timerSet` channel — a receive doubles as the handshake that the worker has parked on the timer — the test asserts the *exact* wait (`reset − now + 5s`, no ±2s tolerance) and fires the channel. Zero real time.
- **The deadline-poll loop** after ctx cancel (`TestWorkerContextCancellation`): not a clock problem — `run()` closes `doneCh` on every exit, so the poll became a blocking `<-worker.doneCh` read.
- **Goroutine-startup sleeps** (`TestWorkerStartStop`, the probe-sequencing polls): `Stop()`-as-handshake — Stop blocks on `doneCh`, and `run()` always completes the probe + initial sync before it can observe `stopCh`. **Zero `time.Sleep` calls survive in `worker_test.go`.**

## New deterministic tests the seam makes writable

- `TestIsRateLimitedFlipsWhenClockCrossesExpiry` — advance the fake clock past `rateLimitExpiry`, the flag flips.
- `TestSetRateLimitedAdaptiveBackoff`/`Fallback` precision-ified — pinned fake now makes the arithmetic exact: future reset → `reset + 5s`; zero **and past** reset → the 15-minute fallback.
- `TestProbeBudgetRateLimitedWaitAndResume` — exact requested wait on the fake timer, fire it, `probeBudget` returns true.
- `TestProbeBudgetStopInterruptsWait` — close `stopCh` while parked; returns false, no post-stop sync.
- `TestRunLoopTickFiresSyncCycle` — feed one tick on the fake ticker, exactly one sync cycle fires (asserted via `getTeamsCalls`), and the ticker was constructed with the configured interval.

## Verification

- `gofmt`, `go vet ./...`, `make staticcheck` clean
- Full `go test -count=1 ./...` green (integration 65.7s); `go test -race ./internal/sync/` green
- The sync package suite dropped to ~0.8s (the sleeps are gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)