### PR TITLE
refactor(fs): route rename find through a shared collectionDir.resolve

### DIFF
--- a/internal/fs/collectiondir.go
+++ b/internal/fs/collectiondir.go
@@ -124,17 +124,41 @@ type lookupResult[T any] struct {
 // action: a .meta sidecar, an item .md, or ENOENT. Pure — the branchy part
 // (meta shadowing, find-or-miss) under test without a mount.
 func (c collectionDir[T]) classify(name string, items []T) lookupResult[T] {
-	l := c.listing(items)
 	if mdName, ok := metaSidecarSource(name); ok {
-		if item, found := l.find(mdName); found {
+		if item, found := c.resolveItem(mdName, items); found {
 			return lookupResult[T]{kind: lookupMeta, item: item}
 		}
 		return lookupResult[T]{kind: lookupNotFound}
 	}
-	if item, ok := l.find(name); ok {
+	if item, ok := c.resolveItem(name, items); ok {
 		return lookupResult[T]{kind: lookupFile, item: item}
 	}
 	return lookupResult[T]{kind: lookupNotFound}
+}
+
+// resolveItem is the pure filename→item round-trip: match name against an
+// already-fetched slice via the collection's listing. classify, resolve, and
+// the Create-overwrite check all go through it, so the filename↔name mapping
+// (sanitizing, collision policy, unicode) lives in one place.
+func (c collectionDir[T]) resolveItem(name string, items []T) (T, bool) {
+	return c.listing(items).find(name)
+}
+
+// resolve is the ctx-ful find the delete tail and both node Rename specs share:
+// fetch the collection, then resolve one name to its item. A fetch failure is an
+// error; a clean miss is (nil, nil) — the (nil, nil)-on-miss contract commitDelete
+// and commitRename both expect. Routing Unlink and Rename through it (alongside
+// Lookup, which reaches resolveItem via classify) keeps the resolve round-trip in
+// one tested place, so a Rename can never ENOENT an entity Lookup/Unlink resolve.
+func (c collectionDir[T]) resolve(ctx context.Context, name string) (*T, error) {
+	items, err := c.fetch(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if item, ok := c.resolveItem(name, items); ok {
+		return &item, nil
+	}
+	return nil, nil
 }
 
 // lookup resolves a child: trio surface first, then the classified item/meta/
@@ -195,7 +219,7 @@ func (c collectionDir[T]) create(ctx context.Context, name string, flags uint32,
 		return nil, nil, 0, syscall.EINVAL
 	}
 	if items, err := c.fetch(ctx); err == nil {
-		if item, ok := c.listing(items).find(name); ok {
+		if item, ok := c.resolveItem(name, items); ok {
 			inode, errno := c.buildFile(ctx, name, item, out)
 			if errno != 0 {
 				return nil, nil, 0, errno
@@ -238,18 +262,9 @@ func (c collectionDir[T]) unlink(ctx context.Context, name string) syscall.Errno
 	dir := c.parent.EmbeddedInode().StableAttr().Ino
 
 	return commitDelete(ctx, c.lfs, deleteSpec[T]{
-		op:  `delete ` + c.noun + ` "` + name + `"`,
-		key: collectionErrorKey(c.trio.kind, c.trio.parentID),
-		find: func(ctx context.Context) (*T, error) {
-			items, err := c.fetch(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if item, ok := c.listing(items).find(name); ok {
-				return &item, nil
-			}
-			return nil, nil
-		},
+		op:     `delete ` + c.noun + ` "` + name + `"`,
+		key:    collectionErrorKey(c.trio.kind, c.trio.parentID),
+		find:   func(ctx context.Context) (*T, error) { return c.resolve(ctx, name) },
 		mutate: c.deleteMutate,
 		forget: c.deleteForget,
 		dir:    dir,

--- a/internal/fs/collectiondir_test.go
+++ b/internal/fs/collectiondir_test.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"context"
+	"errors"
 	"syscall"
 	"testing"
 
@@ -95,5 +96,31 @@ func TestCollectionDirClassify(t *testing.T) {
 		if tc.item != "" && res.item != tc.item {
 			t.Errorf("classify(%q) item = %q, want %q", tc.name, res.item, tc.item)
 		}
+	}
+}
+
+// TestCollectionDirResolve pins the shared ctx-ful find that Unlink and both
+// Rename specs delegate to: a hit returns the item, a clean miss is (nil, nil)
+// (the contract commitDelete/commitRename expect), and a fetch failure
+// propagates the error. It resolves the same names classify resolves, so Rename
+// can never ENOENT an entity Lookup/Unlink still find (#293).
+func TestCollectionDirResolve(t *testing.T) {
+	t.Parallel()
+	cd := testCollectionDir()
+	cd.fetch = func(context.Context) ([]string, error) { return []string{"a", "b"}, nil }
+
+	got, err := cd.resolve(context.Background(), "a.md")
+	if err != nil || got == nil || *got != "a" {
+		t.Errorf("resolve(a.md) = (%v, %v), want (&\"a\", nil)", got, err)
+	}
+
+	got, err = cd.resolve(context.Background(), "z.md")
+	if err != nil || got != nil {
+		t.Errorf("resolve(z.md) = (%v, %v), want (nil, nil) on a clean miss", got, err)
+	}
+
+	cd.fetch = func(context.Context) ([]string, error) { return nil, errors.New("db down") }
+	if _, err := cd.resolve(context.Background(), "a.md"); err == nil {
+		t.Error("resolve must propagate a fetch error, not swallow it")
 	}
 }

--- a/internal/fs/documents.go
+++ b/internal/fs/documents.go
@@ -124,17 +124,9 @@ func (n *DocsNode) Rename(ctx context.Context, name string, newParent fs.InodeEm
 		kind:   "document",
 		errKey: collectionErrorKey("docs", n.parentID()),
 		dirIno: docsDirIno(n.parentID()),
-		find: func(ctx context.Context) (*api.Document, error) {
-			docs, err := n.getDocuments(ctx)
-			if err != nil {
-				return nil, err
-			}
-			doc, ok := n.listing(docs).find(name)
-			if !ok {
-				return nil, nil
-			}
-			return &doc, nil
-		},
+		// Route through the same resolve Lookup/Unlink use so a rename can never
+		// ENOENT a document those still resolve (#293).
+		find: func(ctx context.Context) (*api.Document, error) { return n.collection().resolve(ctx, name) },
 		mutate: func(ctx context.Context, target *api.Document, newName string) (*api.Document, error) {
 			return n.lfs.UpdateDocument(ctx, target.ID, map[string]any{"title": newName}, n.issueID, n.teamID, n.projectID)
 		},

--- a/internal/fs/labels.go
+++ b/internal/fs/labels.go
@@ -102,17 +102,9 @@ func (n *LabelsNode) Rename(ctx context.Context, name string, newParent fs.Inode
 		kind:   "label",
 		errKey: collectionErrorKey("labels", n.teamID),
 		dirIno: labelsDirIno(n.teamID),
-		find: func(ctx context.Context) (*api.Label, error) {
-			labels, err := n.lfs.repo.GetTeamLabels(ctx, n.teamID)
-			if err != nil {
-				return nil, err
-			}
-			label, ok := n.listing(labels).find(name)
-			if !ok {
-				return nil, nil
-			}
-			return &label, nil
-		},
+		// Route through the same resolve Lookup/Unlink use so a rename can never
+		// ENOENT a label those still resolve (#293).
+		find: func(ctx context.Context) (*api.Label, error) { return n.collection().resolve(ctx, name) },
 		mutate: func(ctx context.Context, target *api.Label, newName string) (*api.Label, error) {
 			return n.lfs.UpdateLabel(ctx, target.ID, map[string]any{"name": newName}, n.teamID)
 		},


### PR DESCRIPTION
## Observation

`LabelsNode.Rename` and `DocsNode.Rename` each built a `find` closure that re-implemented `fetch(ctx) → listing(items).find(name) → (nil,nil)` on miss — the exact filename↔name resolution `collectionDir` already owns for Lookup and Unlink. The pattern lived in ~5 near-identical spots, differing only in the fetch call.

## Risk

When the filename↔name mapping changes (collision policy, sanitizing, unicode), an editor had to update every copy. Missing a Rename copy would make Rename `ENOENT` an entity that Lookup/Unlink still resolve — an inconsistency no single test would catch.

## Fix

- Add `collectionDir.resolve(ctx, name) (*T, error)` — the ctx-ful find, `(nil, nil)` on a clean miss (the contract `commitDelete`/`commitRename` expect), fetch error propagated.
- Add the pure `resolveItem(name, items)` it shares with `classify`, so the filename→item round-trip lives in one place.
- Route the delete tail's `find`, both Rename `find` closures, and the Create-overwrite check through them.
- `TestCollectionDirResolve` pins hit / clean-miss / fetch-error.

Now Lookup (via `classify` → `resolveItem`), Unlink, Rename, and Create-overwrite all resolve names through the same code. No filesystem surface or contract changed, so the generated README and `docs/ARCHITECTURE.md` need no update.

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)