### PR TITLE
feat: add FUSE-op OTEL instruments to the serving layer (#264)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -501,9 +501,15 @@ re-`rm`ing a phantom row heals it.
 
 ### `internal/telemetry` — OTEL metrics pipeline
 
-Owns the meter provider the recording packages (api, sync, repo, reconcile)
-record into; fs records no instruments — it only wires the per-request debug
-log. One `MeterProvider`, two renderings: an always-on 5-minute summary line to
+Owns the meter provider the recording packages (api, sync, repo, reconcile,
+fs) record into. `internal/fs` records serving-layer instruments (`metrics.go`,
+meter `linearfs/fuse`): `linearfs.fuse.ops {op, outcome}` and
+`linearfs.fuse.duration {op}` at the three commit tails (create/delete/flush)
+and the editBuffer/renderFile read/write entry points, plus
+`linearfs.embedded_files.fetch {source=memory|disk|cdn}` at the byte-cache
+tiers. Coverage is those cheap choke points, not lookup/readdir (spread across
+every node type with no shared tail). It also wires the optional per-request
+debug log. One `MeterProvider`, two renderings: an always-on 5-minute summary line to
 journald/logs, and a config-gated file export writing one compact JSON line per
 interval to `~/.config/linearfs/metrics.jsonl` through a rotating writer
 (diagnosis = `jq` over that file). There is no OTLP exporter. Exporter failure

--- a/internal/fs/createcommit.go
+++ b/internal/fs/createcommit.go
@@ -96,13 +96,17 @@ type createSpec[T any] struct {
 //   - mutate fails otherwise        -> .error gets the cause, EIO.
 //   - success                       -> clear .error, append .last, persist
 //     (non-fatal on failure), InvalidateCreated(dir, name), run extras, errno 0.
-func commitCreate[T any](ctx context.Context, sink createSink, spec createSpec[T]) (*T, syscall.Errno) {
+func commitCreate[T any](ctx context.Context, sink createSink, spec createSpec[T]) (created *T, errno syscall.Errno) {
+	start := time.Now()
+	defer func() { recordFuseOp(ctx, "create", start, errno) }()
+
 	ctx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
 	created, err := spec.mutate(ctx)
 	if err != nil {
-		msg, errno := classifyMutationErr(spec.op, err)
+		var msg string
+		msg, errno = classifyMutationErr(spec.op, err)
 		log.Printf("Failed to %s: %v", spec.op, err)
 		sink.SetWriteError(spec.key, msg)
 		return nil, errno

--- a/internal/fs/deletecommit.go
+++ b/internal/fs/deletecommit.go
@@ -73,13 +73,17 @@ type deleteSpec[T any] struct {
 //   - mutate fails        -> .error gets the cause, EAGAIN if transient else EIO.
 //   - success             -> clear .error, forget SQLite (non-fatal on failure),
 //     InvalidateDeleted(dir, name), run extras, errno 0.
-func commitDelete[T any](ctx context.Context, sink deleteSink, spec deleteSpec[T]) syscall.Errno {
+func commitDelete[T any](ctx context.Context, sink deleteSink, spec deleteSpec[T]) (errno syscall.Errno) {
+	start := time.Now()
+	defer func() { recordFuseOp(ctx, "delete", start, errno) }()
+
 	ctx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
 	target, err := spec.find(ctx)
 	if err != nil {
-		msg, errno := classifyMutationErr(spec.op, err)
+		var msg string
+		msg, errno = classifyMutationErr(spec.op, err)
 		log.Printf("Failed to %s: %v", spec.op, err)
 		sink.SetWriteError(spec.key, msg)
 		return errno
@@ -91,7 +95,8 @@ func commitDelete[T any](ctx context.Context, sink deleteSink, spec deleteSpec[T
 
 	if err := spec.mutate(ctx, target); err != nil {
 		if !remoteAlreadyGone(err) {
-			msg, errno := classifyMutationErr(spec.op, err)
+			var msg string
+			msg, errno = classifyMutationErr(spec.op, err)
 			log.Printf("Failed to %s: %v", spec.op, err)
 			sink.SetWriteError(spec.key, msg)
 			return errno

--- a/internal/fs/editbuffer.go
+++ b/internal/fs/editbuffer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
@@ -52,7 +53,10 @@ func (b *editBuffer) Open(ctx context.Context, flags uint32) (fs.FileHandle, uin
 	return nil, fuse.FOPEN_KEEP_CACHE, 0
 }
 
-func (b *editBuffer) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
+func (b *editBuffer) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (res fuse.ReadResult, errno syscall.Errno) {
+	start := time.Now()
+	defer func() { recordFuseOp(ctx, "read", start, errno) }()
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -66,7 +70,10 @@ func (b *editBuffer) Read(ctx context.Context, f fs.FileHandle, dest []byte, off
 	return fuse.ReadResultData(b.content[off:end]), 0
 }
 
-func (b *editBuffer) Write(ctx context.Context, f fs.FileHandle, data []byte, off int64) (uint32, syscall.Errno) {
+func (b *editBuffer) Write(ctx context.Context, f fs.FileHandle, data []byte, off int64) (n uint32, errno syscall.Errno) {
+	start := time.Now()
+	defer func() { recordFuseOp(ctx, "write", start, errno) }()
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 

--- a/internal/fs/editcommit.go
+++ b/internal/fs/editcommit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"syscall"
+	"time"
 )
 
 // The edit-commit tail.
@@ -66,7 +67,10 @@ type writeBackSpec[T any] struct {
 //   - no divergence      → clear .error, return (fresh, 0).
 //   - benign reformat    → set .error note, return (fresh, 0).
 //   - fatal divergence   → set .error, return (fresh, syscall.EIO).
-func commitWriteBack[T any](ctx context.Context, sink errorSink, spec writeBackSpec[T]) (*T, syscall.Errno) {
+func commitWriteBack[T any](ctx context.Context, sink errorSink, spec writeBackSpec[T]) (fresh *T, errno syscall.Errno) {
+	start := time.Now()
+	defer func() { recordFuseOp(ctx, "flush", start, errno) }()
+
 	fresh, err := spec.fetch(ctx)
 	if err != nil {
 		// The API accepted the write; we just could not re-read it to verify.

--- a/internal/fs/embeddedfilecache.go
+++ b/internal/fs/embeddedfilecache.go
@@ -68,6 +68,7 @@ func (c *embeddedFileCache) FetchEmbeddedFile(ctx context.Context, file api.Embe
 	c.mu.RLock()
 	if content, ok := c.mem[file.ID]; ok {
 		c.mu.RUnlock()
+		recordEmbeddedFetch(ctx, "memory")
 		return content, nil
 	}
 	c.mu.RUnlock()
@@ -79,6 +80,7 @@ func (c *embeddedFileCache) FetchEmbeddedFile(ctx context.Context, file api.Embe
 
 	if content, err := os.ReadFile(diskPath); err == nil {
 		c.store(file.ID, content)
+		recordEmbeddedFetch(ctx, "disk")
 		return content, nil
 	}
 
@@ -86,6 +88,7 @@ func (c *embeddedFileCache) FetchEmbeddedFile(ctx context.Context, file api.Embe
 	if err != nil {
 		return nil, fmt.Errorf("download file: %w", err)
 	}
+	recordEmbeddedFetch(ctx, "cdn")
 
 	if err := os.WriteFile(diskPath, content, 0644); err != nil {
 		log.Printf("[cache] Warning: failed to cache file %s: %v", file.Filename, err)

--- a/internal/fs/metrics.go
+++ b/internal/fs/metrics.go
@@ -1,0 +1,101 @@
+package fs
+
+// OTEL instruments for the serving layer (meter "linearfs/fuse"). Until this
+// change the fs package recorded nothing — the layer users actually feel was
+// the observability blind spot while api/sync/repo/reconcile were all wired.
+//
+// The instruments bind lazily on first use (the internal/reconcile
+// prunesCounter precedent): the commit tails are free generic functions with no
+// single construction choke to bind at, so threading a metrics handle through
+// every sink would be far more intrusive than a package-level lazy bind. Until
+// telemetry.Init registers a provider the global no-op makes every record free,
+// so there are no nil checks or enable flags.
+//
+// Coverage is deliberately the cheap choke points, not every node type: the
+// three commit tails (create/delete/flush), the editBuffer read/write and
+// renderFile read entry points, and the embedded-file fetch tiers. Lookup and
+// readdir are spread across every node type with no shared tail, so they are
+// left out rather than instrumented invasively — see #264.
+
+import (
+	"context"
+	"sync"
+	"syscall"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/jra3/linear-fuse/internal/telemetry"
+)
+
+type fuseMetrics struct {
+	ops      metric.Int64Counter     // linearfs.fuse.ops {op, outcome}
+	duration metric.Float64Histogram // linearfs.fuse.duration {op}, seconds
+	embedded metric.Int64Counter     // linearfs.embedded_files.fetch {source}
+}
+
+var (
+	fuseMetricsOnce sync.Once
+	fuseMetricsInst fuseMetrics
+)
+
+func fuseMetricsInstance() fuseMetrics {
+	fuseMetricsOnce.Do(func() {
+		m := otel.Meter("linearfs/fuse")
+		fuseMetricsInst = fuseMetrics{
+			ops: telemetry.MustInt64Counter(m, "linearfs.fuse.ops",
+				metric.WithDescription("FUSE operations completed, by op (create|delete|flush|write|read) and outcome (ok|einval|eio|eagain|...)")),
+			duration: telemetry.MustFloat64Histogram(m, "linearfs.fuse.duration",
+				metric.WithUnit("s"),
+				metric.WithDescription("FUSE operation duration by op")),
+			embedded: telemetry.MustInt64Counter(m, "linearfs.embedded_files.fetch",
+				metric.WithDescription("Embedded-file byte fetches, by serving tier (memory|disk|cdn)")),
+		}
+	})
+	return fuseMetricsInst
+}
+
+// outcomeForErrno maps a syscall.Errno to the closed outcome enum shared by the
+// write-outcome breakdown — the failure-model health check the issue calls for.
+// Anything unlisted collapses to "other" so cardinality stays bounded.
+func outcomeForErrno(errno syscall.Errno) string {
+	switch errno {
+	case 0:
+		return "ok"
+	case syscall.EINVAL:
+		return "einval"
+	case syscall.EIO:
+		return "eio"
+	case syscall.EAGAIN:
+		return "eagain"
+	case syscall.ENOENT:
+		return "enoent"
+	case syscall.EMSGSIZE:
+		return "emsgsize"
+	case syscall.EPERM:
+		return "eperm"
+	case syscall.EACCES:
+		return "eacces"
+	default:
+		return "other"
+	}
+}
+
+// recordFuseOp counts one completed FUSE op with its duration and outcome.
+func recordFuseOp(ctx context.Context, op string, start time.Time, errno syscall.Errno) {
+	m := fuseMetricsInstance()
+	m.ops.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("op", op),
+		attribute.String("outcome", outcomeForErrno(errno))))
+	m.duration.Record(ctx, time.Since(start).Seconds(),
+		metric.WithAttributes(attribute.String("op", op)))
+}
+
+// recordEmbeddedFetch counts one embedded-file byte fetch by the tier that
+// served it (memory|disk|cdn) — the CDN visibility the CDN-seam issue wanted.
+func recordEmbeddedFetch(ctx context.Context, source string) {
+	fuseMetricsInstance().embedded.Add(ctx, 1,
+		metric.WithAttributes(attribute.String("source", source)))
+}

--- a/internal/fs/metrics_test.go
+++ b/internal/fs/metrics_test.go
@@ -1,0 +1,116 @@
+package fs
+
+// Serving-layer metrics tests. linearfs.fuse.* and linearfs.embedded_files.fetch
+// bind lazily on first record (the package has no construction choke), so — like
+// the reconcile prune-counter tests — this installs ONE manual-reader provider
+// for the whole binary in TestMain, before any test can bind the instruments.
+// The record tests assert on a synthetic op name / a before-after delta so real
+// commit-tail and fetch activity from other fs tests can't perturb them.
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+var metricsReader *sdkmetric.ManualReader
+
+func TestMain(m *testing.M) {
+	metricsReader = sdkmetric.NewManualReader()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(metricsReader)))
+	os.Exit(m.Run())
+}
+
+// counterValue returns the Int64 sum datapoint for metric name matching every
+// attribute in want, or 0 when none has been recorded.
+func counterValue(t *testing.T, name string, want map[string]string) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := metricsReader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	for _, sm := range rm.ScopeMetrics {
+		for _, md := range sm.Metrics {
+			if md.Name != name {
+				continue
+			}
+			sum, ok := md.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("%s data is %T, want Sum[int64]", name, md.Data)
+			}
+			for _, dp := range sum.DataPoints {
+				if attrsMatch(dp.Attributes, want) {
+					return dp.Value
+				}
+			}
+		}
+	}
+	return 0
+}
+
+func attrsMatch(set attribute.Set, want map[string]string) bool {
+	for k, v := range want {
+		got, ok := set.Value(attribute.Key(k))
+		if !ok || got.AsString() != v {
+			return false
+		}
+	}
+	return true
+}
+
+func TestOutcomeForErrno(t *testing.T) {
+	t.Parallel()
+	cases := map[syscall.Errno]string{
+		0:                "ok",
+		syscall.EINVAL:   "einval",
+		syscall.EIO:      "eio",
+		syscall.EAGAIN:   "eagain",
+		syscall.ENOENT:   "enoent",
+		syscall.EMSGSIZE: "emsgsize",
+		syscall.EPERM:    "eperm",
+		syscall.EACCES:   "eacces",
+		syscall.ENOSPC:   "other",
+	}
+	for errno, want := range cases {
+		if got := outcomeForErrno(errno); got != want {
+			t.Errorf("outcomeForErrno(%v) = %q, want %q", errno, got, want)
+		}
+	}
+}
+
+// TestRecordFuseOp records under a synthetic op so no production path collides,
+// and asserts the outcome is derived from the errno.
+func TestRecordFuseOp(t *testing.T) {
+	ctx := context.Background()
+	recordFuseOp(ctx, "smoke-test-op", time.Now(), syscall.EINVAL)
+
+	if got := counterValue(t, "linearfs.fuse.ops",
+		map[string]string{"op": "smoke-test-op", "outcome": "einval"}); got != 1 {
+		t.Errorf("ops{op=smoke-test-op,outcome=einval} = %d, want 1", got)
+	}
+	// The wrong-outcome datapoint must not exist for this synthetic op.
+	if got := counterValue(t, "linearfs.fuse.ops",
+		map[string]string{"op": "smoke-test-op", "outcome": "ok"}); got != 0 {
+		t.Errorf("ops{op=smoke-test-op,outcome=ok} = %d, want 0", got)
+	}
+}
+
+// TestRecordEmbeddedFetch asserts a fetch bumps its tier counter by exactly one
+// (a before-after delta, since the memory|disk|cdn enum is shared with real
+// fetch paths).
+func TestRecordEmbeddedFetch(t *testing.T) {
+	ctx := context.Background()
+	before := counterValue(t, "linearfs.embedded_files.fetch", map[string]string{"source": "disk"})
+	recordEmbeddedFetch(ctx, "disk")
+	after := counterValue(t, "linearfs.embedded_files.fetch", map[string]string{"source": "disk"})
+	if after != before+1 {
+		t.Errorf("embedded_files.fetch{source=disk} = %d, want %d", after, before+1)
+	}
+}

--- a/internal/fs/renderfile.go
+++ b/internal/fs/renderfile.go
@@ -107,6 +107,9 @@ func (r *renderFile) Open(ctx context.Context, flags uint32) (fs.FileHandle, uin
 }
 
 func (r *renderFile) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
+	start := time.Now()
+	defer func() { recordFuseOp(ctx, "read", start, 0) }()
+
 	content, _, _ := r.renderNow(ctx)
 	return readWindow(content, dest, off), 0
 }


### PR DESCRIPTION
## Summary

`api`, `sync`, `repo`, and `reconcile` all recorded OTEL instruments, but `internal/fs` — the serving layer users actually feel — recorded **none** (it only wired the per-request debug log). This closes that blind spot with a serving-layer meter (`linearfs/fuse`).

Closes #264.

## Instruments

- `linearfs.fuse.ops {op, outcome}` (counter) + `linearfs.fuse.duration {op}` (histogram, seconds), recorded at:
  - the three commit tails — `commitCreate` (op `create`), `commitDelete` (op `delete`), `commitWriteBack` (op `flush`)
  - the buffer/render read-write entry points — `editBuffer.Read`/`renderFile.Read` (op `read`), `editBuffer.Write` (op `write`)
  - The `outcome` enum (`ok|einval|eio|eagain|enoent|emsgsize|eperm|eacces|other`) is derived from the returned `syscall.Errno`, so the write-outcome breakdown doubles as the failure-model health check the issue asked for.
- `linearfs.embedded_files.fetch {source=memory|disk|cdn}` (counter), recorded at each byte-cache tier in `FetchEmbeddedFile` — the CDN-fetch visibility the CDN-seam issue (#262) pointed at.

## Design notes

- **Lazy binding.** The instruments bind on first record via a `sync.Once` (the `internal/reconcile` `prunesCounter` precedent) because the commit tails are free generic functions with no construction choke to bind at — threading a metrics handle through every sink would be far more intrusive. Until `telemetry.Init` registers a provider, the global no-op makes every record free (no nil checks, no enable flags).
- **Coverage is the cheap choke points, not every op.** `lookup`/`readdir` are spread across every node type with no shared tail, so they're deliberately left out rather than instrumented invasively — noted in the code and the issue.
- **Named returns + deferred record** capture the outcome at whichever exit fires. The two error-classify sites in the commit tails switched from `:=` (which shadowed the named `errno`) to explicit assignment.

## Overlap with #262 (open)

This branches off `main`, so it does **not** include the still-open CDN-seam PR (#262). The two touch the same two spots — `embeddedfilecache.go`'s `FetchEmbeddedFile` and the `ARCHITECTURE.md` telemetry section — so a small, mechanical merge resolution is expected when the second of the two lands. The `linearfs.embedded_files.fetch` instrument is identical regardless of whether the CDN tier fetches via the old inline `download` or #262's `CDNClient.Get`.

## Testing

- New `internal/fs/metrics_test.go`: a manual-reader `TestMain` (needed because the instruments bind lazily), a table test for the errno→outcome mapping, and record assertions (synthetic op name + before/after delta so real commit-tail/fetch activity from other tests can't perturb them).
- `go test ./...` green; integration suite green; `make staticcheck` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)