### PR TITLE
refactor(fs): extract commitRename tail; dedup Labels/Docs Rename

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -87,7 +87,10 @@ persist-before-invalidate ordering are unit-tested with a recording sink
 
 ### Rename save (`renameSave`)
 The **deep module** owning the atomic-save Rename tail — the rename-shaped
-sibling of the WriteBack tail in the edit-path family. Editors and the Claude
+sibling of the WriteBack tail in the edit-path family. Not to be confused with
+[[rename-tail]] (`commitRename`), the mutation-tail family's rename sibling that
+renames an *entity* (a label's name / a doc's title); this one moves editor
+scratch-temp *bytes* onto a canonical `.md`. Editors and the Claude
 Code Edit/Write tools never write a file in place: they write a sibling scratch
 temp file (see the Edit buffer's scratch counterpart in
 `internal/fs/atomicwrite.go`, #145) and rename(2) it onto the canonical `.md`.
@@ -176,6 +179,41 @@ phantom heals it (and is exactly the recovery the forget-exhaustion `.error`
 names) — and the details sync **prunes** rows a (provably complete, sub-page-cap)
 fetch no longer returns, scoped by issue and a pre-fetch `synced_at` cutoff so
 rows created mid-fetch survive.
+
+### Rename tail (`commitRename`)
+The **deep module** owning the invariant tail of every *entity* rename — a
+label's name, a document's title — the rename-shaped fourth sibling of the
+Create/WriteBack/Delete tails. `LabelsNode.Rename` and `DocsNode.Rename` had
+hand-copied it byte-parallel; `commitRename` (`internal/fs/renamecommit.go`,
+generic over `T`) collapses both into a spec literal. Its contract:
+guard (`_create`, `.meta` sidecar, cross-dir → `EPERM`/`EXDEV`; a target
+lacking `.md` → `EINVAL` **plus a helpful `.error`**) → parse the new name →
+`find` the current entity by its old name (nil → `ENOENT`) → `mutate` (call the
+API rename, returning the API's updated entity) → **persist-gate** the
+reflection through `persistOrEIO` (see [[persist-gate]]; a wedge fails loud with
+`unconfirmedEditMsg` and skips invalidation) → on success clear `.error` and
+fire **both** `InvalidateRenamed` calls, the `.md` pair and its `.meta` twin
+(the sidecar names are computed by the tail via `metaSidecarName`, not a spec
+field). It **persists the API-returned entity, not the requested name**, so
+server-side name normalization is captured for free. It reuses the existing
+`renameSink` seam (ErrorSink + `InvalidateRenamed`, satisfied by `*LinearFS`) —
+no new sink — and carries **no read-your-writes compare and no telemetry**
+(matching [[rename-save]]). Unit-tested with a recording sink over the exact
+9-branch table, no FUSE mount, SQLite, or API.
+
+Not to be confused with [[rename-save]], the *atomic-save* Rename tail that
+flushes editor scratch-temp bytes onto a canonical `.md` (issue/project/
+initiative); that one owns the temp-file adoption/consume dance, this one owns
+the entity-name mutation. The two rename tails are disjoint: `renameSave` is the
+edit-path's rename sibling (bytes into a file), `commitRename` is the mutation-
+tail family's rename sibling (a new name for an entity).
+
+The absence of a compare here is deliberate and principled: **read-your-writes
+verification is a layer *above* the commit-tail primitives, not part of them.**
+`commitRename`, `commitCreate`, and `commitDelete` are pure mutate → persist-gate
+→ invalidate — they trust the mutation's echoed entity. Only the edit path adds a
+compare (see [[read-your-writes-verification]]), and it lives in the layer above
+the commit tail (`editFlush`/`commitWriteBack`), not inside it.
 
 ### Name→ID resolution (`resolveIssueUpdate`)
 marshal returns an issue update whose relational fields hold *names* (a state name,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -488,9 +488,14 @@ building blocks:
 **Read flow:** kernel → `Lookup`/`Readdir`/`Read` → Repository → SQLite →
 marshal to markdown bytes. `mtime` = `updatedAt`, `ctime` = `createdAt`.
 
-**Write flow (the important interaction).** Three sibling commit tails own the
+**Write flow (the important interaction).** Four sibling commit tails own the
 write directions: `commitCreate` (`createcommit.go`), `commitWriteBack`
-(`editcommit.go`), `commitDelete` (`deletecommit.go`). For an edit:
+(`editcommit.go`), `commitDelete` (`deletecommit.go`), and `commitRename`
+(`renamecommit.go`) — the entity-rename tail that mutates then confirms local
+reflection through the persist gate (`persistOrEIO`) and re-cohers the
+`.md`/`.meta` pair; it carries no read-your-writes compare (that verification is
+a layer above the commit-tail primitives) and no telemetry (matching
+`renameSave`). For an edit:
 1. `Write` buffers bytes in the `editBuffer`; `Flush` parses the markdown via
    `marshal`. Editor save-via-rename (temp file + `rename`) is caught by a
    scratch node and routed through the same path (`atomicwrite.go`,

--- a/internal/fs/documents.go
+++ b/internal/fs/documents.go
@@ -115,74 +115,33 @@ func (n *DocsNode) Unlink(ctx context.Context, name string) syscall.Errno {
 	return n.collection().unlink(ctx, name)
 }
 
+// Rename renames a document by changing its title on Linear. The whole rename
+// tail — special-name/cross-dir guards, name parsing, find, mutate, persist gate,
+// and kernel re-coherence of the .md and its .meta twin — lives in commitRename;
+// this handler is the document-specific spec.
 func (n *DocsNode) Rename(ctx context.Context, name string, newParent fs.InodeEmbedder, newName string, flags uint32) syscall.Errno {
-	if n.lfs.debug {
-		log.Printf("Rename document: %s -> %s", name, newName)
-	}
-
-	// Don't allow renaming _create
-	if name == "_create" {
-		return syscall.EPERM
-	}
-
-	// The .meta sidecar is read-only; its name follows the .md's.
-	if _, isMeta := metaSidecarSource(name); isMeta {
-		return syscall.EPERM
-	}
-
-	// For same-directory rename, compare inode numbers
-	if newParent.EmbeddedInode().StableAttr().Ino != n.EmbeddedInode().StableAttr().Ino {
-		if n.lfs.debug {
-			log.Printf("Rename: cross-directory not allowed")
-		}
-		return syscall.EXDEV
-	}
-
-	// Extract new title from filename (remove .md suffix, convert dashes to spaces)
-	if !strings.HasSuffix(newName, ".md") {
-		return syscall.EINVAL
-	}
-	newTitle := strings.TrimSuffix(newName, ".md")
-	newTitle = strings.ReplaceAll(newTitle, "-", " ")
-
-	docs, err := n.getDocuments(ctx)
-	if err != nil {
-		return syscall.EIO
-	}
-
-	doc, ok := n.listing(docs).find(name)
-	if !ok {
-		return syscall.ENOENT
-	}
-
-	// Update document title
-	updatedDoc, err := n.lfs.UpdateDocument(ctx, doc.ID, map[string]any{"title": newTitle}, n.issueID, n.teamID, n.projectID)
-	if err != nil {
-		log.Printf("Failed to rename document: %v", err)
-		msg, errno := classifyMutationErr("rename document "+name+" -> "+newName, err)
-		n.lfs.SetWriteError(collectionErrorKey("docs", n.parentID()), msg)
-		return errno
-	}
-	// Persist gates the rename: like the edit tail, a reflection the local cache
-	// can't serve fails loud (retry, then EIO) rather than swallowing it. The
-	// rename is on Linear and idempotent, so the .error says re-saving is safe
-	// (#278). See persistgate.go.
-	errKey := collectionErrorKey("docs", n.parentID())
-	if errno := persistOrEIO(ctx, n.lfs, errKey,
-		func(err error) string { return unconfirmedEditMsg("rename document "+name+" -> "+newName, err) },
-		func(ctx context.Context, d *api.Document) error { return n.lfs.UpsertDocument(ctx, *d) },
-		updatedDoc); errno != 0 {
-		return errno
-	}
-	n.lfs.ClearWriteError(errKey)
-	if n.lfs.debug {
-		log.Printf("Document renamed successfully: %s -> %s", doc.Title, newTitle)
-	}
-	// Invalidate kernel cache for old and new names — the .meta sidecar's
-	// name follows the .md's, so both pairs move.
-	n.lfs.InvalidateRenamed(docsDirIno(n.parentID()), name, newName, 0)
-	n.lfs.InvalidateRenamed(docsDirIno(n.parentID()), metaSidecarName(name), metaSidecarName(newName), 0)
-	return 0
+	return commitRename(ctx, n.lfs, name, newParent, newName, renameSpec[api.Document]{
+		kind:   "document",
+		errKey: collectionErrorKey("docs", n.parentID()),
+		dirIno: docsDirIno(n.parentID()),
+		find: func(ctx context.Context) (*api.Document, error) {
+			docs, err := n.getDocuments(ctx)
+			if err != nil {
+				return nil, err
+			}
+			doc, ok := n.listing(docs).find(name)
+			if !ok {
+				return nil, nil
+			}
+			return &doc, nil
+		},
+		mutate: func(ctx context.Context, target *api.Document, newName string) (*api.Document, error) {
+			return n.lfs.UpdateDocument(ctx, target.ID, map[string]any{"title": newName}, n.issueID, n.teamID, n.projectID)
+		},
+		persist: func(ctx context.Context, fresh *api.Document) error {
+			return n.lfs.UpsertDocument(ctx, *fresh)
+		},
+	})
 }
 
 // newDocumentInode builds the read/write DocumentFileNode inode for an existing

--- a/internal/fs/labels.go
+++ b/internal/fs/labels.go
@@ -93,75 +93,33 @@ func (n *LabelsNode) Unlink(ctx context.Context, name string) syscall.Errno {
 	return n.collection().unlink(ctx, name)
 }
 
+// Rename renames a label by changing its name on Linear. The whole rename tail —
+// special-name/cross-dir guards, name parsing, find, mutate, persist gate, and
+// kernel re-coherence of the .md and its .meta twin — lives in commitRename; this
+// handler is the label-specific spec.
 func (n *LabelsNode) Rename(ctx context.Context, name string, newParent fs.InodeEmbedder, newName string, flags uint32) syscall.Errno {
-	if n.lfs.debug {
-		log.Printf("Rename label: %s -> %s (newParent type: %T)", name, newName, newParent)
-	}
-
-	// Don't allow renaming _create
-	if name == "_create" {
-		return syscall.EPERM
-	}
-
-	// The .meta sidecar is read-only; its name follows the .md's.
-	if _, isMeta := metaSidecarSource(name); isMeta {
-		return syscall.EPERM
-	}
-
-	// For same-directory rename, newParent should be the same inode as us
-	// Compare by inode number
-	if newParent.EmbeddedInode().StableAttr().Ino != n.EmbeddedInode().StableAttr().Ino {
-		if n.lfs.debug {
-			log.Printf("Rename: cross-directory not allowed")
-		}
-		return syscall.EXDEV
-	}
-
-	// Extract new label name from filename (remove .md suffix, convert dashes to spaces)
-	if !strings.HasSuffix(newName, ".md") {
-		return syscall.EINVAL
-	}
-	newLabelName := strings.TrimSuffix(newName, ".md")
-	newLabelName = strings.ReplaceAll(newLabelName, "-", " ")
-
-	labels, err := n.lfs.repo.GetTeamLabels(ctx, n.teamID)
-	if err != nil {
-		return syscall.EIO
-	}
-
-	label, ok := n.listing(labels).find(name)
-	if !ok {
-		return syscall.ENOENT
-	}
-
-	// Update label name
-	updatedLabel, err := n.lfs.UpdateLabel(ctx, label.ID, map[string]any{"name": newLabelName}, n.teamID)
-	if err != nil {
-		log.Printf("Failed to rename label: %v", err)
-		msg, errno := classifyMutationErr("rename label "+name+" -> "+newName, err)
-		n.lfs.SetWriteError(collectionErrorKey("labels", n.teamID), msg)
-		return errno
-	}
-	// Persist gates the rename: like the edit tail, a reflection the local cache
-	// can't serve fails loud (retry, then EIO) rather than swallowing it. The
-	// rename is on Linear and idempotent, so the .error says re-saving is safe
-	// (#278). See persistgate.go.
-	errKey := collectionErrorKey("labels", n.teamID)
-	if errno := persistOrEIO(ctx, n.lfs, errKey,
-		func(err error) string { return unconfirmedEditMsg("rename label "+name+" -> "+newName, err) },
-		func(ctx context.Context, l *api.Label) error { return n.lfs.UpsertLabel(ctx, n.teamID, *l) },
-		updatedLabel); errno != 0 {
-		return errno
-	}
-	n.lfs.ClearWriteError(errKey)
-	if n.lfs.debug {
-		log.Printf("Label renamed successfully: %s -> %s", label.Name, newLabelName)
-	}
-	// Invalidate kernel cache for old and new names — the .meta sidecar's
-	// name follows the .md's, so both pairs move.
-	n.lfs.InvalidateRenamed(labelsDirIno(n.teamID), name, newName, 0)
-	n.lfs.InvalidateRenamed(labelsDirIno(n.teamID), metaSidecarName(name), metaSidecarName(newName), 0)
-	return 0
+	return commitRename(ctx, n.lfs, name, newParent, newName, renameSpec[api.Label]{
+		kind:   "label",
+		errKey: collectionErrorKey("labels", n.teamID),
+		dirIno: labelsDirIno(n.teamID),
+		find: func(ctx context.Context) (*api.Label, error) {
+			labels, err := n.lfs.repo.GetTeamLabels(ctx, n.teamID)
+			if err != nil {
+				return nil, err
+			}
+			label, ok := n.listing(labels).find(name)
+			if !ok {
+				return nil, nil
+			}
+			return &label, nil
+		},
+		mutate: func(ctx context.Context, target *api.Label, newName string) (*api.Label, error) {
+			return n.lfs.UpdateLabel(ctx, target.ID, map[string]any{"name": newName}, n.teamID)
+		},
+		persist: func(ctx context.Context, fresh *api.Label) error {
+			return n.lfs.UpsertLabel(ctx, n.teamID, *fresh)
+		},
+	})
 }
 
 func (n *LabelsNode) Create(ctx context.Context, name string, flags uint32, mode uint32, out *fuse.EntryOut) (*fs.Inode, fs.FileHandle, uint32, syscall.Errno) {

--- a/internal/fs/renamecommit.go
+++ b/internal/fs/renamecommit.go
@@ -1,0 +1,153 @@
+package fs
+
+import (
+	"context"
+	"log"
+	"strings"
+	"syscall"
+
+	"github.com/hanwen/go-fuse/v2/fs"
+)
+
+// The entity-rename tail.
+//
+// This is the entity-rename sibling of commitDelete (deletecommit.go), NOT the
+// atomic-save tail — that is renameSave (renamesave.go). renameSave persists an
+// editor's scratch temp file onto the one canonical .md; commitRename renames a
+// collection item (a label, a document) by changing the entity's own name on
+// Linear. They share the renameSink seam but nothing else: renameSave flushes
+// buffered bytes through a file node, while commitRename resolves an entity,
+// calls its rename mutation, and reflects the result.
+//
+// Every collection rename ended the same way: reject the special names
+// (_create, the .meta sidecar), reject a cross-directory move, parse the new
+// name out of the target filename (strip ".md", dashes -> spaces), resolve the
+// current entity, call the API rename, gate the local reflection, and re-coher
+// the kernel's view of BOTH the item's .md name and its .meta twin. That tail
+// was copy-pasted byte-for-byte across LabelsNode.Rename and DocsNode.Rename.
+//
+// commitRename is the one deep module that owns the tail, the rename-path
+// member of the reflection-contract family (commitCreate / commitWriteBack /
+// commitDelete). Structured like commitDelete — find -> mutate -> gate ->
+// coherence — but with three deliberate differences: no telemetry (matches
+// renameSave), the gate is persistOrEIO rather than retrySQLite+forget (a
+// rename reflects an updated row, it does not remove one), and success fires
+// TWO InvalidateRenamed calls (the .md pair and its .meta sidecar pair). Each
+// handler hands the tail a small spec; the module owns the failure model, the
+// .error reporting, the persist gate, and the coherence policy. It depends only
+// on the renameSink seam plus the spec's closures, so it is unit-tested with a
+// recording sink and stub closures — no FUSE mount, SQLite, or API.
+
+// renameSpec describes the per-entity parts of a collection rename. T is the
+// entity type (api.Label, api.Document). Everything T-specific lives in these
+// fields and closures; the tail itself is fully generic.
+type renameSpec[T any] struct {
+	// kind names the entity in composed op labels, e.g. "label" or "document".
+	// The tail builds the op string from kind + the old and new names.
+	kind string
+	// errKey identifies the .error sidecar (the collection's shared namespace,
+	// e.g. collectionErrorKey("labels", teamID)).
+	errKey string
+	// dirIno is the entity directory's inode. The cross-directory (EXDEV) check
+	// and every rename invalidation key off it.
+	dirIno uint64
+	// find resolves the CURRENT entity by the old name. Return (nil, nil) when it
+	// does not exist -> .error note + ENOENT; a non-nil error is classified like
+	// a mutation failure (transient -> EAGAIN, else EIO).
+	find func(ctx context.Context) (*T, error)
+	// mutate calls the API rename with the parsed new name and RETURNS the
+	// server's updated entity — the tail persists that returned value, so any
+	// server-side name normalization is captured for free.
+	mutate func(ctx context.Context, target *T, newName string) (*T, error)
+	// persist upserts the updated entity to SQLite for immediate visibility. Fed
+	// to persistOrEIO: a reflection the local cache can't serve fails loud (retry,
+	// then EIO) rather than swallowing the divergence (#278).
+	persist func(ctx context.Context, fresh *T) error
+}
+
+// commitRename runs a collection item rename: reject special names and
+// cross-directory moves, parse the new entity name, find, mutate, gate the
+// reflection, then re-coher the kernel. It returns the errno the handler should
+// return.
+//
+// Contract (guard order matters):
+//   - name == "_create"              -> EPERM, no .error, no invalidation.
+//   - name is a .meta sidecar        -> EPERM, no .error, no invalidation.
+//   - cross-directory                -> EXDEV, no .error, no invalidation.
+//   - newName lacks ".md"            -> EINVAL, a helpful .error naming the rule.
+//   - find fails                     -> .error gets the cause, classified errno.
+//   - find returns nil               -> .error notes the unknown name, ENOENT.
+//   - mutate fails                   -> .error gets the cause, classified errno;
+//     NO invalidation (the rename never landed).
+//   - persist wedge (retried)        -> .error says re-saving is safe, EIO; NO
+//     invalidation (the reflection is unconfirmed).
+//   - success                        -> clear .error, invalidate BOTH the .md
+//     pair and its .meta twin (exact old->new names), errno 0.
+func commitRename[T any](ctx context.Context, sink renameSink, name string, newParent fs.InodeEmbedder, newName string, spec renameSpec[T]) syscall.Errno {
+	// The _create trigger and the read-only .meta sidecars are not renamable.
+	if name == createTriggerName {
+		return syscall.EPERM
+	}
+	if _, isMeta := metaSidecarSource(name); isMeta {
+		return syscall.EPERM
+	}
+
+	// A collection rename stays within the collection directory.
+	if newParent.EmbeddedInode().StableAttr().Ino != spec.dirIno {
+		return syscall.EXDEV
+	}
+
+	// The new entity name comes from the target filename: strip ".md" and turn
+	// dashes back into spaces (the inverse of the filename sanitizer). A target
+	// without ".md" has no editable-item form, so reject it loudly — today's
+	// handlers returned a bare EINVAL, which told an agent nothing.
+	if !strings.HasSuffix(newName, ".md") {
+		sink.SetWriteError(spec.errKey, "Operation: rename "+spec.kind+" "+name+" -> "+newName+
+			"\nError: a "+spec.kind+" file must end in .md; rename onto a name like \"new-title.md\".")
+		return syscall.EINVAL
+	}
+	parsedName := strings.ReplaceAll(strings.TrimSuffix(newName, ".md"), "-", " ")
+
+	op := "rename " + spec.kind + " " + name + " -> " + newName
+
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
+
+	target, err := spec.find(ctx)
+	if err != nil {
+		msg, errno := classifyMutationErr(op, err)
+		log.Printf("Failed to %s: %v", op, err)
+		sink.SetWriteError(spec.errKey, msg)
+		return errno
+	}
+	if target == nil {
+		sink.SetWriteError(spec.errKey, "Operation: "+op+"\nError: no such entry. It may have been renamed or deleted; list the directory for current names.")
+		return syscall.ENOENT
+	}
+
+	fresh, err := spec.mutate(ctx, target, parsedName)
+	if err != nil {
+		msg, errno := classifyMutationErr(op, err)
+		log.Printf("Failed to %s: %v", op, err)
+		sink.SetWriteError(spec.errKey, msg)
+		return errno
+	}
+
+	// Persist gates the rename: like the edit tail, a reflection the local cache
+	// can't serve fails loud (retry, then EIO) rather than swallowing it. The
+	// rename is already on Linear and idempotent, so the .error says re-saving is
+	// safe (#278). No invalidation on a wedge — the local view is unconfirmed.
+	if errno := persistOrEIO(ctx, sink, spec.errKey,
+		func(err error) string { return unconfirmedEditMsg(op, err) },
+		spec.persist, fresh); errno != 0 {
+		return errno
+	}
+
+	sink.ClearWriteError(spec.errKey)
+
+	// Invalidate both the item's .md pair and its .meta twin — the sidecar's name
+	// follows the .md's, so both move together.
+	sink.InvalidateRenamed(spec.dirIno, name, newName, 0)
+	sink.InvalidateRenamed(spec.dirIno, metaSidecarName(name), metaSidecarName(newName), 0)
+	return 0
+}

--- a/internal/fs/renamecommit_test.go
+++ b/internal/fs/renamecommit_test.go
@@ -1,0 +1,277 @@
+package fs
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// fakeRenameEntity is a synthetic entity so the commitRename tail can be
+// exercised generically without a real api.Label/api.Document.
+type fakeRenameEntity struct {
+	ID   string
+	Name string
+}
+
+// recordingCommitRenameSpec builds a renameSpec[fakeRenameEntity] whose
+// find/mutate/persist closures record their calls, so a test can assert which
+// stages ran and what arguments they saw.
+type recordingCommitRenameSpec struct {
+	spec renameSpec[fakeRenameEntity]
+
+	findCalls int
+	findRet   *fakeRenameEntity
+	findErr   error
+
+	mutateCalls   int
+	mutateNewName string // the newName that reached mutate (asserts the parse)
+	mutateRet     *fakeRenameEntity
+	mutateErr     error
+
+	persistCalls int
+	persistErr   error
+}
+
+func newRecordingCommitRenameSpec() *recordingCommitRenameSpec {
+	r := &recordingCommitRenameSpec{
+		findRet:   &fakeRenameEntity{ID: "ent-1", Name: "foo"},
+		mutateRet: &fakeRenameEntity{ID: "ent-1", Name: "new name"},
+	}
+	r.spec = renameSpec[fakeRenameEntity]{
+		kind:   "label",
+		errKey: "labels:TEAM",
+		dirIno: 0, // matches the zero-value renameParent inode (same directory)
+		find: func(ctx context.Context) (*fakeRenameEntity, error) {
+			r.findCalls++
+			return r.findRet, r.findErr
+		},
+		mutate: func(ctx context.Context, target *fakeRenameEntity, newName string) (*fakeRenameEntity, error) {
+			r.mutateCalls++
+			r.mutateNewName = newName
+			return r.mutateRet, r.mutateErr
+		},
+		persist: func(ctx context.Context, fresh *fakeRenameEntity) error {
+			r.persistCalls++
+			return r.persistErr
+		},
+	}
+	return r
+}
+
+func TestCommitRename_Contract(t *testing.T) {
+	// The persist-wedge case retries through sqliteRetryBackoff; zero the sleeps
+	// so the whole table stays fast.
+	orig := sqliteRetryBackoff
+	sqliteRetryBackoff = []time.Duration{0} // one immediate attempt, no sleeps
+	t.Cleanup(func() { sqliteRetryBackoff = orig })
+
+	cases := []struct {
+		name string
+		// input
+		oldName string
+		newName string
+		dirIno  uint64 // set nonzero to force a cross-directory rename
+		findErr error
+		findNil bool
+		mutErr  error
+		perErr  error
+		// expectations
+		wantErrno       syscall.Errno
+		wantFind        bool
+		wantMutate      bool
+		wantPersist     bool
+		wantSets        int
+		wantClears      int
+		wantInvalidates int
+		wantErrSubstr   string // substring the set .error must contain (if wantSets>0)
+	}{
+		{
+			name:            "1 _create is not renamable",
+			oldName:         "_create",
+			newName:         "whatever.md",
+			wantErrno:       syscall.EPERM,
+			wantInvalidates: 0,
+		},
+		{
+			name:            "2 meta sidecar is not renamable",
+			oldName:         "foo.meta",
+			newName:         "bar.md",
+			wantErrno:       syscall.EPERM,
+			wantInvalidates: 0,
+		},
+		{
+			name:            "3 cross-directory rejected",
+			oldName:         "foo.md",
+			newName:         "bar.md",
+			dirIno:          7,
+			wantErrno:       syscall.EXDEV,
+			wantInvalidates: 0,
+		},
+		{
+			name:            "4 target lacks .md suffix sets a helpful error",
+			oldName:         "foo.md",
+			newName:         "bar",
+			wantErrno:       syscall.EINVAL,
+			wantSets:        1,
+			wantErrSubstr:   ".md",
+			wantInvalidates: 0,
+		},
+		{
+			name:            "5 find error is classified",
+			oldName:         "foo.md",
+			newName:         "bar.md",
+			findErr:         errors.New("boom"),
+			wantErrno:       syscall.EIO,
+			wantFind:        true,
+			wantSets:        1,
+			wantInvalidates: 0,
+		},
+		{
+			name:            "6 find nil is ENOENT",
+			oldName:         "foo.md",
+			newName:         "bar.md",
+			findNil:         true,
+			wantErrno:       syscall.ENOENT,
+			wantFind:        true,
+			wantSets:        1,
+			wantErrSubstr:   "no such entry",
+			wantInvalidates: 0,
+		},
+		{
+			name:            "7 mutate error is classified, no invalidation",
+			oldName:         "foo.md",
+			newName:         "bar.md",
+			mutErr:          errors.New("api down"),
+			wantErrno:       syscall.EIO,
+			wantFind:        true,
+			wantMutate:      true,
+			wantSets:        1,
+			wantInvalidates: 0,
+		},
+		{
+			name:            "8 persist wedge fails loud, no invalidation",
+			oldName:         "foo.md",
+			newName:         "bar.md",
+			perErr:          errors.New("sqlite busy"),
+			wantErrno:       syscall.EIO,
+			wantFind:        true,
+			wantMutate:      true,
+			wantPersist:     true,
+			wantSets:        1,
+			wantErrSubstr:   "SUCCEEDED on Linear",
+			wantInvalidates: 0,
+		},
+		{
+			name:            "9 success clears error and fires both pairs",
+			oldName:         "foo.md",
+			newName:         "new-name.md",
+			wantErrno:       0,
+			wantFind:        true,
+			wantMutate:      true,
+			wantPersist:     true,
+			wantClears:      1,
+			wantInvalidates: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &renameRecorder{}
+			rec := newRecordingCommitRenameSpec()
+			rec.spec.dirIno = tc.dirIno
+			rec.findErr = tc.findErr
+			if tc.findNil {
+				rec.findRet = nil
+			}
+			rec.mutateErr = tc.mutErr
+			rec.persistErr = tc.perErr
+
+			errno := commitRename(context.Background(), sink, tc.oldName,
+				&renameParent{}, tc.newName, rec.spec)
+
+			if errno != tc.wantErrno {
+				t.Errorf("errno = %v, want %v", errno, tc.wantErrno)
+			}
+			if (rec.findCalls > 0) != tc.wantFind {
+				t.Errorf("find called = %v (%d), want %v", rec.findCalls > 0, rec.findCalls, tc.wantFind)
+			}
+			if (rec.mutateCalls > 0) != tc.wantMutate {
+				t.Errorf("mutate called = %v (%d), want %v", rec.mutateCalls > 0, rec.mutateCalls, tc.wantMutate)
+			}
+			if (rec.persistCalls > 0) != tc.wantPersist {
+				t.Errorf("persist called = %v (%d), want %v", rec.persistCalls > 0, rec.persistCalls, tc.wantPersist)
+			}
+			if sink.sets != tc.wantSets {
+				t.Errorf("SetWriteError calls = %d, want %d (msg=%q)", sink.sets, tc.wantSets, sink.setMsg)
+			}
+			if sink.clears != tc.wantClears {
+				t.Errorf("ClearWriteError calls = %d, want %d", sink.clears, tc.wantClears)
+			}
+			if len(sink.invalidates) != tc.wantInvalidates {
+				t.Fatalf("invalidates = %v, want %d", sink.invalidates, tc.wantInvalidates)
+			}
+			if tc.wantSets > 0 && tc.wantErrSubstr != "" && !strings.Contains(sink.setMsg, tc.wantErrSubstr) {
+				t.Errorf(".error %q does not contain %q", sink.setMsg, tc.wantErrSubstr)
+			}
+			// Any .error the tail sets must be keyed to the spec's errKey.
+			if tc.wantSets > 0 && sink.setKey != rec.spec.errKey {
+				t.Errorf("SetWriteError key = %q, want %q", sink.setKey, rec.spec.errKey)
+			}
+		})
+	}
+}
+
+// TestCommitRename_ParseReachesMutate proves the "foo-bar.md" -> "foo bar"
+// dash-to-space parse runs before mutate, so the API sees the human name.
+func TestCommitRename_ParseReachesMutate(t *testing.T) {
+	orig := sqliteRetryBackoff
+	sqliteRetryBackoff = []time.Duration{0}
+	t.Cleanup(func() { sqliteRetryBackoff = orig })
+
+	sink := &renameRecorder{}
+	rec := newRecordingCommitRenameSpec()
+
+	errno := commitRename(context.Background(), sink, "foo.md",
+		&renameParent{}, "new-name.md", rec.spec)
+
+	if errno != 0 {
+		t.Fatalf("errno = %v, want 0", errno)
+	}
+	if rec.mutateNewName != "new name" {
+		t.Errorf("mutate saw newName %q, want %q (dashes should become spaces, .md stripped)", rec.mutateNewName, "new name")
+	}
+}
+
+// TestCommitRename_SuccessInvalidatesBothPairs pins the exact old->new names for
+// the .md pair and its .meta twin on the success path.
+func TestCommitRename_SuccessInvalidatesBothPairs(t *testing.T) {
+	orig := sqliteRetryBackoff
+	sqliteRetryBackoff = []time.Duration{0}
+	t.Cleanup(func() { sqliteRetryBackoff = orig })
+
+	sink := &renameRecorder{}
+	rec := newRecordingCommitRenameSpec()
+	// dirIno stays 0 to match the zero-value renameParent inode (same
+	// directory), exactly as renamesave_test.go pins its invalidation strings.
+
+	errno := commitRename(context.Background(), sink, "foo.md",
+		&renameParent{}, "bar.md", rec.spec)
+
+	if errno != 0 {
+		t.Fatalf("errno = %v, want 0", errno)
+	}
+	wantMD := `renamed(0,"foo.md","bar.md",0)`
+	wantMeta := `renamed(0,"foo.meta","bar.meta",0)`
+	if len(sink.invalidates) != 2 {
+		t.Fatalf("invalidates = %v, want 2", sink.invalidates)
+	}
+	if sink.invalidates[0] != wantMD {
+		t.Errorf("md invalidate = %q, want %q", sink.invalidates[0], wantMD)
+	}
+	if sink.invalidates[1] != wantMeta {
+		t.Errorf("meta invalidate = %q, want %q", sink.invalidates[1], wantMeta)
+	}
+}


### PR DESCRIPTION
## What

Extracts `commitRename[T]` (`internal/fs/renamecommit.go`), the entity-rename member of the reflection-contract commit-tail family (`commitCreate` / `commitWriteBack` / `commitDelete`). `LabelsNode.Rename` and `DocsNode.Rename` had hand-copied the same ~70-line tail byte-parallel — the one write path where the confirmed-reflection contract was applied by copy-paste instead of through a shared tail. Each handler now collapses to a ~24-line `renameSpec` literal.

## Design (grilled)

Structured like `commitDelete` (find → mutate → gate → coherence) with three deliberate differences:
- **No telemetry** (matches `renameSave`).
- **Gate is `persistOrEIO`**, not `retrySQLite`+forget — a rename reflects an *updated* row, it doesn't remove one.
- **Success fires two `InvalidateRenamed` calls** — the `.md` pair and its `.meta` twin (baked in: the sidecar name follows the `.md` mechanically).

Other locked decisions: reuses the existing `renameSink` seam; **persists the API-returned entity** so server-side name normalization is captured for free; **no read-your-writes compare** — that verification stays a layer *above* the commit-tail primitives (recorded in `CONTEXT.md`); the full front-half (guards + parse) lifts into the tail so every branch is unit-testable. Row 4 gains a helpful `.error` on a non-`.md` target (the originals returned a bare `EINVAL`).

## Tests

`renamecommit_test.go` covers all nine contract branches against the reused `renameRecorder` fake + stub closures — no FUSE mount, SQLite, or API. Failure paths assert **zero** invalidations; success asserts **both** with exact old→new names. Full `fs` suite + the offline integration test (`TestOffline_LabelCreateRenameDelete`, which drives the rewired handler through a real mount) are green.

## Docs

`ARCHITECTURE.md` now lists four sibling tails; `CONTEXT.md` gains a *Rename tail* section cross-linked with *Rename save*, plus the read-your-writes-layering principle.

## Follow-ups (from /code-review — not blocking)

- #291 — harden the tests to guard the normalization contract + classified-errno mapping
- #292 — pre-existing: `editcommit` passes an entity UUID where `unconfirmedEditMsg` wants an op label (surfaced here)
- #293 — route the two rename `find` closures through a shared `collectionDir` resolve
- #294 — `commitRename` emits no fuse-op telemetry (deliberate; reconsider)

🤖 Generated with [Claude Code](https://claude.com/claude-code)