### PR TITLE
feat: two-speed sync cycle — lean by default, full every FullSyncInterval (#242)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1115,6 +1115,37 @@ raw `SELECT *` positional scans would misalign on one layout — every issue
 scan uses an explicit column list (sqlc expands `*` itself;
 `ListIssuesByLabel` was made explicit by hand).
 
+### Cycle taxonomy (`syncCycle`, lean/full)
+The worker's sync cycle has two speeds (`internal/sync/worker.go`, #242 —
+slice 1 of the #238 sync-cycle diet). A **full** cycle is the complete
+pre-diet behavior verbatim: `syncWorkspace` (users + initiatives +
+project-label catalog) and per-team `syncTeamMetadata`
+(states/labels/cycles/projects/members) — with every prune license — plus
+the incremental issues sync. A **lean** cycle (the steady-state default)
+runs only the cheap `GetTeams` enumeration and each team's incremental
+issues sync: no `GetWorkspace`, no `GetTeamMetadata`, and therefore no
+metadata prunes (pruning stays licensed exclusively by the full cycle's
+complete drains, so the metadata deletion/staleness bound is the full-cycle
+interval). The decision is **time-based off a persisted timestamp**, not an
+in-memory counter: `nextCycleMode` reads the `sync_schedule` row keyed
+`full_cycle` and answers full when the row is missing (cold start — a fresh
+store populates exactly as fast as before) or ≥ `Config.FullSyncInterval`
+(default 10m) old; `SyncNow` bypasses the decision and is always full. Only
+a full cycle that ran to completion stamps the row (with `w.now()`, through
+the clock seam) — a budget-skipped or `GetTeams`-failed cycle does not, so
+the full sync stays due rather than silently stretching the staleness
+bound; conversely a restart mid-window reads the fresh persisted stamp and
+starts lean (no redundant full-cycle storm). `sync_schedule(key, last_run)`
+is deliberately a generic key/value schedule table: later diet slices hang
+probe watermarks and the hourly ID-reconcile key off the same table. Cycle
+mode is observable as the `mode` attribute on
+`linearfs.sync.cycle_duration` (per-mode sample counts double as the cycle
+counter). Tested at the worker's API-client seam
+(`worker_test.go` "Lean/Full Cycle Taxonomy"): scripted multi-cycle
+sequences on the fake clock assert per-cycle op windows (`opsDuring`), the
+restart case runs a second Worker over the same store, and the budget-skip
+case asserts the stamp was withheld.
+
 ### Worker clock seam (`Worker.now`/`newTimer`/`newTicker`)
 The sync worker's timing goes through three unexported function fields on
 `Worker` (`internal/sync/worker.go`) — `now func() time.Time`, `newTimer

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -102,7 +102,7 @@ observed — a stuck reservation is exactly the anomaly worth seeing.
 
 | Instrument | Kind | Attributes | Recorded |
 |---|---|---|---|
-| `linearfs.sync.cycle_duration` | histogram (s) | — | defer-recorded inside `syncAllTeams`, one sample per cycle for all three invokers (initial run, ticker, `SyncNow`). Budget-skipped cycles record ~0s — that near-zero spike IS the skip signature |
+| `linearfs.sync.cycle_duration` | histogram (s) | `mode` = `lean` \| `full` | defer-recorded inside `syncCycle`, one sample per cycle for all three invokers (initial run, ticker, `SyncNow`). `mode` is the cycle's speed (#242): `full` = workspace + team-metadata drains + issues (cold start, `SyncNow`, and every `FullSyncInterval`, default 10m, off the persisted `sync_schedule` timestamp); `lean` = incremental issues only, skipping the `GetWorkspace`/`GetTeamMetadata` fetches. The per-mode sample counts double as the cycle-mode counter — no separate instrument. Budget-skipped cycles record ~0s (attributed with the mode they would have run) — that near-zero spike IS the skip signature |
 | `linearfs.sync.detail_outcomes` | counter | `outcome` = `synced` \| `deferred` | at `syncDetails`' two exits (the `deferAll` gate paths and the per-issue ledger). **Every issue leaving `syncDetails` is counted exactly once**, so summing both series gives issues processed |
 | `linearfs.sync.prunes` | counter | `collection` | inside `reconcile.Collection`, only when a prune **actually executes** (suppressed-by-unclean or nil prunes record nothing) |
 | `linearfs.sync.pending_depth` | observable gauge | — | `COUNT(*)` of `pending_detail_sync` (the detail-retry backlog), evaluated only at collect time; a count error skips the observation |

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -287,6 +287,11 @@ type SyncMetum struct {
 	IssueCount         sql.NullInt64 `json:"issue_count"`
 }
 
+type SyncSchedule struct {
+	Key     string    `json:"key"`
+	LastRun time.Time `json:"last_run"`
+}
+
 type Team struct {
 	ID        string         `json:"id"`
 	Key       string         `json:"key"`

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -111,6 +111,16 @@ ON CONFLICT(team_id) DO UPDATE SET
     last_issue_updated_at = excluded.last_issue_updated_at,
     issue_count = excluded.issue_count;
 
+-- Sync schedule queries
+
+-- name: GetSyncSchedule :one
+SELECT last_run FROM sync_schedule WHERE key = ?;
+
+-- name: UpsertSyncSchedule :exec
+INSERT INTO sync_schedule (key, last_run)
+VALUES (?, ?)
+ON CONFLICT(key) DO UPDATE SET last_run = excluded.last_run;
+
 -- Teams queries
 
 -- name: ListTeams :many

--- a/internal/db/queries.sql.go
+++ b/internal/db/queries.sql.go
@@ -674,6 +674,19 @@ func (q *Queries) GetSyncMeta(ctx context.Context, teamID string) (SyncMetum, er
 	return i, err
 }
 
+const getSyncSchedule = `-- name: GetSyncSchedule :one
+
+SELECT last_run FROM sync_schedule WHERE key = ?
+`
+
+// Sync schedule queries
+func (q *Queries) GetSyncSchedule(ctx context.Context, key string) (time.Time, error) {
+	row := q.db.QueryRowContext(ctx, getSyncSchedule, key)
+	var last_run time.Time
+	err := row.Scan(&last_run)
+	return last_run, err
+}
+
 const getTeamIssueCount = `-- name: GetTeamIssueCount :one
 SELECT COUNT(*) FROM issues WHERE team_id = ?
 `
@@ -3447,6 +3460,22 @@ func (q *Queries) UpsertSyncMeta(ctx context.Context, arg UpsertSyncMetaParams) 
 		arg.LastIssueUpdatedAt,
 		arg.IssueCount,
 	)
+	return err
+}
+
+const upsertSyncSchedule = `-- name: UpsertSyncSchedule :exec
+INSERT INTO sync_schedule (key, last_run)
+VALUES (?, ?)
+ON CONFLICT(key) DO UPDATE SET last_run = excluded.last_run
+`
+
+type UpsertSyncScheduleParams struct {
+	Key     string    `json:"key"`
+	LastRun time.Time `json:"last_run"`
+}
+
+func (q *Queries) UpsertSyncSchedule(ctx context.Context, arg UpsertSyncScheduleParams) error {
+	_, err := q.db.ExecContext(ctx, upsertSyncSchedule, arg.Key, arg.LastRun)
 	return err
 }
 

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -56,6 +56,17 @@ CREATE TABLE IF NOT EXISTS sync_meta (
     issue_count INTEGER DEFAULT 0
 );
 
+-- Sync schedule: persisted last-run timestamps for scheduled sync work, one
+-- row per schedule key (e.g. full_cycle for the lean/full cycle taxonomy).
+-- Persisting the timestamp -- rather than an in-memory counter -- means a
+-- restart or a skipped cycle cannot silently stretch a staleness bound.
+-- Later slices reuse this table for other schedule keys (probe watermarks,
+-- the hourly ID-reconcile sweep).
+CREATE TABLE IF NOT EXISTS sync_schedule (
+    key TEXT PRIMARY KEY,
+    last_run DATETIME NOT NULL
+);
+
 -- Teams table: cache team info
 CREATE TABLE IF NOT EXISTS teams (
     id TEXT PRIMARY KEY,

--- a/internal/integration/fixture_parity_test.go
+++ b/internal/integration/fixture_parity_test.go
@@ -25,6 +25,7 @@ import (
 // render, or it is written only by machinery the fixture harness bypasses.
 var fixtureExcludedTables = map[string]string{
 	"sync_meta":           "sync-worker bookkeeping (last-sync watermarks); no mount-visible render",
+	"sync_schedule":       "sync-worker bookkeeping (persisted schedule timestamps, e.g. last full cycle); no mount-visible render",
 	"pending_detail_sync": "sync-worker retry ledger for failed detail fetches; no mount-visible render",
 }
 

--- a/internal/sync/metrics.go
+++ b/internal/sync/metrics.go
@@ -24,7 +24,7 @@ import (
 
 // syncMetrics holds the Worker-bound sync instruments (meter "linearfs/sync").
 type syncMetrics struct {
-	cycleDuration  metric.Float64Histogram // linearfs.sync.cycle_duration, seconds
+	cycleDuration  metric.Float64Histogram // linearfs.sync.cycle_duration {mode}, seconds
 	detailOutcomes metric.Int64Counter     // linearfs.sync.detail_outcomes {outcome}
 }
 
@@ -33,15 +33,19 @@ func newSyncMetrics() syncMetrics {
 	return syncMetrics{
 		cycleDuration: telemetry.MustFloat64Histogram(m, "linearfs.sync.cycle_duration",
 			metric.WithUnit("s"),
-			metric.WithDescription("Duration of one syncAllTeams cycle (budget-skipped cycles record ~0)")),
+			metric.WithDescription("Duration of one sync cycle, by mode (lean|full); budget-skipped cycles record ~0")),
 		detailOutcomes: telemetry.MustInt64Counter(m, "linearfs.sync.detail_outcomes",
 			metric.WithDescription("Issues leaving syncDetails' per-issue ledger, by outcome (synced|deferred)")),
 	}
 }
 
-// recordCycle records one sync cycle's duration.
-func (sm syncMetrics) recordCycle(d time.Duration) {
-	sm.cycleDuration.Record(context.Background(), d.Seconds())
+// recordCycle records one sync cycle's duration, attributed with the cycle's
+// mode (lean|full) — the histogram's per-mode sample counts double as the
+// cycle-mode counter, so lean/full cadence is visible without a second
+// instrument.
+func (sm syncMetrics) recordCycle(d time.Duration, mode cycleMode) {
+	sm.cycleDuration.Record(context.Background(), d.Seconds(),
+		metric.WithAttributes(attribute.String("mode", string(mode))))
 }
 
 // recordDetailOutcomes counts issues leaving syncDetails' ledger. Every issue

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -76,19 +76,21 @@ type CatchUpModeToggler interface {
 
 // Worker handles background synchronization of Linear issues to SQLite
 type Worker struct {
-	client    APIClient
-	store     *db.Store
-	extractor *reconcile.Extractor // embedded-file extraction (HEAD + upsert)
-	interval  time.Duration
-	stopCh    chan struct{}
-	doneCh    chan struct{}
-	mu        sync.RWMutex
-	running   bool
-	lastSync  time.Time
-	budget    BudgetReporter     // optional: for rate limit budget logging
-	catchUp   CatchUpModeToggler // optional: controls repo staleness during catch-up
-	cycle     atomic.Int64       // sync-cycle counter; rotates the team order
-	metrics   syncMetrics        // sync-layer instruments, bound at construction
+	client           APIClient
+	store            *db.Store
+	extractor        *reconcile.Extractor // embedded-file extraction (HEAD + upsert)
+	interval         time.Duration
+	fullSyncInterval time.Duration // minimum time between full cycles (see cycleMode)
+
+	stopCh   chan struct{}
+	doneCh   chan struct{}
+	mu       sync.RWMutex
+	running  bool
+	lastSync time.Time
+	budget   BudgetReporter     // optional: for rate limit budget logging
+	catchUp  CatchUpModeToggler // optional: controls repo staleness during catch-up
+	cycle    atomic.Int64       // sync-cycle counter; rotates the team order
+	metrics  syncMetrics        // sync-layer instruments, bound at construction
 
 	// Clock seam: EVERY timing decision in this file goes through these
 	// three fields — no bare time-package clock calls (Now/Since/Until/
@@ -109,6 +111,11 @@ type Worker struct {
 type Config struct {
 	// Interval between sync cycles (default: 2 minutes)
 	Interval time.Duration
+	// FullSyncInterval is the minimum time between full cycles — the cycles
+	// that run the workspace and team-metadata drains with their prune
+	// licenses (default: 10 minutes). Cycles in between are lean: per-team
+	// incremental issues sync only. See cycleMode.
+	FullSyncInterval time.Duration
 	// PageSize for API pagination (default: 100)
 	PageSize int
 }
@@ -116,8 +123,9 @@ type Config struct {
 // DefaultConfig returns a Config with default values
 func DefaultConfig() Config {
 	return Config{
-		Interval: 2 * time.Minute,
-		PageSize: 100,
+		Interval:         2 * time.Minute,
+		FullSyncInterval: 10 * time.Minute,
+		PageSize:         100,
 	}
 }
 
@@ -126,20 +134,24 @@ func NewWorker(client APIClient, store *db.Store, cfg Config) *Worker {
 	if cfg.Interval == 0 {
 		cfg.Interval = 2 * time.Minute
 	}
+	if cfg.FullSyncInterval == 0 {
+		cfg.FullSyncInterval = 10 * time.Minute
+	}
 	// The observable pending-depth gauge registers here too: construction is
 	// the sync layer's one binding point (phase-2 pattern).
 	registerPendingDepthGauge(store.Queries())
 	return &Worker{
-		client:    client,
-		store:     store,
-		extractor: &reconcile.Extractor{Q: store.Queries(), AuthHeader: client.AuthHeader},
-		interval:  cfg.Interval,
-		stopCh:    make(chan struct{}),
-		doneCh:    make(chan struct{}),
-		metrics:   newSyncMetrics(),
-		now:       realNow,
-		newTimer:  realNewTimer,
-		newTicker: realNewTicker,
+		client:           client,
+		store:            store,
+		extractor:        &reconcile.Extractor{Q: store.Queries(), AuthHeader: client.AuthHeader},
+		interval:         cfg.Interval,
+		fullSyncInterval: cfg.FullSyncInterval,
+		stopCh:           make(chan struct{}),
+		doneCh:           make(chan struct{}),
+		metrics:          newSyncMetrics(),
+		now:              realNow,
+		newTimer:         realNewTimer,
+		newTicker:        realNewTicker,
 	}
 }
 
@@ -194,9 +206,10 @@ func (w *Worker) LastSync() time.Time {
 	return w.lastSync
 }
 
-// SyncNow triggers an immediate sync cycle
+// SyncNow triggers an immediate sync cycle. An explicit sync request always
+// runs full — "sync now" means everything, unconditionally.
 func (w *Worker) SyncNow(ctx context.Context) error {
-	return w.syncAllTeams(ctx)
+	return w.syncCycle(ctx, cycleFull)
 }
 
 func (w *Worker) run(ctx context.Context) {
@@ -213,7 +226,9 @@ func (w *Worker) run(ctx context.Context) {
 		return
 	}
 
-	// Initial sync
+	// Initial sync — full on cold start (no persisted full-cycle timestamp),
+	// lean when a restart lands mid-window with a fresh persisted timestamp
+	// (nextCycleMode honors the stamp; no spurious full cycle on restart).
 	if err := w.syncAllTeams(ctx); err != nil {
 		log.Printf("[sync] initial sync failed: %v", err)
 	}
@@ -235,13 +250,68 @@ func (w *Worker) run(ctx context.Context) {
 	}
 }
 
+// cycleMode names the two speeds of a sync cycle. A full cycle is the
+// complete workspace + per-team metadata + issues sync with every prune
+// license; a lean cycle (the steady-state default) runs only the per-team
+// incremental issues sync — no GetWorkspace, no GetTeamMetadata — which is
+// where ~90% of a quiet cycle's complexity went (#238). The string values
+// double as the metric attribute (linearfs.sync.cycle_duration {mode}).
+type cycleMode string
+
+const (
+	cycleLean cycleMode = "lean"
+	cycleFull cycleMode = "full"
+)
+
+// scheduleKeyFullCycle keys the persisted last-full-cycle timestamp in the
+// sync_schedule table. The timestamp is persisted — not an in-memory counter
+// — so restarts and skipped cycles cannot silently stretch the metadata
+// staleness bound past FullSyncInterval.
+const scheduleKeyFullCycle = "full_cycle"
+
+// nextCycleMode decides the speed of the next scheduled cycle from the
+// persisted schedule: full when the last-full-cycle timestamp is missing
+// (cold start — a fresh store must populate exactly as fast as today) or
+// ≥ fullSyncInterval old, lean otherwise. A restart mid-window reads the
+// fresh persisted timestamp and correctly starts lean. SyncNow bypasses this
+// entirely (always full).
+func (w *Worker) nextCycleMode(ctx context.Context) cycleMode {
+	lastRun, err := w.store.Queries().GetSyncSchedule(ctx, scheduleKeyFullCycle)
+	if err != nil || lastRun.IsZero() {
+		// Cold start (no row yet) — or an unreadable schedule, where
+		// over-syncing is the safe direction.
+		return cycleFull
+	}
+	if w.now().Sub(lastRun) >= w.fullSyncInterval {
+		return cycleFull
+	}
+	return cycleLean
+}
+
+// syncAllTeams runs one scheduled sync cycle at whatever speed the persisted
+// schedule calls for. run's initial sync and the ticker come through here;
+// SyncNow calls syncCycle directly with cycleFull.
 func (w *Worker) syncAllTeams(ctx context.Context) error {
+	return w.syncCycle(ctx, w.nextCycleMode(ctx))
+}
+
+// syncCycle runs one sync cycle in the given mode. Full mode is the complete
+// pre-#242 syncAllTeams behavior verbatim: workspace sync (users +
+// initiatives + project-label catalog, with their prune licenses), then per
+// team the metadata sync (states/labels/cycles/projects/members, with their
+// prune licenses) and the incremental issues sync. Lean mode skips the
+// workspace and team-metadata fetches entirely and runs only the (cheap)
+// teams list plus each team's incremental issues sync; nothing prunes in a
+// lean cycle beyond what the issues path always did. A completed full cycle
+// stamps the persisted last-full-cycle timestamp; a budget-skipped or failed
+// cycle does not, so the full sync stays due.
+func (w *Worker) syncCycle(ctx context.Context, mode cycleMode) error {
 	// One linearfs.sync.cycle_duration sample per cycle, whichever caller
 	// invoked it (run's initial sync, the ticker, SyncNow). A budget-skipped
 	// cycle records its ~0s duration too — a burst of near-zero samples IS
 	// the signature of budget-gated skipping.
 	start := w.now()
-	defer func() { w.metrics.recordCycle(w.now().Sub(start)) }()
+	defer func() { w.metrics.recordCycle(w.now().Sub(start), mode) }()
 
 	// Skip entire sync cycle when budget is critically high
 	if w.budgetExceeds(budgetSkipSyncPct) {
@@ -257,10 +327,13 @@ func (w *Worker) syncAllTeams(ctx context.Context) error {
 	// H-5: Drain any issues that were queued during a previous rate-limit backoff
 	w.drainPendingDetailSync(ctx)
 
-	// First, sync workspace-level entities
-	if err := w.syncWorkspace(ctx); err != nil {
-		log.Printf("[sync] workspace sync failed: %v", err)
-		// Continue with teams even if workspace sync fails
+	// First, sync workspace-level entities (full cycles only — the workspace
+	// drain is one of the two fetch classes the lean cycle exists to skip)
+	if mode == cycleFull {
+		if err := w.syncWorkspace(ctx); err != nil {
+			log.Printf("[sync] workspace sync failed: %v", err)
+			// Continue with teams even if workspace sync fails
+		}
 	}
 
 	// Sync teams list
@@ -289,15 +362,30 @@ func (w *Worker) syncAllTeams(ctx context.Context) error {
 			log.Printf("[sync] upsert team %s failed: %v", team.Key, err)
 		}
 
-		// Sync team metadata (states, labels, cycles, projects, members)
-		if err := w.syncTeamMetadata(ctx, team); err != nil {
-			log.Printf("[sync] sync team %s metadata failed: %v", team.Key, err)
+		// Sync team metadata (states, labels, cycles, projects, members) —
+		// full cycles only, the other fetch class the lean cycle skips
+		if mode == cycleFull {
+			if err := w.syncTeamMetadata(ctx, team); err != nil {
+				log.Printf("[sync] sync team %s metadata failed: %v", team.Key, err)
+			}
 		}
 
 		// Sync team issues
 		if err := w.syncTeam(ctx, team); err != nil {
 			log.Printf("[sync] sync team %s failed: %v", team.Key, err)
 			// Continue with other teams
+		}
+	}
+
+	// A full cycle that ran to completion stamps the persisted schedule so
+	// the next fullSyncInterval's worth of cycles run lean. Stamped through
+	// the clock seam: the next cycle's nextCycleMode compares against w.now().
+	if mode == cycleFull {
+		if err := w.store.Queries().UpsertSyncSchedule(ctx, db.UpsertSyncScheduleParams{
+			Key:     scheduleKeyFullCycle,
+			LastRun: w.now(),
+		}); err != nil {
+			log.Printf("[sync] persist full-cycle timestamp failed: %v", err)
 		}
 	}
 

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -302,9 +302,13 @@ func (w *Worker) syncAllTeams(ctx context.Context) error {
 // prune licenses) and the incremental issues sync. Lean mode skips the
 // workspace and team-metadata fetches entirely and runs only the (cheap)
 // teams list plus each team's incremental issues sync; nothing prunes in a
-// lean cycle beyond what the issues path always did. A completed full cycle
-// stamps the persisted last-full-cycle timestamp; a budget-skipped or failed
-// cycle does not, so the full sync stays due.
+// lean cycle beyond what the issues path always did. A full cycle that runs
+// to completion stamps the persisted last-full-cycle timestamp; a
+// budget-skipped or teams-fetch-failed cycle returns early and does not, so
+// the full sync stays due. A cycle whose workspace or per-team metadata sync
+// fails partway DOES stamp (those failures log-and-continue): retrying the
+// full drains every 2 minutes under budget pressure is the burn pattern the
+// diet exists to stop, so a partial failure waits for the next window.
 func (w *Worker) syncCycle(ctx context.Context, mode cycleMode) error {
 	// One linearfs.sync.cycle_duration sample per cycle, whichever caller
 	// invoked it (run's initial sync, the ticker, SyncNow). A budget-skipped

--- a/internal/sync/worker_test.go
+++ b/internal/sync/worker_test.go
@@ -116,7 +116,7 @@ type mockAPIClient struct {
 	viewerErr        error                        // if set, GetViewer (the cold-start budget probe) fails with this
 	getViewerCalls   int32
 	opMu             gosync.Mutex
-	opOrder          []string // call order across GetViewer/GetWorkspace/GetTeams (probe-sequencing tests)
+	opOrder          []string // call order across GetViewer/GetWorkspace/GetTeamMetadata/GetTeams (probe-sequencing + lean/full cycle tests)
 }
 
 // recordOp appends op to the observed call order.
@@ -204,6 +204,7 @@ func (m *mockAPIClient) GetTeamIssuesPage(ctx context.Context, teamID string, cu
 }
 
 func (m *mockAPIClient) GetTeamMetadata(ctx context.Context, teamID string) (*api.TeamMetadata, error) {
+	m.recordOp("GetTeamMetadata")
 	if m.simulateError != nil {
 		return nil, m.simulateError
 	}
@@ -1433,6 +1434,234 @@ func TestRunLoopTickFiresSyncCycle(t *testing.T) {
 	if calls := atomic.LoadInt32(&mock.getTeamsCalls); calls != 2 {
 		t.Errorf("GetTeams calls = %d, want exactly 2 (initial sync + the injected tick)", calls)
 	}
+}
+
+// =============================================================================
+// Lean/Full Cycle Taxonomy Tests (#242)
+// =============================================================================
+
+// opsDuring runs fn and returns only the ops the mock recorded during it —
+// the per-cycle window the lean/full assertions are made against.
+func opsDuring(m *mockAPIClient, fn func()) []string {
+	before := len(m.callOrder())
+	fn()
+	return m.callOrder()[before:]
+}
+
+// containsOp reports whether op appears in ops.
+func containsOp(ops []string, op string) bool {
+	for _, o := range ops {
+		if o == op {
+			return true
+		}
+	}
+	return false
+}
+
+// assertCycleOps asserts one cycle's fetch classes: a full cycle issues both
+// GetWorkspace and GetTeamMetadata, a lean cycle issues neither; every
+// non-skipped cycle issues GetTeams (the cheap team enumeration the issues
+// sync needs either way).
+func assertCycleOps(t *testing.T, label string, ops []string, wantFull bool) {
+	t.Helper()
+	if !containsOp(ops, "GetTeams") {
+		t.Errorf("%s: ops = %v, want GetTeams in every non-skipped cycle", label, ops)
+	}
+	for _, op := range []string{"GetWorkspace", "GetTeamMetadata"} {
+		if got := containsOp(ops, op); got != wantFull {
+			t.Errorf("%s: ops = %v, %s present = %v, want %v", label, ops, op, got, wantFull)
+		}
+	}
+}
+
+// cycleTestWorker builds the standard lean/full-cycle fixture: one team with
+// metadata, a fake clock, a 2-minute cycle interval and a 10-minute full-sync
+// interval.
+func cycleTestWorker(t *testing.T, store *db.Store) (*Worker, *mockAPIClient, *fakeClock) {
+	t.Helper()
+	clock := newFakeClock()
+	mock := newMockAPIClient()
+	mock.teams = []api.Team{{ID: "team-1", Key: "TST", Name: "Test"}}
+	mock.statesByTeam["team-1"] = []api.State{{ID: "state-1", Name: "Todo", Type: "unstarted"}}
+	worker := NewWorker(mock, store, Config{Interval: 2 * time.Minute, FullSyncInterval: 10 * time.Minute})
+	clock.install(worker)
+	return worker, mock, clock
+}
+
+// TestScheduledCyclesLeanUntilFullIntervalElapses scripts the steady-state
+// cadence: a cold-start full cycle, then lean cycles (no workspace or
+// team-metadata fetches) every 2 minutes until 10 minutes have elapsed since
+// the persisted full-cycle timestamp, at which point the cycle runs full
+// again and re-arms the window.
+func TestScheduledCyclesLeanUntilFullIntervalElapses(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	worker, mock, clock := cycleTestWorker(t, store)
+
+	// Cycle 1: cold start — no persisted timestamp — runs full.
+	ops := opsDuring(mock, func() {
+		if err := worker.syncAllTeams(ctx); err != nil {
+			t.Fatalf("cycle 1: %v", err)
+		}
+	})
+	assertCycleOps(t, "cycle 1 (cold start)", ops, true)
+
+	// The full cycle persisted its timestamp — at the fake clock's now, via
+	// the clock seam, readable from the store.
+	stamped, err := store.Queries().GetSyncSchedule(ctx, scheduleKeyFullCycle)
+	if err != nil {
+		t.Fatalf("GetSyncSchedule after full cycle: %v", err)
+	}
+	if !stamped.Equal(clock.now()) {
+		t.Errorf("persisted full-cycle timestamp = %v, want %v (w.now() at stamp time)", stamped, clock.now())
+	}
+
+	// Cycles 2-5 (+2m…+8m): inside the window — lean, issues only.
+	for i := 2; i <= 5; i++ {
+		clock.advance(2 * time.Minute)
+		ops := opsDuring(mock, func() {
+			if err := worker.syncAllTeams(ctx); err != nil {
+				t.Fatalf("cycle %d: %v", i, err)
+			}
+		})
+		assertCycleOps(t, fmt.Sprintf("cycle %d (in-window)", i), ops, false)
+	}
+
+	// Cycle 6 (+10m): the full-sync interval has elapsed — full again.
+	clock.advance(2 * time.Minute)
+	ops = opsDuring(mock, func() {
+		if err := worker.syncAllTeams(ctx); err != nil {
+			t.Fatalf("cycle 6: %v", err)
+		}
+	})
+	assertCycleOps(t, "cycle 6 (interval elapsed)", ops, true)
+
+	// Cycle 7 (+12m): the full cycle re-armed the window — lean again.
+	clock.advance(2 * time.Minute)
+	ops = opsDuring(mock, func() {
+		if err := worker.syncAllTeams(ctx); err != nil {
+			t.Fatalf("cycle 7: %v", err)
+		}
+	})
+	assertCycleOps(t, "cycle 7 (window re-armed)", ops, false)
+}
+
+// TestSyncNowAlwaysRunsFull: an explicit sync request runs full even when the
+// persisted full-cycle timestamp is fresh (a scheduled cycle at the same
+// instant would run lean).
+func TestSyncNowAlwaysRunsFull(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	worker, mock, clock := cycleTestWorker(t, store)
+
+	// Arm the window with a cold-start full cycle, then move barely inside it.
+	if err := worker.syncAllTeams(ctx); err != nil {
+		t.Fatalf("arming full cycle: %v", err)
+	}
+	clock.advance(2 * time.Minute)
+
+	// A scheduled cycle here is lean…
+	ops := opsDuring(mock, func() {
+		if err := worker.syncAllTeams(ctx); err != nil {
+			t.Fatalf("scheduled cycle: %v", err)
+		}
+	})
+	assertCycleOps(t, "scheduled cycle mid-window", ops, false)
+
+	// …but SyncNow at the very same instant is full, unconditionally.
+	ops = opsDuring(mock, func() {
+		if err := worker.SyncNow(ctx); err != nil {
+			t.Fatalf("SyncNow: %v", err)
+		}
+	})
+	assertCycleOps(t, "SyncNow mid-window", ops, true)
+}
+
+// TestRestartHonorsPersistedFullCycleTimestamp: the persistence requirement.
+// A fresh Worker over a store carrying a fresh full-cycle timestamp starts
+// lean (a restart mid-window must not force an extra full cycle), while a
+// fresh Worker over a fresh store starts full (cold start).
+func TestRestartHonorsPersistedFullCycleTimestamp(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("fresh store starts full", func(t *testing.T) {
+		t.Parallel()
+		store := openTestStore(t)
+		defer store.Close()
+
+		worker, mock, _ := cycleTestWorker(t, store)
+		ops := opsDuring(mock, func() {
+			if err := worker.syncAllTeams(ctx); err != nil {
+				t.Fatalf("cold-start cycle: %v", err)
+			}
+		})
+		assertCycleOps(t, "cold start", ops, true)
+	})
+
+	t.Run("fresh persisted timestamp starts lean", func(t *testing.T) {
+		t.Parallel()
+		store := openTestStore(t)
+		defer store.Close()
+
+		// "Previous process": a full cycle stamps the schedule, then exits.
+		prev, _, prevClock := cycleTestWorker(t, store)
+		if err := prev.syncAllTeams(ctx); err != nil {
+			t.Fatalf("previous process full cycle: %v", err)
+		}
+
+		// "Restart" 2 minutes later: a brand-new Worker over the same store.
+		worker, mock, clock := cycleTestWorker(t, store)
+		clock.advance(prevClock.now().Sub(clock.now()) + 2*time.Minute)
+		ops := opsDuring(mock, func() {
+			if err := worker.syncAllTeams(ctx); err != nil {
+				t.Fatalf("post-restart cycle: %v", err)
+			}
+		})
+		assertCycleOps(t, "restart mid-window", ops, false)
+	})
+}
+
+// TestBudgetSkippedCycleLeavesFullCycleDue: a budget-skipped cycle runs
+// nothing, so it must not stamp the persisted timestamp — the full sync stays
+// due and fires on the next unblocked cycle rather than silently stretching
+// the metadata staleness bound.
+func TestBudgetSkippedCycleLeavesFullCycleDue(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	worker, mock, _ := cycleTestWorker(t, store)
+	budget := &mockBudgetReporter{count: 1300, pct: 87.0} // >80% — skip
+	worker.SetBudgetReporter(budget)
+
+	ops := opsDuring(mock, func() {
+		if err := worker.syncAllTeams(ctx); err != nil {
+			t.Fatalf("budget-skipped cycle: %v", err)
+		}
+	})
+	if len(ops) != 0 {
+		t.Errorf("budget-skipped cycle issued ops %v, want none", ops)
+	}
+	if _, err := store.Queries().GetSyncSchedule(ctx, scheduleKeyFullCycle); !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("GetSyncSchedule after skipped cycle: err = %v, want sql.ErrNoRows (no stamp)", err)
+	}
+
+	// Budget recovers — the still-due full cycle fires.
+	budget.count, budget.pct = 100, 10.0
+	ops = opsDuring(mock, func() {
+		if err := worker.syncAllTeams(ctx); err != nil {
+			t.Fatalf("unblocked cycle: %v", err)
+		}
+	})
+	assertCycleOps(t, "first unblocked cycle", ops, true)
 }
 
 // =============================================================================


### PR DESCRIPTION
Implements #242 (slice 1 of the #238 sync-cycle diet): the sync worker gets a lean/full cycle taxonomy.

## Behavior changes

- **Lean cycles are the new steady-state default.** A lean cycle runs only the cheap `GetTeams` enumeration plus each team's incremental issues sync — **no `GetWorkspace`, no `GetTeamMetadata`**, and therefore no metadata prunes. This alone removes the two fetch classes that were ~90% of a quiet cycle's complexity.
- **Full cycles are byte-for-byte the previous behavior**: `syncWorkspace` (users + initiatives + project-label catalog) and per-team `syncTeamMetadata` (states/labels/cycles/projects/members), with every existing prune license, plus the issues sync. Metadata staleness/deletion bounds become the full-cycle interval.
- **Full-cycle trigger is time-based off a persisted timestamp**, not an in-memory counter: new `sync_schedule(key TEXT PRIMARY KEY, last_run DATETIME)` table, key `full_cycle`. A cycle runs full when the stamp is missing (**cold start** — fresh mounts populate exactly as fast as today), when ≥ `Config.FullSyncInterval` (new field, default **10m**, alongside `Interval`) has elapsed, and on **`SyncNow`** (always full, unconditionally).
- **Only a full cycle that ran to completion stamps the schedule** — a budget-skipped or `GetTeams`-failed cycle leaves the full sync due, so skipped cycles can't stretch the staleness bound. Conversely, a **restart mid-window** reads the fresh persisted stamp and starts lean (no redundant full-cycle storm).
- **Budget gates unchanged** (`budgetSkipSyncPct` skip, detail-defer threshold, everything in the client).

## Design decisions

- **Schedule table shape**: generic key/value — `sync_schedule(key, last_run)` — deliberately not a single-purpose column on `sync_meta`, so later diet slices (probe watermarks, the hourly ID-reconcile) hang new keys off the same table. `CREATE TABLE IF NOT EXISTS` in `schema.sql` means existing databases pick it up on next open, no migration needed. sqlc generates `GetSyncSchedule`/`UpsertSyncSchedule`; the driver's `_time_format=sqlite` scan returns `time.Time` directly (no manual timestamp parsing — the `ParseSQLiteTime` trap only applies to string/`MAX()` reads).
- **Entry points**: `SyncNow` → `syncCycle(ctx, cycleFull)`; the run loop (initial sync + ticker) → `syncAllTeams` → `nextCycleMode` (persisted-schedule read through `w.now()`) → `syncCycle`. Every timing decision rides the existing clock seam; the no-bare-time grep rule on `worker.go` still returns nothing.
- **Stamp written with `w.now()`** (not `db.Now()`) so the next cycle's comparison and the stamp share one clock — which is also what makes the fake-clock tests exact.
- **Metrics**: `linearfs.sync.cycle_duration` gains a `mode` attribute (`lean`|`full`); the per-mode histogram sample counts double as the cycle-mode counter, so no second instrument. Budget-skipped cycles record ~0s attributed with the mode they would have run. `docs/telemetry.md` updated; `CONTEXT.md` gains a "Cycle taxonomy" entry.
- `GetTeams` stays in lean cycles (the issues sync needs the team list; it is the ~80-complexity cheap query, not one of the drains the diet targets). Team-row upserts (a local DB write off that response) also stay per-cycle.

## Tests

New worker-seam tests (fake clock + op-recording mock, zero real waiting):
- `TestScheduledCyclesLeanUntilFullIntervalElapses` — scripted 7-cycle sequence: cold-start full (stamp asserted in the store at exactly `w.now()`), four in-window lean cycles issuing no `GetWorkspace`/`GetTeamMetadata`, full again at +10m, lean after the window re-arms.
- `TestSyncNowAlwaysRunsFull` — same instant, scheduled cycle is lean but `SyncNow` is full.
- `TestRestartHonorsPersistedFullCycleTimestamp` — a fresh `Worker` over a store with a fresh persisted stamp starts lean; over a fresh store it starts full.
- `TestBudgetSkippedCycleLeavesFullCycleDue` — skipped cycle issues no ops and withholds the stamp; the first unblocked cycle runs full.

Existing prune tests (full-cycle paths `syncTeamMetadata`/`syncWorkspace`) untouched and green. `sync_schedule` added to the fixture-parity exclusion list (sync-worker bookkeeping, no mount-visible render).

`go build ./...` ✓ — full `go test ./...` (integration included) ✓ — `make staticcheck` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)