### PR TITLE
Fix the three verification-sweep bugs (#258, #259, #260)

### DIFF
--- a/internal/cmd/mount.go
+++ b/internal/cmd/mount.go
@@ -32,7 +32,15 @@ func init() {
 }
 
 func runMount(cmd *cobra.Command, args []string) error {
-	cfg, err := config.Load()
+	// --config names an exact file (unreadable = error); without it the
+	// default XDG path applies (missing = defaults + env).
+	var cfg *config.Config
+	var err error
+	if configPath, _ := cmd.Flags().GetString("config"); configPath != "" {
+		cfg, err = config.LoadFrom(configPath)
+	} else {
+		cfg, err = config.Load()
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,22 +114,40 @@ func DefaultRequestLogPath() string {
 	return filepath.Join(configDir, "linearfs", "requests.jsonl")
 }
 
-// Load loads configuration using the real environment.
+// Load loads configuration using the real environment and the default config
+// path. A missing default file is fine: defaults + env apply.
 func Load() (*Config, error) {
 	return LoadWithEnv(os.Getenv)
+}
+
+// LoadFrom loads configuration from an explicitly named config file (the
+// --config flag). Unlike Load, an unreadable file is an error — the user
+// asked for that exact file, so silently falling back to defaults would mount
+// with the wrong config. Environment variables still override.
+func LoadFrom(path string) (*Config, error) {
+	return loadPath(os.Getenv, path, true)
 }
 
 // LoadWithEnv loads configuration using the provided environment lookup function.
 // This allows tests to provide isolated environment values.
 func LoadWithEnv(getenv func(string) string) (*Config, error) {
+	return loadPath(getenv, getConfigPathWithEnv(getenv), false)
+}
+
+// loadPath reads path into DefaultConfig, then applies env overrides.
+// explicit governs the missing-file contract: the default path is optional,
+// a user-named path is not.
+func loadPath(getenv func(string) string, path string, explicit bool) (*Config, error) {
 	cfg := DefaultConfig()
 
-	// Try to load from config file
-	configPath := getConfigPathWithEnv(getenv)
-	if data, err := os.ReadFile(configPath); err == nil {
+	data, err := os.ReadFile(path)
+	switch {
+	case err == nil:
 		if err := yaml.Unmarshal(data, cfg); err != nil {
-			return nil, fmt.Errorf("failed to parse config file: %w", err)
+			return nil, fmt.Errorf("failed to parse config file %s: %w", path, err)
 		}
+	case explicit:
+		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
 
 	// Environment variables override config file

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -458,3 +458,44 @@ cache:
 		t.Errorf("LoadWithEnv() Log.Level = %q, want %q (default)", cfg.Log.Level, "info")
 	}
 }
+
+func TestLoadFrom(t *testing.T) {
+	t.Run("explicit file loads", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "custom.yaml")
+		if err := os.WriteFile(path, []byte("api_key: from-file\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("LINEAR_API_KEY", "")
+		cfg, err := LoadFrom(path)
+		if err != nil {
+			t.Fatalf("LoadFrom() error: %v", err)
+		}
+		if cfg.APIKey != "from-file" {
+			t.Errorf("LoadFrom() APIKey = %q, want %q", cfg.APIKey, "from-file")
+		}
+	})
+
+	t.Run("missing explicit file is an error", func(t *testing.T) {
+		// Unlike Load's optional default path, a user-named --config file
+		// that can't be read must fail loudly, not mount with defaults.
+		_, err := LoadFrom(filepath.Join(t.TempDir(), "nope.yaml"))
+		if err == nil {
+			t.Fatal("LoadFrom() with missing file: want error, got nil")
+		}
+	})
+
+	t.Run("env overrides explicit file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "custom.yaml")
+		if err := os.WriteFile(path, []byte("api_key: from-file\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("LINEAR_API_KEY", "from-env")
+		cfg, err := LoadFrom(path)
+		if err != nil {
+			t.Fatalf("LoadFrom() error: %v", err)
+		}
+		if cfg.APIKey != "from-env" {
+			t.Errorf("LoadFrom() APIKey = %q, want %q", cfg.APIKey, "from-env")
+		}
+	})
+}

--- a/internal/db/nowdiscipline_test.go
+++ b/internal/db/nowdiscipline_test.go
@@ -1,0 +1,91 @@
+package db
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSyncedAtStampsUseDBNow enforces the write-side time invariant: every
+// SyncedAt / DetailSyncedAt stamp persisted to SQLite must come from db.Now()
+// (UTC), never a bare time.Now(). SQLite orders timestamp TEXT
+// lexicographically and the driver binds a time.Time with its zone offset, so
+// a local-zone stamp misorders against UTC cutoff strings — reconcile's
+// cutoff-before-fetch prune pattern silently deletes fresh rows east of UTC.
+//
+// This is the persisted-stamp sibling of the sync worker's clock-seam grep
+// rule (internal/sync/clock.go). Two shapes are flagged across all non-test
+// sources under internal/:
+//
+//  1. direct:   SyncedAt: time.Now()
+//  2. indirect: a function that both calls bare time.Now() and builds a
+//     composite literal with a SyncedAt/DetailSyncedAt field (the
+//     now := time.Now(); ...; SyncedAt: now pattern)
+//
+// If shape 2 ever false-positives (a function legitimately using time.Now()
+// for display while also stamping via db.Now()), hoist the display time into
+// a helper rather than weakening this test.
+func TestSyncedAtStampsUseDBNow(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var violations []string
+	fset := token.NewFileSet()
+
+	err = filepath.Walk(filepath.Join(root, "internal"), func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			var timeNowPos []token.Pos
+			var stampPos []token.Pos
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				switch node := n.(type) {
+				case *ast.CallExpr:
+					if sel, ok := node.Fun.(*ast.SelectorExpr); ok {
+						if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "time" && sel.Sel.Name == "Now" {
+							timeNowPos = append(timeNowPos, node.Pos())
+						}
+					}
+				case *ast.KeyValueExpr:
+					if key, ok := node.Key.(*ast.Ident); ok &&
+						(key.Name == "SyncedAt" || key.Name == "DetailSyncedAt") {
+						stampPos = append(stampPos, node.Pos())
+					}
+				}
+				return true
+			})
+			if len(timeNowPos) > 0 && len(stampPos) > 0 {
+				violations = append(violations,
+					fset.Position(stampPos[0]).String()+
+						" — function "+fn.Name.Name+" stamps SyncedAt and calls bare time.Now() (at "+
+						fset.Position(timeNowPos[0]).String()+"); stamp via db.Now() instead")
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, v := range violations {
+		t.Error(v)
+	}
+}

--- a/internal/fs/attachments.go
+++ b/internal/fs/attachments.go
@@ -353,7 +353,7 @@ func (n *AttachmentsNode) upsertAttachment(ctx context.Context, att api.Attachme
 		Url:        att.URL,
 		SourceType: sql.NullString{String: att.SourceType, Valid: att.SourceType != ""},
 		Metadata:   json.RawMessage("{}"),
-		SyncedAt:   time.Now(),
+		SyncedAt:   db.Now(),
 		Data:       data,
 	}); err != nil {
 		log.Printf("[attachments] upsert to DB failed: %v", err)

--- a/internal/fs/embeddedfilecache.go
+++ b/internal/fs/embeddedfilecache.go
@@ -36,6 +36,18 @@ type embeddedFileCache struct {
 	mem map[string][]byte
 }
 
+// embeddedFileCacheDir returns the on-disk byte-cache root under the
+// platform's user cache dir — ~/.cache/linearfs/files per XDG on Linux,
+// ~/Library/Caches/linearfs/files on macOS (identical to the previously
+// hardcoded macOS-only path, so existing caches carry over).
+func embeddedFileCacheDir() string {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		dir = filepath.Join(os.Getenv("HOME"), ".cache")
+	}
+	return filepath.Join(dir, "linearfs", "files")
+}
+
 // newEmbeddedFileCache builds the cache rooted at dir. auth supplies the CDN
 // Authorization header; persist records a freshly-cached file's on-disk path and
 // size (best-effort). Both are late-bound closures because the repo they reach is

--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
 	gosync "sync"
 	"time"
@@ -122,7 +121,7 @@ func NewLinearFS(cfg *config.Config, debug bool) (*LinearFS, error) {
 	}
 
 	// Initialize file cache directory
-	cacheDir := filepath.Join(os.Getenv("HOME"), "Library", "Caches", "linearfs", "files")
+	cacheDir := embeddedFileCacheDir()
 	if err := os.MkdirAll(cacheDir, 0755); err != nil {
 		log.Printf("[linearfs] Warning: failed to create cache dir: %v", err)
 	}

--- a/internal/fs/relations.go
+++ b/internal/fs/relations.go
@@ -197,7 +197,7 @@ func (n *RelationsNode) createRelation(ctx context.Context, raw []byte) syscall.
 			}
 		},
 		persist: func(ctx context.Context, rel *api.IssueRelation) error {
-			now := time.Now()
+			now := db.Now()
 			// Prefer the server's authoritative relation times; fall back to now()
 			// if the mutation echoed a zero time.
 			created := rel.CreatedAt

--- a/internal/repo/sqlite.go
+++ b/internal/repo/sqlite.go
@@ -1321,7 +1321,7 @@ func (r *SQLiteRepository) upsertHistoryCache(ctx context.Context, issueID strin
 	}
 	if err := r.store.Queries().UpsertIssueHistoryCache(ctx, db.UpsertIssueHistoryCacheParams{
 		IssueID:  issueID,
-		SyncedAt: time.Now(),
+		SyncedAt: db.Now(),
 		Data:     data,
 	}); err != nil {
 		log.Printf("[repo] upsert history cache %s failed: %v", issueID, err)

--- a/internal/testutil/fixtures/fstest.go
+++ b/internal/testutil/fixtures/fstest.go
@@ -272,7 +272,7 @@ func PopulateInitiative(ctx context.Context, store *db.Store, initiative api.Ini
 		if err := q.UpsertInitiativeProject(ctx, db.UpsertInitiativeProjectParams{
 			InitiativeID: initiative.ID,
 			ProjectID:    proj.ID,
-			SyncedAt:     time.Now(),
+			SyncedAt:     db.Now(),
 		}); err != nil {
 			return err
 		}
@@ -312,8 +312,8 @@ func PopulateEmbeddedFiles(ctx context.Context, store *db.Store, issueID string,
 			Filename:  file.Filename,
 			MimeType:  sql.NullString{String: file.MimeType, Valid: file.MimeType != ""},
 			Source:    file.Source,
-			CreatedAt: time.Now(),
-			SyncedAt:  time.Now(),
+			CreatedAt: db.Now(),
+			SyncedAt:  db.Now(),
 		}
 		if err := q.UpsertEmbeddedFile(ctx, params); err != nil {
 			return err
@@ -438,7 +438,7 @@ func PopulateIssueHistory(ctx context.Context, store *db.Store, issueID string, 
 	}
 	return store.Queries().UpsertIssueHistoryCache(ctx, db.UpsertIssueHistoryCacheParams{
 		IssueID:  issueID,
-		SyncedAt: time.Now(),
+		SyncedAt: db.Now(),
 		Data:     data,
 	})
 }
@@ -451,7 +451,7 @@ func PopulateTeamMembers(ctx context.Context, store *db.Store, teamID string, us
 		if err := q.UpsertTeamMember(ctx, db.UpsertTeamMemberParams{
 			TeamID:   teamID,
 			UserID:   uid,
-			SyncedAt: time.Now(),
+			SyncedAt: db.Now(),
 		}); err != nil {
 			return err
 		}
@@ -464,7 +464,7 @@ func PopulateTeamMembers(ctx context.Context, store *db.Store, teamID string, us
 func PopulateViewer(ctx context.Context, store *db.Store, userID string) error {
 	return store.Queries().SetViewerUserID(ctx, db.SetViewerUserIDParams{
 		UserID:   userID,
-		SyncedAt: time.Now(),
+		SyncedAt: db.Now(),
 	})
 }
 


### PR DESCRIPTION
Three bugs filed from the 2026-07-11 ARCHITECTURE.md verification sweep, one commit each:

**#258 — SyncedAt stamps bypass db.Now()** (`b4546b2`): fs/attachments.go and fs/relations.go write tails stamped local-zone `time.Now()` into timestamps that feed cutoff-compared prunes — SQLite compares timestamp TEXT lexicographically, so fresh rows east of UTC could sort before a UTC cutoff and be pruned. Also fixed the benign repo history-cache stamp and five testutil fixture stamps. New `TestSyncedAtStampsUseDBNow` (internal/db) walks internal/ non-test sources via go/ast and flags any function that both stamps SyncedAt/DetailSyncedAt and calls bare `time.Now()` — it caught the fixture sites the original sweep missed, and catches the `now := time.Now()` indirection a line-grep can't.

**#259 — embedded-file cache path** (`0faebc0`): `~/Library/Caches` was hardcoded on every OS. Now `os.UserCacheDir()` — identical path on macOS (existing caches carry over), XDG `~/.cache/linearfs/files` on Linux.

**#260 — inert --config flag** (this commit): the flag existed but `config.Load()` never saw it. `config.LoadFrom(path)` loads a user-named file and fails loudly if unreadable (mounting with silently-wrong config is worse than no flag); the default path keeps missing-is-fine; env still overrides. Covered by `TestLoadFrom`.

Full suite (unit + integration) and staticcheck green.

Fixes #258, fixes #259, fixes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)