### PR TITLE
refactor: relationListing — direction-aware listing for relations/

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -710,6 +710,54 @@ distinguishes not-found (`ENOENT`) from couldn't-look (`EIO`) via the
 slices (`TestAttachmentListing*`: round-trip, cross-family dedup, extension
 edges, linkName), no mount.
 
+### Relation listing (`relationListing`)
+The **deep module** owning the `{type}-{ID}.rel` filenames of the relations
+directory — the *direction-aware* sibling of [[named-listing]],
+[[indexed-listing]], and [[attachment-listing]], covering the last collection
+not on a listing module. One relation table projects in two directions:
+outgoing relations name themselves from the raw type and the related issue
+(`blocks-ENG-123.rel`), inverse ones from `inverseRelationType` and the source
+issue (`blocked-by-ENG-456.rel`). `relationListing{outgoing, inverse}`
+(`internal/fs/relationlisting.go`) exposes `entries()` (Readdir: outgoing
+first, then inverse — today's order) and `find(name)` (Lookup) returning a
+tagged entry carrying the direction (render and Unlink policy differ by it),
+and owns `relationFileName` — the `%s-%s.rel` format string exists exactly
+once. Before it, the derivation and the direction split were restated at four
+sites across Readdir/Lookup/createRelation, and the file had no test twin.
+
+**Collisions are first-match, emit-once — [[named-listing]]'s policy,
+inherited WITH its rationale:** the .rel name is a resolution key (`rm` must
+delete exactly what `find` matched), so a disambiguated
+`blocks-ENG-123 (2).rel` would mint a name that resolves nowhere. `entries()`
+implements the emit-once (first wins) and `find` replays `entries()`, so
+readdir and find agree by construction. Nil-issue/empty-identifier relations
+are skipped (they would derive a broken name).
+
+Two recorded behavior changes rode the collapse. (1) Lookup adopted
+[[attachment-listing]]'s `listing(ctx, &fetchErr)` seam: a store failure now
+returns `EIO` instead of masquerading as `ENOENT` (the old code discarded
+fetch errors). Readdir keeps failing whole-directory on either fetch error —
+attachments' best-effort Readdir is justified by *independent* sources, and
+both relation fetches hit the same table. (2) `relationContent` renders
+through `yaml.Marshal` over ordered structs (declaration-order fields keep the
+output byte-identical for plain values) instead of hand-`Sprintf`: a title
+containing a colon used to emit INVALID YAML — the .rel twin of the catalog
+render fix. The **no-delimiter format is preserved** (plain YAML body, not
+frontmatter).
+
+The create surface parses its command through `parseRelationInput` (pure:
+`"<type> <ISSUE-ID>"`, bare identifier defaults to `related`, FieldErrors for
+empty content/bad type) and derives its `.last` path and kernel-entry name
+from the *parsed input* by necessity — the mutation's echoed relation lacks
+the related issue — but through the shared `relationFileName`. Boundary note:
+`parseRelationInput` lives in `fs`, not `marshal` — marshal's seam is
+markdown↔entity, and a one-line command syntax for a write-only trigger is
+not a markdown document, so the parse-side-lives-in-marshal instinct doesn't
+over-apply. The caller fetches and passes the slices (ordering is the repo's
+job); pure of the repo, unit-tested on literals (`TestRelationListing*`,
+`TestRelationContent`, `TestParseRelationInput`), the fetch-error seam tested
+against a real store (`TestRelationsNodeListingFetchErrSeam`), no mount.
+
 ### Entity-directory manifest (`dirManifest`)
 The **deep module** owning the *static* children of an entity directory — the
 `issue.md`/`issue.meta`/`.error`/`.last`/`history.md` files and the

--- a/internal/fs/relationlisting.go
+++ b/internal/fs/relationlisting.go
@@ -1,0 +1,171 @@
+package fs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jra3/linear-fuse/internal/api"
+	"gopkg.in/yaml.v3"
+)
+
+// relationListing owns the `{type}-{ID}.rel` filenames of the relations
+// directory — the direction-aware sibling of namedListing (labels/docs/
+// milestones), indexedListing (comments/updates), and attachmentListing.
+// The directory projects one relation table in two directions: outgoing
+// relations name themselves from the relation type and the related issue
+// ("blocks-ENG-123.rel"), inverse relations from the inverted type and the
+// source issue ("blocked-by-ENG-456.rel"). Both Readdir and Lookup derive
+// names through this one module over one canonical order (outgoing first,
+// then inverse — the repo's order within each), so a file you can `ls` you
+// can also open and `rm` — before this, each surface restated the derivation
+// and the direction split independently (four sites), and the file had no
+// test twin.
+//
+// Collisions are first-match, emit-once — namedListing's recorded policy, for
+// its recorded reason: the .rel name is a resolution key (`rm` must delete
+// exactly what find matched), so a disambiguated "blocks-ENG-123 (2).rel"
+// would mint a name that resolves nowhere. entries() implements the emit-once
+// (first wins) and find() replays entries(), so readdir and find agree by
+// construction. Entries with a nil issue or empty identifier are skipped —
+// they would derive a broken name.
+//
+// Ordering is the repo's job, never this module's: the caller fetches both
+// direction slices and passes them; the module is pure and unit-tested on
+// literals.
+type relationListing struct {
+	outgoing []api.IssueRelation
+	inverse  []api.IssueRelation
+}
+
+// relationEntry is one derived directory entry: the final name, the relation
+// it resolves to, and which direction derived it (the render and Unlink
+// policies differ by direction).
+type relationEntry struct {
+	relation  api.IssueRelation
+	name      string
+	isInverse bool
+}
+
+// relationFileName derives a relation file's name. The create surface reuses
+// it for its .last path and kernel-entry name, so the format string exists
+// exactly once.
+func relationFileName(relType, identifier string) string {
+	return fmt.Sprintf("%s-%s.rel", relType, identifier)
+}
+
+// inverseRelationType returns the inverse relation type name
+func inverseRelationType(relType string) string {
+	switch relType {
+	case "blocks":
+		return "blocked-by"
+	case "duplicate":
+		return "duplicated-by"
+	case "related":
+		return "related-to"
+	case "similar":
+		return "similar-to"
+	default:
+		return relType + "-inverse"
+	}
+}
+
+// entries is the Readdir projection: outgoing relations first, then inverse,
+// each name emitted once (first wins), skipping entries whose issue is nil or
+// unidentified.
+func (l relationListing) entries() []relationEntry {
+	result := make([]relationEntry, 0, len(l.outgoing)+len(l.inverse))
+	seen := make(map[string]struct{}, len(l.outgoing)+len(l.inverse))
+	emit := func(rel api.IssueRelation, name string, isInverse bool) {
+		if _, dup := seen[name]; dup {
+			return
+		}
+		seen[name] = struct{}{}
+		result = append(result, relationEntry{relation: rel, name: name, isInverse: isInverse})
+	}
+	for _, rel := range l.outgoing {
+		if rel.RelatedIssue == nil || rel.RelatedIssue.Identifier == "" {
+			continue
+		}
+		emit(rel, relationFileName(rel.Type, rel.RelatedIssue.Identifier), false)
+	}
+	for _, rel := range l.inverse {
+		if rel.Issue == nil || rel.Issue.Identifier == "" {
+			continue
+		}
+		emit(rel, relationFileName(inverseRelationType(rel.Type), rel.Issue.Identifier), true)
+	}
+	return result
+}
+
+// find replays the same derivation and returns the entry whose name matches —
+// the Lookup projection. Every name entries() emits resolves here by
+// construction.
+func (l relationListing) find(name string) (relationEntry, bool) {
+	for _, e := range l.entries() {
+		if e.name == name {
+			return e, true
+		}
+	}
+	return relationEntry{}, false
+}
+
+// relationContent renders a relation file's YAML body — a plain YAML document
+// with no frontmatter delimiters (the .rel format has never had them). The
+// encoder marshals struct fields in declaration order, so output is
+// byte-identical to the old hand-Sprintf for plain values, and quotes where
+// YAML demands — a title containing a colon used to render INVALID YAML (the
+// .rel twin of the catalog-render fix).
+func relationContent(rel api.IssueRelation, isInverse bool) string {
+	var v any
+	switch {
+	case isInverse && rel.Issue != nil:
+		v = struct {
+			Type  string `yaml:"type"`
+			From  string `yaml:"from"`
+			Title string `yaml:"title,omitempty"`
+		}{rel.Type, rel.Issue.Identifier, rel.Issue.Title}
+	case rel.RelatedIssue != nil:
+		v = struct {
+			Type  string `yaml:"type"`
+			To    string `yaml:"to"`
+			Title string `yaml:"title,omitempty"`
+		}{rel.Type, rel.RelatedIssue.Identifier, rel.RelatedIssue.Title}
+	default:
+		v = struct {
+			Type string `yaml:"type"`
+		}{rel.Type}
+	}
+	out, err := yaml.Marshal(v)
+	if err != nil {
+		// Structs of plain strings cannot fail to marshal; degrade to the
+		// bare type line rather than an empty file.
+		return "type: " + rel.Type + "\n"
+	}
+	return string(out)
+}
+
+// parseRelationInput parses the relations _create command syntax:
+// "<type> <ISSUE-ID>", or a bare "<ISSUE-ID>" defaulting the type to
+// "related". Pure syntax only — the identifier→issue resolution stays with
+// the caller, which owns the repo. (This lives in fs, not marshal: marshal's
+// seam is markdown↔entity, and a one-line command for a write-only trigger
+// is not a markdown document.)
+func parseRelationInput(content string) (relType, identifier string, err error) {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return "", "", &FieldError{Field: "content", Message: `empty content. Write "<type> <ISSUE-ID>", e.g. "blocks ENG-123".`}
+	}
+	parts := strings.Fields(content)
+	if len(parts) == 1 {
+		// Just identifier, default to "related"
+		relType, identifier = "related", parts[0]
+	} else {
+		relType, identifier = parts[0], parts[1]
+	}
+
+	validTypes := map[string]bool{"blocks": true, "duplicate": true, "related": true, "similar": true}
+	if !validTypes[relType] {
+		return "", "", &FieldError{Field: "type", Value: relType, Message: "invalid relation type. Use one of: blocks, duplicate, related, similar."}
+	}
+	return relType, identifier, nil
+}

--- a/internal/fs/relationlisting_test.go
+++ b/internal/fs/relationlisting_test.go
@@ -1,0 +1,288 @@
+package fs
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/jra3/linear-fuse/internal/api"
+	"github.com/jra3/linear-fuse/internal/db"
+	"github.com/jra3/linear-fuse/internal/repo"
+	"gopkg.in/yaml.v3"
+)
+
+// TestRelationListingRoundTrip guards the module's core invariant: every name
+// entries() emits resolves back through find to the same relation with the
+// same direction, so a file you can ls you can also open and rm.
+func TestRelationListingRoundTrip(t *testing.T) {
+	t.Parallel()
+	l := relationListing{
+		outgoing: []api.IssueRelation{
+			{ID: "r1", Type: "blocks", RelatedIssue: &api.ParentIssue{Identifier: "ENG-1"}},
+			{ID: "r2", Type: "related", RelatedIssue: &api.ParentIssue{Identifier: "ENG-2"}},
+		},
+		inverse: []api.IssueRelation{
+			{ID: "r3", Type: "blocks", Issue: &api.ParentIssue{Identifier: "ENG-3"}},
+			{ID: "r4", Type: "duplicate", Issue: &api.ParentIssue{Identifier: "ENG-4"}},
+		},
+	}
+
+	entries := l.entries()
+	if len(entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(entries))
+	}
+	seen := make(map[string]bool)
+	for _, e := range entries {
+		if seen[e.name] {
+			t.Errorf("duplicate name emitted: %q", e.name)
+		}
+		seen[e.name] = true
+
+		got, ok := l.find(e.name)
+		if !ok {
+			t.Errorf("entries() emitted %q but find missed it", e.name)
+			continue
+		}
+		if got.relation.ID != e.relation.ID || got.isInverse != e.isInverse {
+			t.Errorf("find(%q) = (id=%s, isInverse=%v), want (id=%s, isInverse=%v)",
+				e.name, got.relation.ID, got.isInverse, e.relation.ID, e.isInverse)
+		}
+	}
+
+	if _, ok := l.find("blocks-ENG-999.rel"); ok {
+		t.Error("find matched a name no entry has")
+	}
+}
+
+// TestRelationListingDirections pins the direction split: an outgoing
+// relation names itself from the raw type and the related issue, an inverse
+// one from the inverted type and the source issue — and find reports which
+// side derived the match (Unlink and the render depend on it).
+func TestRelationListingDirections(t *testing.T) {
+	t.Parallel()
+	l := relationListing{
+		outgoing: []api.IssueRelation{
+			{ID: "out", Type: "blocks", RelatedIssue: &api.ParentIssue{Identifier: "ENG-1"}},
+		},
+		inverse: []api.IssueRelation{
+			{ID: "in", Type: "blocks", Issue: &api.ParentIssue{Identifier: "ENG-2"}},
+		},
+	}
+
+	got, ok := l.find("blocks-ENG-1.rel")
+	if !ok || got.relation.ID != "out" || got.isInverse {
+		t.Errorf("find(blocks-ENG-1.rel) = (%+v, %v), want the outgoing relation with isInverse=false", got, ok)
+	}
+
+	got, ok = l.find("blocked-by-ENG-2.rel")
+	if !ok || got.relation.ID != "in" || !got.isInverse {
+		t.Errorf("find(blocked-by-ENG-2.rel) = (%+v, %v), want the inverse relation with isInverse=true", got, ok)
+	}
+
+	// The inverse relation must NOT also answer to its raw-type name.
+	if _, ok := l.find("blocks-ENG-2.rel"); ok {
+		t.Error("find matched an inverse relation by its un-inverted type name")
+	}
+}
+
+// TestInverseRelationType pins the type inversion for all four relation types
+// plus the unknown-type fallback.
+func TestInverseRelationType(t *testing.T) {
+	t.Parallel()
+	cases := []struct{ in, want string }{
+		{"blocks", "blocked-by"},
+		{"duplicate", "duplicated-by"},
+		{"related", "related-to"},
+		{"similar", "similar-to"},
+		{"mystery", "mystery-inverse"},
+	}
+	for _, c := range cases {
+		if got := inverseRelationType(c.in); got != c.want {
+			t.Errorf("inverseRelationType(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestRelationListingSkipsIncomplete: a relation with a nil issue or an empty
+// identifier would derive a broken name, so it produces no entry and no find
+// match — today's guard, kept.
+func TestRelationListingSkipsIncomplete(t *testing.T) {
+	t.Parallel()
+	l := relationListing{
+		outgoing: []api.IssueRelation{
+			{ID: "r1", Type: "blocks", RelatedIssue: nil},
+			{ID: "r2", Type: "blocks", RelatedIssue: &api.ParentIssue{Identifier: ""}},
+		},
+		inverse: []api.IssueRelation{
+			{ID: "r3", Type: "blocks", Issue: nil},
+			{ID: "r4", Type: "blocks", Issue: &api.ParentIssue{Identifier: ""}},
+		},
+	}
+	if got := l.entries(); len(got) != 0 {
+		t.Errorf("entries() = %d entries, want 0 (incomplete relations skipped): %+v", len(got), got)
+	}
+	if _, ok := l.find("blocks-.rel"); ok {
+		t.Error("find matched a relation with an empty identifier")
+	}
+}
+
+// TestRelationListingCollisionFirstWins guards the collision contract
+// inherited from namedListing: duplicate-name inputs emit one dirent and find
+// returns the first, so readdir and find agree by construction. The .rel name
+// is a resolution key (rm deletes what find matched) — disambiguation would
+// mint names that resolve nowhere.
+func TestRelationListingCollisionFirstWins(t *testing.T) {
+	t.Parallel()
+	l := relationListing{
+		outgoing: []api.IssueRelation{
+			{ID: "first", Type: "blocks", RelatedIssue: &api.ParentIssue{Identifier: "ENG-1"}},
+			{ID: "second", Type: "blocks", RelatedIssue: &api.ParentIssue{Identifier: "ENG-1"}},
+		},
+	}
+
+	entries := l.entries()
+	if len(entries) != 1 {
+		t.Fatalf("entries() = %d entries, want 1 (collision collapsed): %+v", len(entries), entries)
+	}
+	if entries[0].name != "blocks-ENG-1.rel" {
+		t.Errorf("entries()[0].name = %q, want %q", entries[0].name, "blocks-ENG-1.rel")
+	}
+	if hit, ok := l.find("blocks-ENG-1.rel"); !ok || hit.relation.ID != "first" {
+		t.Errorf("find(blocks-ENG-1.rel) = (id=%s, %v), want the first item (id=first)", hit.relation.ID, ok)
+	}
+}
+
+// TestRelationsNodeListingFetchErrSeam exercises the listing(ctx, &fetchErr)
+// seam Lookup uses to distinguish couldn't-look from not-found: a healthy
+// store with no matching relation leaves fetchErr nil (a genuine miss →
+// ENOENT), while a failing store sets it (→ EIO). Before this seam, Lookup
+// discarded fetch errors and misreported a store failure as ENOENT.
+func TestRelationsNodeListingFetchErrSeam(t *testing.T) {
+	t.Parallel()
+
+	store, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("db.Open failed: %v", err)
+	}
+	lfs := &LinearFS{}
+	lfs.repo = repo.NewSQLiteRepository(store, nil)
+
+	ctx := context.Background()
+	n := &RelationsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}, issueID: "issue-1"}
+
+	// Healthy store, no relations: a miss with no fetch error (→ ENOENT).
+	var fetchErr error
+	if _, ok := n.listing(ctx, &fetchErr).find("blocks-ENG-1.rel"); ok {
+		t.Error("find matched a relation in an empty store")
+	}
+	if fetchErr != nil {
+		t.Errorf("fetchErr = %v on a healthy store, want nil", fetchErr)
+	}
+
+	// Failing store: the miss carries the fetch error (→ EIO).
+	if err := store.Close(); err != nil {
+		t.Fatalf("store.Close failed: %v", err)
+	}
+	fetchErr = nil
+	if _, ok := n.listing(ctx, &fetchErr).find("blocks-ENG-1.rel"); ok {
+		t.Error("find matched a relation against a closed store")
+	}
+	if fetchErr == nil {
+		t.Error("fetchErr = nil on a closed store, want the fetch error recorded")
+	}
+}
+
+// TestRelationContent pins the rendered YAML body for both directions: field
+// order (type, to/from, title), title omitted when empty, and — the recorded
+// behavior change — a colon-bearing title renders VALID YAML (the old
+// hand-Sprintf emitted it unquoted, the same bug class as the catalog fix).
+func TestRelationContent(t *testing.T) {
+	t.Parallel()
+
+	outgoing := api.IssueRelation{
+		Type:         "blocks",
+		RelatedIssue: &api.ParentIssue{Identifier: "ENG-1", Title: "Fix the bug"},
+	}
+	if got, want := relationContent(outgoing, false), "type: blocks\nto: ENG-1\ntitle: Fix the bug\n"; got != want {
+		t.Errorf("outgoing render = %q, want %q", got, want)
+	}
+
+	inverse := api.IssueRelation{
+		Type:  "blocks",
+		Issue: &api.ParentIssue{Identifier: "ENG-2", Title: "Upstream work"},
+	}
+	if got, want := relationContent(inverse, true), "type: blocks\nfrom: ENG-2\ntitle: Upstream work\n"; got != want {
+		t.Errorf("inverse render = %q, want %q", got, want)
+	}
+
+	untitled := api.IssueRelation{
+		Type:         "related",
+		RelatedIssue: &api.ParentIssue{Identifier: "ENG-3"},
+	}
+	if got, want := relationContent(untitled, false), "type: related\nto: ENG-3\n"; got != want {
+		t.Errorf("untitled render = %q, want %q (title omitted when empty)", got, want)
+	}
+
+	// A colon in the title demands quoting; the output must parse back as
+	// YAML with the title intact.
+	colon := api.IssueRelation{
+		Type:         "related",
+		RelatedIssue: &api.ParentIssue{Identifier: "ENG-4", Title: "Q3: Bets"},
+	}
+	rendered := relationContent(colon, false)
+	var parsed struct {
+		Type  string `yaml:"type"`
+		To    string `yaml:"to"`
+		Title string `yaml:"title"`
+	}
+	if err := yaml.Unmarshal([]byte(rendered), &parsed); err != nil {
+		t.Fatalf("colon-bearing title rendered invalid YAML: %v\n%s", err, rendered)
+	}
+	if parsed.Title != "Q3: Bets" || parsed.To != "ENG-4" || parsed.Type != "related" {
+		t.Errorf("colon-title round-trip = %+v, want the original values intact", parsed)
+	}
+}
+
+// TestParseRelationInput covers the _create command syntax: explicit type,
+// bare identifier defaulting to "related", the empty-content FieldError, and
+// the invalid-type FieldError.
+func TestParseRelationInput(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		in             string
+		wantType       string
+		wantIdentifier string
+		wantErrField   string // non-empty: expect a *FieldError on this field
+	}{
+		{"explicit type", "blocks ENG-123", "blocks", "ENG-123", ""},
+		{"bare identifier defaults to related", "ENG-123", "related", "ENG-123", ""},
+		{"surrounding whitespace", "  similar ENG-7 \n", "similar", "ENG-7", ""},
+		{"empty", "", "", "", "content"},
+		{"whitespace only", "  \n ", "", "", "content"},
+		{"invalid type", "bogus ENG-1", "", "", "type"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			relType, identifier, err := parseRelationInput(tt.in)
+			if tt.wantErrField != "" {
+				var ferr *FieldError
+				if !errors.As(err, &ferr) {
+					t.Fatalf("parseRelationInput(%q) err = %v, want *FieldError on %q", tt.in, err, tt.wantErrField)
+				}
+				if ferr.Field != tt.wantErrField {
+					t.Errorf("parseRelationInput(%q) FieldError.Field = %q, want %q", tt.in, ferr.Field, tt.wantErrField)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseRelationInput(%q) unexpected err: %v", tt.in, err)
+			}
+			if relType != tt.wantType || identifier != tt.wantIdentifier {
+				t.Errorf("parseRelationInput(%q) = (%q, %q), want (%q, %q)",
+					tt.in, relType, identifier, tt.wantType, tt.wantIdentifier)
+			}
+		})
+	}
+}

--- a/internal/fs/relations.go
+++ b/internal/fs/relations.go
@@ -3,7 +3,6 @@ package fs
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"strings"
 	"syscall"
 	"time"
@@ -26,36 +25,36 @@ var _ fs.NodeLookuper = (*RelationsNode)(nil)
 var _ fs.NodeGetattrer = (*RelationsNode)(nil)
 
 func (n *RelationsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
-	// Get both outgoing and incoming relations
-	relations, err := n.lfs.repo.GetIssueRelations(ctx, n.issueID)
-	if err != nil {
-		return nil, syscall.EIO
-	}
-	inverseRelations, err := n.lfs.repo.GetIssueInverseRelations(ctx, n.issueID)
-	if err != nil {
+	// Unlike attachments' best-effort Readdir (two independent sources), both
+	// fetches here hit the same table — a failure in either fails the whole
+	// directory.
+	var fetchErr error
+	listing := n.listing(ctx, &fetchErr)
+	if fetchErr != nil {
 		return nil, syscall.EIO
 	}
 
 	entries := n.trio().entries()
-
-	// Add outgoing relations (e.g., "blocks-ENG-123.rel")
-	for _, rel := range relations {
-		if rel.RelatedIssue != nil && rel.RelatedIssue.Identifier != "" {
-			name := fmt.Sprintf("%s-%s.rel", rel.Type, rel.RelatedIssue.Identifier)
-			entries = append(entries, fuse.DirEntry{Name: name, Mode: syscall.S_IFREG})
-		}
+	for _, e := range listing.entries() {
+		entries = append(entries, fuse.DirEntry{Name: e.name, Mode: syscall.S_IFREG})
 	}
-
-	// Add incoming relations (e.g., "blocked-by-ENG-456.rel")
-	for _, rel := range inverseRelations {
-		if rel.Issue != nil && rel.Issue.Identifier != "" {
-			inverseName := inverseRelationType(rel.Type)
-			name := fmt.Sprintf("%s-%s.rel", inverseName, rel.Issue.Identifier)
-			entries = append(entries, fuse.DirEntry{Name: name, Mode: syscall.S_IFREG})
-		}
-	}
-
 	return fs.NewListDirStream(entries), 0
+}
+
+// listing fetches both direction slices and builds the name-derivation module.
+// When fetchErr is non-nil the first fetch error is also recorded there
+// (Lookup distinguishes "not found" from "couldn't look").
+func (n *RelationsNode) listing(ctx context.Context, fetchErr *error) relationListing {
+	outgoing, oerr := n.lfs.repo.GetIssueRelations(ctx, n.issueID)
+	inverse, ierr := n.lfs.repo.GetIssueInverseRelations(ctx, n.issueID)
+	if fetchErr != nil {
+		if oerr != nil {
+			*fetchErr = oerr
+		} else if ierr != nil {
+			*fetchErr = ierr
+		}
+	}
+	return relationListing{outgoing: outgoing, inverse: inverse}
 }
 
 // trio declares the relations collection's writable surfaces.
@@ -68,36 +67,21 @@ func (n *RelationsNode) Lookup(ctx context.Context, name string, out *fuse.Entry
 		return inode, 0
 	}
 
-	// Parse relation filename: "type-IDENTIFIER.rel"
+	// Every relation file is named "{type}-{IDENTIFIER}.rel"; skip the repo
+	// fetches for anything else.
 	if !strings.HasSuffix(name, ".rel") {
 		return nil, syscall.ENOENT
 	}
 
-	baseName := strings.TrimSuffix(name, ".rel")
-	// Find the relation
-	relations, _ := n.lfs.repo.GetIssueRelations(ctx, n.issueID)
-	for _, rel := range relations {
-		if rel.RelatedIssue != nil && rel.RelatedIssue.Identifier != "" {
-			expectedName := fmt.Sprintf("%s-%s", rel.Type, rel.RelatedIssue.Identifier)
-			if baseName == expectedName {
-				return n.createRelationFileNode(ctx, name, rel, false, out)
-			}
+	var fetchErr error
+	entry, ok := n.listing(ctx, &fetchErr).find(name)
+	if !ok {
+		if fetchErr != nil {
+			return nil, syscall.EIO
 		}
+		return nil, syscall.ENOENT
 	}
-
-	// Check inverse relations
-	inverseRelations, _ := n.lfs.repo.GetIssueInverseRelations(ctx, n.issueID)
-	for _, rel := range inverseRelations {
-		if rel.Issue != nil && rel.Issue.Identifier != "" {
-			inverseName := inverseRelationType(rel.Type)
-			expectedName := fmt.Sprintf("%s-%s", inverseName, rel.Issue.Identifier)
-			if baseName == expectedName {
-				return n.createRelationFileNode(ctx, name, rel, true, out)
-			}
-		}
-	}
-
-	return nil, syscall.ENOENT
+	return n.createRelationFileNode(ctx, name, entry.relation, entry.isInverse, out)
 }
 
 func (n *RelationsNode) createRelationFileNode(ctx context.Context, name string, rel api.IssueRelation, isInverse bool, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
@@ -124,22 +108,6 @@ func (n *RelationsNode) createRelationFileNode(ctx context.Context, name string,
 	return n.newRenderInode(ctx, out, name, node, relationIno(inoKey), 30*time.Second), 0
 }
 
-// inverseRelationType returns the inverse relation type name
-func inverseRelationType(relType string) string {
-	switch relType {
-	case "blocks":
-		return "blocked-by"
-	case "duplicate":
-		return "duplicated-by"
-	case "related":
-		return "related-to"
-	case "similar":
-		return "similar-to"
-	default:
-		return relType + "-inverse"
-	}
-}
-
 // RelationFileNode represents a relation file (read-only info + rm-to-delete).
 // It embeds renderFile for Open/Read/Getattr and keeps only its Unlink.
 type RelationFileNode struct {
@@ -162,26 +130,6 @@ func (n *RelationFileNode) refreshFrom(fresh fs.InodeEmbedder) {
 	n.render = f.render
 	n.relation, n.isInverse, n.issueID = f.relation, f.isInverse, f.issueID
 	n.renderMu.Unlock()
-}
-
-// relationContent renders a relation file's YAML body.
-func relationContent(rel api.IssueRelation, isInverse bool) string {
-	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("type: %s\n", rel.Type))
-
-	if isInverse && rel.Issue != nil {
-		sb.WriteString(fmt.Sprintf("from: %s\n", rel.Issue.Identifier))
-		if rel.Issue.Title != "" {
-			sb.WriteString(fmt.Sprintf("title: %s\n", rel.Issue.Title))
-		}
-	} else if rel.RelatedIssue != nil {
-		sb.WriteString(fmt.Sprintf("to: %s\n", rel.RelatedIssue.Identifier))
-		if rel.RelatedIssue.Title != "" {
-			sb.WriteString(fmt.Sprintf("title: %s\n", rel.RelatedIssue.Title))
-		}
-	}
-
-	return sb.String()
 }
 
 func (n *RelationFileNode) Unlink(ctx context.Context, name string) syscall.Errno {
@@ -212,12 +160,10 @@ func (n *RelationFileNode) Unlink(ctx context.Context, name string) syscall.Errn
 	})
 }
 
-// createRelation is the relations create surface's onFlush: parse
-// "type identifier" (or just "identifier", defaulting to "related") and run
-// the create tail.
+// createRelation is the relations create surface's onFlush: parse the
+// command via parseRelationInput (relationlisting.go), resolve the target
+// issue, and run the create tail.
 func (n *RelationsNode) createRelation(ctx context.Context, raw []byte) syscall.Errno {
-	content := strings.TrimSpace(string(raw))
-
 	// relatedID carries the resolved target issue's ID from mutate to persist
 	// (the API's echoed relation doesn't include it).
 	var relatedID string
@@ -227,22 +173,10 @@ func (n *RelationsNode) createRelation(ctx context.Context, raw []byte) syscall.
 		op:  "create relation",
 		key: collectionErrorKey("relations", n.issueID),
 		mutate: func(ctx context.Context) (*api.IssueRelation, error) {
-			if content == "" {
-				return nil, &FieldError{Field: "content", Message: `empty content. Write "<type> <ISSUE-ID>", e.g. "blocks ENG-123".`}
-			}
-			parts := strings.Fields(content)
-			if len(parts) == 1 {
-				// Just identifier, default to "related"
-				relationType = "related"
-				relatedIdentifier = parts[0]
-			} else {
-				relationType = parts[0]
-				relatedIdentifier = parts[1]
-			}
-
-			validTypes := map[string]bool{"blocks": true, "duplicate": true, "related": true, "similar": true}
-			if !validTypes[relationType] {
-				return nil, &FieldError{Field: "type", Value: relationType, Message: "invalid relation type. Use one of: blocks, duplicate, related, similar."}
+			var err error
+			relationType, relatedIdentifier, err = parseRelationInput(string(raw))
+			if err != nil {
+				return nil, err
 			}
 
 			relatedIssue, err := n.lfs.repo.GetIssueByIdentifier(ctx, relatedIdentifier)
@@ -253,9 +187,12 @@ func (n *RelationsNode) createRelation(ctx context.Context, raw []byte) syscall.
 
 			return n.lfs.mutator().CreateIssueRelation(ctx, n.issueID, relatedIssue.ID, relationType)
 		},
+		// The name derives from the parsed input (through the shared
+		// relationFileName) by necessity: the API's echoed relation doesn't
+		// include the related issue.
 		result: func(*api.IssueRelation) WriteResult {
 			return WriteResult{
-				Path:  relationType + "-" + relatedIdentifier + ".rel",
+				Path:  relationFileName(relationType, relatedIdentifier),
 				Title: relationType + " " + relatedIdentifier,
 			}
 		},
@@ -283,7 +220,7 @@ func (n *RelationsNode) createRelation(ctx context.Context, raw []byte) syscall.
 		},
 		dir: relationsDirIno(n.issueID),
 		entryName: func(*api.IssueRelation) string {
-			return relationType + "-" + relatedIdentifier + ".rel"
+			return relationFileName(relationType, relatedIdentifier)
 		},
 	})
 	return errno


### PR DESCRIPTION
## The module

`relations/` was the last collection not on a listing module. The `{type}-{ID}.rel` name derivation and the outgoing/inverse direction split were restated at four sites (Readdir's two loops, Lookup's two loops, createRelation's entryName/`.last` derivation), the content render hand-`Sprintf`'d unescaped YAML, and the file had no test twin.

`relationListing` (`internal/fs/relationlisting.go`) is the direction-aware sibling of `namedListing`/`indexedListing`/`attachmentListing`:

- **Pure over two slices** the caller fetches (ordering is the repo's job): `entries()` is the Readdir projection (outgoing first, then inverse; nil-issue/empty-identifier relations skipped), `find(name)` is the Lookup projection returning a tagged entry carrying the direction.
- **`relationFileName`** — the `%s-%s.rel` format string exists exactly once; all sites derive through it, including create's `.last` path and kernel-entry name (which derive from the *parsed input* by necessity — the mutation's echoed relation lacks the related issue).
- **Collision policy: first-match, emit-once** — inherited from `namedListing` with its rationale: the `.rel` name is a resolution key (`rm` must delete what `find` matched), so disambiguation would mint names resolving nowhere. `entries()` implements emit-once and `find` replays `entries()`, so readdir and find agree by construction.
- **`parseRelationInput`** extracts create's command parse as a pure function (bare identifier defaults to `related`; FieldErrors for empty content / bad type); the identifier→issue resolution stays in the mutate closure. It lives in `fs`, not `marshal` — a one-line command syntax for a write-only trigger is not a markdown document.
- `inverseRelationType` moved into the module (unknown-type `-inverse` fallback kept).

## Behavior changes (2, both recorded in CONTEXT.md)

1. **Lookup store-failure `ENOENT` → `EIO`.** Lookup adopts `attachmentListing`'s `listing(ctx, &fetchErr)` seam; the old code discarded fetch errors (`relations, _ := ...`), so a store failure misreported as not-found. Readdir keeps failing whole-directory on either fetch error — attachments' best-effort Readdir is justified by *independent* sources, and both relation fetches hit the same table.
2. **Colon-bearing titles now render valid YAML.** `relationContent` renders via `yaml.Marshal` over ordered structs — byte-identical to the old hand-`Sprintf` for plain values, correctly quoted where YAML demands (a title like `Q3: Bets` used to emit INVALID YAML — the `.rel` twin of the round-16 catalog fix). The no-delimiter format (plain YAML body, not frontmatter) is preserved.

## Tests

relations gets its first test twin (`internal/fs/relationlisting_test.go`, pure, no mount, style-matched to `TestAttachmentListing*`/`TestNamedListing*`):

- Round-trip: every name `entries()` emits resolves via `find` with the correct direction.
- Direction correctness: outgoing `blocks-X` → `isInverse=false`, inverse `blocked-by-Y` → `isInverse=true`; the inverse doesn't answer to its un-inverted name.
- `inverseRelationType`: all four types + unknown fallback.
- Skip: nil `RelatedIssue`/`Issue` or empty identifier → no entry, no find match.
- First-match/emit-once: duplicate-name inputs emit one dirent, `find` returns the first.
- Fetch-error seam against a real store: healthy store + genuine miss leaves `fetchErr` nil (→ ENOENT); closed store sets it (→ EIO).
- Content render: outgoing/inverse/omitted-empty-title, and a `Q3: Bets` title asserting the output unmarshals back as valid YAML with the title intact.
- `parseRelationInput` table: explicit type, bare-identifier default, empty-content FieldError, invalid-type FieldError.

`gofmt` clean, `go vet ./...`, `make staticcheck`, full `go test ./...` (incl. integration), and `go test -race ./internal/fs/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)