### PR TITLE
fix: paginate hardening — cursor-cycle stall guard, early vars check, composite budget preflight (#232)

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -465,7 +465,16 @@ func (c *Client) ArchiveIssue(ctx context.Context, issueID string) error {
 // the paginated GetTeamProjects (too complexity-expensive to share the
 // combined query; see queryTeamMetadata). The returned sets are complete:
 // the sync worker prunes against them.
+//
+// The LowBudget preflight refuses BEFORE paying the combined query: the
+// query itself admits at a lower reserve than the drains and the projects
+// fetchAll behind it, so without the preflight a budget between the two
+// floors buys the combined result and then discards it when a follow-up
+// refuses (ErrBudget's burn-and-discard, observed live, one level up).
 func (c *Client) GetTeamMetadata(ctx context.Context, teamID string) (*TeamMetadata, error) {
+	if c.LowBudget() {
+		return nil, fmt.Errorf("team metadata %s: %w", teamID, ErrBudget)
+	}
 	var result struct {
 		Team struct {
 			States struct {
@@ -551,7 +560,14 @@ func (c *Client) GetTeamMetadata(ctx context.Context, teamID string) (*TeamMetad
 // initiative_projects junction rows against it, so a truncated list would
 // read as removals. Every returned Initiative has a complete Projects.Nodes
 // and a nil Projects.PageInfo.
+//
+// LowBudget preflight for the same reason as GetTeamMetadata: refuse before
+// paying the combined query rather than after, when a per-initiative drain
+// would refuse and discard it.
 func (c *Client) GetWorkspace(ctx context.Context) (*WorkspaceData, error) {
+	if c.LowBudget() {
+		return nil, fmt.Errorf("workspace: %w", ErrBudget)
+	}
 	var result struct {
 		Users       conn[User]       `json:"users"`
 		Initiatives conn[Initiative] `json:"initiatives"`

--- a/internal/api/paginate.go
+++ b/internal/api/paginate.go
@@ -32,13 +32,20 @@ import (
 // discard pages already paid for, and observed live it burned one token
 // per cycle on a page-1 fetch it then threw away, forever. The transport's
 // own gate (the rateBudget priority-reserve ladder in Client.query) remains
-// the hard floor under a running drain. Exported so schedulers (the reconcile pass
-// in internal/repo) can distinguish "retry later" from "broken" with
-// errors.Is; treating it as an ordinary error is always safe.
+// the hard floor under a running drain. The composite fetches
+// (GetTeamMetadata, GetWorkspace) return it from their own LowBudget
+// preflight too, for the same reason: refusing before the paid combined
+// query beats discarding it when a follow-up drain refuses. Exported so
+// callers can distinguish "retry later" from "broken" with errors.Is;
+// treating it as an ordinary error is always safe. (The reconcile pass in
+// internal/repo preflights with LowBudget directly instead of matching
+// this error.)
 var ErrBudget = errors.New("pagination deferred: rate-limit budget low")
 
 // errStalledCursor reports a connection that claims more pages but supplies
-// no advancing cursor — returned rather than looping forever.
+// no genuinely advancing cursor — empty, repeated, or revisiting any cursor
+// already consumed this drain (an A→B→A cycle would otherwise run to
+// maxDrainPages before erroring) — returned rather than looping forever.
 var errStalledCursor = errors.New("pagination stalled: hasNextPage with non-advancing endCursor")
 
 // maxDrainPages is a defence-in-depth backstop behind the stall guard; no
@@ -72,13 +79,15 @@ type pageFetch[N any] func(ctx context.Context, after string) (conn[N], error)
 //     fetch (nothing is spent; a started drain runs to completion);
 //   - any error from fetch, wrapped with the page number and cursor;
 //   - a missing pageInfo (the query did not select it);
-//   - errStalledCursor if a page reports hasNextPage with an empty or
-//     non-advancing endCursor;
+//   - errStalledCursor if a page reports hasNextPage with an empty endCursor
+//     or one already consumed this drain (immediate repeats and longer
+//     cycles alike);
 //   - ctx cancellation between pages.
 func drainFrom[N any](ctx context.Context, c *Client, after string, fetch pageFetch[N]) ([]N, error) {
 	if c.LowBudget() {
 		return nil, fmt.Errorf("paginate: %w", ErrBudget)
 	}
+	seen := map[string]bool{after: true}
 	var all []N
 	for page := 1; ; page++ {
 		if page > maxDrainPages {
@@ -101,9 +110,10 @@ func drainFrom[N any](ctx context.Context, c *Client, after string, fetch pageFe
 			return all, nil
 		}
 		next := cn.PageInfo.EndCursor
-		if next == "" || next == after {
+		if next == "" || seen[next] {
 			return nil, fmt.Errorf("paginate: page %d (cursor %q): %w", page, next, errStalledCursor)
 		}
+		seen[next] = true
 		after = next
 	}
 }
@@ -140,6 +150,12 @@ func fetchAll[N any](ctx context.Context, c *Client, query string, vars map[stri
 // Same query contract, vars rules, ordering, all-or-nothing result, and
 // error modes as fetchAll.
 func drain[N any](ctx context.Context, c *Client, query string, vars map[string]any, pi *PageInfo, path ...string) ([]N, error) {
+	// The vars contract is checked before the !HasNextPage short-circuit: a
+	// violation is a programming bug and must fail on every call, not ship
+	// latently and detonate the first time the connection overflows a page.
+	if _, ok := vars["after"]; ok {
+		return nil, fmt.Errorf("paginate: vars must not contain %q (owned by the module)", "after")
+	}
 	if pi == nil {
 		return nil, fmt.Errorf("paginate: connection %q missing pageInfo (query must select it)", strings.Join(path, "."))
 	}
@@ -148,9 +164,6 @@ func drain[N any](ctx context.Context, c *Client, query string, vars map[string]
 	}
 	if pi.EndCursor == "" {
 		return nil, fmt.Errorf("paginate: connection %q: %w", strings.Join(path, "."), errStalledCursor)
-	}
-	if _, ok := vars["after"]; ok {
-		return nil, fmt.Errorf("paginate: vars must not contain %q (owned by the module)", "after")
 	}
 	return drainFrom(ctx, c, pi.EndCursor, connFetch[N](c, query, vars, path))
 }

--- a/internal/api/paginate_test.go
+++ b/internal/api/paginate_test.go
@@ -86,6 +86,44 @@ func TestDrainFromStalledCursorFailsLoudly(t *testing.T) {
 	}
 }
 
+func TestDrainFromAlternatingCursorFailsLoudly(t *testing.T) {
+	// A cursor cycle longer than one (A→B→A→…) advances `after` every
+	// iteration, so the previous-cursor-only guard never fired — the loop
+	// ran toward maxDrainPages (10000 paid requests). The seen-set stops it
+	// at the first revisit.
+	var afters []string
+	fetch := func(_ context.Context, after string) (conn[int], error) {
+		afters = append(afters, after)
+		next := "A"
+		if after == "A" {
+			next = "B"
+		}
+		return conn[int]{PageInfo: pi(true, next), Nodes: []int{1}}, nil
+	}
+	got, err := drainFrom(context.Background(), NewClient("test"), "", fetch)
+	if !errors.Is(err, errStalledCursor) {
+		t.Fatalf("err = %v, want errStalledCursor", err)
+	}
+	if got != nil {
+		t.Errorf("nodes = %v, want nil (all-or-nothing)", got)
+	}
+	// "", A, B — the revisit of A is detected without a third paid fetch of it.
+	if want := []string{"", "A", "B"}; !equalStrings(afters, want) {
+		t.Errorf("cursors fetched = %v, want %v (stop at first revisit)", afters, want)
+	}
+}
+
+func TestDrainRejectsAfterVarOnEveryCall(t *testing.T) {
+	// The vars contract must fail on single-page connections too — not ship
+	// latently and detonate on the first page overflow.
+	c := NewClient("test")
+	_, err := drain[int](context.Background(), c, "query", map[string]any{"after": "x"},
+		pi(false, ""), "things")
+	if err == nil || !strings.Contains(err.Error(), `vars must not contain "after"`) {
+		t.Fatalf("err = %v, want vars-after contract error on a complete connection", err)
+	}
+}
+
 func TestDrainFromMissingPageInfoIsError(t *testing.T) {
 	fetch := func(_ context.Context, _ string) (conn[int], error) {
 		return conn[int]{Nodes: []int{1}}, nil // no pageInfo selected
@@ -144,6 +182,41 @@ func TestDrainFromBudgetRefusesToStart(t *testing.T) {
 	}
 	if calls != 0 {
 		t.Errorf("fetch calls = %d, want 0 (refusal spends nothing)", calls)
+	}
+}
+
+func TestCompositeFetchesRefuseBeforePayingCombinedQuery(t *testing.T) {
+	// GetTeamMetadata/GetWorkspace pay a combined query and then drain; the
+	// combined query alone admits below the drains' reserve, so without a
+	// preflight a low budget bought the combined result and discarded it
+	// when a follow-up drain refused (burn-and-discard, observed live).
+	for _, tc := range []struct {
+		name string
+		call func(c *Client) error
+	}{
+		{"GetTeamMetadata", func(c *Client) error {
+			_, err := c.GetTeamMetadata(context.Background(), "team-1")
+			return err
+		}},
+		{"GetWorkspace", func(c *Client) error {
+			_, err := c.GetWorkspace(context.Background())
+			return err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := testutil.NewMockLinearServer()
+			defer mock.Close()
+			c := NewClient("test")
+			c.SetAPIURL(mock.URL())
+			drainClientBudget(c)
+
+			if err := tc.call(c); !errors.Is(err, ErrBudget) {
+				t.Fatalf("err = %v, want ErrBudget", err)
+			}
+			if n := len(mock.Calls()); n != 0 {
+				t.Errorf("API calls = %d, want 0 (refusal must precede the paid combined query)", n)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Addresses the code-fix half of #232 (findings 4, 3, 1, and 10a of the recovered PR #164 review; see the verification table on the issue).

## Finding 4 — alternating-cursor stall (the headline hole)
`drainFrom`'s only cursor check was `next == "" || next == after` — the immediately-previous cursor. A cursor cycle of length ≥2 (A→B→A→…) advances `after` every iteration and never trips it, running toward `maxDrainPages = 10000` paid requests. Now a seen-cursor set (seeded with the resume cursor) stalls loudly at the first revisit, without a second paid fetch of the revisited page. Test: `TestDrainFromAlternatingCursorFailsLoudly` asserts the exact fetch sequence `["", A, B]`.

## Finding 3 — latent vars-contract violation
`drain()` checked the reserved `"after"` var only after the `!HasNextPage` short-circuit: a call site passing `after` worked on every single-page connection and errored only on first page overflow — a programming-bug guard surfacing as a data-dependent outage. Hoisted above the short-circuit (matching `fetchAll`). Test: `TestDrainRejectsAfterVarOnEveryCall`.

## Finding 1 — composite burn-and-discard
`GetTeamMetadata`/`GetWorkspace` paid their combined query, then a follow-up drain (or the projects `fetchAll`) refused with `ErrBudget`, discarding the paid result — the exact loop `ErrBudget`'s doc says it prevents, one level up. rateBudget (PR #180) did not close this: the combined query admits at the skeleton reserve (0.05) while `LowBudget()` refuses at the list reserve (0.15), so any budget between the floors reproduces it. Both composites now preflight `LowBudget()` and return `ErrBudget` before spending anything. Test: `TestCompositeFetchesRefuseBeforePayingCombinedQuery` asserts zero API calls under low budget.

## Finding 10a — ErrBudget doc drift
The comment promised "schedulers (the reconcile pass in internal/repo) can distinguish … with errors.Is" — no such consumer exists (reconcile preflights with `LowBudget()` directly). Rewritten to match reality and document the new composite preflights.

Full suite + staticcheck green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)