### PR TITLE
fix(fs): edit persist-wedge .error uses a real op label, not the errKey UUID

### DIFF
--- a/internal/fs/comments.go
+++ b/internal/fs/comments.go
@@ -167,6 +167,7 @@ func (n *CommentNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno 
 		// response, persist, and surface divergence via .error.
 		writeBack: writeBackSpec[api.Comment]{
 			errKey: commentErrKey,
+			op:     "save comment " + n.comment.ID,
 			fetch:  func(ctx context.Context) (*api.Comment, error) { return updatedComment, nil },
 			persist: func(ctx context.Context, fresh *api.Comment) error {
 				return n.lfs.UpsertComment(ctx, n.issueID, *fresh)

--- a/internal/fs/documents.go
+++ b/internal/fs/documents.go
@@ -260,6 +260,7 @@ func (n *DocumentFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.E
 		// response, persist, and surface divergence via .error.
 		writeBack: writeBackSpec[api.Document]{
 			errKey:  docErrKey,
+			op:      "save document " + documentFilename(n.document),
 			fetch:   func(ctx context.Context) (*api.Document, error) { return updatedDoc, nil },
 			persist: func(ctx context.Context, fresh *api.Document) error { return n.lfs.UpsertDocument(ctx, *fresh) },
 			compare: func(fresh *api.Document) []writeBackResult {

--- a/internal/fs/editcommit.go
+++ b/internal/fs/editcommit.go
@@ -38,6 +38,12 @@ type writeBackSpec[T any] struct {
 	// errKey identifies the .error file to set or clear (an entity ID, or a
 	// collectionErrorKey for collection-scoped entities like labels/milestones).
 	errKey string
+	// op is the human-readable operation label for a persist-wedge .error, e.g.
+	// "save issue ENG-1" or "save label bug.md" — a verb+target an agent can act
+	// on, NOT the errKey (which is an entity UUID or collection namespace). It is
+	// the edit-path counterpart of the op string commitRename composes, and must
+	// be set by every caller so the #278 recovery message reads sensibly.
+	op string
 	// fetch returns the authoritative post-write value. For issues this is an
 	// independent API re-fetch (catches server-side silent reverts of large
 	// bodies); for entities with no single-entity getter it may return the
@@ -96,7 +102,7 @@ func commitWriteBack[T any](ctx context.Context, sink errorSink, spec writeBackS
 		// signal whose recovery (re-saving) is safe because the edit is idempotent
 		// (#278). See persistgate.go.
 		if errno := persistOrEIO(ctx, sink, spec.errKey,
-			func(err error) string { return unconfirmedEditMsg(spec.errKey, err) },
+			func(err error) string { return unconfirmedEditMsg(spec.op, err) },
 			spec.persist, fresh); errno != 0 {
 			return fresh, errno
 		}

--- a/internal/fs/editcommit_test.go
+++ b/internal/fs/editcommit_test.go
@@ -143,7 +143,8 @@ func TestCommitWriteBack_PersistFailureFailsLoud(t *testing.T) {
 	fresh := &ent{title: "x"}
 	persists := 0
 	got, errno := commitWriteBack(context.Background(), sink, writeBackSpec[ent]{
-		errKey:  "K",
+		errKey:  "9f3c-uuid",
+		op:      "save issue ENG-1",
 		fetch:   func(context.Context) (*ent, error) { return fresh, nil },
 		persist: func(context.Context, *ent) error { persists++; return errors.New("db down") },
 		compare: func(*ent) []writeBackResult { return nil },
@@ -157,13 +158,18 @@ func TestCommitWriteBack_PersistFailureFailsLoud(t *testing.T) {
 	if persists != len(sqliteRetryBackoff) {
 		t.Errorf("persist attempts = %d, want %d (retried before giving up)", persists, len(sqliteRetryBackoff))
 	}
-	if sink.setCalls != 1 || sink.setKey != "K" {
-		t.Errorf("SetWriteError: calls=%d key=%q, want 1 on K", sink.setCalls, sink.setKey)
+	if sink.setCalls != 1 || sink.setKey != "9f3c-uuid" {
+		t.Errorf("SetWriteError: calls=%d key=%q, want 1 on the errKey", sink.setCalls, sink.setKey)
 	}
-	for _, want := range []string{"SUCCEEDED on Linear", "Re-saving is safe", "db down"} {
+	// The wedge .error must render the human-readable op label, NOT the errKey
+	// UUID that identifies the sidecar (#292).
+	for _, want := range []string{"Operation: save issue ENG-1", "SUCCEEDED on Linear", "Re-saving is safe", "db down"} {
 		if !strings.Contains(sink.setMsg, want) {
 			t.Errorf(".error = %q, want it to contain %q", sink.setMsg, want)
 		}
+	}
+	if strings.Contains(sink.setMsg, "Operation: 9f3c-uuid") {
+		t.Errorf(".error = %q, must not render the errKey UUID as the operation", sink.setMsg)
 	}
 	if sink.clears != 0 {
 		t.Errorf("ClearWriteError calls = %d, want 0 on a loud failure", sink.clears)

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -331,6 +331,7 @@ func (i *InitiativeInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall
 		// divergence via .error. The project-link side-work (in mutate) stays there.
 		writeBack: writeBackSpec[api.Initiative]{
 			errKey: i.initiativeID,
+			op:     "save initiative " + i.initiative.Name,
 			fetch: func(ctx context.Context) (*api.Initiative, error) {
 				return i.lfs.verify().GetInitiative(ctx, i.initiativeID)
 			},

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -524,6 +524,7 @@ func (i *IssueFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errn
 		// and surface any divergence via .error.
 		writeBack: writeBackSpec[api.Issue]{
 			errKey:  i.issue.ID,
+			op:      "save issue " + i.issue.Identifier,
 			fetch:   func(ctx context.Context) (*api.Issue, error) { return i.lfs.verify().GetIssue(ctx, i.issue.ID) },
 			persist: func(ctx context.Context, fresh *api.Issue) error { return i.lfs.UpsertIssue(ctx, *fresh) },
 			compare: func(fresh *api.Issue) []writeBackResult {

--- a/internal/fs/labels.go
+++ b/internal/fs/labels.go
@@ -202,6 +202,7 @@ func (n *LabelFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errn
 		// surface divergence via .error.
 		writeBack: writeBackSpec[api.Label]{
 			errKey:  labelErrKey,
+			op:      "save label " + labelFilename(n.label),
 			fetch:   func(ctx context.Context) (*api.Label, error) { return updatedLabel, nil },
 			persist: func(ctx context.Context, fresh *api.Label) error { return n.lfs.UpsertLabel(ctx, n.teamID, *fresh) },
 			compare: func(fresh *api.Label) []writeBackResult {

--- a/internal/fs/milestones.go
+++ b/internal/fs/milestones.go
@@ -178,6 +178,7 @@ func (n *MilestoneFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.
 		// projectID so it never clobbers the association with a fallible lookup.
 		writeBack: writeBackSpec[api.ProjectMilestone]{
 			errKey: milestoneErrKey,
+			op:     "save milestone " + milestoneFilename(n.milestone),
 			fetch:  func(ctx context.Context) (*api.ProjectMilestone, error) { return updated, nil },
 			persist: func(ctx context.Context, fresh *api.ProjectMilestone) error {
 				return n.lfs.UpsertProjectMilestone(ctx, n.projectID, *fresh)

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -496,6 +496,7 @@ func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Er
 		// via .error. The initiative-link side-work (in mutate) stays there.
 		writeBack: writeBackSpec[api.Project]{
 			errKey: p.project.ID,
+			op:     "save project " + p.project.Name,
 			fetch:  func(ctx context.Context) (*api.Project, error) { return p.lfs.verify().GetProject(ctx, p.project.ID) },
 			persist: func(ctx context.Context, fresh *api.Project) error {
 				return p.lfs.UpsertProject(ctx, p.team.ID, *fresh)


### PR DESCRIPTION
## Problem

`commitWriteBack` rendered the #278 persist-wedge `.error` via `unconfirmedEditMsg(spec.errKey, err)`, so the message's `Operation:` line showed the entity **UUID** (or a collection namespace like `labels:<team>`) instead of a human-readable verb+target. On a persist wedge after a successful issue/project/comment/doc/label/milestone edit, an agent reading `.error` got an opaque id — degrading the #278 recovery message. The `op`-named parameter of `unconfirmedEditMsg` was a lie at the edit call site.

The rename tail already does this correctly (`commitRename` composes `"rename label foo.md -> bar.md"`), so the same helper yielded two qualities of message depending on caller.

## Fix

- Add an `op string` field to `writeBackSpec` — the edit-path counterpart of the op string `commitRename` composes.
- Set a `"save <kind> <identifier>"` label at all 7 edit call sites (issues, initiatives, comments, milestones, projects, labels, documents).
- `commitWriteBack` now renders `unconfirmedEditMsg(spec.op, err)`.

## Test

`TestCommitWriteBack_PersistFailureFailsLoud` now feeds a UUID `errKey` plus a distinct `op` label and asserts the `.error` carries `Operation: save issue ENG-1` and **never** the raw UUID — guarding the contract so a regression back to `errKey` would fail the suite.

No filesystem surface or contract changed, so the generated README and `docs/ARCHITECTURE.md` need no update.

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)