### PR TITLE
feat: sync team documents into SQLite (close last live-API read surface, #261)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -100,8 +100,9 @@ Two rules govern the whole design:
    keeps SQLite fresh. Two deliberate exceptions block on the network: embedded
    attachment bytes (`*.png`, `*.pdf`) fall through memory → disk → a lazy CDN
    GET (`embeddedFileCache`), and a handful of interactive-tier synchronous
-   reads (team documents aren't synced to SQLite, and a few write-flow
-   re-checks) — see `WithInteractive` under the rate budget.
+   reads (a few write-flow re-checks, e.g. the attachment-listing live
+   re-check and the project read-your-writes re-fetch) — see `WithInteractive`
+   under the rate budget.
 2. **Writes go straight to the API, then backfill the cache.** The `api.Client`
    only talks to Linear — it never writes SQLite. The FUSE write handlers
    (`Flush`, `Mkdir`, `_create`, `rm`/`rmdir`) are responsible for upserting the
@@ -383,11 +384,11 @@ The serving end and the largest package, built on `go-fuse/v2`. The root struct
   `MutationClient` (`mutationclient.go`, every mutation; swappable in tests via
   `testutil/mockmutation`), a `verifyReader` for read-your-writes refetches,
   and a catalog-refresher seam for the stale-catalog flow below.
-- **Persistence:** `SQLiteRepository` (nearly all reads — team documents are
-  the exception: they aren't synced, so `teams/{KEY}/docs/` fetches live via
-  the `api.Client` at the interactive tier), `db.Store`, the `sync.Worker`, and
-  the mount-lifetime `lifeCtx`/`spawn` pair that ties every background
-  goroutine to unmount.
+- **Persistence:** `SQLiteRepository` (every metadata read, including
+  `teams/{KEY}/docs/`, which is served from SQLite with a stale-while-revalidate
+  background refresh like the project/initiative doc surfaces), `db.Store`, the
+  `sync.Worker`, and the mount-lifetime `lifeCtx`/`spawn` pair that ties every
+  background goroutine to unmount.
 - **Sub-modules (embedded structs):** `writeFeedback` (the `.error` *and*
   `.last` state), `embeddedFileCache` (memory → disk → CDN bytes for embedded
   files), and `kernelNotify` (the only coupling to `*fuse.Server`).

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -945,10 +945,10 @@ func (c *Client) GetIssueHistory(ctx context.Context, issueID string) ([]IssueHi
 		map[string]any{"issueId": issueID}, "issue", "history")
 }
 
-// GetTeamDocuments returns an empty list since Linear API doesn't support team-level documents
-// Documents can be attached to issues or projects, but not directly to teams
+// GetTeamDocuments fetches documents attached directly to a team, drained.
 func (c *Client) GetTeamDocuments(ctx context.Context, teamID string) ([]Document, error) {
-	return []Document{}, nil
+	return fetchAll[Document](ctx, c, queryTeamDocuments,
+		map[string]any{"teamId": teamID}, "documents")
 }
 
 // GetProjectDocuments fetches documents for a project, drained.

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -799,17 +799,26 @@ func TestGetProjectDocuments(t *testing.T) {
 
 func TestGetTeamDocuments(t *testing.T) {
 	t.Parallel()
+	mock := testutil.NewMockLinearServer()
+	defer mock.Close()
+
+	doc := testutil.FixtureDocument()
+	mock.SetResponse("TeamDocuments", testutil.ProjectDocumentsResponse(doc))
 
 	client := NewClient("test-api-key")
+	client.SetAPIURL(mock.URL())
 
-	// GetTeamDocuments always returns empty (Linear API doesn't support team-level docs)
 	docs, err := client.GetTeamDocuments(context.Background(), "team-123")
 	if err != nil {
 		t.Fatalf("GetTeamDocuments failed: %v", err)
 	}
 
-	if len(docs) != 0 {
-		t.Errorf("expected 0 documents, got %d", len(docs))
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(docs))
+	}
+
+	if docs[0].Title != "Test Document" {
+		t.Errorf("expected title 'Test Document', got %q", docs[0].Title)
 	}
 }
 

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -146,6 +146,7 @@ fragment DocumentFields on Document {
   issue { id identifier }
   project { id }
   initiative { id name }
+  team { id key name }
 }
 `
 
@@ -864,6 +865,15 @@ query ProjectDocuments($projectId: ID!, $after: String) {
 var queryInitiativeDocuments = `
 query InitiativeDocuments($initiativeId: ID!, $after: String) {
   documents(first: 100, after: $after, filter: { initiative: { id: { eq: $initiativeId } } }) {
+    pageInfo { hasNextPage endCursor }
+    nodes { ...DocumentFields }
+  }
+}
+` + DocumentFieldsFragment
+
+var queryTeamDocuments = `
+query TeamDocuments($teamId: ID!, $after: String) {
+  documents(first: 100, after: $after, filter: { team: { id: { eq: $teamId } } }) {
     pageInfo { hasNextPage endCursor }
     nodes { ...DocumentFields }
   }

--- a/internal/api/ratebudget.go
+++ b/internal/api/ratebudget.go
@@ -158,9 +158,9 @@ type interactiveCtxKey struct{}
 //
 // ADOPTION NOTE (PR1): this is the mechanism only. On-demand FS read call
 // The FS layer threads it at its synchronous, user-blocking API call sites
-// (GetTeamDocuments; the attachment-create authoritative re-check) — most
-// read paths never need it because they are SQLite-first with *background*
-// refresh, and background work must stay at base tier.
+// (the attachment-listing live re-check and the project read-your-writes
+// re-fetch) — most read paths never need it because they are SQLite-first
+// with *background* refresh, and background work must stay at base tier.
 //
 // RULE: apply WithInteractive at the moment of the synchronous call, never
 // store a promoted ctx or hand it to a goroutine that outlives the FUSE

--- a/internal/db/convert.go
+++ b/internal/db/convert.go
@@ -602,6 +602,9 @@ func APIDocumentToDBDocument(document api.Document) (UpsertDocumentParams, error
 	if document.Initiative != nil {
 		params.InitiativeID = sql.NullString{String: document.Initiative.ID, Valid: true}
 	}
+	if document.Team != nil {
+		params.TeamID = sql.NullString{String: document.Team.ID, Valid: true}
+	}
 	if document.Creator != nil {
 		params.CreatorID = sql.NullString{String: document.Creator.ID, Valid: true}
 	}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -69,6 +69,7 @@ type Document struct {
 	IssueID      sql.NullString  `json:"issue_id"`
 	ProjectID    sql.NullString  `json:"project_id"`
 	InitiativeID sql.NullString  `json:"initiative_id"`
+	TeamID       sql.NullString  `json:"team_id"`
 	CreatorID    sql.NullString  `json:"creator_id"`
 	Url          sql.NullString  `json:"url"`
 	CreatedAt    sql.NullTime    `json:"created_at"`

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -477,8 +477,8 @@ SELECT * FROM documents WHERE issue_id = ? ORDER BY title;
 SELECT * FROM documents WHERE project_id = ? ORDER BY title;
 
 -- name: UpsertDocument :exec
-INSERT INTO documents (id, slug_id, title, icon, color, content, content_data, issue_id, project_id, initiative_id, creator_id, url, created_at, updated_at, synced_at, data)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO documents (id, slug_id, title, icon, color, content, content_data, issue_id, project_id, initiative_id, team_id, creator_id, url, created_at, updated_at, synced_at, data)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
     slug_id = excluded.slug_id,
     title = excluded.title,
@@ -489,6 +489,7 @@ ON CONFLICT(id) DO UPDATE SET
     issue_id = excluded.issue_id,
     project_id = excluded.project_id,
     initiative_id = excluded.initiative_id,
+    team_id = excluded.team_id,
     creator_id = excluded.creator_id,
     url = excluded.url,
     created_at = excluded.created_at,
@@ -519,6 +520,15 @@ DELETE FROM documents WHERE initiative_id = ?;
 
 -- name: GetInitiativeDocumentsSyncedAt :one
 SELECT MAX(synced_at) FROM documents WHERE initiative_id = ?;
+
+-- name: ListTeamDocuments :many
+SELECT * FROM documents WHERE team_id = ? ORDER BY title;
+
+-- name: DeleteTeamDocuments :exec
+DELETE FROM documents WHERE team_id = ?;
+
+-- name: GetTeamDocumentsSyncedAt :one
+SELECT MAX(synced_at) FROM documents WHERE team_id = ?;
 
 -- =============================================================================
 -- Initiatives queries

--- a/internal/db/queries.sql.go
+++ b/internal/db/queries.sql.go
@@ -280,6 +280,15 @@ func (q *Queries) DeleteProjectUpdates(ctx context.Context, projectID string) er
 	return err
 }
 
+const deleteTeamDocuments = `-- name: DeleteTeamDocuments :exec
+DELETE FROM documents WHERE team_id = ?
+`
+
+func (q *Queries) DeleteTeamDocuments(ctx context.Context, teamID sql.NullString) error {
+	_, err := q.db.ExecContext(ctx, deleteTeamDocuments, teamID)
+	return err
+}
+
 const getInitiative = `-- name: GetInitiative :one
 
 SELECT id, slug_id, name, description, icon, color, status, sort_order, target_date, owner_id, url, created_at, updated_at, synced_at, data FROM initiatives WHERE id = ?
@@ -736,6 +745,17 @@ func (q *Queries) GetSyncSchedule(ctx context.Context, key string) (time.Time, e
 	return last_run, err
 }
 
+const getTeamDocumentsSyncedAt = `-- name: GetTeamDocumentsSyncedAt :one
+SELECT MAX(synced_at) FROM documents WHERE team_id = ?
+`
+
+func (q *Queries) GetTeamDocumentsSyncedAt(ctx context.Context, teamID sql.NullString) (interface{}, error) {
+	row := q.db.QueryRowContext(ctx, getTeamDocumentsSyncedAt, teamID)
+	var max interface{}
+	err := row.Scan(&max)
+	return max, err
+}
+
 const getTeamIssueCount = `-- name: GetTeamIssueCount :one
 SELECT COUNT(*) FROM issues WHERE team_id = ?
 `
@@ -849,7 +869,7 @@ func (q *Queries) ListCycleIssues(ctx context.Context, cycleID sql.NullString) (
 }
 
 const listInitiativeDocuments = `-- name: ListInitiativeDocuments :many
-SELECT id, slug_id, title, icon, color, content, content_data, issue_id, project_id, initiative_id, creator_id, url, created_at, updated_at, synced_at, data FROM documents WHERE initiative_id = ? ORDER BY title
+SELECT id, slug_id, title, icon, color, content, content_data, issue_id, project_id, initiative_id, team_id, creator_id, url, created_at, updated_at, synced_at, data FROM documents WHERE initiative_id = ? ORDER BY title
 `
 
 func (q *Queries) ListInitiativeDocuments(ctx context.Context, initiativeID sql.NullString) ([]Document, error) {
@@ -872,6 +892,7 @@ func (q *Queries) ListInitiativeDocuments(ctx context.Context, initiativeID sql.
 			&i.IssueID,
 			&i.ProjectID,
 			&i.InitiativeID,
+			&i.TeamID,
 			&i.CreatorID,
 			&i.Url,
 			&i.CreatedAt,
@@ -1115,7 +1136,7 @@ func (q *Queries) ListIssueComments(ctx context.Context, issueID string) ([]Comm
 
 const listIssueDocuments = `-- name: ListIssueDocuments :many
 
-SELECT id, slug_id, title, icon, color, content, content_data, issue_id, project_id, initiative_id, creator_id, url, created_at, updated_at, synced_at, data FROM documents WHERE issue_id = ? ORDER BY title
+SELECT id, slug_id, title, icon, color, content, content_data, issue_id, project_id, initiative_id, team_id, creator_id, url, created_at, updated_at, synced_at, data FROM documents WHERE issue_id = ? ORDER BY title
 `
 
 // =============================================================================
@@ -1141,6 +1162,7 @@ func (q *Queries) ListIssueDocuments(ctx context.Context, issueID sql.NullString
 			&i.IssueID,
 			&i.ProjectID,
 			&i.InitiativeID,
+			&i.TeamID,
 			&i.CreatorID,
 			&i.Url,
 			&i.CreatedAt,
@@ -1312,7 +1334,7 @@ func (q *Queries) ListPendingDetailSync(ctx context.Context) ([]ListPendingDetai
 }
 
 const listProjectDocuments = `-- name: ListProjectDocuments :many
-SELECT id, slug_id, title, icon, color, content, content_data, issue_id, project_id, initiative_id, creator_id, url, created_at, updated_at, synced_at, data FROM documents WHERE project_id = ? ORDER BY title
+SELECT id, slug_id, title, icon, color, content, content_data, issue_id, project_id, initiative_id, team_id, creator_id, url, created_at, updated_at, synced_at, data FROM documents WHERE project_id = ? ORDER BY title
 `
 
 func (q *Queries) ListProjectDocuments(ctx context.Context, projectID sql.NullString) ([]Document, error) {
@@ -1335,6 +1357,7 @@ func (q *Queries) ListProjectDocuments(ctx context.Context, projectID sql.NullSt
 			&i.IssueID,
 			&i.ProjectID,
 			&i.InitiativeID,
+			&i.TeamID,
 			&i.CreatorID,
 			&i.Url,
 			&i.CreatedAt,
@@ -1658,6 +1681,51 @@ func (q *Queries) ListTeamCycles(ctx context.Context, teamID string) ([]Cycle, e
 			&i.EndsAt,
 			&i.CompletedAt,
 			&i.Progress,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.SyncedAt,
+			&i.Data,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listTeamDocuments = `-- name: ListTeamDocuments :many
+SELECT id, slug_id, title, icon, color, content, content_data, issue_id, project_id, initiative_id, team_id, creator_id, url, created_at, updated_at, synced_at, data FROM documents WHERE team_id = ? ORDER BY title
+`
+
+func (q *Queries) ListTeamDocuments(ctx context.Context, teamID sql.NullString) ([]Document, error) {
+	rows, err := q.db.QueryContext(ctx, listTeamDocuments, teamID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Document{}
+	for rows.Next() {
+		var i Document
+		if err := rows.Scan(
+			&i.ID,
+			&i.SlugID,
+			&i.Title,
+			&i.Icon,
+			&i.Color,
+			&i.Content,
+			&i.ContentData,
+			&i.IssueID,
+			&i.ProjectID,
+			&i.InitiativeID,
+			&i.TeamID,
+			&i.CreatorID,
+			&i.Url,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.SyncedAt,
@@ -2818,8 +2886,8 @@ func (q *Queries) UpsertCycle(ctx context.Context, arg UpsertCycleParams) error 
 }
 
 const upsertDocument = `-- name: UpsertDocument :exec
-INSERT INTO documents (id, slug_id, title, icon, color, content, content_data, issue_id, project_id, initiative_id, creator_id, url, created_at, updated_at, synced_at, data)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO documents (id, slug_id, title, icon, color, content, content_data, issue_id, project_id, initiative_id, team_id, creator_id, url, created_at, updated_at, synced_at, data)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
     slug_id = excluded.slug_id,
     title = excluded.title,
@@ -2830,6 +2898,7 @@ ON CONFLICT(id) DO UPDATE SET
     issue_id = excluded.issue_id,
     project_id = excluded.project_id,
     initiative_id = excluded.initiative_id,
+    team_id = excluded.team_id,
     creator_id = excluded.creator_id,
     url = excluded.url,
     created_at = excluded.created_at,
@@ -2849,6 +2918,7 @@ type UpsertDocumentParams struct {
 	IssueID      sql.NullString  `json:"issue_id"`
 	ProjectID    sql.NullString  `json:"project_id"`
 	InitiativeID sql.NullString  `json:"initiative_id"`
+	TeamID       sql.NullString  `json:"team_id"`
 	CreatorID    sql.NullString  `json:"creator_id"`
 	Url          sql.NullString  `json:"url"`
 	CreatedAt    sql.NullTime    `json:"created_at"`
@@ -2869,6 +2939,7 @@ func (q *Queries) UpsertDocument(ctx context.Context, arg UpsertDocumentParams) 
 		arg.IssueID,
 		arg.ProjectID,
 		arg.InitiativeID,
+		arg.TeamID,
 		arg.CreatorID,
 		arg.Url,
 		arg.CreatedAt,

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -287,6 +287,7 @@ CREATE TABLE IF NOT EXISTS documents (
     issue_id TEXT,
     project_id TEXT,
     initiative_id TEXT,
+    team_id TEXT,
     creator_id TEXT,
     url TEXT,
     created_at DATETIME,
@@ -299,6 +300,7 @@ CREATE INDEX IF NOT EXISTS idx_documents_slug ON documents(slug_id);
 CREATE INDEX IF NOT EXISTS idx_documents_issue ON documents(issue_id);
 CREATE INDEX IF NOT EXISTS idx_documents_project ON documents(project_id);
 CREATE INDEX IF NOT EXISTS idx_documents_initiative ON documents(initiative_id);
+CREATE INDEX IF NOT EXISTS idx_documents_team ON documents(team_id);
 CREATE INDEX IF NOT EXISTS idx_documents_creator ON documents(creator_id);
 
 -- =============================================================================

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -109,6 +109,23 @@ func migrateSchema(db *sql.DB) error {
 			return fmt.Errorf("add issues.detail_synced_at: %w", err)
 		}
 	}
+
+	// team_id scopes documents to their owning team (team-level documents).
+	// Safe under sqlc: generated queries expand SELECT * into an explicit
+	// named column list, so the driver honors schema order regardless of
+	// where ALTER TABLE physically appends the column on a migrated DB.
+	hasTeamDoc, err := tableHasColumn(db, "documents", "team_id")
+	if err != nil {
+		return err
+	}
+	if !hasTeamDoc {
+		if _, err := db.Exec("ALTER TABLE documents ADD COLUMN team_id TEXT"); err != nil {
+			return fmt.Errorf("add documents.team_id: %w", err)
+		}
+		if _, err := db.Exec("CREATE INDEX IF NOT EXISTS idx_documents_team ON documents(team_id)"); err != nil {
+			return fmt.Errorf("index documents.team_id: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/internal/fs/documents.go
+++ b/internal/fs/documents.go
@@ -36,7 +36,7 @@ func (n *DocsNode) getDocuments(ctx context.Context) ([]api.Document, error) {
 		return n.lfs.repo.GetIssueDocuments(ctx, n.issueID)
 	}
 	if n.teamID != "" {
-		return n.lfs.GetTeamDocuments(ctx, n.teamID)
+		return n.lfs.repo.GetTeamDocuments(ctx, n.teamID)
 	}
 	if n.projectID != "" {
 		return n.lfs.repo.GetProjectDocuments(ctx, n.projectID)

--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -532,13 +532,6 @@ func (lfs *LinearFS) UpdateComment(ctx context.Context, issueID string, commentI
 	return lfs.mutator().UpdateComment(ctx, commentID, body)
 }
 
-// GetTeamDocuments returns documents for a team (currently via API as not
-// synced). This is a synchronous API call on a live FUSE path — the caller's
-// user is blocked on it — so it promotes to the interactive budget tier.
-func (lfs *LinearFS) GetTeamDocuments(ctx context.Context, teamID string) ([]api.Document, error) {
-	return lfs.client.GetTeamDocuments(api.WithInteractive(ctx), teamID)
-}
-
 func (lfs *LinearFS) UpdateDocument(ctx context.Context, documentID string, input map[string]any, issueID, teamID, projectID string) (*api.Document, error) {
 	return lfs.mutator().UpdateDocument(ctx, documentID, input)
 }

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -97,6 +97,7 @@ Mount point: %s (all paths below are relative to this mount point)
 teams/{KEY}/
   team.md, states.md, labels.md     [read-only metadata]
   project-labels.md                 [symlink to ../../project-labels.md]
+  docs/                             [team-level documents; same surface as issues/docs]
   issues/                           [mkdir "Title" for quick create]
     _create                         [write full frontmatter+body to create one issue with all fields]
     .error                          [read-only: last failed issue creation]

--- a/internal/integration/fixture_read_test.go
+++ b/internal/integration/fixture_read_test.go
@@ -344,6 +344,44 @@ func TestFixtureDocsNewMdWriteOnly(t *testing.T) {
 	}
 }
 
+// TestFixtureTeamDocsServedFromSQLite guards the team-documents surface: it is
+// served from the Repository (SQLite) like every other read, not via a blocking
+// live API call (#261). The fixture seeds one team-level document.
+func TestFixtureTeamDocsServedFromSQLite(t *testing.T) {
+	teamDocsDir := filepath.Join(teamPath(testTeamKey), "docs")
+	entries, err := os.ReadDir(teamDocsDir)
+	if err != nil {
+		t.Fatalf("Failed to read team docs directory: %v", err)
+	}
+
+	docCount := 0
+	for _, entry := range entries {
+		if entry.Name() == "_create" || strings.HasSuffix(entry.Name(), ".meta") {
+			continue
+		}
+		if !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		docCount++
+
+		content, err := os.ReadFile(filepath.Join(teamDocsDir, entry.Name()))
+		if err != nil {
+			t.Fatalf("Failed to read team document %s: %v", entry.Name(), err)
+		}
+		doc, err := parseFrontmatter(content)
+		if err != nil {
+			t.Fatalf("Failed to parse team document %s: %v", entry.Name(), err)
+		}
+		if _, ok := doc.Frontmatter["title"]; !ok {
+			t.Errorf("Team document %s missing title field", entry.Name())
+		}
+	}
+
+	if docCount != 1 {
+		t.Errorf("Expected 1 team document served from SQLite, got %d", docCount)
+	}
+}
+
 // =============================================================================
 // Project Read Tests (fixture: test-project)
 // =============================================================================

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -335,6 +335,14 @@ func populateTestFixtures(ctx context.Context, store *db.Store) error {
 		return err
 	}
 
+	// Populate team-level documents
+	teamDocs := []api.Document{
+		fixtures.FixtureAPITeamDocument(team.ID, 1),
+	}
+	if err := fixtures.PopulateDocuments(ctx, store, teamDocs); err != nil {
+		return err
+	}
+
 	// Populate cycle
 	cycle := fixtures.FixtureAPICycle()
 	if err := fixtures.PopulateCycle(ctx, store, cycle, team.ID); err != nil {

--- a/internal/repo/sqlite.go
+++ b/internal/repo/sqlite.go
@@ -1028,6 +1028,52 @@ func (r *SQLiteRepository) refreshInitiativeDocuments(ctx context.Context, initi
 	return nil
 }
 
+func (r *SQLiteRepository) GetTeamDocuments(ctx context.Context, teamID string) ([]api.Document, error) {
+	docs, err := r.store.Queries().ListTeamDocuments(ctx, sql.NullString{String: teamID, Valid: true})
+	if err != nil {
+		return nil, fmt.Errorf("list team documents: %w", err)
+	}
+
+	r.maybeRefreshSWR(swrSpec{
+		kind: kindTeamDocs,
+		id:   teamID,
+		syncedAt: func() (interface{}, error) {
+			return r.store.Queries().GetTeamDocumentsSyncedAt(context.Background(), sql.NullString{String: teamID, Valid: true})
+		},
+		refresh: func(ctx context.Context) error {
+			return r.refreshTeamDocuments(ctx, teamID)
+		},
+		// No orphan handler: a team is the sync root, not a sub-resource, so a
+		// not-found on its docs must not cascade-delete the team (owned by the
+		// full team sync). Upsert-only refresh, like the project/initiative twins.
+	})
+
+	return db.DBDocumentsToAPIDocuments(docs)
+}
+
+// refreshTeamDocuments fetches documents from API and stores in SQLite.
+// Upsert-only (nil Prune): nothing licenses a prune for this fetch.
+func (r *SQLiteRepository) refreshTeamDocuments(ctx context.Context, teamID string) error {
+	docs, err := r.client.GetTeamDocuments(ctx, teamID)
+	if err != nil {
+		return err
+	}
+
+	reconcile.Collection(ctx, reconcile.CollectionSpec[api.Document]{
+		Label: "team document " + teamID,
+		Kind:  "document",
+		Items: docs,
+		Upsert: func(ctx context.Context, doc api.Document) error {
+			params, err := db.APIDocumentToDBDocument(doc)
+			if err != nil {
+				return err
+			}
+			return r.store.Queries().UpsertDocument(ctx, params)
+		},
+	})
+	return nil
+}
+
 // =============================================================================
 // Initiatives
 // =============================================================================

--- a/internal/repo/swr.go
+++ b/internal/repo/swr.go
@@ -23,6 +23,7 @@ const (
 	kindHistory           refreshKind = "history"
 	kindProjectDocs       refreshKind = "project-docs"
 	kindInitiativeDocs    refreshKind = "initiative-docs"
+	kindTeamDocs          refreshKind = "team-docs"
 	kindProjectUpdates    refreshKind = "project-updates"
 	kindInitiativeUpdates refreshKind = "initiative-updates"
 	kindProjectLinks      refreshKind = "project-links"

--- a/internal/testutil/fixtures/api.go
+++ b/internal/testutil/fixtures/api.go
@@ -352,6 +352,22 @@ func FixtureAPIProjectDocument(projectID string, n int) api.Document {
 	}
 }
 
+// FixtureAPITeamDocument returns a document attached directly to a team.
+func FixtureAPITeamDocument(teamID string, n int) api.Document {
+	user := FixtureAPIUser()
+	return api.Document{
+		ID:        fmt.Sprintf("doc-team-%s-%d", teamID, n),
+		Title:     fmt.Sprintf("Team Document %d", n),
+		Content:   fmt.Sprintf("# Team Document %d\n\nDocument attached to team %s.", n, teamID),
+		SlugID:    fmt.Sprintf("team-doc-%s-%d", teamID, n),
+		URL:       fmt.Sprintf("https://linear.app/test/document/team-doc-%s-%d", teamID, n),
+		CreatedAt: fixtureTime,
+		UpdatedAt: fixtureTime,
+		Creator:   &user,
+		Team:      &api.Team{ID: teamID},
+	}
+}
+
 // FixtureAPIProject returns a test project.
 func FixtureAPIProject() api.Project {
 	user := FixtureAPIUser()


### PR DESCRIPTION
## Summary

`teams/{KEY}/docs/` was the one FUSE read surface that violated rule 1 (**reads never touch the Linear API**): it served from a blocking, interactive-tier `client.GetTeamDocuments`, so it failed offline and under rate-limit. Worse, the API client was a stub returning `[]Document{}` with a comment claiming Linear had no team-level documents — but the schema does support them (`Document.team` + `DocumentFilter.team`), so the surface silently served *nothing*.

This makes team documents a real, SQLite-backed read like every other surface, removing the documented rule-1 exception and one `WithInteractive` call site.

Closes #261.

## What changed

- **api**: real `GetTeamDocuments` — `fetchAll` over a team-filtered `documents` query, a faithful twin of `GetProjectDocuments`. `DocumentFields` fragment gains `team { id key name }`.
- **db**: `documents.team_id` column (+ index); idempotent `ALTER TABLE ADD COLUMN` migration following the `detail_synced_at` precedent. Safe under sqlc because generated queries expand `SELECT *` into an explicit named column list, so the driver honors schema order regardless of where the migrated column physically lands. `UpsertDocument` + new `ListTeamDocuments` / `GetTeamDocumentsSyncedAt` / `DeleteTeamDocuments` queries; `convert.go` maps `Document.Team → TeamID`.
- **repo**: `GetTeamDocuments` serves from SQLite with a stale-while-revalidate background refresh (`kindTeamDocs`), sibling of the project/initiative doc surfaces. No orphan handler — a team is the sync root, not a sub-resource, so a not-found on its docs must not cascade-delete the team.
- **fs**: `DocsNode` team branch reads through the repo; deleted `LinearFS.GetTeamDocuments` and its `WithInteractive` call site.
- **docs**: removed the rule-1 exception from `ARCHITECTURE.md`; generated README (`root.go`) now lists `teams/{KEY}/docs/`.
- **tests**: `FixtureAPITeamDocument` + fixture seed + an integration read test asserting team docs are served from SQLite; rewrote the API client test from the old empty-list stub to the mock-server pattern.

## Design note

Project and initiative docs are also served purely via SWR-on-read (they are **not** in the sync worker's full cycle), so matching that pattern for team docs is the consistent choice — no worker change is needed, and adding one would diverge from the sibling surfaces.

## Testing

- `go test ./...` green (unit).
- Full integration suite green on re-run. One flake (`TestRejectedSaveKeepsDirtyContentReadable`, an unrelated `project.md` staleness test) appeared once under whole-suite load and passed in isolation and on re-run — the documented pre-existing whole-suite flake.
- `make staticcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)