### PR TITLE
feat: validation-failure refresh-and-retry for catalog resolution (#246)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -131,6 +131,27 @@ shared primitives (also used singly by initiatives and projects).
 resolver — same `FieldError` contract, but a pure function over a catalog slice
 rather than a method on the resolver seam.
 
+**Catalog refresh-and-retry (#246):** a `Resolve*` miss against the locally-cached
+catalog (state/label/project/milestone/cycle/user/initiative) is not necessarily a
+bad name — the catalog rides a minutes-long sync cadence, so a name a teammate
+created moments ago is a *local* miss. Each resolver therefore routes its lookup
+through `resolveWithRefresh` (`internal/fs/catalogrefresh.go`): on an
+`unknownNameError` — the typed local-miss marker `resolveByName` mints, message
+byte-identical to the old `fmt.Errorf` — it triggers exactly ONE targeted refresh
+of that catalog and retries the resolution ONCE, then surfaces the original error
+unchanged. The seam is `LinearFS.catalogRefreshImpl` (injectable via
+`InjectTestCatalogRefresher`); the default reuses the sync worker's complete-drain
+machinery (`Worker.RefreshTeamCatalogs` for team-scoped kinds,
+`RefreshWorkspaceCatalogs` for users/initiatives; milestones map project→team
+locally via `GetProjectPrimaryTeamKey` first), so budget gates and prune licensing
+apply unchanged. Without a worker (fixture mode) the default declines and the miss
+surfaces as before — offline suites are network-free by construction. API-side
+rejections (`classifyMutationErr` territory) never reach this path: the refresh
+arms only on the typed local miss, before any mutation is attempted.
+`ResolveProjectSlugToID` (initiative.md's workspace-wide slug resolution) is
+deliberately outside: scoping its refresh would mean draining every team's
+projects for one miss.
+
 ### Project-label selection (`projectlabels.go`)
 The workspace project-label surface (#130). Linear's `ProjectLabel` is
 **workspace-scoped** — the schema has no team edge at all (contrast `IssueLabel`'s

--- a/internal/fs/catalogrefresh.go
+++ b/internal/fs/catalogrefresh.go
@@ -1,0 +1,143 @@
+package fs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+)
+
+// Validation-failure refresh-and-retry (#246).
+//
+// The name→ID resolvers (linearfs.go's Resolve* methods) resolve against the
+// locally-cached catalog in SQLite, which rides a minutes-long sync cadence —
+// so a name a teammate created moments ago is a *local* miss, not a bad name.
+// Every resolver therefore routes its lookup through resolveWithRefresh: on a
+// miss it triggers exactly ONE targeted refresh of that catalog and retries
+// the resolution ONCE, and only then surfaces the original validation error
+// (same message, same .error / EINVAL contract as before). API-side rejections
+// (classifyMutationErr territory) never reach this path — the refresh fires
+// only on the typed local-miss error below, before any mutation is attempted.
+
+// CatalogKind names one locally-cached name→ID catalog a resolver can miss
+// against. It scopes the targeted refresh: team-scoped kinds refresh via the
+// team-metadata drain, workspace-scoped kinds via the workspace drain.
+type CatalogKind string
+
+const (
+	CatalogStates      CatalogKind = "states"      // scopeID = team ID
+	CatalogLabels      CatalogKind = "labels"      // scopeID = team ID
+	CatalogProjects    CatalogKind = "projects"    // scopeID = team ID
+	CatalogMilestones  CatalogKind = "milestones"  // scopeID = project ID
+	CatalogCycles      CatalogKind = "cycles"      // scopeID = team ID
+	CatalogUsers       CatalogKind = "users"       // scopeID unused (workspace)
+	CatalogInitiatives CatalogKind = "initiatives" // scopeID unused (workspace)
+)
+
+// unknownNameError marks a LOCAL name→ID resolution miss: the name is absent
+// from the cached catalog. It is the one trigger for the refresh-and-retry —
+// repo/infrastructure failures pass through untouched. Error() must stay
+// byte-identical to the historical "unknown <label>: <name>" message; the
+// .error content is part of the write contract.
+type unknownNameError struct{ label, name string }
+
+func (e *unknownNameError) Error() string {
+	return fmt.Sprintf("unknown %s: %s", e.label, e.name)
+}
+
+// resolveWithRefresh runs resolve against the local catalog; on an
+// unknown-name miss it triggers exactly one targeted refresh of the named
+// catalog and retries the resolution once. No loops: a second miss surfaces
+// the same error the first produced. A refresh failure (budget refusal,
+// network, no sync worker) is logged and swallowed — the caller's error is
+// the original miss, exactly as if the refresh never existed.
+func (lfs *LinearFS) resolveWithRefresh(ctx context.Context, kind CatalogKind, scopeID string, resolve func() (string, error)) (string, error) {
+	id, err := resolve()
+	var miss *unknownNameError
+	if err == nil || !errors.As(err, &miss) {
+		return id, err
+	}
+	if refreshErr := lfs.refreshCatalog(ctx, kind, scopeID); refreshErr != nil {
+		log.Printf("[fs] %s catalog refresh after resolution miss (%v) failed: %v", kind, err, refreshErr)
+		return "", err
+	}
+	return resolve()
+}
+
+// refreshCatalog dispatches one targeted catalog refresh through the seam:
+// the injected test stub when present, otherwise the sync-worker-backed
+// default. Reads the field under the same lock InjectTestCatalogRefresher
+// writes it (mutatorMu, shared with the sibling mutator/verifier seams).
+func (lfs *LinearFS) refreshCatalog(ctx context.Context, kind CatalogKind, scopeID string) error {
+	lfs.mutatorMu.RLock()
+	impl := lfs.catalogRefreshImpl
+	lfs.mutatorMu.RUnlock()
+	if impl == nil {
+		impl = lfs.refreshCatalogViaSync
+	}
+	return impl(ctx, kind, scopeID)
+}
+
+// refreshCatalogViaSync is the production refresh: it reuses the sync
+// worker's existing complete-drain machinery (fetch from the API, upsert to
+// SQLite, prune under the same licenses as a background cycle), so budget
+// gates — GetTeamMetadata's and GetWorkspace's LowBudget preflights — apply
+// automatically. Without a worker (fixture mode, unit tests) it declines,
+// which keeps offline suites network-free by construction: the resolver then
+// surfaces the original miss unchanged.
+func (lfs *LinearFS) refreshCatalogViaSync(ctx context.Context, kind CatalogKind, scopeID string) error {
+	w := lfs.syncWorker
+	if w == nil {
+		return fmt.Errorf("catalog refresh unavailable: no sync worker")
+	}
+	switch kind {
+	case CatalogUsers, CatalogInitiatives:
+		return w.RefreshWorkspaceCatalogs(ctx)
+	case CatalogMilestones:
+		// Milestones ride the team-metadata drain (nested under projects);
+		// map the owning project to its canonical team first — locally, no
+		// API. A project not yet in the store cannot be scoped, so the
+		// refresh declines and the miss surfaces.
+		teamID, err := lfs.projectPrimaryTeamID(ctx, scopeID)
+		if err != nil {
+			return fmt.Errorf("resolve team for project %s: %w", scopeID, err)
+		}
+		return w.RefreshTeamCatalogs(ctx, teamID)
+	default: // states, labels, cycles, projects — team-scoped, one combined drain
+		return w.RefreshTeamCatalogs(ctx, scopeID)
+	}
+}
+
+// projectPrimaryTeamID maps a project ID to its canonical team's ID via the
+// local store (GetProjectPrimaryTeamKey owns the "which team hosts this
+// project" rule; it returns the key, so match it against the teams table).
+func (lfs *LinearFS) projectPrimaryTeamID(ctx context.Context, projectID string) (string, error) {
+	if lfs.store == nil || lfs.repo == nil {
+		return "", fmt.Errorf("no local store")
+	}
+	key, err := lfs.store.Queries().GetProjectPrimaryTeamKey(ctx, projectID)
+	if err != nil {
+		return "", err
+	}
+	teams, err := lfs.repo.GetTeams(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, team := range teams {
+		if team.Key == key {
+			return team.ID, nil
+		}
+	}
+	return "", fmt.Errorf("no team with key %s", key)
+}
+
+// InjectTestCatalogRefresher swaps the validation-failure catalog-refresh
+// seam for a test stub, so offline suites can exercise the refresh-and-retry
+// contract (stale catalog → refresh supplies the name → write succeeds)
+// without the network. Pass nil to restore the default sync-worker-backed
+// behavior.
+func (lfs *LinearFS) InjectTestCatalogRefresher(fn func(ctx context.Context, kind CatalogKind, scopeID string) error) {
+	lfs.mutatorMu.Lock()
+	defer lfs.mutatorMu.Unlock()
+	lfs.catalogRefreshImpl = fn
+}

--- a/internal/fs/catalogrefresh_test.go
+++ b/internal/fs/catalogrefresh_test.go
@@ -1,0 +1,156 @@
+package fs
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jra3/linear-fuse/internal/api"
+)
+
+// scriptedResolve returns a resolve closure that replays outcomes in order and
+// counts its calls.
+func scriptedResolve(calls *int, outcomes ...func() (string, error)) func() (string, error) {
+	i := 0
+	return func() (string, error) {
+		*calls++
+		out := outcomes[min(i, len(outcomes)-1)]
+		i++
+		return out()
+	}
+}
+
+func hit(id string) func() (string, error) {
+	return func() (string, error) { return id, nil }
+}
+
+func missState(name string) func() (string, error) {
+	return func() (string, error) { return "", &unknownNameError{label: "state", name: name} }
+}
+
+func infraErr(msg string) func() (string, error) {
+	return func() (string, error) { return "", errors.New(msg) }
+}
+
+// TestResolveWithRefresh pins the whole refresh-and-retry contract: exactly one
+// refresh, exactly one retry, refresh only on the typed local miss, and the
+// original error message surviving every failure shape.
+func TestResolveWithRefresh(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name         string
+		outcomes     []func() (string, error)
+		refreshErr   error
+		wantID       string
+		wantErr      string // "" = success expected
+		wantResolves int
+		wantRefresh  int
+	}{
+		{
+			name:         "hit needs no refresh",
+			outcomes:     []func() (string, error){hit("id-1")},
+			wantID:       "id-1",
+			wantResolves: 1,
+			wantRefresh:  0,
+		},
+		{
+			name:         "stale catalog self-heals: miss, refresh, hit",
+			outcomes:     []func() (string, error){missState("Paused"), hit("id-2")},
+			wantID:       "id-2",
+			wantResolves: 2,
+			wantRefresh:  1,
+		},
+		{
+			name:         "nonexistent name: one refresh, one retry, same error",
+			outcomes:     []func() (string, error){missState("Nope")},
+			wantErr:      "unknown state: Nope",
+			wantResolves: 2,
+			wantRefresh:  1,
+		},
+		{
+			name:         "infrastructure error never refreshes",
+			outcomes:     []func() (string, error){infraErr("db down")},
+			wantErr:      "db down",
+			wantResolves: 1,
+			wantRefresh:  0,
+		},
+		{
+			name:         "refresh failure surfaces the original miss",
+			outcomes:     []func() (string, error){missState("Paused"), hit("never-reached")},
+			refreshErr:   errors.New("budget refused"),
+			wantErr:      "unknown state: Paused",
+			wantResolves: 1,
+			wantRefresh:  1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lfs := &LinearFS{}
+			refreshes := 0
+			lfs.catalogRefreshImpl = func(ctx context.Context, kind CatalogKind, scopeID string) error {
+				refreshes++
+				if kind != CatalogStates || scopeID != "team-x" {
+					t.Errorf("refresh scoped to %s/%s, want states/team-x", kind, scopeID)
+				}
+				return tc.refreshErr
+			}
+
+			resolves := 0
+			id, err := lfs.resolveWithRefresh(ctx, CatalogStates, "team-x",
+				scriptedResolve(&resolves, tc.outcomes...))
+
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("want success, got %v", err)
+				}
+				if id != tc.wantID {
+					t.Errorf("id = %q, want %q", id, tc.wantID)
+				}
+			} else {
+				if err == nil || err.Error() != tc.wantErr {
+					t.Fatalf("err = %v, want %q (the pre-refresh message, unchanged)", err, tc.wantErr)
+				}
+			}
+			if resolves != tc.wantResolves {
+				t.Errorf("resolve ran %d times, want %d", resolves, tc.wantResolves)
+			}
+			if refreshes != tc.wantRefresh {
+				t.Errorf("refresh ran %d times, want %d", refreshes, tc.wantRefresh)
+			}
+		})
+	}
+}
+
+// TestResolveWithRefreshDeclinesWithoutWorker: with no injected stub and no
+// sync worker (fixture/offline mode), the default refresh declines and the
+// original miss surfaces — no network, no panic. This is what keeps every
+// pre-existing offline test's .error content byte-identical.
+func TestResolveWithRefreshDeclinesWithoutWorker(t *testing.T) {
+	lfs := &LinearFS{}
+	resolves := 0
+	_, err := lfs.resolveWithRefresh(context.Background(), CatalogStates, "team-x",
+		scriptedResolve(&resolves, missState("Ghost")))
+	if err == nil || err.Error() != "unknown state: Ghost" {
+		t.Fatalf("err = %v, want the original miss unchanged", err)
+	}
+	if resolves != 1 {
+		t.Errorf("resolve ran %d times, want 1 (refresh declined, no retry)", resolves)
+	}
+}
+
+// TestResolveByNameMintsTypedMiss: the generic resolver's miss is the typed
+// local-miss marker with the historical message, so the refresh trigger and
+// the .error contract stay in lockstep.
+func TestResolveByNameMintsTypedMiss(t *testing.T) {
+	_, err := resolveByName([]api.State{{ID: "s1", Name: "Todo"}}, "Ghost", "state",
+		func(s api.State) string { return s.Name }, func(s api.State) string { return s.ID })
+	if err == nil || err.Error() != "unknown state: Ghost" {
+		t.Fatalf("err = %v, want %q", err, "unknown state: Ghost")
+	}
+	var miss *unknownNameError
+	if !errors.As(err, &miss) {
+		t.Fatalf("miss is not *unknownNameError: %T", err)
+	}
+}

--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -30,7 +30,14 @@ type LinearFS struct {
 	client       *api.Client    // Reads (on-demand fetch) + infrastructure (stats, viewer, close)
 	mutatorImpl  MutationClient // Mutations only; defaults to client, swappable for tests
 	verifierImpl verifyReader   // Read-your-writes re-fetch; defaults to client, swappable for tests
-	mutatorMu    gosync.RWMutex // guards mutatorImpl + verifierImpl (handlers read while tests swap)
+	mutatorMu    gosync.RWMutex // guards mutatorImpl + verifierImpl + catalogRefreshImpl (handlers read while tests swap)
+
+	// catalogRefreshImpl is the validation-failure catalog-refresh seam (#246):
+	// how a name→ID resolution miss refreshes its catalog before the one retry
+	// (see catalogrefresh.go). nil selects the default, sync-worker-backed
+	// refreshCatalogViaSync; tests swap in a stub via InjectTestCatalogRefresher
+	// so offline suites stay network-free.
+	catalogRefreshImpl func(ctx context.Context, kind CatalogKind, scopeID string) error
 
 	repo       *repo.SQLiteRepository // For all read operations
 	store      *db.Store              // SQLite store (owned by repo, kept for sync worker)
@@ -536,8 +543,17 @@ func (lfs *LinearFS) UpdateDocument(ctx context.Context, documentID string, inpu
 	return lfs.mutator().UpdateDocument(ctx, documentID, input)
 }
 
-// ResolveUserID converts an email or name to a user ID
+// ResolveUserID converts an email or name to a user ID. A local catalog miss
+// triggers one targeted refresh + retry (see catalogrefresh.go).
 func (lfs *LinearFS) ResolveUserID(ctx context.Context, identifier string) (string, error) {
+	return lfs.resolveWithRefresh(ctx, CatalogUsers, "", func() (string, error) {
+		return lfs.lookupUserID(ctx, identifier)
+	})
+}
+
+// lookupUserID is ResolveUserID's local half: one pass over the cached users,
+// exact email → case-insensitive email → name → case-insensitive name.
+func (lfs *LinearFS) lookupUserID(ctx context.Context, identifier string) (string, error) {
 	users, err := lfs.repo.GetUsers(ctx)
 	if err != nil {
 		return "", err
@@ -572,7 +588,7 @@ func (lfs *LinearFS) ResolveUserID(ctx context.Context, identifier string) (stri
 		}
 	}
 
-	return "", fmt.Errorf("unknown user: %s", identifier)
+	return "", &unknownNameError{label: "user", name: identifier}
 }
 
 // ResolveIssueID converts an issue identifier (e.g., "ENG-123") to its UUID
@@ -587,19 +603,38 @@ func (lfs *LinearFS) ResolveIssueID(ctx context.Context, identifier string) (str
 	return issue.ID, nil
 }
 
-// ResolveStateID converts a state name to its ID for a given team
+// ResolveStateID converts a state name to its ID for a given team. A local
+// catalog miss triggers one targeted refresh + retry (see catalogrefresh.go).
 func (lfs *LinearFS) ResolveStateID(ctx context.Context, teamID string, stateName string) (string, error) {
-	states, err := lfs.repo.GetTeamStates(ctx, teamID)
-	if err != nil {
-		return "", err
-	}
-	return resolveByName(states, stateName, "state",
-		func(s api.State) string { return s.Name }, func(s api.State) string { return s.ID })
+	return lfs.resolveWithRefresh(ctx, CatalogStates, teamID, func() (string, error) {
+		states, err := lfs.repo.GetTeamStates(ctx, teamID)
+		if err != nil {
+			return "", err
+		}
+		return resolveByName(states, stateName, "state",
+			func(s api.State) string { return s.Name }, func(s api.State) string { return s.ID })
+	})
 }
 
-// ResolveLabelIDs converts label names to their IDs for a given team
-// Returns the list of label IDs and any labels that couldn't be resolved
+// ResolveLabelIDs converts label names to their IDs for a given team.
+// Returns the list of label IDs and any labels that couldn't be resolved.
+// Local misses may just be a stale catalog, so one targeted refresh + one
+// retry runs before the misses are reported (see catalogrefresh.go).
 func (lfs *LinearFS) ResolveLabelIDs(ctx context.Context, teamID string, labelNames []string) ([]string, []string, error) {
+	ids, notFound, err := lfs.lookupLabelIDs(ctx, teamID, labelNames)
+	if err != nil || len(notFound) == 0 {
+		return ids, notFound, err
+	}
+	if refreshErr := lfs.refreshCatalog(ctx, CatalogLabels, teamID); refreshErr != nil {
+		log.Printf("[fs] labels catalog refresh after resolution miss (%v) failed: %v", notFound, refreshErr)
+		return ids, notFound, nil
+	}
+	return lfs.lookupLabelIDs(ctx, teamID, labelNames)
+}
+
+// lookupLabelIDs is ResolveLabelIDs' local half: one case-insensitive pass
+// over the cached team labels.
+func (lfs *LinearFS) lookupLabelIDs(ctx context.Context, teamID string, labelNames []string) ([]string, []string, error) {
 	labels, err := lfs.repo.GetTeamLabels(ctx, teamID)
 	if err != nil {
 		return nil, nil, err
@@ -625,14 +660,17 @@ func (lfs *LinearFS) ResolveLabelIDs(ctx context.Context, teamID string, labelNa
 	return ids, notFound, nil
 }
 
-// ResolveProjectID converts a project name to its ID for a given team
+// ResolveProjectID converts a project name to its ID for a given team. A local
+// catalog miss triggers one targeted refresh + retry (see catalogrefresh.go).
 func (lfs *LinearFS) ResolveProjectID(ctx context.Context, teamID string, projectName string) (string, error) {
-	projects, err := lfs.repo.GetTeamProjects(ctx, teamID)
-	if err != nil {
-		return "", err
-	}
-	return resolveByName(projects, projectName, "project",
-		func(p api.Project) string { return p.Name }, func(p api.Project) string { return p.ID })
+	return lfs.resolveWithRefresh(ctx, CatalogProjects, teamID, func() (string, error) {
+		projects, err := lfs.repo.GetTeamProjects(ctx, teamID)
+		if err != nil {
+			return "", err
+		}
+		return resolveByName(projects, projectName, "project",
+			func(p api.Project) string { return p.Name }, func(p api.Project) string { return p.ID })
+	})
 }
 
 // ResolveProjectSlugToID converts a project slug to its ID by searching all teams.
@@ -659,14 +697,17 @@ func (lfs *LinearFS) ResolveProjectSlugToID(ctx context.Context, projectSlug str
 	return "", fmt.Errorf("unknown project slug: %s", projectSlug)
 }
 
-// ResolveMilestoneID converts a milestone name to its ID for a given project
+// ResolveMilestoneID converts a milestone name to its ID for a given project.
+// A local catalog miss triggers one targeted refresh + retry (see catalogrefresh.go).
 func (lfs *LinearFS) ResolveMilestoneID(ctx context.Context, projectID string, milestoneName string) (string, error) {
-	milestones, err := lfs.repo.GetProjectMilestones(ctx, projectID)
-	if err != nil {
-		return "", err
-	}
-	return resolveByName(milestones, milestoneName, "milestone",
-		func(m api.ProjectMilestone) string { return m.Name }, func(m api.ProjectMilestone) string { return m.ID })
+	return lfs.resolveWithRefresh(ctx, CatalogMilestones, projectID, func() (string, error) {
+		milestones, err := lfs.repo.GetProjectMilestones(ctx, projectID)
+		if err != nil {
+			return "", err
+		}
+		return resolveByName(milestones, milestoneName, "milestone",
+			func(m api.ProjectMilestone) string { return m.Name }, func(m api.ProjectMilestone) string { return m.ID })
+	})
 }
 
 // UpdateProjectMilestone updates an existing milestone via the mutation seam,
@@ -689,24 +730,30 @@ func (lfs *LinearFS) UpdateProjectMilestone(ctx context.Context, milestoneID str
 	return milestone, nil
 }
 
-// ResolveCycleID resolves a cycle name to its ID
+// ResolveCycleID resolves a cycle name to its ID. A local catalog miss
+// triggers one targeted refresh + retry (see catalogrefresh.go).
 func (lfs *LinearFS) ResolveCycleID(ctx context.Context, teamID string, cycleName string) (string, error) {
-	cycles, err := lfs.repo.GetTeamCycles(ctx, teamID)
-	if err != nil {
-		return "", err
-	}
-	return resolveByName(cycles, cycleName, "cycle",
-		func(c api.Cycle) string { return c.Name }, func(c api.Cycle) string { return c.ID })
+	return lfs.resolveWithRefresh(ctx, CatalogCycles, teamID, func() (string, error) {
+		cycles, err := lfs.repo.GetTeamCycles(ctx, teamID)
+		if err != nil {
+			return "", err
+		}
+		return resolveByName(cycles, cycleName, "cycle",
+			func(c api.Cycle) string { return c.Name }, func(c api.Cycle) string { return c.ID })
+	})
 }
 
-// ResolveInitiativeID converts an initiative name to its ID
+// ResolveInitiativeID converts an initiative name to its ID. A local catalog
+// miss triggers one targeted refresh + retry (see catalogrefresh.go).
 func (lfs *LinearFS) ResolveInitiativeID(ctx context.Context, initiativeName string) (string, error) {
-	initiatives, err := lfs.repo.GetInitiatives(ctx)
-	if err != nil {
-		return "", err
-	}
-	return resolveByName(initiatives, initiativeName, "initiative",
-		func(i api.Initiative) string { return i.Name }, func(i api.Initiative) string { return i.ID })
+	return lfs.resolveWithRefresh(ctx, CatalogInitiatives, "", func() (string, error) {
+		initiatives, err := lfs.repo.GetInitiatives(ctx)
+		if err != nil {
+			return "", err
+		}
+		return resolveByName(initiatives, initiativeName, "initiative",
+			func(i api.Initiative) string { return i.Name }, func(i api.Initiative) string { return i.ID })
+	})
 }
 
 // UpdateLabel updates a label

--- a/internal/fs/resolve.go
+++ b/internal/fs/resolve.go
@@ -40,7 +40,9 @@ func resolveByName[T any](items []T, name, label string, nameOf, idOf func(T) st
 			return idOf(it), nil
 		}
 	}
-	return "", fmt.Errorf("unknown %s: %s", label, name)
+	// Typed local-miss marker: same message as the old fmt.Errorf, but it is
+	// what arms the refresh-and-retry (see catalogrefresh.go).
+	return "", &unknownNameError{label: label, name: name}
 }
 
 // Name→ID resolution for issue edits.

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -302,6 +302,11 @@ Failure model (every writable surface follows this contract):
 - Whatever the errno, the reason lands in .error; success clears it.
 So an edit that "fails" or appears to no-op is explained at the sibling .error.
 
+Stale-catalog self-healing: a name that resolves nowhere locally (a status,
+label, assignee, project, milestone, cycle, or initiative created in Linear
+moments ago) triggers ONE targeted catalog refresh and one retry before the
+write fails — a value that really exists usually just works on first write.
+
 Validated issue fields: status, assignee, labels, priority, project, milestone, cycle, parent
 Validated project fields: initiatives, labels
 Reference files: states.md (valid statuses), labels.md (valid issue labels),

--- a/internal/integration/readme_test.go
+++ b/internal/integration/readme_test.go
@@ -32,7 +32,9 @@ func TestGeneratedReadmeMatchesBehavior(t *testing.T) {
 	// "creates one item" pins the per-write-cycle semantics (each write to
 	// _create creates another item — the old node-level buffers silently
 	// swallowed the second write, so nothing documented it).
-	for _, want := range []string{".last", "issue.meta", "initiative.meta", "recent/", "recent created updates", "relations, updates", "creates one item"} {
+	// "targeted catalog refresh" pins the stale-catalog self-healing doc (#246):
+	// a local name→ID miss refreshes the catalog once and retries before .error.
+	for _, want := range []string{".last", "issue.meta", "initiative.meta", "recent/", "recent created updates", "relations, updates", "creates one item", "targeted catalog refresh"} {
 		if !strings.Contains(readme, want) {
 			t.Errorf("README does not mention %q", want)
 		}

--- a/internal/integration/validation_refresh_test.go
+++ b/internal/integration/validation_refresh_test.go
@@ -1,0 +1,224 @@
+package integration
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	gosync "sync"
+	"testing"
+
+	"github.com/jra3/linear-fuse/internal/api"
+	"github.com/jra3/linear-fuse/internal/db"
+	"github.com/jra3/linear-fuse/internal/fs"
+	"github.com/jra3/linear-fuse/internal/testutil/mockmutation"
+)
+
+// Validation-failure refresh-and-retry (#246), exercised at the write-handler
+// seam: FUSE writes against the mounted fixture store, mutations through the
+// mock client, and the catalog refresh through the injected test seam so the
+// suite stays network-free.
+
+// catalogRefreshRecorder installs a stub catalog refresher that records every
+// call and runs onRefresh (which may upsert the "just created in Linear"
+// entity into the fixture store). Restored on cleanup.
+func catalogRefreshRecorder(t *testing.T, onRefresh func(ctx context.Context) error) *refreshCalls {
+	t.Helper()
+	rec := &refreshCalls{}
+	lfs.InjectTestCatalogRefresher(func(ctx context.Context, kind fs.CatalogKind, scopeID string) error {
+		rec.mu.Lock()
+		rec.calls = append(rec.calls, string(kind)+"/"+scopeID)
+		rec.mu.Unlock()
+		if onRefresh != nil {
+			return onRefresh(ctx)
+		}
+		return nil
+	})
+	t.Cleanup(func() { lfs.InjectTestCatalogRefresher(nil) })
+	return rec
+}
+
+type refreshCalls struct {
+	mu    gosync.Mutex
+	calls []string
+}
+
+func (r *refreshCalls) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.calls...)
+}
+
+// createRefreshTestIssue creates a fresh fixture issue via issues/_create (so
+// the shared fixture issues stay untouched) and returns its identifier.
+func createRefreshTestIssue(t *testing.T, title string) string {
+	t.Helper()
+	if err := writeCreateSpec(t, "---\ntitle: "+title+"\n---\nrefresh-retry probe body\n"); err != nil {
+		t.Fatalf("create probe issue: %v", err)
+	}
+	for _, e := range parseLastSidecar(t, issuesLastPath(testTeamKey)) {
+		if e["title"] == title && e["identifier"] != "" {
+			return e["identifier"]
+		}
+	}
+	t.Fatalf("issues/.last has no entry for %q", title)
+	return ""
+}
+
+// readIssueError returns the issue-level .error content ("" when clear —
+// missing file and empty file both count as clear).
+func readIssueError(t *testing.T, identifier string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(issueDirPath(testTeamKey, identifier), ".error"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// TestStaleCatalogWriteSelfHeals: a frontmatter write referencing a label that
+// exists remotely but not locally succeeds after exactly one targeted refresh
+// + retry — the refresh stub plays "Linear has it", upserting the label the
+// way the real refresh's team-metadata drain would.
+func TestStaleCatalogWriteSelfHeals(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-only: exercises the injected catalog-refresh seam")
+	}
+	enableMockMutations(t)
+	identifier := createRefreshTestIssue(t, "Stale Catalog Self-Heal Probe")
+
+	rec := catalogRefreshRecorder(t, func(ctx context.Context) error {
+		label := api.Label{
+			ID:    "label-teammate-fresh",
+			Name:  "TeammateFresh",
+			Color: "#00ff00",
+			Team:  &api.Team{ID: testTeamID},
+		}
+		params, err := db.APILabelToDBLabel(label)
+		if err != nil {
+			return err
+		}
+		return testStore.Queries().UpsertLabel(ctx, params)
+	})
+
+	path := issueFilePath(testTeamKey, identifier)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read probe issue: %v", err)
+	}
+	modified, err := modifyFrontmatter(content, "labels", []string{"TeammateFresh"})
+	if err != nil {
+		t.Fatalf("modify frontmatter: %v", err)
+	}
+	if err := os.WriteFile(path, modified, 0644); err != nil {
+		t.Fatalf("write should self-heal via refresh+retry, got: %v", err)
+	}
+
+	calls := rec.snapshot()
+	if len(calls) != 1 || calls[0] != "labels/"+testTeamID {
+		t.Errorf("refresh calls = %v, want exactly [labels/%s]", calls, testTeamID)
+	}
+	if e := readIssueError(t, identifier); e != "" {
+		t.Errorf(".error should be clear after a self-healed write, got: %s", e)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("re-read issue: %v", err)
+	}
+	if !strings.Contains(string(after), "TeammateFresh") {
+		t.Errorf("label not applied after self-heal:\n%s", after)
+	}
+}
+
+// TestNonexistentNameFailsAfterOneRefresh: a genuinely nonexistent name still
+// fails with the same .error message as before — after exactly one refresh
+// attempt, never more.
+func TestNonexistentNameFailsAfterOneRefresh(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-only: exercises the injected catalog-refresh seam")
+	}
+	enableMockMutations(t)
+	identifier := createRefreshTestIssue(t, "Nonexistent Name Probe")
+
+	rec := catalogRefreshRecorder(t, nil) // refresh finds nothing new
+
+	path := issueFilePath(testTeamKey, identifier)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read probe issue: %v", err)
+	}
+	modified, err := modifyFrontmatter(content, "status", "__no_such_state__")
+	if err != nil {
+		t.Fatalf("modify frontmatter: %v", err)
+	}
+	if err := os.WriteFile(path, modified, 0644); err == nil {
+		t.Fatal("write with a nonexistent status should fail (EINVAL)")
+	}
+
+	calls := rec.snapshot()
+	if len(calls) != 1 || calls[0] != "states/"+testTeamID {
+		t.Errorf("refresh calls = %v, want exactly [states/%s]", calls, testTeamID)
+	}
+	errContent := readIssueError(t, identifier)
+	if !strings.Contains(errContent, "unknown state: __no_such_state__") {
+		t.Errorf(".error lost the pre-refresh message, got: %s", errContent)
+	}
+	if !strings.Contains(errContent, "states.md") {
+		t.Errorf(".error lost the states.md pointer, got: %s", errContent)
+	}
+}
+
+// rejectingMutator is the mock mutation client with UpdateIssue failing the
+// way a server-side rejection does — classifyMutationErr territory.
+type rejectingMutator struct {
+	*mockmutation.Client
+}
+
+func (r rejectingMutator) UpdateIssue(ctx context.Context, issueID string, input map[string]any) error {
+	return errors.New("server rejected the update")
+}
+
+// TestAPIRejectionDoesNotRefresh: an API-side rejection takes the existing
+// classifier path untouched — resolution succeeded locally, so the catalog
+// refresh never fires.
+func TestAPIRejectionDoesNotRefresh(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-only: exercises the injected catalog-refresh seam")
+	}
+	enableMockMutations(t)
+	identifier := createRefreshTestIssue(t, "API Rejection Probe")
+
+	// Swap in the rejecting mutator for the edit itself (restored before
+	// enableMockMutations' own cleanup resets to the real client).
+	lfs.InjectTestMutationClient(rejectingMutator{mockmutation.New(
+		mockmutation.WithTeamKey(testTeamKey),
+		mockmutation.WithStore(lfs.GetStore()),
+	)})
+	t.Cleanup(func() { lfs.InjectTestMutationClient(nil) })
+
+	rec := catalogRefreshRecorder(t, nil)
+
+	path := issueFilePath(testTeamKey, identifier)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read probe issue: %v", err)
+	}
+	// "Done" resolves against the fixture catalog, so the failure is purely
+	// the mutation's.
+	modified, err := modifyFrontmatter(content, "status", "Done")
+	if err != nil {
+		t.Fatalf("modify frontmatter: %v", err)
+	}
+	if err := os.WriteFile(path, modified, 0644); err == nil {
+		t.Fatal("write should surface the API rejection")
+	}
+
+	if calls := rec.snapshot(); len(calls) != 0 {
+		t.Errorf("API-side rejection must not trigger a catalog refresh, got: %v", calls)
+	}
+	errContent := readIssueError(t, identifier)
+	if !strings.Contains(errContent, "update issue") {
+		t.Errorf(".error should carry the classifier's mutation message, got: %s", errContent)
+	}
+}

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -603,6 +603,25 @@ func (w *Worker) syncInitiativeProjects(ctx context.Context, initiative api.Init
 // Team Metadata Sync
 // =============================================================================
 
+// RefreshTeamCatalogs synchronously re-syncs one team's catalog metadata —
+// states, labels, cycles, projects (with milestones), and members — on demand.
+// It backs the write path's validation-failure refresh (#246): a frontmatter
+// write that fails name→ID resolution against the local catalog triggers
+// exactly one of these before its single retry. Reuses the background cycle's
+// complete-drain machinery, so budget gates (GetTeamMetadata's LowBudget
+// preflight) and prune licensing apply unchanged.
+func (w *Worker) RefreshTeamCatalogs(ctx context.Context, teamID string) error {
+	return w.syncTeamMetadata(ctx, api.Team{ID: teamID})
+}
+
+// RefreshWorkspaceCatalogs synchronously re-syncs the workspace-level catalogs
+// (users, initiatives with their project links, project labels) on demand —
+// the workspace-scoped sibling of RefreshTeamCatalogs (#246). Budget-gated by
+// GetWorkspace's LowBudget preflight.
+func (w *Worker) RefreshWorkspaceCatalogs(ctx context.Context) error {
+	return w.syncWorkspace(ctx)
+}
+
 // syncTeamMetadata syncs all metadata for a team: states, labels, cycles,
 // projects (with milestones), and members. GetTeamMetadata drains every
 // unbounded connection, so meta is the complete server-side truth — which


### PR DESCRIPTION
## Summary

Implements #246 (diet slice 5 of the #238 PRD): when a frontmatter write fails **local** name→ID resolution against a cached catalog — a state, label, project, milestone, cycle, assignee, or initiative name that isn't in SQLite yet — the write handler triggers **one** targeted refresh of that catalog, retries the resolution **once**, and only then surfaces the existing validation error to `.error`/`EINVAL`. A name a teammate created minutes ago self-heals instead of failing on the sync cadence; API-side rejections (`classifyMutationErr` territory) are untouched.

## Design

- **Trigger:** `resolveByName` now mints a typed `*unknownNameError` (message byte-identical to the old `fmt.Errorf`, so `.error` content is unchanged). Only this error arms the refresh; repo/infrastructure errors pass through untouched.
- **Wrap point — inside the resolve layer:** `resolveWithRefresh` (`internal/fs/catalogrefresh.go`) wraps every `Resolve*` lookup on `LinearFS` (state, labels, project, milestone, cycle, user, initiative), so issue `Flush`, `issues/_create`, and the project/initiative edit paths (`reconcileLinks`) all inherit the behavior with zero call-site edits.
- **One new seam:** `LinearFS.catalogRefreshImpl` (a single function field, guarded by the existing `mutatorMu`; swappable via `InjectTestCatalogRefresher`). The default routes through the sync worker's existing complete-drain machinery via two new exported wrappers — `Worker.RefreshTeamCatalogs` (states/labels/cycles/projects+milestones/members via `GetTeamMetadata`) and `Worker.RefreshWorkspaceCatalogs` (users/initiatives via `GetWorkspace`) — so **budget gates (LowBudget preflights) and prune licensing apply unchanged**. Milestones map project→team locally via `GetProjectPrimaryTeamKey` first (no API).
- **Offline by construction:** without a sync worker (fixture mode, unit tests) the default refresh declines and the original miss surfaces exactly as before — no network, same `.error`.
- **Exactly once:** one refresh + one retry per resolution, no loops; a refresh failure is logged and the original miss surfaces.

Deliberately out of scope: `ResolveProjectSlugToID` (initiative.md's workspace-wide slug resolution — a scoped refresh would drain every team's projects for one miss) and `ResolveIssueID` (issues aren't a catalog). Recorded in CONTEXT.md.

## Tests

- `internal/fs/catalogrefresh_test.go`: unit table pinning the whole contract — hit/no-refresh, miss→refresh→hit, persistent miss (same error, refresh ran once, resolve ran twice), infra error never refreshes, refresh failure surfaces the miss, no-worker decline, typed-miss message compatibility.
- `internal/integration/validation_refresh_test.go` (write-handler seam, mock mutation client + real SQLite store, mounted FUSE, network-free):
  - **stale-catalog success** — label missing locally, injected refresh supplies it, write succeeds, exactly one `labels/team-1` refresh, `.error` clear;
  - **nonexistent name** — refresh runs exactly once, the pre-refresh `.error` message (`unknown state: …` + `states.md` pointer) surfaces unchanged;
  - **API rejection** — locally-valid status, `UpdateIssue` rejects → classifier path, **zero** refresh calls.
- Generated README documents the self-healing (validation_errors section) and `TestGeneratedReadmeMatchesBehavior` pins it; CONTEXT.md gains a "Catalog refresh-and-retry" entry.

`go build ./...`, full `go test ./...`, and `make staticcheck` are green (one integration-suite run hit the known pre-existing whole-suite flake; 3 subsequent runs green).

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)