### PR TITLE
fix: syncWorkspace error aggregation + GetInitiative projects drain (#226)

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -915,9 +915,25 @@ func (c *Client) DeleteDocument(ctx context.Context, documentID string) error {
 	return execMutationOK(ctx, c, mutationDeleteDocument, map[string]any{"id": documentID}, "documentDelete")
 }
 
-// GetInitiative fetches a single initiative by ID
+// GetInitiative fetches a single initiative by ID, with its projects
+// connection drained — same contract as GetWorkspace's initiatives: the
+// result is persisted whole (the initiative.md edit tail upserts it, and
+// the projects list rides in the data blob that backs the FUSE view), so a
+// truncated list would clobber a previously complete one. Complete
+// Projects.Nodes, nil Projects.PageInfo.
 func (c *Client) GetInitiative(ctx context.Context, initiativeID string) (*Initiative, error) {
-	return fetchOne[Initiative](ctx, c, queryInitiative, map[string]any{"id": initiativeID}, "initiative")
+	init, err := fetchOne[Initiative](ctx, c, queryInitiative, map[string]any{"id": initiativeID}, "initiative")
+	if err != nil {
+		return nil, err
+	}
+	moreProjects, err := drain[InitiativeProject](ctx, c, queryInitiativeProjectsPage,
+		map[string]any{"id": initiativeID}, init.Projects.PageInfo, "initiative", "projects")
+	if err != nil {
+		return nil, fmt.Errorf("drain initiative %s projects: %w", init.Slug, err)
+	}
+	init.Projects.Nodes = append(init.Projects.Nodes, moreProjects...)
+	init.Projects.PageInfo = nil
+	return init, nil
 }
 
 // =============================================================================

--- a/internal/api/drain_e2e_test.go
+++ b/internal/api/drain_e2e_test.go
@@ -153,6 +153,54 @@ func TestGetWorkspaceDrainsNestedInitiativeProjects(t *testing.T) {
 	}
 }
 
+func TestGetInitiativeDrainsNestedProjects(t *testing.T) {
+	t.Parallel()
+	mock := testutil.NewMockLinearServer()
+	defer mock.Close()
+
+	mock.SetResponse("Initiative", map[string]any{
+		"initiative": map[string]any{
+			"id": "init-1", "name": "Big Initiative", "slugId": "big",
+			"projects": connOf(pf(true, "proj-cursor"),
+				map[string]any{"id": "p1", "name": "One", "slugId": "one"}),
+		},
+	})
+	mock.SetResponse("InitiativeProjectsPage", map[string]any{
+		"initiative": map[string]any{
+			"projects": connOf(pf(false, ""),
+				map[string]any{"id": "p2", "name": "Two", "slugId": "two"}),
+		},
+	})
+
+	c := NewClient("test")
+	c.SetAPIURL(mock.URL())
+
+	init, err := c.GetInitiative(context.Background(), "init-1")
+	if err != nil {
+		t.Fatalf("GetInitiative: %v", err)
+	}
+	if len(init.Projects.Nodes) != 2 || init.Projects.Nodes[0].ID != "p1" || init.Projects.Nodes[1].ID != "p2" {
+		t.Fatalf("initiative projects = %+v, want [p1 p2]", init.Projects.Nodes)
+	}
+	if init.Projects.PageInfo != nil {
+		t.Error("initiative Projects.PageInfo should be cleared after drain")
+	}
+
+	// The drain must resume from the first page's cursor.
+	var drainCall *testutil.GraphQLCall
+	for i, call := range mock.Calls() {
+		if call.Operation == "InitiativeProjectsPage" {
+			drainCall = &mock.Calls()[i]
+		}
+	}
+	if drainCall == nil {
+		t.Fatal("no InitiativeProjectsPage drain call recorded")
+	}
+	if drainCall.Variables["after"] != "proj-cursor" {
+		t.Errorf("drain after = %v, want proj-cursor", drainCall.Variables["after"])
+	}
+}
+
 func TestGetWorkspaceProjectIDsPaginates(t *testing.T) {
 	t.Parallel()
 	mock := testutil.NewMockLinearServer()

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -870,7 +870,8 @@ query Initiative($id: String!) {
       name
       email
     }
-    projects {
+    projects(first: 250) {
+      pageInfo { hasNextPage endCursor }
       nodes {
         id
         name

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -297,10 +297,11 @@ type Initiative struct {
 }
 
 type InitiativeProjects struct {
-	// PageInfo is populated by queries that select it (queryWorkspace and
-	// its drain pages) and consumed by GetWorkspace, which drains any
-	// remainder and then clears it — callers downstream of GetWorkspace
-	// always see a complete Nodes list and a nil PageInfo.
+	// PageInfo is populated by queries that select it (queryWorkspace,
+	// queryInitiative, and their drain pages) and consumed by GetWorkspace
+	// and GetInitiative, which drain any remainder and then clear it —
+	// callers downstream always see a complete Nodes list and a nil
+	// PageInfo.
 	PageInfo *PageInfo           `json:"pageInfo,omitempty"`
 	Nodes    []InitiativeProject `json:"nodes"`
 }

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -498,15 +498,16 @@ func (w *Worker) syncWorkspace(ctx context.Context) error {
 
 	var errs []error
 
-	// Process users
+	// Process users. Failures accumulate into errs so the pass reports them
+	// (the caller logs and continues); processing still covers every item.
 	for _, user := range data.Users {
 		params, err := db.APIUserToDBUser(user)
 		if err != nil {
-			log.Printf("[sync] convert user %s failed: %v", user.Email, err)
+			errs = append(errs, fmt.Errorf("convert user %s: %w", user.Email, err))
 			continue
 		}
 		if err := w.store.Queries().UpsertUser(ctx, params); err != nil {
-			log.Printf("[sync] upsert user %s failed: %v", user.Email, err)
+			errs = append(errs, fmt.Errorf("upsert user %s: %w", user.Email, err))
 		}
 	}
 	log.Printf("[sync] synced %d users", len(data.Users))
@@ -515,11 +516,11 @@ func (w *Worker) syncWorkspace(ctx context.Context) error {
 	for _, initiative := range data.Initiatives {
 		params, err := db.APIInitiativeToDBInitiative(initiative)
 		if err != nil {
-			log.Printf("[sync] convert initiative %s failed: %v", initiative.Slug, err)
+			errs = append(errs, fmt.Errorf("convert initiative %s: %w", initiative.Slug, err))
 			continue
 		}
 		if err := w.store.Queries().UpsertInitiative(ctx, params); err != nil {
-			log.Printf("[sync] upsert initiative %s failed: %v", initiative.Slug, err)
+			errs = append(errs, fmt.Errorf("upsert initiative %s: %w", initiative.Slug, err))
 			continue
 		}
 

--- a/internal/sync/worker_test.go
+++ b/internal/sync/worker_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	gosync "sync"
 	"sync/atomic"
 	"testing"
@@ -794,6 +795,34 @@ func TestWorkerSyncWorkspace(t *testing.T) {
 	}
 	if len(initiatives) != 1 {
 		t.Errorf("Expected 1 initiative, got %d", len(initiatives))
+	}
+}
+
+// TestWorkerSyncWorkspaceSurfacesUpsertFailure: a workspace pass whose
+// upserts fail must return an error, not report success (the errs
+// aggregation was once dead code — every failure path logged and continued,
+// so a fully-failed pass returned nil).
+func TestWorkerSyncWorkspaceSurfacesUpsertFailure(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	ctx := context.Background()
+
+	mock := newMockAPIClient()
+	mock.users = []api.User{{ID: "user-1", Email: "alice@test.com", Name: "Alice", Active: true}}
+	mock.initiatives = []api.Initiative{{ID: "init-1", Slug: "q1-goals", Name: "Q1 Goals"}}
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+
+	// Closing the store makes every upsert fail while the fetch succeeds.
+	store.Close()
+
+	err := worker.syncWorkspace(ctx)
+	if err == nil {
+		t.Fatal("syncWorkspace returned nil with every upsert failing")
+	}
+	for _, want := range []string{"upsert user alice@test.com", "upsert initiative q1-goals"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err, want)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #226.

## 1. `syncWorkspace` masked total sync failure

The `errs` aggregation was dead scaffolding: declared, gated on, never appended to. Every user/initiative convert+upsert failure was `log.Printf` + `continue`, so a fully-failed workspace pass returned nil and the worker recorded success. Failures now aggregate into the returned error (processing still covers every item; the caller logs and continues to teams, as before). `syncInitiativeProjects` (best-effort) and `syncProjectLabels` (isolated) keep their documented policies.

Regression test: `TestWorkerSyncWorkspaceSurfacesUpsertFailure` (fetch succeeds, store closed → every upsert fails → error names both failed upserts).

## 2. Nested initiative projects truncation — the real site

One correction to the issue text: `queries.go:587`/`:636` (queryWorkspace and its drain page) are **already drained** — `GetWorkspace` drains each initiative's projects via `queryInitiativeProjectsPage` (client.go, shipped in #164/#220, with an e2e test). The undrained hole was **`queryInitiative`**: a bare `projects { nodes }` selection (Linear default-caps at 50, and with no `pageInfo` selected there isn't even a tripwire).

That query is the read-your-writes verify fetch after an initiative.md edit (`commitWriteBack` → `GetInitiative` → `UpsertInitiative`), and the projects list rides in the `data` JSON blob that backs `repo.GetInitiatives` — i.e. the FUSE view. So editing initiative.md on an initiative with >50 projects clobbered its previously complete projects listing down to 50 until the next workspace sync.

`queryInitiative` now selects `projects(first: 250)` + `pageInfo`, and `GetInitiative` drains the remainder through the already-existing `queryInitiativeProjectsPage`, then clears `PageInfo` — the same "complete Nodes, nil PageInfo" contract as `GetWorkspace` (comment on `InitiativeProjects.PageInfo` updated).

Regression test: `TestGetInitiativeDrainsNestedProjects` (mirrors the workspace drain e2e test, asserts the drain resumes from the first page's cursor).

Full suite green locally (unit + integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)