### PR TITLE
feat: expose links/ surface on projects and initiatives (#249)

### DIFF
--- a/docs/plans/2026-07-10-project-initiative-links.md
+++ b/docs/plans/2026-07-10-project-initiative-links.md
@@ -1,0 +1,116 @@
+# Project & Initiative external-link surface (issue #249)
+
+**Branch:** `feat/249-project-attachments` · **Worktree:** `linear-fuse-249-project-attachments`
+
+## Summary
+
+Issue #249 asks to expose an `attachments/` surface on projects (and ideally
+initiatives), mirroring the per-issue `attachments/` directory. Schema
+investigation shows the underlying Linear entity is **not** `Attachment`
+(issue-only; `AttachmentCreateInput.issueId` is required) but a distinct entity,
+**`EntityExternalLink`** — the "Links / Resources" section on projects and
+initiatives.
+
+Decision: name the FS surface **`links/`** (honest to `EntityExternalLink`,
+whose field is `label` not `title`) and cover **both projects and initiatives**
+(same entity + mutations, small marginal cost).
+
+```
+teams/{KEY}/projects/{slug}/links/
+  _create      # echo "https://notes.granola.ai/... [Onboarding Sync]" > _create
+  .error
+  .last
+  *.link
+initiatives/{slug}/links/
+  _create
+  .error
+  .last
+  *.link
+```
+
+Write contract identical to issue attachments: write `"URL [label]"` to
+`_create`, read back `.last`/`.error`, `rm *.link` to delete. Reuses the generic
+collection machinery (`collectionTrio`, `commitCreate`, `commitDelete`).
+
+## Linear API facts (verified against docs/linear-schema.graphql)
+
+- **Entity:** `type EntityExternalLink { id, label: String!, url: String!, sortOrder, creator, project, initiative, createdAt, updatedAt }`
+- **Read:** `project.externalLinks(...)` → `EntityExternalLinkConnection!`;
+  `initiative.links(...)` → `EntityExternalLinkConnection!`
+- **Create:** `entityExternalLinkCreate(input: EntityExternalLinkCreateInput)` → `EntityExternalLinkPayload!`
+  - Input: `{ url: String!, label: String!, projectId?, initiativeId?, cycleId?, teamId?, sortOrder?, id? }` — supply exactly one parent id.
+- **Update:** `entityExternalLinkUpdate(id, input)` (label/url/sortOrder)
+- **Delete:** `entityExternalLinkDelete(id)` → payload with `success`
+- No dedup-by-url semantics on the server (unlike issue attachments, where
+  `attachmentLinkURL` upserts on duplicate URL). So the idempotency pre-check
+  in the create path must be our own (query existing links, match by url).
+
+## Implementation layers
+
+Mirrors the issue-attachment code paths noted in the exploration. Reference
+points (in the issue plumbing) to copy from:
+
+### 1. `internal/api` — new EntityExternalLink entity
+- **types.go:** add `EntityExternalLink` struct (mirror `Attachment` at types.go:360; fields: ID, Label, URL, SortOrder, Creator, CreatedAt, UpdatedAt).
+- **queries.go:**
+  - `EntityExternalLinkFieldsFragment` (mirror `AttachmentFieldsFragment` queries.go:240).
+  - `queryProjectExternalLinks` (`project(id).externalLinks(first:100)`), `queryInitiativeExternalLinks` (`initiative(id).links(first:100)`).
+  - `mutationCreateEntityExternalLink`, `mutationDeleteEntityExternalLink` (+ update if we want edit later). Project each through the fragment (per CLAUDE.md fragment rule).
+- **client.go:** `GetProjectLinks(ctx, projectID)`, `GetInitiativeLinks(ctx, initiativeID)`, `CreateEntityExternalLink(ctx, parentKind, parentID, url, label)`, `DeleteEntityExternalLink(ctx, id)`. Use `fetchNodes[EntityExternalLink]` for the reads (mirror `GetIssueAttachments` client.go:889).
+
+### 2. `internal/api/mutationclient.go` — extend the mutation seam
+- Add `CreateEntityExternalLink` + `DeleteEntityExternalLink` to the `MutationClient` interface and the real impl (mirror `LinkURL`/`DeleteAttachment` mutationclient.go:64).
+- Update `internal/testutil/mockmutation` accordingly.
+
+### 3. `internal/db` — storage
+- **schema.sql:** new table `entity_external_links` (id PK, `project_id` NULL, `initiative_id` NULL, label, url, sort_order, creator_*, created_at, updated_at, synced_at, data JSON). Indexes on `project_id` and `initiative_id`. (Polymorphic parent via two nullable FKs, matching how the codebase keeps IDs globally unique.)
+- **queries.sql:** `ListProjectLinks`, `ListInitiativeLinks`, `UpsertEntityExternalLink`, `DeleteEntityExternalLink`, `PruneProjectLinks`, `PruneInitiativeLinks`. Run `sqlc generate`.
+- **convert.go:** `APIEntityExternalLinkToDB(...)`, `DBEntityExternalLinkToAPI(...)`, slice variants (mirror convert.go:882).
+
+### 4. `internal/repo` — access methods
+- Interface (`repo.go`) + sqlite impl (`sqlite.go`) + mock (`mock.go`):
+  `GetProjectLinks(ctx, projectID)`, `GetInitiativeLinks(ctx, initiativeID)`
+  (mirror `GetIssueAttachments` sqlite.go:1093).
+
+### 5. `internal/fs` — the `links/` node
+- New `LinksNode` generalized like `DocsNode` (documents.go:19) — carry
+  `projectID`/`initiativeID`, dispatch on whichever is set; single parent key via
+  a `linkParentID(...)` helper.
+  - `Readdir`/`Lookup` mirror `AttachmentsNode` (attachments.go:30/71).
+  - `trio()` → `collectionTrio{kind:"links", parentID, onFlush: createLink}`.
+  - `listing()` → fetch project/initiative links, wrap in a `linkListing`
+    (mirror `attachmentListing` / `attachmentlisting.go`; name = `sanitizeFilename(label)+".link"`).
+  - `ExternalLinkNode` (`*.link` file) mirror `ExternalAttachmentNode`
+    (attachments.go:209) incl. `Unlink` → `commitDelete`.
+  - `createLink` mirror `createAttachment` (attachments.go:269) incl. our own
+    url-dedup pre-check via `GetProjectLinks`/`GetInitiativeLinks`.
+- **ino.go:** `linksDirIno(parentID)=ino("links", id)`, `externalLinkIno(id)=ino("extlink", id)` (guard: `TestInodeNamespaceDistinct`).
+- **Wire-in:**
+  - projects.go manifest (~projects.go:298): `m.subdir("links", linksDirIno(project.ID), ...)`.
+  - initiatives.go manifest (~initiatives.go:155): `m.subdir("links", linksDirIno(initiative.ID), ...)`.
+
+### 6. Sync / reconcile (optional for MVP, needed for background freshness)
+- `internal/reconcile/details.go` (~:94) + `internal/sync/worker.go` — reconcile
+  project/initiative links so they populate without a write. MVP can fetch
+  lazily on Readdir (like `AttachmentsNode` does via repo) and defer sync
+  integration; note the gap if deferred.
+
+### 7. Generated README (REQUIRED — CLAUDE.md contract)
+- Update `generateReadme` (internal/fs/root.go) to document the project/initiative
+  `links/` surface (directory map + `_create` behavior + write-only note).
+- Extend `TestGeneratedReadmeMatchesBehavior` (internal/integration/readme_test.go)
+  to assert the `links/` surface is described and `_create` is unreadable.
+
+### 8. Tests
+- Unit: `LinksNode` readdir/lookup/create/delete; url-dedup pre-check; label
+  sanitization/dedup. Mock mutation client.
+- Integration: create a link on a project + on an initiative, read `.last`, `rm`.
+
+## Open questions / risks
+- **Dedup:** confirm server behavior on duplicate url per parent — schema shows no
+  unique-url guarantee for `EntityExternalLink`, so our create pre-check is the
+  only dedup. Verify against live API before relying on it.
+- **`label` required:** `_create` line must always yield a non-empty label;
+  default to the URL when no `[label]` given (matches issue-attachment title default).
+- **Reconcile scope:** decide MVP (lazy fetch only) vs. full sync-worker
+  integration for this branch.

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -891,6 +891,18 @@ func (c *Client) GetIssueAttachments(ctx context.Context, issueID string) ([]Att
 		map[string]any{"issueId": issueID}, "issue", "attachments")
 }
 
+// GetProjectLinks fetches the external links ("Links / Resources") for a project.
+func (c *Client) GetProjectLinks(ctx context.Context, projectID string) ([]EntityExternalLink, error) {
+	return fetchNodes[EntityExternalLink](ctx, c, queryProjectExternalLinks,
+		map[string]any{"projectId": projectID}, "project", "externalLinks")
+}
+
+// GetInitiativeLinks fetches the external links for an initiative.
+func (c *Client) GetInitiativeLinks(ctx context.Context, initiativeID string) ([]EntityExternalLink, error) {
+	return fetchNodes[EntityExternalLink](ctx, c, queryInitiativeExternalLinks,
+		map[string]any{"initiativeId": initiativeID}, "initiative", "links")
+}
+
 // GetIssueHistory fetches the history/audit trail for an issue, drained —
 // it backs history.md live and an old issue's trail outgrows a page.
 func (c *Client) GetIssueHistory(ctx context.Context, issueID string) ([]IssueHistoryEntry, error) {
@@ -999,6 +1011,23 @@ func (c *Client) LinkURL(ctx context.Context, issueID, url, title string) (*Atta
 // DeleteAttachment deletes an attachment
 func (c *Client) DeleteAttachment(ctx context.Context, attachmentID string) error {
 	return execMutationOK(ctx, c, mutationDeleteAttachment, map[string]any{"id": attachmentID}, "attachmentDelete")
+}
+
+// =============================================================================
+// Entity External Links (project/initiative "Links / Resources")
+// =============================================================================
+
+// CreateEntityExternalLink creates an external link on a project or initiative.
+// The input map carries the EntityExternalLinkCreateInput fields — required
+// `url` and `label`, plus exactly one parent id (`projectId` or `initiativeId`).
+func (c *Client) CreateEntityExternalLink(ctx context.Context, input map[string]any) (*EntityExternalLink, error) {
+	return execMutation[EntityExternalLink](ctx, c, mutationCreateEntityExternalLink,
+		map[string]any{"input": input}, "entityExternalLinkCreate", "entityExternalLink")
+}
+
+// DeleteEntityExternalLink deletes an external link by ID.
+func (c *Client) DeleteEntityExternalLink(ctx context.Context, id string) error {
+	return execMutationOK(ctx, c, mutationDeleteEntityExternalLink, map[string]any{"id": id}, "entityExternalLinkDelete")
 }
 
 // LowBudget reports whether a conservatively-priced list-tier request would

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -251,6 +251,22 @@ fragment AttachmentFields on Attachment {
 }
 `
 
+// EntityExternalLinkFieldsFragment is a GraphQL fragment for external-link
+// fields on a project or initiative ("Links / Resources"). One field set backs
+// the project.externalLinks / initiative.links reads and the create mutation, so
+// a created link carries the same fields a fetched one does.
+const EntityExternalLinkFieldsFragment = `
+fragment EntityExternalLinkFields on EntityExternalLink {
+  id
+  label
+  url
+  sortOrder
+  createdAt
+  updatedAt
+  creator { id name email }
+}
+`
+
 // ProjectMilestoneFields is the shared projection for a project milestone,
 // used by the nested selections in queryTeamProjects/queryProject and the
 // create/update mutations.
@@ -734,6 +750,32 @@ query IssueAttachments($issueId: String!) {
 }
 ` + AttachmentFieldsFragment
 
+// queryProjectExternalLinks fetches the external links ("Links / Resources") for
+// a project. DELIBERATE cap: first: 100, single page, no drain — same rationale
+// as queryIssueAttachments (this serves the interactive link create re-check, a
+// user-blocking write path fetchAll's LowBudget gate must never sit on).
+var queryProjectExternalLinks = `
+query ProjectExternalLinks($projectId: String!) {
+  project(id: $projectId) {
+    externalLinks(first: 100) {
+      nodes { ...EntityExternalLinkFields }
+    }
+  }
+}
+` + EntityExternalLinkFieldsFragment
+
+// queryInitiativeExternalLinks fetches the external links for an initiative.
+// Same single-page cap and rationale as queryProjectExternalLinks.
+var queryInitiativeExternalLinks = `
+query InitiativeExternalLinks($initiativeId: String!) {
+  initiative(id: $initiativeId) {
+    links(first: 100) {
+      nodes { ...EntityExternalLinkFields }
+    }
+  }
+}
+` + EntityExternalLinkFieldsFragment
+
 var mutationCreateComment = `
 mutation CreateComment($issueId: String!, $body: String!) {
   commentCreate(input: { issueId: $issueId, body: $body }) {
@@ -899,6 +941,27 @@ mutation AttachmentLinkURL($issueId: String!, $url: String!, $title: String) {
 const mutationDeleteAttachment = `
 mutation DeleteAttachment($id: String!) {
   attachmentDelete(id: $id) {
+    success
+  }
+}
+`
+
+// =============================================================================
+// Entity External Links (project/initiative "Links / Resources")
+// =============================================================================
+
+var mutationCreateEntityExternalLink = `
+mutation CreateEntityExternalLink($input: EntityExternalLinkCreateInput!) {
+  entityExternalLinkCreate(input: $input) {
+    success
+    entityExternalLink { ...EntityExternalLinkFields }
+  }
+}
+` + EntityExternalLinkFieldsFragment
+
+const mutationDeleteEntityExternalLink = `
+mutation DeleteEntityExternalLink($id: String!) {
+  entityExternalLinkDelete(id: $id) {
     success
   }
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -369,6 +369,20 @@ type Attachment struct {
 	UpdatedAt  time.Time              `json:"updatedAt"`
 }
 
+// EntityExternalLink represents an external link ("Links / Resources") on a
+// project or initiative. It is a distinct Linear entity from Attachment (which
+// is issue-only): its parent is a project or initiative, and its display field
+// is Label rather than Title.
+type EntityExternalLink struct {
+	ID        string    `json:"id"`
+	Label     string    `json:"label"`
+	URL       string    `json:"url"`
+	SortOrder float64   `json:"sortOrder"`
+	Creator   *User     `json:"creator"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
 // EmbeddedFile represents a file uploaded to Linear's CDN (image, PDF, etc.)
 type EmbeddedFile struct {
 	ID        string    // SHA256 hash of URL

--- a/internal/db/convert.go
+++ b/internal/db/convert.go
@@ -930,6 +930,61 @@ func DBAttachmentsToAPIAttachments(attachments []Attachment) ([]api.Attachment, 
 }
 
 // =============================================================================
+// Entity External Link Conversion (project/initiative "Links / Resources")
+// =============================================================================
+
+// APIEntityExternalLinkToDB converts an api.EntityExternalLink to
+// UpsertEntityExternalLinkParams. Exactly one of projectID/initiativeID is set
+// (the other empty), matching the entity's polymorphic parent.
+func APIEntityExternalLinkToDB(link api.EntityExternalLink, projectID, initiativeID string) (UpsertEntityExternalLinkParams, error) {
+	data, err := json.Marshal(link)
+	if err != nil {
+		return UpsertEntityExternalLinkParams{}, err
+	}
+
+	params := UpsertEntityExternalLinkParams{
+		ID:           link.ID,
+		ProjectID:    sql.NullString{String: projectID, Valid: projectID != ""},
+		InitiativeID: sql.NullString{String: initiativeID, Valid: initiativeID != ""},
+		Label:        link.Label,
+		Url:          link.URL,
+		SortOrder:    sql.NullFloat64{Float64: link.SortOrder, Valid: true},
+		CreatedAt:    sql.NullTime{Time: link.CreatedAt, Valid: !link.CreatedAt.IsZero()},
+		UpdatedAt:    sql.NullTime{Time: link.UpdatedAt, Valid: !link.UpdatedAt.IsZero()},
+		SyncedAt:     Now(),
+		Data:         data,
+	}
+	if link.Creator != nil {
+		params.CreatorID = sql.NullString{String: link.Creator.ID, Valid: true}
+		params.CreatorName = sql.NullString{String: link.Creator.Name, Valid: true}
+		params.CreatorEmail = sql.NullString{String: link.Creator.Email, Valid: true}
+	}
+	return params, nil
+}
+
+// DBEntityExternalLinkToAPI converts a db.EntityExternalLink to api.EntityExternalLink
+func DBEntityExternalLinkToAPI(link EntityExternalLink) (api.EntityExternalLink, error) {
+	var apiLink api.EntityExternalLink
+	if err := json.Unmarshal(link.Data, &apiLink); err != nil {
+		return api.EntityExternalLink{}, err
+	}
+	return apiLink, nil
+}
+
+// DBEntityExternalLinksToAPI converts a slice of db.EntityExternalLink to api.EntityExternalLink
+func DBEntityExternalLinksToAPI(links []EntityExternalLink) ([]api.EntityExternalLink, error) {
+	result := make([]api.EntityExternalLink, len(links))
+	for i, link := range links {
+		apiLink, err := DBEntityExternalLinkToAPI(link)
+		if err != nil {
+			return nil, err
+		}
+		result[i] = apiLink
+	}
+	return result, nil
+}
+
+// =============================================================================
 // EmbeddedFile Conversion (images, PDFs from Linear CDN)
 // =============================================================================
 

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -90,6 +90,22 @@ type EmbeddedFile struct {
 	SyncedAt  time.Time      `json:"synced_at"`
 }
 
+type EntityExternalLink struct {
+	ID           string          `json:"id"`
+	ProjectID    sql.NullString  `json:"project_id"`
+	InitiativeID sql.NullString  `json:"initiative_id"`
+	Label        string          `json:"label"`
+	Url          string          `json:"url"`
+	SortOrder    sql.NullFloat64 `json:"sort_order"`
+	CreatorID    sql.NullString  `json:"creator_id"`
+	CreatorName  sql.NullString  `json:"creator_name"`
+	CreatorEmail sql.NullString  `json:"creator_email"`
+	CreatedAt    sql.NullTime    `json:"created_at"`
+	UpdatedAt    sql.NullTime    `json:"updated_at"`
+	SyncedAt     time.Time       `json:"synced_at"`
+	Data         json.RawMessage `json:"data"`
+}
+
 type Initiative struct {
 	ID          string          `json:"id"`
 	SlugID      string          `json:"slug_id"`

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -666,6 +666,50 @@ DELETE FROM attachments WHERE issue_id = ? AND synced_at < ?;
 DELETE FROM attachments WHERE issue_id = ?;
 
 -- =============================================================================
+-- Entity external links queries (project/initiative "Links / Resources")
+-- =============================================================================
+
+-- name: ListProjectLinks :many
+-- The id tiebreaker keeps the order deterministic on equal sort_order, so
+-- linkListing dedup suffixes stay stable across calls.
+SELECT * FROM entity_external_links WHERE project_id = ? ORDER BY sort_order, id;
+
+-- name: ListInitiativeLinks :many
+SELECT * FROM entity_external_links WHERE initiative_id = ? ORDER BY sort_order, id;
+
+-- name: GetProjectLinksSyncedAt :one
+SELECT MAX(synced_at) FROM entity_external_links WHERE project_id = ?;
+
+-- name: GetInitiativeLinksSyncedAt :one
+SELECT MAX(synced_at) FROM entity_external_links WHERE initiative_id = ?;
+
+-- name: UpsertEntityExternalLink :exec
+INSERT INTO entity_external_links (id, project_id, initiative_id, label, url, sort_order, creator_id, creator_name, creator_email, created_at, updated_at, synced_at, data)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+    project_id = excluded.project_id,
+    initiative_id = excluded.initiative_id,
+    label = excluded.label,
+    url = excluded.url,
+    sort_order = excluded.sort_order,
+    creator_id = excluded.creator_id,
+    creator_name = excluded.creator_name,
+    creator_email = excluded.creator_email,
+    created_at = excluded.created_at,
+    updated_at = excluded.updated_at,
+    synced_at = excluded.synced_at,
+    data = excluded.data;
+
+-- name: DeleteEntityExternalLink :exec
+DELETE FROM entity_external_links WHERE id = ?;
+
+-- name: DeleteProjectLinks :exec
+DELETE FROM entity_external_links WHERE project_id = ?;
+
+-- name: DeleteInitiativeLinks :exec
+DELETE FROM entity_external_links WHERE initiative_id = ?;
+
+-- =============================================================================
 -- Embedded Files queries (images, PDFs from Linear CDN)
 -- =============================================================================
 

--- a/internal/db/queries.sql.go
+++ b/internal/db/queries.sql.go
@@ -50,6 +50,15 @@ func (q *Queries) DeleteDocument(ctx context.Context, id string) error {
 	return err
 }
 
+const deleteEntityExternalLink = `-- name: DeleteEntityExternalLink :exec
+DELETE FROM entity_external_links WHERE id = ?
+`
+
+func (q *Queries) DeleteEntityExternalLink(ctx context.Context, id string) error {
+	_, err := q.db.ExecContext(ctx, deleteEntityExternalLink, id)
+	return err
+}
+
 const deleteInitiative = `-- name: DeleteInitiative :exec
 DELETE FROM initiatives WHERE id = ?
 `
@@ -65,6 +74,15 @@ DELETE FROM documents WHERE initiative_id = ?
 
 func (q *Queries) DeleteInitiativeDocuments(ctx context.Context, initiativeID sql.NullString) error {
 	_, err := q.db.ExecContext(ctx, deleteInitiativeDocuments, initiativeID)
+	return err
+}
+
+const deleteInitiativeLinks = `-- name: DeleteInitiativeLinks :exec
+DELETE FROM entity_external_links WHERE initiative_id = ?
+`
+
+func (q *Queries) DeleteInitiativeLinks(ctx context.Context, initiativeID sql.NullString) error {
+	_, err := q.db.ExecContext(ctx, deleteInitiativeLinks, initiativeID)
 	return err
 }
 
@@ -217,6 +235,15 @@ func (q *Queries) DeleteProjectDocuments(ctx context.Context, projectID sql.Null
 	return err
 }
 
+const deleteProjectLinks = `-- name: DeleteProjectLinks :exec
+DELETE FROM entity_external_links WHERE project_id = ?
+`
+
+func (q *Queries) DeleteProjectLinks(ctx context.Context, projectID sql.NullString) error {
+	_, err := q.db.ExecContext(ctx, deleteProjectLinks, projectID)
+	return err
+}
+
 const deleteProjectMilestone = `-- name: DeleteProjectMilestone :exec
 DELETE FROM project_milestones WHERE id = ?
 `
@@ -290,6 +317,17 @@ SELECT MAX(synced_at) FROM documents WHERE initiative_id = ?
 
 func (q *Queries) GetInitiativeDocumentsSyncedAt(ctx context.Context, initiativeID sql.NullString) (interface{}, error) {
 	row := q.db.QueryRowContext(ctx, getInitiativeDocumentsSyncedAt, initiativeID)
+	var max interface{}
+	err := row.Scan(&max)
+	return max, err
+}
+
+const getInitiativeLinksSyncedAt = `-- name: GetInitiativeLinksSyncedAt :one
+SELECT MAX(synced_at) FROM entity_external_links WHERE initiative_id = ?
+`
+
+func (q *Queries) GetInitiativeLinksSyncedAt(ctx context.Context, initiativeID sql.NullString) (interface{}, error) {
+	row := q.db.QueryRowContext(ctx, getInitiativeLinksSyncedAt, initiativeID)
 	var max interface{}
 	err := row.Scan(&max)
 	return max, err
@@ -539,6 +577,17 @@ SELECT MAX(synced_at) FROM documents WHERE project_id = ?
 
 func (q *Queries) GetProjectDocumentsSyncedAt(ctx context.Context, projectID sql.NullString) (interface{}, error) {
 	row := q.db.QueryRowContext(ctx, getProjectDocumentsSyncedAt, projectID)
+	var max interface{}
+	err := row.Scan(&max)
+	return max, err
+}
+
+const getProjectLinksSyncedAt = `-- name: GetProjectLinksSyncedAt :one
+SELECT MAX(synced_at) FROM entity_external_links WHERE project_id = ?
+`
+
+func (q *Queries) GetProjectLinksSyncedAt(ctx context.Context, projectID sql.NullString) (interface{}, error) {
+	row := q.db.QueryRowContext(ctx, getProjectLinksSyncedAt, projectID)
 	var max interface{}
 	err := row.Scan(&max)
 	return max, err
@@ -812,6 +861,47 @@ func (q *Queries) ListInitiativeDocuments(ctx context.Context, initiativeID sql.
 			&i.InitiativeID,
 			&i.CreatorID,
 			&i.Url,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.SyncedAt,
+			&i.Data,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listInitiativeLinks = `-- name: ListInitiativeLinks :many
+SELECT id, project_id, initiative_id, label, url, sort_order, creator_id, creator_name, creator_email, created_at, updated_at, synced_at, data FROM entity_external_links WHERE initiative_id = ? ORDER BY sort_order, id
+`
+
+func (q *Queries) ListInitiativeLinks(ctx context.Context, initiativeID sql.NullString) ([]EntityExternalLink, error) {
+	rows, err := q.db.QueryContext(ctx, listInitiativeLinks, initiativeID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []EntityExternalLink{}
+	for rows.Next() {
+		var i EntityExternalLink
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.InitiativeID,
+			&i.Label,
+			&i.Url,
+			&i.SortOrder,
+			&i.CreatorID,
+			&i.CreatorName,
+			&i.CreatorEmail,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.SyncedAt,
@@ -1336,6 +1426,53 @@ func (q *Queries) ListProjectLabels(ctx context.Context) ([]ProjectLabel, error)
 			&i.IsGroup,
 			&i.ParentID,
 			&i.RetiredAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.SyncedAt,
+			&i.Data,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listProjectLinks = `-- name: ListProjectLinks :many
+
+SELECT id, project_id, initiative_id, label, url, sort_order, creator_id, creator_name, creator_email, created_at, updated_at, synced_at, data FROM entity_external_links WHERE project_id = ? ORDER BY sort_order, id
+`
+
+// =============================================================================
+// Entity external links queries (project/initiative "Links / Resources")
+// =============================================================================
+// The id tiebreaker keeps the order deterministic on equal sort_order, so
+// linkListing dedup suffixes stay stable across calls.
+func (q *Queries) ListProjectLinks(ctx context.Context, projectID sql.NullString) ([]EntityExternalLink, error) {
+	rows, err := q.db.QueryContext(ctx, listProjectLinks, projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []EntityExternalLink{}
+	for rows.Next() {
+		var i EntityExternalLink
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.InitiativeID,
+			&i.Label,
+			&i.Url,
+			&i.SortOrder,
+			&i.CreatorID,
+			&i.CreatorName,
+			&i.CreatorEmail,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.SyncedAt,
@@ -2768,6 +2905,59 @@ func (q *Queries) UpsertEmbeddedFile(ctx context.Context, arg UpsertEmbeddedFile
 		arg.Source,
 		arg.CreatedAt,
 		arg.SyncedAt,
+	)
+	return err
+}
+
+const upsertEntityExternalLink = `-- name: UpsertEntityExternalLink :exec
+INSERT INTO entity_external_links (id, project_id, initiative_id, label, url, sort_order, creator_id, creator_name, creator_email, created_at, updated_at, synced_at, data)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+    project_id = excluded.project_id,
+    initiative_id = excluded.initiative_id,
+    label = excluded.label,
+    url = excluded.url,
+    sort_order = excluded.sort_order,
+    creator_id = excluded.creator_id,
+    creator_name = excluded.creator_name,
+    creator_email = excluded.creator_email,
+    created_at = excluded.created_at,
+    updated_at = excluded.updated_at,
+    synced_at = excluded.synced_at,
+    data = excluded.data
+`
+
+type UpsertEntityExternalLinkParams struct {
+	ID           string          `json:"id"`
+	ProjectID    sql.NullString  `json:"project_id"`
+	InitiativeID sql.NullString  `json:"initiative_id"`
+	Label        string          `json:"label"`
+	Url          string          `json:"url"`
+	SortOrder    sql.NullFloat64 `json:"sort_order"`
+	CreatorID    sql.NullString  `json:"creator_id"`
+	CreatorName  sql.NullString  `json:"creator_name"`
+	CreatorEmail sql.NullString  `json:"creator_email"`
+	CreatedAt    sql.NullTime    `json:"created_at"`
+	UpdatedAt    sql.NullTime    `json:"updated_at"`
+	SyncedAt     time.Time       `json:"synced_at"`
+	Data         json.RawMessage `json:"data"`
+}
+
+func (q *Queries) UpsertEntityExternalLink(ctx context.Context, arg UpsertEntityExternalLinkParams) error {
+	_, err := q.db.ExecContext(ctx, upsertEntityExternalLink,
+		arg.ID,
+		arg.ProjectID,
+		arg.InitiativeID,
+		arg.Label,
+		arg.Url,
+		arg.SortOrder,
+		arg.CreatorID,
+		arg.CreatorName,
+		arg.CreatorEmail,
+		arg.CreatedAt,
+		arg.UpdatedAt,
+		arg.SyncedAt,
+		arg.Data,
 	)
 	return err
 }

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -394,6 +394,31 @@ CREATE INDEX IF NOT EXISTS idx_attachments_issue ON attachments(issue_id);
 CREATE INDEX IF NOT EXISTS idx_attachments_url ON attachments(url);
 
 -- =============================================================================
+-- Entity external links (project/initiative "Links / Resources")
+-- A distinct Linear entity from attachments (which are issue-only): the parent
+-- is a project or initiative (exactly one of the two id columns is set), and
+-- the display field is `label` rather than `title`.
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS entity_external_links (
+    id TEXT PRIMARY KEY,
+    project_id TEXT,     -- set for project links (NULL for initiative links)
+    initiative_id TEXT,  -- set for initiative links (NULL for project links)
+    label TEXT NOT NULL,
+    url TEXT NOT NULL,
+    sort_order REAL,
+    creator_id TEXT,
+    creator_name TEXT,
+    creator_email TEXT,
+    created_at DATETIME,
+    updated_at DATETIME,
+    synced_at DATETIME NOT NULL,
+    data JSON NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_external_links_project ON entity_external_links(project_id);
+CREATE INDEX IF NOT EXISTS idx_entity_external_links_initiative ON entity_external_links(initiative_id);
+
+-- =============================================================================
 -- Embedded Files (images, PDFs uploaded to Linear CDN)
 -- =============================================================================
 CREATE TABLE IF NOT EXISTS embedded_files (

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -153,6 +153,9 @@ func (i *InitiativeNode) manifest() *dirManifest {
 	m.subdir("updates", initiativeUpdatesDirIno(initiative.ID), func() dirChild {
 		return &InitiativeUpdatesNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}, initiativeID: initiative.ID}
 	})
+	m.subdir("links", linksDirIno(initiative.ID), func() dirChild {
+		return &LinksNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}, initiativeID: initiative.ID}
+	})
 
 	return m
 }

--- a/internal/fs/ino.go
+++ b/internal/fs/ino.go
@@ -47,6 +47,11 @@ func attachmentsDirIno(issueID string) uint64          { return ino("attachments
 func embeddedFileIno(fileID string) uint64             { return ino("file", fileID) }
 func externalAttachmentIno(attachmentID string) uint64 { return ino("extatt", attachmentID) }
 
+// External links (project/initiative "Links / Resources") ------------------
+
+func linksDirIno(parentID string) uint64   { return ino("links", parentID) }
+func externalLinkIno(linkID string) uint64 { return ino("extlink", linkID) }
+
 // Relations ----------------------------------------------------------------
 
 func relationsDirIno(issueID string) uint64 { return ino("relations", issueID) }

--- a/internal/fs/ino_test.go
+++ b/internal/fs/ino_test.go
@@ -48,6 +48,8 @@ func TestInodeNamespaceDistinct(t *testing.T) {
 		"attachmentsDirIno":       attachmentsDirIno(id),
 		"embeddedFileIno":         embeddedFileIno(id),
 		"externalAttachmentIno":   externalAttachmentIno(id),
+		"linksDirIno":             linksDirIno(id),
+		"externalLinkIno":         externalLinkIno(id),
 		"relationsDirIno":         relationsDirIno(id),
 		"relationIno":             relationIno(id),
 		"labelsDirIno":            labelsDirIno(id),

--- a/internal/fs/linklisting.go
+++ b/internal/fs/linklisting.go
@@ -1,0 +1,62 @@
+package fs
+
+import (
+	"github.com/jra3/linear-fuse/internal/api"
+)
+
+// linkListing owns the filenames of a links/ directory — the project/initiative
+// "Links / Resources" surface. Unlike attachmentListing it holds one item family
+// (external links), so it is a thin wrapper: both Readdir and Lookup derive names
+// through it over one canonical order, so a file you can `ls` you can also open
+// and `rm`.
+//
+// Collisions are DEDUPLICATED (`foo (2).link`) via the shared deduplicateFilename
+// counter, the same freedom attachmentListing has and for the same reason: link
+// filenames are resolution keys nowhere else (nothing name-resolves an external
+// link). Ordering is the repo's job: the list queries carry a deterministic
+// ORDER BY (sort_order, id) so a name keeps its dedup suffix across calls. The
+// caller fetches and passes the slice; the module is pure and unit-testable on
+// literals.
+type linkListing struct {
+	links []api.EntityExternalLink
+}
+
+// linkEntry is one derived directory entry: the final (deduplicated) name plus
+// the link it names.
+type linkEntry struct {
+	name string
+	link *api.EntityExternalLink
+}
+
+// externalLinkName derives an external link's base filename (before dedup). The
+// create surface reuses it for its .last path and kernel-entry name, so the
+// derivation is written exactly once.
+func externalLinkName(link api.EntityExternalLink) string {
+	return sanitizeFilename(link.Label) + ".link"
+}
+
+// entries derives every entry's final name through one shared dedup counter —
+// the Readdir projection.
+func (l linkListing) entries() []linkEntry {
+	result := make([]linkEntry, 0, len(l.links))
+	nameCount := make(map[string]int)
+	for i := range l.links {
+		result = append(result, linkEntry{
+			name: deduplicateFilename(externalLinkName(l.links[i]), nameCount),
+			link: &l.links[i],
+		})
+	}
+	return result
+}
+
+// find replays the same derivation and returns the entry whose final name
+// matches — the Lookup projection. Every name entries() emits resolves here by
+// construction.
+func (l linkListing) find(name string) (linkEntry, bool) {
+	for _, e := range l.entries() {
+		if e.name == name {
+			return e, true
+		}
+	}
+	return linkEntry{}, false
+}

--- a/internal/fs/linklisting_test.go
+++ b/internal/fs/linklisting_test.go
@@ -1,0 +1,87 @@
+package fs
+
+import (
+	"testing"
+
+	"github.com/jra3/linear-fuse/internal/api"
+)
+
+// TestLinkListingRoundTrip guards the module's core invariant: every name
+// entries() emits resolves back through find to the same link, so a file you
+// can ls you can also open and rm.
+func TestLinkListingRoundTrip(t *testing.T) {
+	t.Parallel()
+	l := linkListing{
+		links: []api.EntityExternalLink{
+			{ID: "l1", Label: "Onboarding Sync"},
+			{ID: "l2", Label: "Onboarding Sync"}, // duplicate label
+			{ID: "l3", Label: "Design"},
+		},
+	}
+
+	entries := l.entries()
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+	seen := make(map[string]bool)
+	for _, e := range entries {
+		if seen[e.name] {
+			t.Errorf("duplicate name emitted: %q", e.name)
+		}
+		seen[e.name] = true
+
+		got, ok := l.find(e.name)
+		if !ok {
+			t.Errorf("entries() emitted %q but find missed it", e.name)
+			continue
+		}
+		if got.link == nil || got.link.ID != e.link.ID {
+			t.Errorf("find(%q) resolved to a different link: %+v", e.name, got)
+		}
+	}
+
+	if _, ok := l.find("nope.link"); ok {
+		t.Error("find matched a name no entry has")
+	}
+}
+
+// TestLinkListingDedupNames pins the derived names: labels sanitized + .link,
+// with a counter before the extension for collisions.
+func TestLinkListingDedupNames(t *testing.T) {
+	t.Parallel()
+	l := linkListing{
+		links: []api.EntityExternalLink{
+			{ID: "l1", Label: "foo"},
+			{ID: "l2", Label: "foo"},
+			{ID: "l3", Label: "a/b"},
+		},
+	}
+
+	want := []string{"foo.link", "foo (2).link", "a-b.link"}
+	entries := l.entries()
+	if len(entries) != len(want) {
+		t.Fatalf("expected %d entries, got %d", len(want), len(entries))
+	}
+	for i, e := range entries {
+		if e.name != want[i] {
+			t.Errorf("entry %d: got %q, want %q", i, e.name, want[i])
+		}
+	}
+}
+
+// TestExternalLinkName pins the link name derivation the create surface shares
+// with the listing.
+func TestExternalLinkName(t *testing.T) {
+	t.Parallel()
+	cases := []struct{ label, want string }{
+		{"Spec doc", "Spec doc.link"},
+		{"a/b\\c", "a-b-c.link"},
+		{"  trimmed. ", "trimmed.link"},
+		{"", "untitled.link"},
+	}
+	for _, c := range cases {
+		if got := externalLinkName(api.EntityExternalLink{Label: c.label}); got != c.want {
+			t.Errorf("externalLinkName(%q) = %q, want %q", c.label, got, c.want)
+		}
+	}
+}

--- a/internal/fs/links.go
+++ b/internal/fs/links.go
@@ -1,0 +1,267 @@
+package fs
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/jra3/linear-fuse/internal/api"
+	"github.com/jra3/linear-fuse/internal/db"
+)
+
+// LinksNode represents a links/ directory on a project or initiative — the
+// "Links / Resources" surface backed by Linear's EntityExternalLink entity
+// (distinct from issue attachments, which live in AttachmentsNode). Exactly one
+// of projectID/initiativeID is set, dispatched like DocsNode.
+type LinksNode struct {
+	attrNode
+	projectID    string
+	initiativeID string
+}
+
+var _ fs.NodeReaddirer = (*LinksNode)(nil)
+var _ fs.NodeLookuper = (*LinksNode)(nil)
+var _ fs.NodeGetattrer = (*LinksNode)(nil)
+
+// parentID returns the single non-empty parent ID (project or initiative). Used
+// for the .error/.last key, the kernel-cache inode, and the create input.
+func (n *LinksNode) parentID() string {
+	if n.projectID != "" {
+		return n.projectID
+	}
+	return n.initiativeID
+}
+
+// getLinks fetches the external links for whichever parent is set.
+func (n *LinksNode) getLinks(ctx context.Context) ([]api.EntityExternalLink, error) {
+	if n.projectID != "" {
+		return n.lfs.repo.GetProjectLinks(ctx, n.projectID)
+	}
+	return n.lfs.repo.GetInitiativeLinks(ctx, n.initiativeID)
+}
+
+// liveLinks fetches the parent's links straight from the API, promoted to
+// interactive so a tight detail budget can't stall a user's blocking write.
+func (n *LinksNode) liveLinks(ctx context.Context) ([]api.EntityExternalLink, error) {
+	ctx = api.WithInteractive(ctx)
+	if n.projectID != "" {
+		return n.lfs.client.GetProjectLinks(ctx, n.projectID)
+	}
+	return n.lfs.client.GetInitiativeLinks(ctx, n.initiativeID)
+}
+
+func (n *LinksNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
+	entries := n.trio().entries()
+
+	// Listing is best-effort: a failed fetch lists empty rather than failing
+	// the whole directory.
+	for _, e := range n.listing(ctx, nil).entries() {
+		entries = append(entries, fuse.DirEntry{Name: e.name, Mode: syscall.S_IFREG})
+	}
+	return fs.NewListDirStream(entries), 0
+}
+
+// listing fetches the links and builds the name-derivation module. A failed
+// fetch leaves it empty; when fetchErr is non-nil it also records the error so
+// Lookup distinguishes "not found" from "couldn't look".
+func (n *LinksNode) listing(ctx context.Context, fetchErr *error) linkListing {
+	links, err := n.getLinks(ctx)
+	if fetchErr != nil && err != nil {
+		*fetchErr = err
+	}
+	return linkListing{links: links}
+}
+
+// trio declares the links collection's writable surfaces.
+func (n *LinksNode) trio() collectionTrio {
+	return collectionTrio{kind: "links", parentID: n.parentID(), onFlush: n.createLink}
+}
+
+func (n *LinksNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+	if inode, ok := n.lfs.lookupCollectionTrio(ctx, n, n.trio(), name, out); ok {
+		return inode, 0
+	}
+
+	var fetchErr error
+	entry, ok := n.listing(ctx, &fetchErr).find(name)
+	if !ok {
+		if fetchErr != nil {
+			return nil, syscall.EIO
+		}
+		return nil, syscall.ENOENT
+	}
+	return n.createExternalLinkNode(ctx, name, *entry.link, out), 0
+}
+
+func (n *LinksNode) createExternalLinkNode(ctx context.Context, name string, link api.EntityExternalLink, out *fuse.EntryOut) *fs.Inode {
+	node := &ExternalLinkNode{
+		renderFile: renderFile{
+			BaseNode: BaseNode{lfs: n.lfs},
+			render: func(context.Context) ([]byte, time.Time, time.Time) {
+				return []byte(externalLinkContent(link)), link.UpdatedAt, link.CreatedAt
+			},
+		},
+		link:         link,
+		projectID:    n.projectID,
+		initiativeID: n.initiativeID,
+	}
+	return n.newRenderInode(ctx, out, name, node, externalLinkIno(link.ID), 30*time.Second)
+}
+
+// ExternalLinkNode represents a .link file for a project/initiative external
+// link. It embeds renderFile for Open/Read/Getattr and keeps only its Unlink.
+type ExternalLinkNode struct {
+	renderFile
+	link         api.EntityExternalLink
+	projectID    string
+	initiativeID string
+}
+
+var _ fs.NodeUnlinker = (*ExternalLinkNode)(nil)
+
+// refreshFrom adopts a fresh twin's link and render closure (refresh.go);
+// renderMu doubles as the entity-field lock.
+func (n *ExternalLinkNode) refreshFrom(fresh fs.InodeEmbedder) {
+	f, ok := fresh.(*ExternalLinkNode)
+	if !ok {
+		return
+	}
+	n.renderMu.Lock()
+	n.render = f.render
+	n.link, n.projectID, n.initiativeID = f.link, f.projectID, f.initiativeID
+	n.renderMu.Unlock()
+}
+
+// externalLinkContent renders a .link file's YAML body.
+func externalLinkContent(link api.EntityExternalLink) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("label: %s\n", link.Label))
+	sb.WriteString(fmt.Sprintf("url: %s\n", link.URL))
+	return sb.String()
+}
+
+func (n *ExternalLinkNode) parentID() string {
+	if n.projectID != "" {
+		return n.projectID
+	}
+	return n.initiativeID
+}
+
+func (n *ExternalLinkNode) Unlink(ctx context.Context, name string) syscall.Errno {
+	return commitDelete(ctx, n.lfs, deleteSpec[api.EntityExternalLink]{
+		op:  `delete link "` + name + `"`,
+		key: collectionErrorKey("links", n.parentID()),
+		find: func(context.Context) (*api.EntityExternalLink, error) {
+			// Snapshot: a concurrent refresh (refresh.go) may swap the field.
+			n.renderMu.Lock()
+			link := n.link
+			n.renderMu.Unlock()
+			return &link, nil
+		},
+		mutate: func(ctx context.Context, l *api.EntityExternalLink) error {
+			return n.lfs.mutator().DeleteEntityExternalLink(ctx, l.ID)
+		},
+		forget: func(ctx context.Context, l *api.EntityExternalLink) error {
+			return n.lfs.store.Queries().DeleteEntityExternalLink(ctx, l.ID)
+		},
+		dir:  linksDirIno(n.parentID()),
+		name: name,
+	})
+}
+
+// createLink is the links create surface's onFlush: parse "url [label]" and run
+// the create tail.
+func (n *LinksNode) createLink(ctx context.Context, raw []byte) syscall.Errno {
+	content := strings.TrimSpace(string(raw))
+
+	// Idempotency: if the URL is already linked, re-linking it is a success, not
+	// a duplicate. Unlike issue attachments Linear does NOT dedup external links
+	// by URL server-side, so the cache pre-check is the only guard against a
+	// retry minting a second identical link. It returns 0 without a .last entry
+	// (nothing was created).
+	if url := strings.SplitN(content, " ", 2)[0]; url != "" {
+		if existing, err := n.getLinks(ctx); err == nil {
+			for _, l := range existing {
+				if linkURLsEqual(l.URL, url) {
+					n.lfs.ClearWriteError(collectionErrorKey("links", n.parentID()))
+					return 0
+				}
+			}
+		}
+	}
+
+	_, errno := commitCreate(ctx, n.lfs, createSpec[api.EntityExternalLink]{
+		op:  "create link",
+		key: collectionErrorKey("links", n.parentID()),
+		mutate: func(ctx context.Context) (*api.EntityExternalLink, error) {
+			if content == "" {
+				return nil, &FieldError{Field: "content", Message: `empty content. Write "<url> [label]".`}
+			}
+			// Parse "url [label]" or just "url" (label defaults to the URL).
+			parts := strings.SplitN(content, " ", 2)
+			url := parts[0]
+			label := url
+			if len(parts) > 1 {
+				label = parts[1]
+			}
+
+			input := map[string]any{"url": url, "label": label}
+			if n.projectID != "" {
+				input["projectId"] = n.projectID
+			} else {
+				input["initiativeId"] = n.initiativeID
+			}
+
+			link, err := n.lfs.mutator().CreateEntityExternalLink(ctx, input)
+			if err == nil {
+				return link, nil
+			}
+			// The mutation may have committed before the response was lost (a
+			// network blip). Re-check authoritatively: if the URL is now linked,
+			// treat it as the idempotent success it is.
+			if live, lerr := n.liveLinks(ctx); lerr == nil {
+				for _, ex := range live {
+					if linkURLsEqual(ex.URL, url) {
+						return &ex, nil
+					}
+				}
+			}
+			return nil, err
+		},
+		result: func(l *api.EntityExternalLink) WriteResult {
+			return WriteResult{URL: l.URL, Path: externalLinkName(*l), Title: l.Label}
+		},
+		persist: func(ctx context.Context, l *api.EntityExternalLink) error {
+			n.upsertLink(ctx, *l)
+			return nil
+		},
+		dir:       linksDirIno(n.parentID()),
+		entryName: func(l *api.EntityExternalLink) string { return externalLinkName(*l) },
+	})
+	return errno
+}
+
+// upsertLink writes a link to SQLite for immediate visibility. Failures are
+// logged, not fatal: the SWR refresh will reconcile.
+func (n *LinksNode) upsertLink(ctx context.Context, link api.EntityExternalLink) {
+	params, err := db.APIEntityExternalLinkToDB(link, n.projectID, n.initiativeID)
+	if err != nil {
+		log.Printf("[links] convert for DB failed: %v", err)
+		return
+	}
+	if err := n.lfs.store.Queries().UpsertEntityExternalLink(ctx, params); err != nil {
+		log.Printf("[links] upsert to DB failed: %v", err)
+	}
+}
+
+// linkURLsEqual reports whether two link URLs refer to the same target, ignoring
+// surrounding whitespace and a trailing slash — the same tolerance
+// attachmentURLsEqual applies.
+func linkURLsEqual(a, b string) bool {
+	return strings.TrimRight(strings.TrimSpace(a), "/") == strings.TrimRight(strings.TrimSpace(b), "/")
+}

--- a/internal/fs/manifest_test.go
+++ b/internal/fs/manifest_test.go
@@ -48,12 +48,12 @@ func TestDirManifestRoundTrip(t *testing.T) {
 		{
 			name: "project",
 			m:    projectDir.manifest(),
-			want: []string{"project.md", "project.meta", ".error", "docs", "updates", "milestones"},
+			want: []string{"project.md", "project.meta", ".error", "docs", "updates", "milestones", "links"},
 		},
 		{
 			name: "initiative",
 			m:    initiativeDir.manifest(),
-			want: []string{"initiative.md", "initiative.meta", ".error", "docs", "projects", "updates"},
+			want: []string{"initiative.md", "initiative.meta", ".error", "docs", "projects", "updates", "links"},
 		},
 	}
 

--- a/internal/fs/mutationclient.go
+++ b/internal/fs/mutationclient.go
@@ -63,6 +63,10 @@ type MutationClient interface {
 	// Attachments
 	LinkURL(ctx context.Context, issueID, url, title string) (*api.Attachment, error)
 	DeleteAttachment(ctx context.Context, attachmentID string) error
+
+	// Entity external links (project/initiative "Links / Resources")
+	CreateEntityExternalLink(ctx context.Context, input map[string]any) (*api.EntityExternalLink, error)
+	DeleteEntityExternalLink(ctx context.Context, id string) error
 }
 
 // compile-time assertion that the concrete client satisfies the seam.

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -296,6 +296,9 @@ func (p *ProjectNode) manifest() *dirManifest {
 	m.subdir("milestones", milestonesDirIno(project.ID), func() dirChild {
 		return &MilestonesNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}, projectID: project.ID}
 	})
+	m.subdir("links", linksDirIno(project.ID), func() dirChild {
+		return &LinksNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}, projectID: project.ID}
+	})
 
 	return m
 }

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -148,6 +148,11 @@ teams/{KEY}/
       .last                         [read-only: recent created milestones]
       {name}.md                     [read/write: name, targetDate, sortOrder + body; rm to delete]
       {name}.meta                   [read-only: id]
+    links/                          [external links ("Links / Resources")]
+      _create                       [write "URL [label]" to link]
+      .error                        [read-only: last failed write here]
+      .last                         [read-only: recent created links]
+      {label}.link                  [read-only: label, url; rm to delete]
     {ISSUE-ID} symlinks
   cycles/
     current                         [symlink to active cycle]
@@ -169,6 +174,11 @@ initiatives/{slug}/
     .error                          [read-only: last failed write here]
     .last                           [read-only: recent created updates]
     {seq}-{date}-{health}.md        [read-only]
+  links/                            [external links ("Links / Resources")]
+    _create                         [write "URL [label]" to link]
+    .error                          [read-only: last failed write here]
+    .last                           [read-only: recent created links]
+    {label}.link                    [read-only: label, url; rm to delete]
 
 users/{name}/                       [issue symlinks + user.md]
 my/assigned|created|active/         [your issue symlinks]
@@ -186,6 +196,7 @@ CREATE:  mkdir %s/teams/ENG/issues/"New Issue Title"   (quick: title only)
          echo "text" > docs/"Title.md"
          echo "---\nhealth: atRisk\n---\nBlocked" > updates/_create
 LINK:    echo "https://github.com/org/repo/pull/123" > attachments/_create
+         echo "https://notes.granola.ai/x [Onboarding Sync]" > projects/my-project/links/_create
          echo "blocks ENG-456" > relations/_create
          echo -e "Phase 1\nInitial milestone" > milestones/_create
 INITIATIVES:

--- a/internal/integration/fixture_parity_test.go
+++ b/internal/integration/fixture_parity_test.go
@@ -234,6 +234,32 @@ func TestFixtureAttachmentLinkFile(t *testing.T) {
 	}
 }
 
+// TestFixtureProjectLinkFile: the seeded project/initiative external links (#249)
+// surface as *.link files under links/, carrying label + url.
+func TestFixtureProjectLinkFile(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode: asserts the seeded synthetic external link")
+	}
+
+	for _, dir := range []string{
+		filepath.Join(projectsPath(testTeamKey), "test-project", "links"),
+		filepath.Join(initiativePath("test-initiative"), "links"),
+	} {
+		path := filepath.Join(dir, "Onboarding Notes.link")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("read %s: %v", path, err)
+			continue
+		}
+		content := string(data)
+		for _, want := range []string{"label: Onboarding Notes", "url: https://notes.granola.ai/onboarding-sync"} {
+			if !strings.Contains(content, want) {
+				t.Errorf("%s missing %q:\n%s", path, want, content)
+			}
+		}
+	}
+}
+
 // TestFixtureIssueHistoryRendered: the seeded history cache renders a real
 // change in history.md (not the empty-history placeholder).
 func TestFixtureIssueHistoryRendered(t *testing.T) {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -386,6 +386,19 @@ func populateTestFixtures(ctx context.Context, store *db.Store) error {
 		return err
 	}
 
+	// Populate external links for the project and initiative (links/ *.link
+	// files). Distinct IDs: the two share a primary key otherwise, and the
+	// second upsert would clobber the first (ON CONFLICT(id)).
+	projLink := fixtures.FixtureAPIEntityExternalLink()
+	if err := fixtures.PopulateProjectLinks(ctx, store, project.ID, []api.EntityExternalLink{projLink}); err != nil {
+		return err
+	}
+	initLink := fixtures.FixtureAPIEntityExternalLink()
+	initLink.ID = "extlink-2"
+	if err := fixtures.PopulateInitiativeLinks(ctx, store, initiative.ID, []api.EntityExternalLink{initLink}); err != nil {
+		return err
+	}
+
 	// Populate cached history for issue-1 (backs the history.md render)
 	if err := fixtures.PopulateIssueHistory(ctx, store, "issue-1", fixtures.FixtureAPIHistoryEntries()); err != nil {
 		return err

--- a/internal/integration/readme_test.go
+++ b/internal/integration/readme_test.go
@@ -38,6 +38,16 @@ func TestGeneratedReadmeMatchesBehavior(t *testing.T) {
 		}
 	}
 
+	// The project/initiative external-link surface (#249): the README must teach
+	// the links/ directory and its "URL [label]" write contract, and the *.link
+	// files must really be read-only (a documented write-only/read-only surface
+	// that lies is the exact failure this test exists to prevent).
+	for _, want := range []string{"links/", ".link", "URL [label]"} {
+		if !strings.Contains(readme, want) {
+			t.Errorf("README does not mention %q (project/initiative links surface)", want)
+		}
+	}
+
 	// The meta split moved server fields out of the editable files. The README's
 	// frontmatter templates must not document them as editable-file fields, or an
 	// agent will look for/edit fields that no longer live there (the exact "the

--- a/internal/integration/symlink_test.go
+++ b/internal/integration/symlink_test.go
@@ -361,10 +361,10 @@ func TestProjectIssueSymlinks(t *testing.T) {
 		t.Fatalf("Failed to read project directory: %v", err)
 	}
 
-	// Check that issue entries (not project.md, .error, docs/, updates/, or milestones/) are symlinks
+	// Check that issue entries (not project.md, .error, docs/, updates/, milestones/, or links/) are symlinks
 	for _, entry := range projectEntries {
 		switch entry.Name() {
-		case "project.md", "project.meta", ".error", ".last", "docs", "updates", "milestones":
+		case "project.md", "project.meta", ".error", ".last", "docs", "updates", "milestones", "links":
 			continue
 		}
 		info, err := entry.Info()

--- a/internal/integration/t6_conformance_test.go
+++ b/internal/integration/t6_conformance_test.go
@@ -247,6 +247,8 @@ func TestWriteContractCreateTrioUniform(t *testing.T) {
 		"relations":          relationsDir,
 		"project-updates":    projectUpdatesDir,
 		"initiative-updates": filepath.Join(initiativePath("test-initiative"), "updates"),
+		"project-links":      filepath.Join(projectsPath(testTeamKey), "test-project", "links"),
+		"initiative-links":   filepath.Join(initiativePath("test-initiative"), "links"),
 	}
 	for name, dir := range surfaces {
 		t.Run(name, func(t *testing.T) {
@@ -305,6 +307,23 @@ func TestWriteContractCreateTrioUniform(t *testing.T) {
 	}
 	if !afound {
 		t.Error("attachments/.last has no entry after an attachment create")
+	}
+
+	// A project link create reports its identity to links/.last (the #249
+	// external-link surface, backed by EntityExternalLink rather than Attachment).
+	projectLinksDir := filepath.Join(projectsPath(testTeamKey), "test-project", "links")
+	linkURL := "https://notes.granola.ai/trio-probe/1"
+	if err := os.WriteFile(filepath.Join(projectLinksDir, "_create"), []byte(linkURL+" Trio Link Probe"), 0200); err != nil {
+		t.Fatalf("create project link: %v", err)
+	}
+	lfound := false
+	for _, e := range parseLastSidecar(t, filepath.Join(projectLinksDir, ".last")) {
+		if e["url"] == linkURL {
+			lfound = true
+		}
+	}
+	if !lfound {
+		t.Error("project links/.last has no entry after a link create")
 	}
 
 	// Updates were the last surface hand-rolling the create tail with no

--- a/internal/repo/sqlite.go
+++ b/internal/repo/sqlite.go
@@ -804,6 +804,9 @@ func (r *SQLiteRepository) deleteOrphanProject(ctx context.Context, projectID st
 	if err := q.DeleteProjectMilestones(ctx, projectID); err != nil {
 		log.Printf("[repo] orphan cleanup: project milestones for %s: %v", projectID, err)
 	}
+	if err := q.DeleteProjectLinks(ctx, sql.NullString{String: projectID, Valid: true}); err != nil {
+		log.Printf("[repo] orphan cleanup: project links for %s: %v", projectID, err)
+	}
 	if err := q.DeleteInitiativeProjectsByProject(ctx, projectID); err != nil {
 		log.Printf("[repo] orphan cleanup: initiative-project links for %s: %v", projectID, err)
 	}
@@ -826,6 +829,9 @@ func (r *SQLiteRepository) deleteOrphanInitiative(ctx context.Context, initiativ
 	}
 	if err := q.DeleteInitiativeUpdates(ctx, initiativeID); err != nil {
 		log.Printf("[repo] orphan cleanup: initiative updates for %s: %v", initiativeID, err)
+	}
+	if err := q.DeleteInitiativeLinks(ctx, sql.NullString{String: initiativeID, Valid: true}); err != nil {
+		log.Printf("[repo] orphan cleanup: initiative links for %s: %v", initiativeID, err)
 	}
 	if err := q.DeleteInitiativeProjects(ctx, initiativeID); err != nil {
 		log.Printf("[repo] orphan cleanup: initiative-project links for %s: %v", initiativeID, err)
@@ -1097,6 +1103,100 @@ func (r *SQLiteRepository) GetIssueAttachments(ctx context.Context, issueID stri
 	}
 
 	return db.DBAttachmentsToAPIAttachments(attachments)
+}
+
+// GetProjectLinks returns a project's external links ("Links / Resources"),
+// refreshing from the API on read when the local rows are stale (SWR), the same
+// contract as GetProjectDocuments.
+func (r *SQLiteRepository) GetProjectLinks(ctx context.Context, projectID string) ([]api.EntityExternalLink, error) {
+	links, err := r.store.Queries().ListProjectLinks(ctx, sql.NullString{String: projectID, Valid: true})
+	if err != nil {
+		return nil, fmt.Errorf("list project links: %w", err)
+	}
+
+	r.maybeRefreshSWR(swrSpec{
+		kind: kindProjectLinks,
+		id:   projectID,
+		syncedAt: func() (interface{}, error) {
+			return r.store.Queries().GetProjectLinksSyncedAt(context.Background(), sql.NullString{String: projectID, Valid: true})
+		},
+		refresh: func(ctx context.Context) error {
+			return r.refreshProjectLinks(ctx, projectID)
+		},
+		orphan: func(ctx context.Context) { r.deleteOrphanProject(ctx, projectID) },
+	})
+
+	return db.DBEntityExternalLinksToAPI(links)
+}
+
+// refreshProjectLinks fetches external links from the API and stores them.
+// Upsert-only (nil Prune): mirrors refreshProjectDocuments — nothing licenses a
+// prune for this single-page fetch.
+func (r *SQLiteRepository) refreshProjectLinks(ctx context.Context, projectID string) error {
+	links, err := r.client.GetProjectLinks(ctx, projectID)
+	if err != nil {
+		return err
+	}
+
+	reconcile.Collection(ctx, reconcile.CollectionSpec[api.EntityExternalLink]{
+		Label: "project link " + projectID,
+		Kind:  "attachment",
+		Items: links,
+		Upsert: func(ctx context.Context, link api.EntityExternalLink) error {
+			params, err := db.APIEntityExternalLinkToDB(link, projectID, "")
+			if err != nil {
+				return err
+			}
+			return r.store.Queries().UpsertEntityExternalLink(ctx, params)
+		},
+	})
+	return nil
+}
+
+// GetInitiativeLinks returns an initiative's external links, SWR-refreshed on
+// read like GetInitiativeDocuments.
+func (r *SQLiteRepository) GetInitiativeLinks(ctx context.Context, initiativeID string) ([]api.EntityExternalLink, error) {
+	links, err := r.store.Queries().ListInitiativeLinks(ctx, sql.NullString{String: initiativeID, Valid: true})
+	if err != nil {
+		return nil, fmt.Errorf("list initiative links: %w", err)
+	}
+
+	r.maybeRefreshSWR(swrSpec{
+		kind: kindInitiativeLinks,
+		id:   initiativeID,
+		syncedAt: func() (interface{}, error) {
+			return r.store.Queries().GetInitiativeLinksSyncedAt(context.Background(), sql.NullString{String: initiativeID, Valid: true})
+		},
+		refresh: func(ctx context.Context) error {
+			return r.refreshInitiativeLinks(ctx, initiativeID)
+		},
+		orphan: func(ctx context.Context) { r.deleteOrphanInitiative(ctx, initiativeID) },
+	})
+
+	return db.DBEntityExternalLinksToAPI(links)
+}
+
+// refreshInitiativeLinks fetches external links from the API and stores them.
+// Upsert-only (nil Prune), mirroring refreshInitiativeDocuments.
+func (r *SQLiteRepository) refreshInitiativeLinks(ctx context.Context, initiativeID string) error {
+	links, err := r.client.GetInitiativeLinks(ctx, initiativeID)
+	if err != nil {
+		return err
+	}
+
+	reconcile.Collection(ctx, reconcile.CollectionSpec[api.EntityExternalLink]{
+		Label: "initiative link " + initiativeID,
+		Kind:  "attachment",
+		Items: links,
+		Upsert: func(ctx context.Context, link api.EntityExternalLink) error {
+			params, err := db.APIEntityExternalLinkToDB(link, "", initiativeID)
+			if err != nil {
+				return err
+			}
+			return r.store.Queries().UpsertEntityExternalLink(ctx, params)
+		},
+	})
+	return nil
 }
 
 func (r *SQLiteRepository) GetIssueEmbeddedFiles(ctx context.Context, issueID string) ([]api.EmbeddedFile, error) {

--- a/internal/repo/sqlite_test.go
+++ b/internal/repo/sqlite_test.go
@@ -2125,6 +2125,10 @@ func TestDeleteOrphanProject(t *testing.T) {
 	mustExec("initiative-project link", q.UpsertInitiativeProject(ctx, db.UpsertInitiativeProjectParams{
 		InitiativeID: "init-1", ProjectID: projectID, SyncedAt: now,
 	}))
+	mustExec("project link", q.UpsertEntityExternalLink(ctx, db.UpsertEntityExternalLinkParams{
+		ID: "el1", ProjectID: sql.NullString{String: projectID, Valid: true},
+		Label: "Link", Url: "https://example.com", SyncedAt: now, Data: []byte("{}"),
+	}))
 	// Sub-resources on the keeper.
 	mustExec("keeper doc", q.UpsertDocument(ctx, db.UpsertDocumentParams{
 		ID: "pd-keep", SlugID: "pd-keep", Title: "Keep",
@@ -2152,6 +2156,9 @@ func TestDeleteOrphanProject(t *testing.T) {
 	}
 	if got := linkCount(t, store, "SELECT COUNT(*) FROM initiative_projects WHERE project_id = ?", projectID); got != 0 {
 		t.Errorf("orphan initiative-project links not deleted: %d remain", got)
+	}
+	if got, _ := q.ListProjectLinks(ctx, sql.NullString{String: projectID, Valid: true}); len(got) != 0 {
+		t.Errorf("orphan project external links not deleted: %d remain", len(got))
 	}
 	// Keeper survives.
 	if _, err := q.GetProject(ctx, otherID); err != nil {
@@ -2197,6 +2204,10 @@ func TestDeleteOrphanInitiative(t *testing.T) {
 	mustExec("init-project link", q.UpsertInitiativeProject(ctx, db.UpsertInitiativeProjectParams{
 		InitiativeID: initID, ProjectID: "some-proj", SyncedAt: now,
 	}))
+	mustExec("init link", q.UpsertEntityExternalLink(ctx, db.UpsertEntityExternalLinkParams{
+		ID: "el2", InitiativeID: sql.NullString{String: initID, Valid: true},
+		Label: "Link", Url: "https://example.com", SyncedAt: now, Data: []byte("{}"),
+	}))
 	// Keeper sub-resource.
 	mustExec("keeper update", q.UpsertInitiativeUpdate(ctx, db.UpsertInitiativeUpdateParams{
 		ID: "iu-keep", InitiativeID: otherID, Body: "keep", CreatedAt: now, UpdatedAt: now, SyncedAt: now, Data: []byte("{}"),
@@ -2215,6 +2226,9 @@ func TestDeleteOrphanInitiative(t *testing.T) {
 	}
 	if got := linkCount(t, store, "SELECT COUNT(*) FROM initiative_projects WHERE initiative_id = ?", initID); got != 0 {
 		t.Errorf("orphan init-project links not deleted: %d remain", got)
+	}
+	if got, _ := q.ListInitiativeLinks(ctx, sql.NullString{String: initID, Valid: true}); len(got) != 0 {
+		t.Errorf("orphan init external links not deleted: %d remain", len(got))
 	}
 	if _, err := q.GetInitiative(ctx, otherID); err != nil {
 		t.Errorf("keeper initiative was deleted: %v", err)

--- a/internal/repo/swr.go
+++ b/internal/repo/swr.go
@@ -25,6 +25,8 @@ const (
 	kindInitiativeDocs    refreshKind = "initiative-docs"
 	kindProjectUpdates    refreshKind = "project-updates"
 	kindInitiativeUpdates refreshKind = "initiative-updates"
+	kindProjectLinks      refreshKind = "project-links"
+	kindInitiativeLinks   refreshKind = "initiative-links"
 )
 
 // key is the one factory for a refresh's dedup-map key.

--- a/internal/testutil/fixtures/api.go
+++ b/internal/testutil/fixtures/api.go
@@ -494,6 +494,21 @@ func FixtureAPIAttachment() api.Attachment {
 	}
 }
 
+// FixtureAPIEntityExternalLink returns a project/initiative external link
+// (rendered as a *.link file in the links/ directory).
+func FixtureAPIEntityExternalLink() api.EntityExternalLink {
+	user := FixtureAPIUser()
+	return api.EntityExternalLink{
+		ID:        "extlink-1",
+		Label:     "Onboarding Notes",
+		URL:       "https://notes.granola.ai/onboarding-sync",
+		SortOrder: 1,
+		Creator:   &user,
+		CreatedAt: fixtureTime,
+		UpdatedAt: fixtureTime,
+	}
+}
+
 // FixtureAPIHistoryEntries returns issue history entries with a describable
 // change (state transition), so HistoryToMarkdown renders a non-empty body.
 func FixtureAPIHistoryEntries() []api.IssueHistoryEntry {

--- a/internal/testutil/fixtures/fstest.go
+++ b/internal/testutil/fixtures/fstest.go
@@ -397,6 +397,38 @@ func PopulateAttachments(ctx context.Context, store *db.Store, issueID string, a
 	return nil
 }
 
+// PopulateProjectLinks inserts external links for a project into the SQLite
+// store (rendered as *.link files in the project's links/ directory).
+func PopulateProjectLinks(ctx context.Context, store *db.Store, projectID string, links []api.EntityExternalLink) error {
+	q := store.Queries()
+	for _, l := range links {
+		params, err := db.APIEntityExternalLinkToDB(l, projectID, "")
+		if err != nil {
+			return err
+		}
+		if err := q.UpsertEntityExternalLink(ctx, params); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PopulateInitiativeLinks inserts external links for an initiative into the
+// SQLite store (rendered as *.link files in the initiative's links/ directory).
+func PopulateInitiativeLinks(ctx context.Context, store *db.Store, initiativeID string, links []api.EntityExternalLink) error {
+	q := store.Queries()
+	for _, l := range links {
+		params, err := db.APIEntityExternalLinkToDB(l, "", initiativeID)
+		if err != nil {
+			return err
+		}
+		if err := q.UpsertEntityExternalLink(ctx, params); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // PopulateIssueHistory caches history entries for an issue (the store behind
 // the history.md render).
 func PopulateIssueHistory(ctx context.Context, store *db.Store, issueID string, entries []api.IssueHistoryEntry) error {

--- a/internal/testutil/mockmutation/mock.go
+++ b/internal/testutil/mockmutation/mock.go
@@ -393,6 +393,21 @@ func (c *Client) LinkURL(ctx context.Context, issueID, url, title string) (*api.
 
 func (c *Client) DeleteAttachment(ctx context.Context, attachmentID string) error { return nil }
 
+// ---- Entity external links (project/initiative "Links / Resources") ----
+
+func (c *Client) CreateEntityExternalLink(ctx context.Context, input map[string]any) (*api.EntityExternalLink, error) {
+	n := c.next()
+	return &api.EntityExternalLink{
+		ID:        fmt.Sprintf("mock-extlink-%d", n),
+		Label:     str(input, "label"),
+		URL:       str(input, "url"),
+		CreatedAt: c.now,
+		UpdatedAt: c.now,
+	}, nil
+}
+
+func (c *Client) DeleteEntityExternalLink(ctx context.Context, id string) error { return nil }
+
 // ---- Read-your-writes verify seam (fs.verifyReader) ----
 //
 // These serve the edit-commit tail's re-fetch: the recorded post-Update state if


### PR DESCRIPTION
Closes #249.

Adds a `links/` directory to **projects and initiatives** for Linear's "Links / Resources" section.

## The key finding
Issue #249 asked to mirror the issue `attachments/` surface, but in Linear's API projects/initiatives **don't have `Attachment`s** — `AttachmentCreateInput.issueId` is required. The real entity behind "Links / Resources" is a separate one, **`EntityExternalLink`** (field is `label`, not `title`), which cleanly supports both projects (`project.externalLinks`) and initiatives (`initiative.links`) with full CRUD. So the initiative "nice-to-have" came for free.

## Surface
```
projects/{slug}/links/  (and initiatives/{slug}/links/)
  _create      # echo "https://notes.granola.ai/x [Onboarding Sync]" > _create
  .error
  .last
  {label}.link # read-only: label, url; rm to delete
```
Same write contract as issue attachments; reuses the collection-trio + commit-tail machinery.

## Layers
- **api** — `EntityExternalLink` type + fragment, read queries, create/delete mutations, client methods, mutation seam + mock
- **db** — `entity_external_links` table (polymorphic project_id/initiative_id) + CRUD; sqlc-generated
- **repo** — `GetProjectLinks`/`GetInitiativeLinks` with SWR refresh-on-read (mirrors project/initiative docs); orphan cleanup now prunes links too
- **fs** — `LinksNode`/`ExternalLinkNode`/`linkListing`, wired into both manifests
- **README** — generated docs updated (guarded by `TestGeneratedReadmeMatchesBehavior`)

## Tests
Unit tests for `linkListing` + inode-namespace guard; fixture read test; write-contract conformance (create → `.last`) for both surfaces; orphan-cleanup tests assert link rows are pruned. Full suite green including the FUSE-mounted integration run.

## Scoped out
Sync-worker prefetch — links populate lazily on read via SWR, exactly like project/initiative docs.

## Not yet verified
Live-API smoke test not run; the client-side URL-dedup pre-check assumes Linear doesn't dedup `EntityExternalLink` by URL (no uniqueness in the schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)