### PR TITLE
fix(fs): confirmed-reflection contract for the remaining swallow sites (#278)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,6 +29,27 @@ return `EIO` on fatal divergence. Generic over the entity type `T`. Lives in
 a small `ErrorSink` seam plus `Fetch`/`Persist`/`Compare` closures, so it is unit-
 tested with a fake sink and stub closures — no FUSE mount, SQLite, or API.
 
+**Persist gates the edit** (#278, see [[persist-gate]]): a reflection the local
+cache can't serve is retried against the `SQLITE_BUSY`/sync-worker race and, on
+exhaustion (a wedge), fails loud — `.error` + `EIO` — instead of the old
+log-and-swallow. `fresh` is still returned so the caller adopts correct data into
+the live fd, so the `EIO` is a pure wedge signal whose recovery (re-saving) is
+safe because the edit is idempotent. The **fetch** swallow is deliberately kept
+(intent-commented): a failed verification re-read is not a failed write.
+
+### Persist gate (`retrySQLite` / `persistOrEIO`)
+The shared **deep module** (`internal/fs/persistgate.go`) that commits a mutation's
+local reflection: retry the `SQLITE_BUSY`/sync-worker transient (`retrySQLite`,
+the generalization of the delete tail's old `forgetWithRetry` — one backoff
+schedule, a package var so tests zero the sleeps), and on exhaustion fail loud
+with a `.error` that states the **safe recovery**. `persistOrEIO` wraps it for the
+edit tail and the hand-rolled label/document renames; the delete tail calls
+`retrySQLite` directly with its own message. `unconfirmedEditMsg` (edit/rename:
+"re-saving is safe — idempotent") and `unconfirmedDeleteMsg` (delete: "re-run rm
+to clear the phantom") are the two recovery messages; a create's `.error` is the
+non-idempotent counterpart ("do NOT recreate"). This is where "confirmed
+reflection or say why in `.error`" lives in one place for every write direction.
+
 The **front half** of each edit (parse, resolve, call API) stays per-entity. For
 issues the resolve step is itself a deep module — see Name→ID resolution below.
 
@@ -139,11 +160,15 @@ notes itself in `.error` before returning `ENOENT`. Generic over `T`, behind the
 Durability of the forget (a stress test caught a delete whose forget lost a
 `SQLITE_BUSY` race to the sync worker, leaving a phantom file that resurrected
 forever): the connection-level `busy_timeout` DSN pragma makes the race rare,
-the tail retries a failed forget before giving up, a delete of an entity Linear
-already lacks ("Entity not found") is **idempotent success** — the row is still
-forgotten, so re-`rm`ing a phantom heals it — and the details sync **prunes**
-rows a (provably complete, sub-page-cap) fetch no longer returns, scoped by
-issue and a pre-fetch `synced_at` cutoff so rows created mid-fetch survive.
+the tail retries a failed forget through the shared `retrySQLite` gate (see
+[[persist-gate]]) and, on exhaustion (a wedge), **fails loud** — `.error` naming
+the self-heal + `EIO`, skipping `InvalidateDeleted` since the phantom row is
+still present (#278). A delete of an entity Linear already lacks ("Entity not
+found") is **idempotent success** — the row is still forgotten, so re-`rm`ing a
+phantom heals it (and is exactly the recovery the forget-exhaustion `.error`
+names) — and the details sync **prunes** rows a (provably complete, sub-page-cap)
+fetch no longer returns, scoped by issue and a pre-fetch `synced_at` cutoff so
+rows created mid-fetch survive.
 
 ### Name→ID resolution (`resolveIssueUpdate`)
 marshal returns an issue update whose relational fields hold *names* (a state name,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -510,11 +510,16 @@ write directions: `commitCreate` (`createcommit.go`), `commitWriteBack`
    markdown reformatting, and flags a silent revert/truncation as `EIO`.
 5. **Upserts the fresh result into SQLite** via the tail's per-spec persist
    closure (direct single-entity upserts; the `reconcile` tails belong to the
-   worker and SWR, not this flow). For a create this upsert **gates success**:
-   an entity Linear accepted but that cannot be reflected locally fails loud
-   (`EIO` + a de-dupe `.error` naming it) rather than a silent no-op, because a
-   no-op invites a retry that duplicates the already-created item (#276). It then
-   re-cohers the kernel through the
+   worker and SWR, not this flow). This upsert **gates success** across every
+   write tail: a mutation Linear accepted but that cannot be reflected locally is
+   retried against the `SQLITE_BUSY`/sync-worker race (`retrySQLite`,
+   `persistgate.go`) and, on exhaustion — a wedge — fails loud (`EIO`) with a
+   `.error` naming the **safe recovery** rather than reporting a clean save over a
+   diverged view (#276/#278). The recovery differs by direction: a **create** is
+   NOT retryable (a blind retry duplicates the already-created item), so its
+   `.error` names the entity and says "do not recreate"; an **edit/rename/delete**
+   is idempotent, so its `.error` says re-issuing is safe (a delete adds "re-run
+   `rm` to clear the phantom"). It then re-cohers the kernel through the
    intent-named `kernelNotify` policy methods — `InvalidateCreated` /
    `InvalidateUpdated` / `InvalidateDeleted` / `InvalidateRenamed`. Handlers
    never hand-pick the raw `InodeNotify`/`EntryNotify` primitives; hand-picked
@@ -523,10 +528,20 @@ write directions: `commitCreate` (`createcommit.go`), `commitWriteBack`
 
 **Delete flow:** `rm` of a comment/doc/label/relation/… or `rmdir`-archive of
 an issue/project goes through `commitDelete`: API delete first, then a
-**required** SQLite forget (retried on `SQLITE_BUSY` — the store is the listing
-source of truth, so a skipped forget resurrects the item as a phantom), then
-`InvalidateDeleted`. "Entity not found" on delete is idempotent success, so
-re-`rm`ing a phantom row heals it.
+**required** SQLite forget (retried on `SQLITE_BUSY` via the same `retrySQLite`
+gate — the store is the listing source of truth, so a skipped forget resurrects
+the item as a phantom). On forget exhaustion it fails loud (`EIO`, `.error`
+naming the self-heal) and skips `InvalidateDeleted` (the phantom row is still
+present); otherwise `InvalidateDeleted` runs. "Entity not found" on delete is
+idempotent success, so re-`rm`ing a phantom row heals it.
+
+**Deliberately-swallowed errors carry a one-line intent note.** A best-effort
+write that is *meant* to be swallowed (a startup optimization, a fetch cache, a
+scheduling ledger, a verification re-read of a write that already landed) carries
+an `// intentionally best-effort: <why> (recovers via <path>)` comment, so a
+future audit distinguishes an audited swallow from a load-bearing one it must
+harden. The load-bearing reflections all commit through the `persistgate.go`
+gate above.
 
 **Special filesystem semantics:**
 - **`_create` trigger files** (write-only, mode 0200): reads are rejected with

--- a/internal/fs/deletecommit.go
+++ b/internal/fs/deletecommit.go
@@ -52,9 +52,9 @@ type deleteSpec[T any] struct {
 	// forget removes the row from SQLite. Required: the store is the source of
 	// truth for listings, so a skipped forget resurrects the deleted item — and
 	// the details sync is not guaranteed to prune it. The tail retries a failed
-	// forget (SQLITE_BUSY races the sync worker) before giving up; an ultimate
-	// failure is non-fatal for the caller but leaves a phantom until a details
-	// sync prunes it or a repeat rm hits the already-gone self-heal path.
+	// forget (SQLITE_BUSY races the sync worker) before giving up; on exhaustion
+	// (a wedge) it fails loud with EIO and a .error naming the self-heal (re-run
+	// rm hits the already-gone path and forgets the row).
 	forget func(ctx context.Context, target *T) error
 	// dir + name drive the kernel-cache coherence policy: the module always
 	// runs InvalidateDeleted(dir, name).
@@ -71,8 +71,10 @@ type deleteSpec[T any] struct {
 //   - find fails          -> .error gets the cause, classified errno.
 //   - find returns nil    -> .error notes the unknown name, ENOENT.
 //   - mutate fails        -> .error gets the cause, EAGAIN if transient else EIO.
-//   - success             -> clear .error, forget SQLite (non-fatal on failure),
-//     InvalidateDeleted(dir, name), run extras, errno 0.
+//   - forget fails (retried) -> .error names the self-heal (re-run rm), EIO; the
+//     coherence policy is skipped since the phantom row is still present.
+//   - success             -> clear .error, forget SQLite, InvalidateDeleted(dir,
+//     name), run extras, errno 0.
 func commitDelete[T any](ctx context.Context, sink deleteSink, spec deleteSpec[T]) (errno syscall.Errno) {
 	start := time.Now()
 	defer func() { recordFuseOp(ctx, "delete", start, errno) }()
@@ -111,8 +113,18 @@ func commitDelete[T any](ctx context.Context, sink deleteSink, spec deleteSpec[T
 
 	sink.ClearWriteError(spec.key)
 
-	if err := forgetWithRetry(ctx, spec.forget, target); err != nil {
-		log.Printf("ERROR: failed to delete entity from SQLite after retries (%s): %v — the deleted item will linger until a details sync prunes it or it is rm'd again", spec.key, err)
+	// Forget gates the delete's local completion: the store is the listing source
+	// of truth, so a dropped forget leaves a phantom row the details sync cannot
+	// always prune. Retry the transient (SQLITE_BUSY racing the sync worker); on
+	// exhaustion — a wedge — fail loud rather than reporting a clean rm over a
+	// listing that still shows the item. Skip the coherence policy: the row is
+	// still present, so invalidating would only repopulate the phantom. The
+	// message names the self-heal (re-run rm) and clarifies it's a local-cache
+	// failure, not a server one (#278).
+	if err := retrySQLite(ctx, spec.forget, target); err != nil {
+		log.Printf("ERROR: failed to forget deleted entity from SQLite after retries (%s): %v — re-run rm to clear the lingering listing entry", spec.key, err)
+		sink.SetWriteError(spec.key, unconfirmedDeleteMsg(spec.op, spec.name, err.Error()))
+		return syscall.EIO
 	}
 
 	sink.InvalidateDeleted(spec.dir, spec.name)
@@ -120,29 +132,6 @@ func commitDelete[T any](ctx context.Context, sink deleteSink, spec deleteSpec[T
 		spec.invalidateExtra(target)
 	}
 	return 0
-}
-
-// forgetWithRetry runs the spec's forget, retrying twice with backoff. The
-// forget must not be lost to a transient failure: the API delete has already
-// succeeded, so a dropped forget leaves a phantom row the details sync cannot
-// always prune. SQLITE_BUSY from racing the sync worker is the observed
-// transient (now largely prevented by the connection-level busy_timeout).
-func forgetWithRetry[T any](ctx context.Context, forget func(ctx context.Context, target *T) error, target *T) error {
-	var err error
-	for attempt, delay := range []time.Duration{0, 200 * time.Millisecond, time.Second} {
-		if delay > 0 {
-			select {
-			case <-time.After(delay):
-			case <-ctx.Done():
-				return err
-			}
-		}
-		if err = forget(ctx, target); err == nil {
-			return nil
-		}
-		log.Printf("forget attempt %d failed: %v", attempt+1, err)
-	}
-	return err
 }
 
 // remoteAlreadyGone reports whether a delete mutation failed because Linear no

--- a/internal/fs/deletecommit_test.go
+++ b/internal/fs/deletecommit_test.go
@@ -142,31 +142,44 @@ func TestCommitDelete_Classification(t *testing.T) {
 	})
 }
 
-// TestCommitDelete_ForgetFailureNonFatal: a SQLite delete failure must not fail
-// a delete Linear already accepted — and the coherence policy still runs. The
-// forget is retried before giving up (the stress-tested failure was a
-// transient SQLITE_BUSY racing the sync worker).
-func TestCommitDelete_ForgetFailureNonFatal(t *testing.T) {
+// TestCommitDelete_ForgetFailureFailsLoud: a SQLite forget that survives the
+// retries is fatal (#278). The delete is on Linear, but the phantom row lingers
+// in the listing, so the tail fails loud (EIO + a "re-run rm" .error) and skips
+// the coherence policy (invalidating would only repopulate the phantom). The
+// forget is retried first (the stress-tested failure was a transient SQLITE_BUSY
+// racing the sync worker).
+func TestCommitDelete_ForgetFailureFailsLoud(t *testing.T) {
+	zeroRetryBackoff(t)
 	sink := &fakeDeleteSink{}
 	mutations, forgets, extras := 0, 0, 0
 	spec := okDeleteSpec(&ent{title: "x"}, &mutations, &forgets, &extras)
 	spec.forget = func(context.Context, *ent) error { forgets++; return errors.New("db down") }
 
-	if errno := commitDelete(context.Background(), sink, spec); errno != 0 {
-		t.Fatalf("errno = %v, want 0 (forget failure must be non-fatal)", errno)
+	if errno := commitDelete(context.Background(), sink, spec); errno != syscall.EIO {
+		t.Fatalf("errno = %v, want EIO (an unforgotten delete leaves a phantom)", errno)
 	}
-	if forgets != 3 {
-		t.Errorf("forget attempts = %d, want 3 (retried before giving up)", forgets)
+	if forgets != len(sqliteRetryBackoff) {
+		t.Errorf("forget attempts = %d, want %d (retried before giving up)", forgets, len(sqliteRetryBackoff))
 	}
-	if sink.clears != 1 || sink.invalidates != 1 || extras != 1 {
-		t.Errorf("tail after forget failure: clears=%d invalidates=%d extras=%d, want 1 each",
-			sink.clears, sink.invalidates, extras)
+	// .error cleared (delete succeeded on Linear) then set to the forget failure.
+	if sink.setCalls != 1 || sink.setKey != "K" {
+		t.Errorf("SetWriteError: calls=%d key=%q, want 1 on K", sink.setCalls, sink.setKey)
+	}
+	for _, want := range []string{"SUCCEEDED on Linear", "Re-run rm", "db down"} {
+		if !strings.Contains(sink.setMsg, want) {
+			t.Errorf(".error = %q, want it to contain %q", sink.setMsg, want)
+		}
+	}
+	// The phantom is still present, so the coherence policy must NOT run.
+	if sink.invalidates != 0 || extras != 0 {
+		t.Errorf("coherence ran on forget failure: invalidates=%d extras=%d, want 0", sink.invalidates, extras)
 	}
 }
 
 // TestCommitDelete_ForgetRetrySucceeds: a transient forget failure (SQLITE_BUSY)
 // recovers on retry — no phantom row, no error surfaced.
 func TestCommitDelete_ForgetRetrySucceeds(t *testing.T) {
+	zeroRetryBackoff(t)
 	sink := &fakeDeleteSink{}
 	mutations, forgets, extras := 0, 0, 0
 	spec := okDeleteSpec(&ent{title: "x"}, &mutations, &forgets, &extras)

--- a/internal/fs/documents.go
+++ b/internal/fs/documents.go
@@ -163,10 +163,18 @@ func (n *DocsNode) Rename(ctx context.Context, name string, newParent fs.InodeEm
 		n.lfs.SetWriteError(collectionErrorKey("docs", n.parentID()), msg)
 		return errno
 	}
-	// Upsert to SQLite so it's immediately visible
-	if err := n.lfs.UpsertDocument(ctx, *updatedDoc); err != nil {
-		log.Printf("Warning: failed to upsert document to SQLite: %v", err)
+	// Persist gates the rename: like the edit tail, a reflection the local cache
+	// can't serve fails loud (retry, then EIO) rather than swallowing it. The
+	// rename is on Linear and idempotent, so the .error says re-saving is safe
+	// (#278). See persistgate.go.
+	errKey := collectionErrorKey("docs", n.parentID())
+	if errno := persistOrEIO(ctx, n.lfs, errKey,
+		func(err error) string { return unconfirmedEditMsg("rename document "+name+" -> "+newName, err) },
+		func(ctx context.Context, d *api.Document) error { return n.lfs.UpsertDocument(ctx, *d) },
+		updatedDoc); errno != 0 {
+		return errno
 	}
+	n.lfs.ClearWriteError(errKey)
 	if n.lfs.debug {
 		log.Printf("Document renamed successfully: %s -> %s", doc.Title, newTitle)
 	}

--- a/internal/fs/editcommit.go
+++ b/internal/fs/editcommit.go
@@ -60,10 +60,13 @@ type writeBackSpec[T any] struct {
 // .error but let the close succeed).
 //
 // Contract:
-//   - fetch fails        → the write succeeded but is unverified: clear .error,
-//     return (nil, 0). The handler keeps its prior local state.
-//   - persist fails      → non-fatal: log and continue (a cache miss must not fail
-//     a write that Linear accepted).
+//   - fetch fails        → the write succeeded but its verification re-read did
+//     not: clear .error, return (nil, 0). A read hiccup is not a failed write;
+//     sync reconciles via updatedAt. The handler keeps its prior local state.
+//   - persist fails      → retried; on exhaustion the reflection is unconfirmed
+//     (a wedge), so fail loud: set a "re-saving is safe" .error and return
+//     (fresh, EIO). fresh is still returned so the caller adopts correct data
+//     into the live fd — the EIO is a wedge signal, not data loss (#278).
 //   - no divergence      → clear .error, return (fresh, 0).
 //   - benign reformat    → set .error note, return (fresh, 0).
 //   - fatal divergence   → set .error, return (fresh, syscall.EIO).
@@ -73,16 +76,29 @@ func commitWriteBack[T any](ctx context.Context, sink errorSink, spec writeBackS
 
 	fresh, err := spec.fetch(ctx)
 	if err != nil {
-		// The API accepted the write; we just could not re-read it to verify.
-		// Treat as success (sync will reconcile) and clear any stale error.
+		// intentionally best-effort: fetch is the verification RE-READ of a write
+		// that already landed (spec.mutate ran in the front half). A read hiccup
+		// (network/timeout/rate-limit) is not a failed write, so we do NOT fail
+		// loud here — EIO on a landed write would trigger a pointless re-PUT, and
+		// retrying the fetch during a rate-limit only digs deeper. The write bumped
+		// updatedAt, so sync reconciles the row; the user's own buffer is what the
+		// fd shows. Treat as success and clear any stale error. (#278)
 		log.Printf("Warning: failed to fetch fresh entity after update (%s): %v", spec.errKey, err)
 		sink.ClearWriteError(spec.errKey)
 		return nil, 0
 	}
 
 	if spec.persist != nil {
-		if err := spec.persist(ctx, fresh); err != nil {
-			log.Printf("Warning: failed to upsert entity to SQLite (%s): %v", spec.errKey, err)
+		// Persist gates the edit: a reflection the local cache can't serve fails
+		// loud (retry, then EIO) rather than swallowing the divergence. The write
+		// is already on Linear and `fresh` is returned so the caller adopts it into
+		// the live fd, so the EIO rides alongside correct data — a pure wedge
+		// signal whose recovery (re-saving) is safe because the edit is idempotent
+		// (#278). See persistgate.go.
+		if errno := persistOrEIO(ctx, sink, spec.errKey,
+			func(err error) string { return unconfirmedEditMsg(spec.errKey, err) },
+			spec.persist, fresh); errno != 0 {
+			return fresh, errno
 		}
 	}
 

--- a/internal/fs/editcommit_test.go
+++ b/internal/fs/editcommit_test.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"context"
 	"errors"
+	"strings"
 	"syscall"
 	"testing"
 )
@@ -131,22 +132,41 @@ func TestCommitWriteBack_NilPersist(t *testing.T) {
 	}
 }
 
-// TestCommitWriteBack_PersistFailureNonFatal confirms a SQLite upsert failure
-// does not fail a write Linear already accepted.
-func TestCommitWriteBack_PersistFailureNonFatal(t *testing.T) {
+// TestCommitWriteBack_PersistFailureFailsLoud confirms a SQLite upsert failure
+// that survives the retries is fatal (#278): the write is on Linear but its
+// reflection is unconfirmed (a wedge), so the tail must return EIO with a
+// "re-saving is safe" .error — while still returning `fresh` so the caller can
+// adopt correct data into the live fd.
+func TestCommitWriteBack_PersistFailureFailsLoud(t *testing.T) {
+	zeroRetryBackoff(t)
 	sink := &fakeSink{}
 	fresh := &ent{title: "x"}
+	persists := 0
 	got, errno := commitWriteBack(context.Background(), sink, writeBackSpec[ent]{
 		errKey:  "K",
 		fetch:   func(context.Context) (*ent, error) { return fresh, nil },
-		persist: func(context.Context, *ent) error { return errors.New("db down") },
+		persist: func(context.Context, *ent) error { persists++; return errors.New("db down") },
 		compare: func(*ent) []writeBackResult { return nil },
 	})
-	if errno != 0 {
-		t.Errorf("errno = %v, want 0 (persist failure must be non-fatal)", errno)
+	if errno != syscall.EIO {
+		t.Errorf("errno = %v, want EIO on unconfirmed reflection", errno)
 	}
-	if got != fresh || sink.clears != 1 {
-		t.Errorf("expected success despite persist failure; got fresh=%v clears=%d", got, sink.clears)
+	if got != fresh {
+		t.Errorf("fresh = %v, want it returned for adopt even on EIO", got)
+	}
+	if persists != len(sqliteRetryBackoff) {
+		t.Errorf("persist attempts = %d, want %d (retried before giving up)", persists, len(sqliteRetryBackoff))
+	}
+	if sink.setCalls != 1 || sink.setKey != "K" {
+		t.Errorf("SetWriteError: calls=%d key=%q, want 1 on K", sink.setCalls, sink.setKey)
+	}
+	for _, want := range []string{"SUCCEEDED on Linear", "Re-saving is safe", "db down"} {
+		if !strings.Contains(sink.setMsg, want) {
+			t.Errorf(".error = %q, want it to contain %q", sink.setMsg, want)
+		}
+	}
+	if sink.clears != 0 {
+		t.Errorf("ClearWriteError calls = %d, want 0 on a loud failure", sink.clears)
 	}
 }
 

--- a/internal/fs/embeddedfilecache.go
+++ b/internal/fs/embeddedfilecache.go
@@ -85,6 +85,10 @@ func (c *embeddedFileCache) FetchEmbeddedFile(ctx context.Context, file api.Embe
 	}
 	recordEmbeddedFetch(ctx, "cdn")
 
+	// intentionally best-effort: the disk cache is a fetch optimization, not a
+	// source of truth. `content` is returned this call regardless, and a cache
+	// miss next time simply re-fetches from the CDN — so a failed write self-
+	// corrects with no divergence to surface. (#278)
 	if err := os.WriteFile(diskPath, content, 0644); err != nil {
 		log.Printf("[cache] Warning: failed to cache file %s: %v", file.Filename, err)
 	} else if c.persist != nil {

--- a/internal/fs/labels.go
+++ b/internal/fs/labels.go
@@ -142,10 +142,18 @@ func (n *LabelsNode) Rename(ctx context.Context, name string, newParent fs.Inode
 		n.lfs.SetWriteError(collectionErrorKey("labels", n.teamID), msg)
 		return errno
 	}
-	// Upsert to SQLite so it's immediately visible
-	if err := n.lfs.UpsertLabel(ctx, n.teamID, *updatedLabel); err != nil {
-		log.Printf("Warning: failed to upsert label to SQLite: %v", err)
+	// Persist gates the rename: like the edit tail, a reflection the local cache
+	// can't serve fails loud (retry, then EIO) rather than swallowing it. The
+	// rename is on Linear and idempotent, so the .error says re-saving is safe
+	// (#278). See persistgate.go.
+	errKey := collectionErrorKey("labels", n.teamID)
+	if errno := persistOrEIO(ctx, n.lfs, errKey,
+		func(err error) string { return unconfirmedEditMsg("rename label "+name+" -> "+newName, err) },
+		func(ctx context.Context, l *api.Label) error { return n.lfs.UpsertLabel(ctx, n.teamID, *l) },
+		updatedLabel); errno != 0 {
+		return errno
 	}
+	n.lfs.ClearWriteError(errKey)
 	if n.lfs.debug {
 		log.Printf("Label renamed successfully: %s -> %s", label.Name, newLabelName)
 	}

--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -266,7 +266,11 @@ func (lfs *LinearFS) EnableSQLiteCache(dbPath string) error {
 			}
 			if v != nil {
 				lfs.repo.SetCurrentUser(v)
-				// Persist viewer ID so next startup is instant
+				// Persist viewer ID so next startup is instant. intentionally
+				// best-effort: this is a startup optimization, not a user write —
+				// a failure just means the next startup re-fetches the viewer via
+				// the API (this same path). No .error surface, nothing to fail
+				// loud to. (#278)
 				if err := store.Queries().SetViewerUserID(ctx, db.SetViewerUserIDParams{
 					UserID:   v.ID,
 					SyncedAt: db.Now(),

--- a/internal/fs/persistgate.go
+++ b/internal/fs/persistgate.go
@@ -1,0 +1,99 @@
+package fs
+
+import (
+	"context"
+	"log"
+	"syscall"
+	"time"
+)
+
+// The persist gate: retry a local reflection of a mutation Linear already
+// accepted, and on exhaustion fail loud instead of swallowing the divergence.
+//
+// A write that reached Linear must eventually show locally. The store is the
+// source of truth for reads, so a dropped SQLite reflection leaves a stale row
+// (edit/rename) or a phantom row (delete) until the next sync reconciles it —
+// and #276 proved that "the sync worker reconciles later" becomes "never" when
+// the daemon is wedged, the exact condition under which the reflection also
+// fails. So the reflection is retried against the common transient
+// (`SQLITE_BUSY` racing the sync worker) and, only when retries are exhausted —
+// i.e. a genuine wedge, not a benign hiccup — surfaced as `EIO` with a `.error`
+// that states the *safe recovery*. Unlike a create (whose retry duplicates), an
+// edit/rename/delete is idempotent, so the message says re-issuing is safe.
+//
+// This is the shared gate the edit tail ([[writeback-tail]]), the hand-rolled
+// label/document renames, and the delete tail ([[delete-tail]]) all commit
+// through, so "confirmed reflection or say why in `.error`" lives in one place.
+
+// sqliteRetryBackoff is the delay before each reflection attempt (the first is
+// immediate). A package var so tests can zero the sleeps; production uses the
+// stress-tuned schedule that rides out a `SQLITE_BUSY` race with the sync
+// worker (the connection-level `busy_timeout` DSN pragma already makes it rare).
+var sqliteRetryBackoff = []time.Duration{0, 200 * time.Millisecond, time.Second}
+
+// retrySQLite retries a local SQLite write that reflects a mutation Linear
+// already accepted. The write must not be lost to a transient (`SQLITE_BUSY`
+// racing the sync worker): a dropped reflection leaves a stale/phantom row the
+// next sync is not guaranteed to reconcile. Shared by the edit/rename persist
+// gate (persistOrEIO) and the delete tail's forget.
+func retrySQLite[T any](ctx context.Context, op func(ctx context.Context, v *T) error, v *T) error {
+	var err error
+	for attempt, delay := range sqliteRetryBackoff {
+		if delay > 0 {
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return err
+			}
+		}
+		if err = op(ctx, v); err == nil {
+			return nil
+		}
+		log.Printf("SQLite reflection attempt %d failed: %v", attempt+1, err)
+	}
+	return err
+}
+
+// persistOrEIO commits a mutation's local reflection through retrySQLite. On
+// success it returns 0 and leaves `.error` untouched — the caller owns the
+// clear (an edit still runs its read-your-writes compare, which may leave a
+// benign note). On retry exhaustion it writes the caller-supplied `.error`
+// message (which MUST state the safe recovery — the mutation is idempotent) and
+// returns EIO, so a reflection the local cache can't yet serve fails loud
+// instead of reporting a clean save on a diverged view (#276/#278).
+func persistOrEIO[T any](
+	ctx context.Context,
+	sink errorSink,
+	key string,
+	msg func(err error) string,
+	persist func(ctx context.Context, v *T) error,
+	v *T,
+) syscall.Errno {
+	if err := retrySQLite(ctx, persist, v); err != nil {
+		log.Printf("Reflection failed after a mutation succeeded on Linear (%s): %v", key, err)
+		sink.SetWriteError(key, msg(err))
+		return syscall.EIO
+	}
+	return 0
+}
+
+// unconfirmedEditMsg renders the `.error` for an edit or rename Linear accepted
+// but whose local reflection failed after retries. Unlike a create's de-dupe
+// message, it tells the caller re-saving is SAFE: the update is idempotent, so a
+// retry re-applies the same change rather than duplicating anything.
+func unconfirmedEditMsg(op string, err error) string {
+	return "Operation: " + op +
+		"\nError: this change SUCCEEDED on Linear but could not be cached locally after retries: " + err.Error() +
+		". Re-saving is safe (the update is idempotent). If it persists, the local cache may be wedged — restart the daemon (systemctl --user restart linearfs) or wait for the next sync to reflect it."
+}
+
+// unconfirmedDeleteMsg renders the `.error` for a delete Linear accepted but
+// whose local forget failed after retries, leaving a phantom row in the
+// listing. It disambiguates local-cache failure from a server failure (the
+// entity IS gone on Linear) and points at the self-heal: re-running `rm` finds
+// the phantom, hits the already-gone path, and forgets the row.
+func unconfirmedDeleteMsg(op, name, err string) string {
+	return "Operation: " + op +
+		"\nError: this delete SUCCEEDED on Linear (" + name + " is gone) but the local listing entry could not be removed after retries: " + err +
+		". Re-run rm to clear it (safe — it is already gone on Linear). If it persists, the local cache may be wedged — restart the daemon (systemctl --user restart linearfs) or wait for the next sync."
+}

--- a/internal/fs/persistgate_test.go
+++ b/internal/fs/persistgate_test.go
@@ -1,0 +1,131 @@
+package fs
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// zeroRetryBackoff removes the reflection retry sleeps for the duration of a
+// test so exhaustion paths run instantly. The fs unit tests are sequential (no
+// t.Parallel), so mutating the package var and restoring it is safe.
+func zeroRetryBackoff(t *testing.T) {
+	t.Helper()
+	saved := sqliteRetryBackoff
+	sqliteRetryBackoff = []time.Duration{0, 0, 0}
+	t.Cleanup(func() { sqliteRetryBackoff = saved })
+}
+
+func TestRetrySQLite_SucceedsOnRetry(t *testing.T) {
+	zeroRetryBackoff(t)
+	attempts := 0
+	err := retrySQLite(context.Background(), func(context.Context, *ent) error {
+		attempts++
+		if attempts < 2 {
+			return errors.New("database is locked (5) (SQLITE_BUSY)")
+		}
+		return nil
+	}, &ent{})
+	if err != nil {
+		t.Fatalf("err = %v, want nil after a retry", err)
+	}
+	if attempts != 2 {
+		t.Errorf("attempts = %d, want 2 (fail once, succeed on retry)", attempts)
+	}
+}
+
+func TestRetrySQLite_ExhaustsAndReturnsLastError(t *testing.T) {
+	zeroRetryBackoff(t)
+	attempts := 0
+	want := errors.New("db down")
+	err := retrySQLite(context.Background(), func(context.Context, *ent) error {
+		attempts++
+		return want
+	}, &ent{})
+	if !errors.Is(err, want) {
+		t.Errorf("err = %v, want the last attempt's error", err)
+	}
+	if attempts != len(sqliteRetryBackoff) {
+		t.Errorf("attempts = %d, want %d", attempts, len(sqliteRetryBackoff))
+	}
+}
+
+func TestRetrySQLite_StopsOnContextCancel(t *testing.T) {
+	// A non-zero delay plus an already-cancelled context returns after the first
+	// failed attempt rather than sleeping out the schedule.
+	saved := sqliteRetryBackoff
+	sqliteRetryBackoff = []time.Duration{0, time.Hour}
+	t.Cleanup(func() { sqliteRetryBackoff = saved })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	attempts := 0
+	err := retrySQLite(ctx, func(context.Context, *ent) error {
+		attempts++
+		return errors.New("boom")
+	}, &ent{})
+	if err == nil {
+		t.Fatal("err = nil, want the failure returned on cancel")
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1 (cancel cut the backoff short)", attempts)
+	}
+}
+
+// TestPersistOrEIO_Success: a persisted reflection returns 0 and leaves .error
+// untouched — the caller owns the clear (an edit's compare may still note it).
+func TestPersistOrEIO_Success(t *testing.T) {
+	zeroRetryBackoff(t)
+	sink := &fakeSink{}
+	errno := persistOrEIO(context.Background(), sink, "K",
+		func(error) string { return "unused" },
+		func(context.Context, *ent) error { return nil },
+		&ent{})
+	if errno != 0 {
+		t.Errorf("errno = %v, want 0", errno)
+	}
+	if sink.setCalls != 0 || sink.clears != 0 {
+		t.Errorf(".error touched on success: sets=%d clears=%d, want 0/0", sink.setCalls, sink.clears)
+	}
+}
+
+// TestPersistOrEIO_ExhaustionFailsLoud is the rename path's coverage: on retry
+// exhaustion it sets the caller's message and returns EIO.
+func TestPersistOrEIO_ExhaustionFailsLoud(t *testing.T) {
+	zeroRetryBackoff(t)
+	sink := &fakeSink{}
+	errno := persistOrEIO(context.Background(), sink, "labels:TST",
+		func(err error) string { return unconfirmedEditMsg("rename label a -> b", err) },
+		func(context.Context, *ent) error { return errors.New("db down") },
+		&ent{})
+	if errno != syscall.EIO {
+		t.Fatalf("errno = %v, want EIO", errno)
+	}
+	if sink.setCalls != 1 || sink.setKey != "labels:TST" {
+		t.Errorf("SetWriteError: calls=%d key=%q, want 1 on labels:TST", sink.setCalls, sink.setKey)
+	}
+	for _, want := range []string{"rename label a -> b", "SUCCEEDED on Linear", "Re-saving is safe", "db down"} {
+		if !strings.Contains(sink.setMsg, want) {
+			t.Errorf(".error = %q, want it to contain %q", sink.setMsg, want)
+		}
+	}
+}
+
+func TestUnconfirmedMessages_StateSafeRecovery(t *testing.T) {
+	edit := unconfirmedEditMsg("save issue ENG-1", errors.New("locked"))
+	if !strings.Contains(edit, "Re-saving is safe") || !strings.Contains(edit, "idempotent") {
+		t.Errorf("edit msg must say re-saving is safe: %q", edit)
+	}
+
+	del := unconfirmedDeleteMsg("delete label \"bug.md\"", "bug.md", "locked")
+	if !strings.Contains(del, "Re-run rm") || !strings.Contains(del, "already gone") {
+		t.Errorf("delete msg must name the re-run rm self-heal: %q", del)
+	}
+	// The delete message must not imply a server failure — the entity IS gone.
+	if !strings.Contains(del, "SUCCEEDED on Linear") {
+		t.Errorf("delete msg must clarify the server delete succeeded: %q", del)
+	}
+}

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -316,11 +316,14 @@ Failure model (every writable surface follows this contract):
 - Reference to something that doesn't exist (a relation target, rm of an unknown name) -> ENOENT
 - Rate-limited or timed out (the write did not take effect; retry shortly) -> EAGAIN
 - Backend/API failure -> EIO
-- A create Linear accepted but that could not be cached locally -> EIO, with a
-  .error that NAMES the created entity and warns not to recreate it: the item
-  already exists remotely, so a blind retry would duplicate it. Restart the
-  daemon or wait for the next sync to reflect it. (A succeeded create is never a
-  silent no-op — it either appears locally or says why in .error.)
+- A mutation Linear accepted but whose local reflection fails after retries ->
+  EIO, and the .error names the SAFE RECOVERY. For a create it NAMES the entity
+  and warns NOT to recreate it (the item exists remotely, so a blind retry
+  duplicates it). For an edit/rename/delete the change is idempotent, so the
+  .error says re-issuing is safe -- for a delete, re-running rm also clears the
+  lingering listing entry. Either way, restart the daemon or wait for the next
+  sync to reflect it. (A succeeded mutation is never a silent no-op -- it appears
+  locally or says why in .error.)
 - Whatever the errno, the reason lands in .error; success clears it. Always read
   .error after any failed write (including an atomic-save rename that returns
   EINVAL/EMSGSIZE) — the errno alone cannot carry the reason.

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -1350,6 +1350,10 @@ type detailOutcome struct {
 func (w *Worker) deferDetailIssues(ctx context.Context, issues []issueRef) {
 	now := db.Now()
 	for _, issue := range issues {
+		// intentionally best-effort: the pending-detail-sync ledger only schedules
+		// detail fetches. A dropped enqueue means this issue's details wait for the
+		// next staleness-driven cycle to re-enqueue it — degraded freshness, never
+		// lost user data, so there is no errno surface to fail loud to. (#278)
 		_ = w.store.Queries().UpsertPendingDetailSync(ctx, db.UpsertPendingDetailSyncParams{
 			IssueID:    issue.ID,
 			Identifier: issue.Identifier,


### PR DESCRIPTION
Applies the "confirmed reflection or say why in `.error`" contract (from #276's create tail + b642867's reconcile-link fix) to the three remaining swallow sites, each grilled per-surface.

New `persistgate.go` owns the shared gate: `retrySQLite` generalizes the delete tail's `forgetWithRetry` into the one retry loop for the `SQLITE_BUSY`/sync-worker race (backoff is a package var so tests zero the sleeps); `persistOrEIO` wraps it. The gate fires loud (`EIO`) only on retry exhaustion — a genuine wedge, not a benign transient.

- **Edit tail** (`editcommit.go`): persist swallow → retry, then `EIO`. `fresh` is still returned so the caller adopts correct data into the live fd; the `EIO` is a pure wedge signal and re-saving is safe (idempotent). The `fetch` swallow is deliberately kept (a failed verification re-read is not a failed write) and intent-commented.
- **Hand-rolled renames** (`labels.go`, `documents.go`): same verdict via `persistOrEIO`, keeping their own `.md`+`.meta` invalidation.
- **Delete tail** (`deletecommit.go`): forget exhaustion → `EIO` + a self-heal message (re-run `rm`), skipping coherence since the phantom row is still present.

Deliberately-swallowed errors (edit fetch, viewer-identity, embedded-file cache, worker detail-sync ledger) now carry an intent comment, with the convention stated once in `ARCHITECTURE.md`.

Docs kept in lockstep: `generateReadme`'s failure model is one unifying statement; `ARCHITECTURE.md`/`CONTEXT.md` tail sections generalized.

Independent of #277 (the write-back watchdog): per-surface defense-in-depth that surfaces a wedge loudly at the write, where #277 heals the process in the background.

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)