### PR TITLE
fix(fs): fail loud on a spent scratch node serving the canonical file

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -77,13 +77,20 @@ canonical files aren't renamable) → target-name guard (`.error` names the one
 writable target, `ENOTSUP`) → flush the bytes through the file's normal edit
 path (a transient file node with a dirty edit buffer, so frontmatter
 validation, read-your-writes verification, and `.error` handling all apply) →
-**adopt on {0, EIO}** → `InvalidateRenamed`. The adopt-on-EIO line is the
-policy, now written once: `Flush` returns `EIO` only on a fatal
+**adopt + consume + `InvalidateRenamed`, all on {0, EIO}**. The adopt-on-EIO
+line is the policy, now written once: `Flush` returns `EIO` only on a fatal
 read-your-writes divergence, by which point the write has already reached
 Linear — refusing to adopt would keep serving stale content while `.error`
-explains the divergence. Lives in `internal/fs/renamesave.go`; each directory
-hands it a small spec (target name, error key, dir/file inos,
-scratch/flush/adopt closures). It depends only on the `renameSink` seam
+explains the divergence. **Consume closes a silent-write-drop race:** on a
+persisted save go-fuse `MvChild`s the spent `scratchFileNode` over the canonical
+name, and until the async `InvalidateRenamed` lands a racing open resolves to
+that dead buffer — whose ops used to `return 0`, silently swallowing a write
+that can no longer persist. A consumed scratch node now returns `ESTALE` from
+`Open`/`Write`/`Flush`/`Fsync`/`Setattr`, so the write fails loud and the
+`ESTALE` on `Open` drives the VFS to re-Lookup the real node (`LOOKUP_REVAL`).
+Lives in `internal/fs/renamesave.go`; each directory hands it a small spec
+(target name, error key, dir/file inos, scratch/flush/adopt closures — the
+scratch closure also returns the per-node consume). It depends only on the `renameSink` seam
 (ErrorSink + `InvalidateRenamed`, satisfied by `*LinearFS` through the
 writeFeedback and kernelNotify promotions), and the scratch lookup is a spec
 closure, so it is unit-tested with a recording sink — no FUSE mount, inode

--- a/internal/fs/atomicwrite.go
+++ b/internal/fs/atomicwrite.go
@@ -33,8 +33,26 @@ import (
 type scratchFileNode struct {
 	BaseNode
 
-	mu  sync.Mutex
-	buf []byte
+	mu       sync.Mutex
+	buf      []byte
+	consumed bool // a rename took the buffer; further access must fail loud
+}
+
+// consume marks the scratch buffer spent after a rename has persisted its bytes.
+// go-fuse leaves the spent node serving the canonical file's name (MvChild)
+// until the rename invalidation lands; a consumed node returns ESTALE from its
+// access ops so the kernel re-Lookups the real node instead of silently
+// accepting writes this dead buffer would never persist.
+func (n *scratchFileNode) consume() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.consumed = true
+}
+
+func (n *scratchFileNode) isConsumed() bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.consumed
 }
 
 var (
@@ -48,6 +66,12 @@ var (
 )
 
 func (n *scratchFileNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
+	if n.isConsumed() {
+		// Spent node still bound to the canonical name after a rename: fail loud
+		// so the VFS retries the open with revalidation and re-Lookups the real
+		// node (ESTALE drives LOOKUP_REVAL).
+		return nil, 0, syscall.ESTALE
+	}
 	return nil, fuse.FOPEN_DIRECT_IO, 0
 }
 
@@ -73,6 +97,9 @@ func (n *scratchFileNode) Read(ctx context.Context, f fs.FileHandle, dest []byte
 func (n *scratchFileNode) Write(ctx context.Context, f fs.FileHandle, data []byte, off int64) (uint32, syscall.Errno) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
+	if n.consumed {
+		return 0, syscall.ESTALE
+	}
 	if newLen := int(off) + len(data); newLen > len(n.buf) {
 		grown := make([]byte, newLen)
 		copy(grown, n.buf)
@@ -85,6 +112,9 @@ func (n *scratchFileNode) Write(ctx context.Context, f fs.FileHandle, data []byt
 func (n *scratchFileNode) Setattr(ctx context.Context, f fs.FileHandle, in *fuse.SetAttrIn, out *fuse.AttrOut) syscall.Errno {
 	n.mu.Lock()
 	defer n.mu.Unlock()
+	if n.consumed {
+		return syscall.ESTALE
+	}
 	if sz, ok := in.GetSize(); ok {
 		switch {
 		case int(sz) < len(n.buf):
@@ -100,9 +130,17 @@ func (n *scratchFileNode) Setattr(ctx context.Context, f fs.FileHandle, in *fuse
 	return 0
 }
 
-func (n *scratchFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno { return 0 }
+func (n *scratchFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno {
+	if n.isConsumed() {
+		return syscall.ESTALE
+	}
+	return 0
+}
 
 func (n *scratchFileNode) Fsync(ctx context.Context, f fs.FileHandle, flags uint32) syscall.Errno {
+	if n.isConsumed() {
+		return syscall.ESTALE
+	}
 	return 0
 }
 
@@ -149,18 +187,21 @@ func newScratchInode(ctx context.Context, parent *BaseNode, parentIno uint64, na
 }
 
 // scratchRenameBytes reports the buffered contents of the scratch file named
-// oldName under parent, and whether oldName actually refers to a scratch file
-// this filesystem created. A directory's Rename handler uses it to decide
-// whether a rename is an editor's atomic save (ok == true, persist the bytes) or
-// something it should reject (ok == false).
-func scratchRenameBytes(parent fs.InodeEmbedder, oldName string) (content []byte, ok bool) {
+// oldName under parent, a closure that marks that scratch node consumed, and
+// whether oldName actually refers to a scratch file this filesystem created. A
+// directory's Rename handler (via renameSave) uses it to decide whether a rename
+// is an editor's atomic save (ok == true, persist the bytes) or something it
+// should reject (ok == false), and to consume the node once the save persists so
+// the spent node — which go-fuse moves over the canonical name — fails loud
+// rather than serving stale, unpersistable writes.
+func scratchRenameBytes(parent fs.InodeEmbedder, oldName string) (content []byte, consume func(), ok bool) {
 	child := parent.EmbeddedInode().GetChild(oldName)
 	if child == nil {
-		return nil, false
+		return nil, nil, false
 	}
 	scratch, isScratch := child.Operations().(*scratchFileNode)
 	if !isScratch {
-		return nil, false
+		return nil, nil, false
 	}
-	return scratch.bytes(), true
+	return scratch.bytes(), scratch.consume, true
 }

--- a/internal/fs/atomicwrite_test.go
+++ b/internal/fs/atomicwrite_test.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"context"
+	"syscall"
 	"testing"
 
 	"github.com/hanwen/go-fuse/v2/fuse"
@@ -82,6 +83,72 @@ func TestScratchFileNode_Truncate(t *testing.T) {
 	}
 	if got := n.bytes(); len(got) != 0 {
 		t.Fatalf("after truncate to 0: %q, want empty", got)
+	}
+}
+
+// TestScratchFileNode_ConsumedRejectsOpen: after a rename has taken the scratch
+// buffer, go-fuse may leave this spent node serving the canonical file's name
+// until the rename invalidation lands. Opening it must fail loud with ESTALE so
+// the kernel re-Lookups the real node, not resolve to a dead buffer that
+// silently accepts writes it will never persist.
+func TestScratchFileNode_ConsumedRejectsOpen(t *testing.T) {
+	t.Parallel()
+	n := &scratchFileNode{}
+
+	// Fresh: Open succeeds — the editor writes the temp file before renaming it.
+	if _, _, errno := n.Open(context.Background(), 0); errno != 0 {
+		t.Fatalf("fresh Open errno=%v, want 0", errno)
+	}
+
+	n.consume()
+
+	if _, _, errno := n.Open(context.Background(), 0); errno != syscall.ESTALE {
+		t.Fatalf("consumed Open errno=%v, want ESTALE", errno)
+	}
+}
+
+// TestScratchFileNode_ConsumedRejectsFlushAndFsync: the flush/fsync of a write
+// that lands on a spent scratch node must fail loud, never the old silent
+// return-0 that reported a dropped write as a clean save.
+func TestScratchFileNode_ConsumedRejectsFlushAndFsync(t *testing.T) {
+	t.Parallel()
+	n := &scratchFileNode{}
+
+	// Fresh: the editor's own close/fsync of the temp file must succeed.
+	if errno := n.Flush(context.Background(), nil); errno != 0 {
+		t.Fatalf("fresh Flush errno=%v, want 0", errno)
+	}
+	if errno := n.Fsync(context.Background(), nil, 0); errno != 0 {
+		t.Fatalf("fresh Fsync errno=%v, want 0", errno)
+	}
+
+	n.consume()
+
+	if errno := n.Flush(context.Background(), nil); errno != syscall.ESTALE {
+		t.Fatalf("consumed Flush errno=%v, want ESTALE", errno)
+	}
+	if errno := n.Fsync(context.Background(), nil, 0); errno != syscall.ESTALE {
+		t.Fatalf("consumed Fsync errno=%v, want ESTALE", errno)
+	}
+}
+
+// TestScratchFileNode_ConsumedRejectsWrite: a write held on an fd opened before
+// the rename consumed the node must not be accepted into a buffer that will
+// never persist — it fails loud so the caller learns the write was not stored.
+func TestScratchFileNode_ConsumedRejectsWrite(t *testing.T) {
+	t.Parallel()
+	n := &scratchFileNode{}
+	n.consume()
+
+	if _, errno := n.Write(context.Background(), nil, []byte("x"), 0); errno != syscall.ESTALE {
+		t.Fatalf("consumed Write errno=%v, want ESTALE", errno)
+	}
+	var in fuse.SetAttrIn
+	in.Size = 0
+	in.Valid = fuse.FATTR_SIZE
+	var out fuse.AttrOut
+	if errno := n.Setattr(context.Background(), nil, &in, &out); errno != syscall.ESTALE {
+		t.Fatalf("consumed Setattr errno=%v, want ESTALE", errno)
 	}
 }
 

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -175,7 +175,7 @@ func (i *InitiativeNode) Rename(ctx context.Context, name string, newParent fs.I
 		errKey:     initiative.ID,
 		dirIno:     i.EmbeddedInode().StableAttr().Ino,
 		fileIno:    initiativeInfoIno(initiative.ID),
-		scratch:    func(oldName string) ([]byte, bool) { return scratchRenameBytes(i, oldName) },
+		scratch:    func(oldName string) ([]byte, func(), bool) { return scratchRenameBytes(i, oldName) },
 		flush: func(ctx context.Context, content []byte) syscall.Errno {
 			fileNode = &InitiativeInfoNode{
 				BaseNode:     BaseNode{lfs: i.lfs},
@@ -192,7 +192,7 @@ func (i *InitiativeNode) Rename(ctx context.Context, name string, newParent fs.I
 // Unlink lets editors clean up an abandoned atomic-save temp file. Only scratch
 // files we created are removable; the canonical entries are not.
 func (i *InitiativeNode) Unlink(ctx context.Context, name string) syscall.Errno {
-	if _, ok := scratchRenameBytes(i, name); ok {
+	if _, _, ok := scratchRenameBytes(i, name); ok {
 		return 0
 	}
 	return syscall.EPERM

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -417,7 +417,7 @@ func (n *IssueDirectoryNode) Rename(ctx context.Context, name string, newParent 
 		errKey:     issue.ID,
 		dirIno:     n.EmbeddedInode().StableAttr().Ino,
 		fileIno:    issueIno(issue.ID),
-		scratch:    func(oldName string) ([]byte, bool) { return scratchRenameBytes(n, oldName) },
+		scratch:    func(oldName string) ([]byte, func(), bool) { return scratchRenameBytes(n, oldName) },
 		flush: func(ctx context.Context, content []byte) syscall.Errno {
 			fileNode = &IssueFileNode{
 				BaseNode:   BaseNode{lfs: n.lfs},
@@ -434,7 +434,7 @@ func (n *IssueDirectoryNode) Rename(ctx context.Context, name string, newParent 
 // is aborted before the rename). Only scratch files we created are removable;
 // the canonical entries (issue.md, comments, etc.) are not.
 func (n *IssueDirectoryNode) Unlink(ctx context.Context, name string) syscall.Errno {
-	if _, ok := scratchRenameBytes(n, name); ok {
+	if _, _, ok := scratchRenameBytes(n, name); ok {
 		return 0
 	}
 	return syscall.EPERM

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -318,7 +318,7 @@ func (p *ProjectNode) Rename(ctx context.Context, name string, newParent fs.Inod
 		errKey:     project.ID,
 		dirIno:     p.EmbeddedInode().StableAttr().Ino,
 		fileIno:    projectInfoIno(project.ID),
-		scratch:    func(oldName string) ([]byte, bool) { return scratchRenameBytes(p, oldName) },
+		scratch:    func(oldName string) ([]byte, func(), bool) { return scratchRenameBytes(p, oldName) },
 		flush: func(ctx context.Context, content []byte) syscall.Errno {
 			fileNode = &ProjectInfoNode{
 				BaseNode:   BaseNode{lfs: p.lfs},
@@ -335,7 +335,7 @@ func (p *ProjectNode) Rename(ctx context.Context, name string, newParent fs.Inod
 // Unlink lets editors clean up an abandoned atomic-save temp file. Only scratch
 // files we created are removable; the canonical entries are not.
 func (p *ProjectNode) Unlink(ctx context.Context, name string) syscall.Errno {
-	if _, ok := scratchRenameBytes(p, name); ok {
+	if _, _, ok := scratchRenameBytes(p, name); ok {
 		return 0
 	}
 	return syscall.EPERM

--- a/internal/fs/renamesave.go
+++ b/internal/fs/renamesave.go
@@ -56,11 +56,12 @@ type renameSaveSpec struct {
 	// the file re-Looks-up to a fresh node instead of serving the spent scratch
 	// inode go-fuse moved into place.
 	fileIno uint64
-	// scratch reports the buffered contents of the scratch file named name, and
-	// whether name refers to a scratch file this filesystem created.
-	// scratchRenameBytes(dir, name) in production; a seam so the tail is
-	// testable without an inode tree.
-	scratch func(name string) ([]byte, bool)
+	// scratch reports the buffered contents of the scratch file named name, a
+	// closure that marks that scratch node consumed, and whether name refers to
+	// a scratch file this filesystem created. scratchRenameBytes(dir, name) in
+	// production; a seam so the tail is testable without an inode tree. The tail
+	// calls consume only on a persisted save (see renameSave).
+	scratch func(name string) (content []byte, consume func(), ok bool)
 	// flush routes the scratch bytes through the entity file's normal edit path:
 	// construct a transient file node with a dirty editBuffer and Flush it
 	// (frontmatter validation, read-your-writes verification, .error handling,
@@ -84,7 +85,7 @@ func renameSave(ctx context.Context, sink renameSink, name string, newParent fs.
 		return syscall.EXDEV
 	}
 
-	content, ok := spec.scratch(name)
+	content, consume, ok := spec.scratch(name)
 	if !ok {
 		// name isn't a scratch file we created — e.g. an attempt to rename the
 		// canonical .md itself. The canonical files aren't renamable.
@@ -108,7 +109,12 @@ func renameSave(ctx context.Context, sink renameSink, name string, newParent fs.
 		// the stored content, and drop the kernel caches: go-fuse will MvChild
 		// the spent scratch inode over the canonical file, so the file must
 		// re-Lookup to a fresh node rather than serve the consumed scratch node.
+		// Consume the scratch node so that, until the async invalidation lands,
+		// the spent node moved over the canonical name fails loud (ESTALE)
+		// instead of silently accepting writes it can no longer persist — that
+		// ESTALE drives the VFS to re-Lookup the real node.
 		spec.adopt()
+		consume()
 		sink.InvalidateRenamed(spec.dirIno, name, newName, spec.fileIno)
 	}
 

--- a/internal/fs/renamesave_test.go
+++ b/internal/fs/renamesave_test.go
@@ -38,6 +38,7 @@ type renameParent struct{ fs.Inode }
 type recordingRenameSpec struct {
 	spec         renameSaveSpec
 	scratchCalls int
+	consumeCalls int
 	flushCalls   int
 	flushContent []byte
 	adoptCalls   int
@@ -50,9 +51,9 @@ func newRecordingRenameSpec(scratchOK bool, flushErrno syscall.Errno) *recording
 		errKey:     "issue-1",
 		dirIno:     0, // matches the zero-value renameParent inode
 		fileIno:    99,
-		scratch: func(name string) ([]byte, bool) {
+		scratch: func(name string) ([]byte, func(), bool) {
 			r.scratchCalls++
-			return []byte("scratch bytes"), scratchOK
+			return []byte("scratch bytes"), func() { r.consumeCalls++ }, scratchOK
 		},
 		flush: func(ctx context.Context, content []byte) syscall.Errno {
 			r.flushCalls++
@@ -82,6 +83,10 @@ func TestRenameSave_FlushOutcomes(t *testing.T) {
 		// failure): nothing to adopt, nothing to invalidate.
 		{"flush EINVAL adopts nothing", syscall.EINVAL, 0, 0},
 	}
+	// The scratch buffer is consumed exactly when the rename succeeds (the same
+	// {0, EIO} branch that adopts): go-fuse has moved the spent node over the
+	// canonical name, so it must reject further access. A rejected save leaves
+	// the scratch usable.
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -102,6 +107,9 @@ func TestRenameSave_FlushOutcomes(t *testing.T) {
 			}
 			if rec.adoptCalls != tc.wantAdopts {
 				t.Errorf("adopt calls = %d, want %d", rec.adoptCalls, tc.wantAdopts)
+			}
+			if rec.consumeCalls != tc.wantAdopts {
+				t.Errorf("consume calls = %d, want %d (consume rides the adopt branch)", rec.consumeCalls, tc.wantAdopts)
 			}
 			if len(sink.invalidates) != tc.wantInvalidates {
 				t.Fatalf("invalidates = %v, want %d call(s)", sink.invalidates, tc.wantInvalidates)
@@ -143,6 +151,9 @@ func TestRenameSave_WrongTarget(t *testing.T) {
 	if rec.flushCalls != 0 || rec.adoptCalls != 0 || len(sink.invalidates) != 0 {
 		t.Errorf("wrong target must stop before flush: flush=%d adopt=%d invalidates=%v",
 			rec.flushCalls, rec.adoptCalls, sink.invalidates)
+	}
+	if rec.consumeCalls != 0 {
+		t.Errorf("consume calls = %d, want 0 (a rejected rename leaves the scratch usable)", rec.consumeCalls)
 	}
 }
 


### PR DESCRIPTION
After an atomic-save rename onto `issue.md`/`project.md`/`initiative.md`, go-fuse `MvChild`s the spent `scratchFileNode` over the canonical name. `renameSave` calls `InvalidateRenamed` to force a re-Lookup to the real node, but kernel-notify is async: a write that wins the race against the pending invalidation resolves to the dead scratch buffer — whose `Flush`/`Fsync`/`Write` returned `0`, **silently dropping a write that can no longer persist**. Surfaced as flaky integration failures (`TestProjectLabelsValidationErrors` "save succeeded" when a rename test ran first, ~1-in-5) and is a real, if narrow, silent-write-drop window in normal editor use.

**Fix:** mark a `scratchFileNode` consumed once a rename persists its bytes. A consumed node returns `ESTALE` from `Open`/`Write`/`Flush`/`Fsync`/`Setattr` instead of a silent success — the same fail-loud principle as the #276/#278 reflection work. `ESTALE` on `Open` drives the Linux VFS to retry the open with revalidation (`LOOKUP_REVAL`), forcing a fresh `Lookup` to the real canonical node, so the racing write transparently re-resolves and validates/persists rather than vanishing.

`renameSave` consumes the scratch exactly on its success branch (`{0, EIO}`); a rejected rename (EXDEV / wrong target / non-scratch) leaves the scratch usable.

Built test-first (TDD): `scratchFileNode` consumed-state behavior + the `renameSave` wiring. The previously-flaky integration pair is now deterministic (20/20).

Independent of #278 (reproduces on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)