### PR TITLE
fix: detail batch of 15 exceeds Linear's 10k per-query complexity cap

### DIFF
--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -72,7 +72,14 @@ type APIClient interface {
 	RateLimitResetAt() time.Time
 }
 
-const detailsBatchSize = 15 // Number of issues to fetch details for in one API call (Linear has 10k complexity limit; 20 was 80-90% of budget)
+// detailsBatchSize is the number of issues per batched details fetch. Linear
+// caps a SINGLE query at 10k complexity, and the per-issue details selection
+// has grown to ~860 points (measured live 2026-07-10: a batch of 15 scored
+// 12,897 and was rejected with "Query too complex" — silently unnoticed for
+// days because the budget ladder was starving detail sync entirely, #239).
+// 10 × ~860 ≈ 8.6k leaves headroom for the selection to grow a little; if a
+// batch is ever rejected again, this constant is the first suspect.
+const detailsBatchSize = 10
 
 // Budget thresholds for rate limit awareness.
 // Detail batches (~2001 complexity each) are expensive; we defer them when budget is tight.


### PR DESCRIPTION
Found live during #247's post-deploy verification, the moment the diet unblocked detail syncing: every batched `IssueDetailsBatch` fetch fails with `Query too complex. Complexity: 12,897. Maximum allowed: 10000`.

`detailsBatchSize = 15` was sized when a detail batch cost ~2k; the per-issue selection has since grown to ~860 points (relations + inverse relations + embedded files et al.), and because the reserve ladder starved detail sync for days (#239), the oversized batch never executed — the bug was invisible until the diet restored budget headroom and the backlog tried to drain. Every batch of 15 fails identically, so `pending_detail_sync` freezes (~154) regardless of budget.

Fix: `detailsBatchSize` 15 → 10 (~8.6k/batch, with the live measurement and a breadcrumb recorded in the const's doc comment).

Full suite + staticcheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)