### PR TITLE
test(fs): close write-path edit-persistence gaps in fixture mode

### DIFF
--- a/internal/integration/edit_persist_test.go
+++ b/internal/integration/edit_persist_test.go
@@ -134,3 +134,91 @@ func TestOffline_AtomicRenameEditPersists(t *testing.T) {
 		t.Fatalf("atomic-rename edit did not persist marker %q\n--- got ---\n%s", marker, after)
 	}
 }
+
+// TestOffline_ProjectEditPersistsDescription is the fixture-mode counterpart of
+// TestClaudeToolEditPersistsProjectDescription (which requires LINEARFS_WRITE_TESTS
+// against the live API, so default CI never runs it). With the mock mutator a
+// write+fsync to project.md must persist the edited body, so the mount serves it
+// back — and the untouched name survives the round trip.
+func TestOffline_ProjectEditPersistsDescription(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode offline edit-persistence check; uses the mock mutator")
+	}
+	enableMockMutations(t)
+
+	path := projectMDPath()
+	orig, err := readFileWithRetry(path, defaultWaitTime)
+	if err != nil {
+		t.Fatalf("read project.md: %v", err)
+	}
+	t.Cleanup(func() { claudeToolWrite(t, path, orig) })
+
+	doc, err := marshal.Parse(orig)
+	if err != nil {
+		t.Fatalf("parse project.md: %v", err)
+	}
+	const marker = "project edit persistence probe ZZZ"
+	doc.Body = strings.TrimRight(doc.Body, "\n") + "\n\n" + marker
+	edited, err := marshal.Render(doc)
+	if err != nil {
+		t.Fatalf("render project.md: %v", err)
+	}
+	claudeToolWrite(t, path, edited)
+
+	after, err := readFileWithRetry(path, defaultWaitTime)
+	if err != nil {
+		t.Fatalf("re-read project.md: %v", err)
+	}
+	got := string(after)
+	for _, want := range []string{marker, "Test Project"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("project edit lost %q\n--- got ---\n%s", want, got)
+		}
+	}
+}
+
+// TestOffline_InitiativeEditPersistsDescription is the initiative counterpart of
+// the project test: the fixture-mode version of
+// TestClaudeToolEditPersistsInitiativeDescription. A write+fsync to
+// initiative.md persists the edited body through the mock mutator, and the
+// untouched name survives the round trip.
+func TestOffline_InitiativeEditPersistsDescription(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode offline edit-persistence check; uses the mock mutator")
+	}
+	enableMockMutations(t)
+
+	dir, err := firstInitiativeDir()
+	if err != nil {
+		t.Skipf("no initiative fixture: %v", err)
+	}
+	path := filepath.Join(dir, "initiative.md")
+	orig, err := readFileWithRetry(path, defaultWaitTime)
+	if err != nil {
+		t.Fatalf("read initiative.md: %v", err)
+	}
+	t.Cleanup(func() { claudeToolWrite(t, path, orig) })
+
+	doc, err := marshal.Parse(orig)
+	if err != nil {
+		t.Fatalf("parse initiative.md: %v", err)
+	}
+	const marker = "initiative edit persistence probe ZZZ"
+	doc.Body = strings.TrimRight(doc.Body, "\n") + "\n\n" + marker
+	edited, err := marshal.Render(doc)
+	if err != nil {
+		t.Fatalf("render initiative.md: %v", err)
+	}
+	claudeToolWrite(t, path, edited)
+
+	after, err := readFileWithRetry(path, defaultWaitTime)
+	if err != nil {
+		t.Fatalf("re-read initiative.md: %v", err)
+	}
+	got := string(after)
+	for _, want := range []string{marker, "Test Initiative"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("initiative edit lost %q\n--- got ---\n%s", want, got)
+		}
+	}
+}

--- a/internal/integration/edit_persist_test.go
+++ b/internal/integration/edit_persist_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -76,5 +77,60 @@ func TestOffline_MilestoneEditPreservesOtherFields(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Errorf("milestone edit lost %q after saving targetDate=%s\n--- got ---\n%s", want, newDate, got)
 		}
+	}
+}
+
+// TestOffline_AtomicRenameEditPersists drives renameSave: an editor's atomic
+// save (write a sibling temp file, rename it over issue.md) must actually LAND
+// the edit, not merely avoid corruption. The existing TestWriteContractAtomicRename*
+// tests assert only no-corruption/no-EROFS and run without the mock mutator, so
+// persist fails there and "a save lands via rename" was unchecked — the exact
+// neighborhood of the spent-scratch drop bug (#280). With the mock, the rename's
+// inline Flush persists and the consumed scratch re-Looks-up to the fresh
+// store-backed node, so the mount serves the edit back.
+func TestOffline_AtomicRenameEditPersists(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode offline edit-persistence check; uses the mock mutator")
+	}
+	enableMockMutations(t)
+
+	path := issueFilePath(testTeamKey, "TST-1")
+	orig, err := readFileWithRetry(path, defaultWaitTime)
+	if err != nil {
+		t.Fatalf("read issue.md: %v", err)
+	}
+	// Restore the original content through the mount so the shared fixture issue
+	// is left unchanged for other tests.
+	t.Cleanup(func() { claudeToolWrite(t, path, orig) })
+
+	doc, err := marshal.Parse(orig)
+	if err != nil {
+		t.Fatalf("parse issue.md: %v", err)
+	}
+	const marker = "atomic rename persistence probe ZZZ"
+	doc.Body = strings.TrimRight(doc.Body, "\n") + "\n\n" + marker
+	edited, err := marshal.Render(doc)
+	if err != nil {
+		t.Fatalf("render issue.md: %v", err)
+	}
+
+	// Atomic save-via-rename: write a sibling scratch temp file, then rename it
+	// over the canonical issue.md. The rename routes the bytes straight through
+	// issue.md's Flush, so a rejected/failed persist surfaces as a rename error.
+	tmp := path + ".tmp.42.cafef00d"
+	if err := os.WriteFile(tmp, edited, 0o644); err != nil {
+		t.Fatalf("write scratch temp: %v", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		t.Fatalf("atomic rename over issue.md should persist with mock mutator: %v", err)
+	}
+
+	after, err := readFileWithRetry(path, defaultWaitTime)
+	if err != nil {
+		t.Fatalf("re-read issue.md: %v", err)
+	}
+	if !strings.Contains(string(after), marker) {
+		t.Fatalf("atomic-rename edit did not persist marker %q\n--- got ---\n%s", marker, after)
 	}
 }

--- a/internal/integration/edit_persist_test.go
+++ b/internal/integration/edit_persist_test.go
@@ -1,0 +1,80 @@
+package integration
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jra3/linear-fuse/internal/api"
+	"github.com/jra3/linear-fuse/internal/marshal"
+	"github.com/jra3/linear-fuse/internal/testutil/fixtures"
+)
+
+// These tests exercise the per-entity EDIT (Flush) persistence paths OFFLINE,
+// through the in-memory mutation fake (enableMockMutations). Unlike the create/
+// archive/rename lifecycle tests in write_offline_test.go, they assert that a
+// content edit to an editable file actually LANDS: after a write+fsync the mount
+// serves the new content back. Before them, milestone edits had zero coverage
+// and project/initiative edit-persistence only ran under LINEARFS_WRITE_TESTS=1
+// against the live API, so the default fixture-mode suite never exercised the
+// edit-commit tail (mutate → upsert SQLite → read-your-writes) for these
+// entities.
+
+// restoreFixtureMilestone re-seeds the "Alpha Release" milestone so an edit
+// test does not leave the shared mount's store mutated for later tests.
+func restoreFixtureMilestone(t *testing.T) {
+	t.Helper()
+	if err := fixtures.PopulateProjectMilestones(context.Background(), testStore,
+		fixtures.FixtureAPIProject().ID,
+		[]api.ProjectMilestone{fixtures.FixtureAPIProjectMilestone()}); err != nil {
+		t.Errorf("restore fixture milestone: %v", err)
+	}
+}
+
+// TestOffline_MilestoneEditPreservesOtherFields drives MilestoneFileNode.Flush:
+// editing ONE milestone field (targetDate) and saving must land the change while
+// leaving the untouched fields (name, description) intact on re-read. This is the
+// starkest write-path gap — a fully editable entity that had no edit test at all
+// — and it guards the whole-entity round trip through the edit-commit tail, not
+// just the single edited field.
+func TestOffline_MilestoneEditPreservesOtherFields(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode offline edit-persistence check; uses the mock mutator")
+	}
+	enableMockMutations(t)
+	t.Cleanup(func() { restoreFixtureMilestone(t) })
+
+	path := filepath.Join(projectsPath(testTeamKey), "test-project", "milestones", "Alpha Release.md")
+
+	orig, err := readFileWithRetry(path, defaultWaitTime)
+	if err != nil {
+		t.Fatalf("read milestone: %v", err)
+	}
+
+	// Edit only the targetDate, leaving name and description untouched.
+	doc, err := marshal.Parse(orig)
+	if err != nil {
+		t.Fatalf("parse milestone: %v", err)
+	}
+	const newDate = "2025-12-01"
+	doc.Frontmatter["targetDate"] = newDate
+	edited, err := marshal.Render(doc)
+	if err != nil {
+		t.Fatalf("render milestone: %v", err)
+	}
+	claudeToolWrite(t, path, edited)
+
+	after, err := readFileWithRetry(path, defaultWaitTime)
+	if err != nil {
+		t.Fatalf("re-read milestone: %v", err)
+	}
+	got := string(after)
+	// The edited field landed, and the fields we never touched survived the
+	// round trip — a partial-echo from the mutation must not zero them.
+	for _, want := range []string{newDate, "Alpha Release", "First alpha release"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("milestone edit lost %q after saving targetDate=%s\n--- got ---\n%s", want, newDate, got)
+		}
+	}
+}

--- a/internal/integration/edit_persist_test.go
+++ b/internal/integration/edit_persist_test.go
@@ -1,15 +1,12 @@
 package integration
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/jra3/linear-fuse/internal/api"
 	"github.com/jra3/linear-fuse/internal/marshal"
-	"github.com/jra3/linear-fuse/internal/testutil/fixtures"
 )
 
 // These tests exercise the per-entity EDIT (Flush) persistence paths OFFLINE,
@@ -22,17 +19,6 @@ import (
 // edit-commit tail (mutate → upsert SQLite → read-your-writes) for these
 // entities.
 
-// restoreFixtureMilestone re-seeds the "Alpha Release" milestone so an edit
-// test does not leave the shared mount's store mutated for later tests.
-func restoreFixtureMilestone(t *testing.T) {
-	t.Helper()
-	if err := fixtures.PopulateProjectMilestones(context.Background(), testStore,
-		fixtures.FixtureAPIProject().ID,
-		[]api.ProjectMilestone{fixtures.FixtureAPIProjectMilestone()}); err != nil {
-		t.Errorf("restore fixture milestone: %v", err)
-	}
-}
-
 // TestOffline_MilestoneEditPreservesOtherFields drives MilestoneFileNode.Flush:
 // editing ONE milestone field (targetDate) and saving must land the change while
 // leaving the untouched fields (name, description) intact on re-read. This is the
@@ -44,7 +30,6 @@ func TestOffline_MilestoneEditPreservesOtherFields(t *testing.T) {
 		t.Skip("fixture-mode offline edit-persistence check; uses the mock mutator")
 	}
 	enableMockMutations(t)
-	t.Cleanup(func() { restoreFixtureMilestone(t) })
 
 	path := filepath.Join(projectsPath(testTeamKey), "test-project", "milestones", "Alpha Release.md")
 
@@ -52,6 +37,10 @@ func TestOffline_MilestoneEditPreservesOtherFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read milestone: %v", err)
 	}
+	// Restore the original content through the mount so the shared fixture
+	// milestone is left unchanged for later tests (a store-only reseed would not
+	// refresh this live node's adopted buffer — see TestFixtureMilestoneFile).
+	t.Cleanup(func() { claudeToolWrite(t, path, orig) })
 
 	// Edit only the targetDate, leaving name and description untouched.
 	doc, err := marshal.Parse(orig)

--- a/internal/testutil/mockmutation/mock.go
+++ b/internal/testutil/mockmutation/mock.go
@@ -326,14 +326,42 @@ func (c *Client) CreateProjectMilestone(ctx context.Context, projectID, name, de
 }
 
 func (c *Client) UpdateProjectMilestone(ctx context.Context, milestoneID string, input api.ProjectMilestoneUpdateInput) (*api.ProjectMilestone, error) {
-	m := &api.ProjectMilestone{ID: milestoneID}
+	// The real mutation returns the WHOLE updated milestone, so overlay the input
+	// onto the current stored state — echoing only the edited fields would zero
+	// the untouched ones (name/targetDate/sortOrder), corrupting the upsert.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	m := c.currentMilestoneLocked(ctx, milestoneID)
 	if input.Name != nil {
 		m.Name = *input.Name
 	}
 	if input.Description != nil {
 		m.Description = *input.Description
 	}
-	return m, nil
+	if input.TargetDate != nil {
+		td := *input.TargetDate
+		if td == "" {
+			m.TargetDate = nil
+		} else {
+			m.TargetDate = &td
+		}
+	}
+	if input.SortOrder != nil {
+		m.SortOrder = *input.SortOrder
+	}
+	return &m, nil
+}
+
+// currentMilestoneLocked returns the current stored milestone, else a bare {ID}.
+// The caller must hold c.mu. Milestones have no post-edit record (no verify
+// getter); the store is the source of truth for the merge base.
+func (c *Client) currentMilestoneLocked(ctx context.Context, id string) api.ProjectMilestone {
+	if c.store != nil {
+		if row, err := c.store.Queries().GetProjectMilestone(ctx, id); err == nil {
+			return db.DBMilestoneToAPIProjectMilestone(row)
+		}
+	}
+	return api.ProjectMilestone{ID: id}
 }
 
 func (c *Client) DeleteProjectMilestone(ctx context.Context, milestoneID string) error { return nil }


### PR DESCRIPTION
Closes three verified write-path test-coverage gaps with fixture-mode, TDD-built integration tests (no live API needed). New file `internal/integration/edit_persist_test.go` plus a `mockmutation` fidelity fix.

## Gaps closed

1. **Milestone edit — was ZERO tests (unit or integration).** `TestOffline_MilestoneEditPreservesOtherFields` edits one field (`targetDate`) and asserts the untouched fields (name, description) survive the round trip. This drove out a real infidelity in the mock mutation client: `UpdateProjectMilestone` echoed only `Name`/`Description` from the input and dropped the rest, so an edit zeroed the store row's name and corrupted re-read-by-name. The real Linear mutation returns the whole milestone, so the fake now overlays the input onto the stored milestone (mirroring the project/initiative `currentXLocked` merge).

2. **Atomic-save-rename persistence — unchecked in fixture mode.** `TestOffline_AtomicRenameEditPersists` writes a sibling temp file and renames it over `issue.md`, asserting the edit actually lands. The existing `TestWriteContractAtomicRename*` tests assert only no-corruption/no-EROFS and run without the mock, so "a save lands via rename" was unchecked — the exact neighborhood of the spent-scratch write-drop bug (#280).

3. **Project/initiative edit persistence — was live-API-only.** `TestOffline_{Project,Initiative}EditPersistsDescription` are fixture-mode counterparts of the `LINEARFS_WRITE_TESTS`-gated `TestClaudeToolEditPersists*` tests, so default CI now exercises those edit-commit tails.

## Rigor

- Each coverage-gap test was **sensitivity-checked** (temporarily disable the mock → the rename/commit returns EIO → RED), proving the tests assert persistence rather than just the no-corruption contract.
- Fixed a shared-mount cleanup pollution the full suite surfaced: the milestone test restores through the mount (clearing the live node's adopted buffer) instead of a store-only reseed that left `TestFixtureMilestoneFile` reading a stale edit.

## Testing

- `go build ./...`, `go vet`, `gofmt` clean
- `go test ./internal/fs/ -race` green
- Full integration suite green (~63s)

No filesystem surface/contract changed (tests + a test-double fidelity fix), so no README/ARCHITECTURE update and no live-service impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)