### PR TITLE
feat(fs): instrument commitRename with a "rename" fuse op

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -584,7 +584,7 @@ gate above.
 Owns the meter provider the recording packages (api, sync, repo, reconcile,
 fs) record into. `internal/fs` records serving-layer instruments (`metrics.go`,
 meter `linearfs/fuse`): `linearfs.fuse.ops {op, outcome}` and
-`linearfs.fuse.duration {op}` at the three commit tails (create/delete/flush)
+`linearfs.fuse.duration {op}` at the four commit tails (create/delete/flush/rename)
 and the editBuffer/renderFile read/write entry points, plus
 `linearfs.embedded_files.fetch {source=memory|disk|cdn}` at the byte-cache
 tiers. Coverage is those cheap choke points, not lookup/readdir (spread across

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -60,8 +60,9 @@ documented in its own section below.
 ## Instruments
 
 Naming: `linearfs.<layer>.<what>`; meter scopes are `linearfs/process`,
-`linearfs/api`, `linearfs/budget`, `linearfs/sync`, `linearfs/swr`.
-Histograms use the SDK default buckets; durations are in **seconds**.
+`linearfs/fuse`, `linearfs/api`, `linearfs/budget`, `linearfs/sync`,
+`linearfs/swr`. Histograms use the SDK default buckets; durations are in
+**seconds**.
 
 ### Process heartbeats — `internal/telemetry/heartbeat.go`
 
@@ -69,6 +70,22 @@ Histograms use the SDK default buckets; durations are in **seconds**.
 |---|---|---|---|
 | `linearfs.process.uptime_seconds` | observable gauge (float64, s) | — | seconds since process start |
 | `linearfs.build.info` | gauge (int64, always 1) | `version`, `commit` | build metadata carried as attributes |
+
+### Serving layer — `internal/fs/metrics.go` (`fuseMetrics`, lazily bound on first record)
+
+| Instrument | Kind | Attributes | Recorded |
+|---|---|---|---|
+| `linearfs.fuse.ops` | counter | `op`, `outcome` = `ok` \| `einval` \| `eio` \| `eagain` \| `enoent` \| `eperm` \| `exdev` \| `eacces` \| `other` | one per completed op at the cheap choke points — the **four** commit tails (`op` = `create` \| `delete` \| `flush` \| `rename`; `rename` added in #294 so entity renames stop reading as "no renames happen") plus the editBuffer `read`/`write` and renderFile `read` entry points. `outcome` is `outcomeForErrno` — a closed enum so cardinality stays bounded |
+| `linearfs.fuse.duration` | histogram (s) | `op` | same sites, wall time of the op |
+| `linearfs.embedded_files.fetch` | counter | `source` = `memory` \| `disk` \| `cdn` | one per embedded-file byte fetch, by the tier that served it |
+
+Coverage is deliberately the shared tails, not every node type: Lookup and
+readdir are spread across every node type with no common choke, so they are
+left out rather than instrumented invasively (#264). The instruments bind
+lazily on first record (no single construction site threads a handle through
+the free-function tails); until `telemetry.Init` registers a provider the
+global no-op makes every record free. `op` is NOT in the summary keep-list, so
+the journald line merges the per-op series (see below).
 
 ### API layer — `internal/api/metrics.go` (`apiMetrics`, bound at `Client` construction)
 

--- a/internal/fs/metrics.go
+++ b/internal/fs/metrics.go
@@ -12,7 +12,7 @@ package fs
 // so there are no nil checks or enable flags.
 //
 // Coverage is deliberately the cheap choke points, not every node type: the
-// three commit tails (create/delete/flush), the editBuffer read/write and
+// four commit tails (create/delete/flush/rename), the editBuffer read/write and
 // renderFile read entry points, and the embedded-file fetch tiers. Lookup and
 // readdir are spread across every node type with no shared tail, so they are
 // left out rather than instrumented invasively — see #264.
@@ -46,7 +46,7 @@ func fuseMetricsInstance() fuseMetrics {
 		m := otel.Meter("linearfs/fuse")
 		fuseMetricsInst = fuseMetrics{
 			ops: telemetry.MustInt64Counter(m, "linearfs.fuse.ops",
-				metric.WithDescription("FUSE operations completed, by op (create|delete|flush|write|read) and outcome (ok|einval|eio|eagain|...)")),
+				metric.WithDescription("FUSE operations completed, by op (create|delete|flush|rename|write|read) and outcome (ok|einval|eio|eagain|...)")),
 			duration: telemetry.MustFloat64Histogram(m, "linearfs.fuse.duration",
 				metric.WithUnit("s"),
 				metric.WithDescription("FUSE operation duration by op")),

--- a/internal/fs/renamecommit.go
+++ b/internal/fs/renamecommit.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/hanwen/go-fuse/v2/fs"
 )
@@ -29,10 +30,12 @@ import (
 // commitRename is the one deep module that owns the tail, the rename-path
 // member of the reflection-contract family (commitCreate / commitWriteBack /
 // commitDelete). Structured like commitDelete — find -> mutate -> gate ->
-// coherence — but with three deliberate differences: no telemetry (matches
-// renameSave), the gate is persistOrEIO rather than retrySQLite+forget (a
-// rename reflects an updated row, it does not remove one), and success fires
-// TWO InvalidateRenamed calls (the .md pair and its .meta sidecar pair). Each
+// coherence — and, like every reflection-contract sibling, it records a fuse op
+// (here "rename") so entity renames are visible in metrics.jsonl (#294). Two
+// deliberate differences from commitDelete: the gate is persistOrEIO rather than
+// retrySQLite+forget (a rename reflects an updated row, it does not remove one),
+// and success fires TWO InvalidateRenamed calls (the .md pair and its .meta
+// sidecar pair). Each
 // handler hands the tail a small spec; the module owns the failure model, the
 // .error reporting, the persist gate, and the coherence policy. It depends only
 // on the renameSink seam plus the spec's closures, so it is unit-tested with a
@@ -83,7 +86,10 @@ type renameSpec[T any] struct {
 //     invalidation (the reflection is unconfirmed).
 //   - success                        -> clear .error, invalidate BOTH the .md
 //     pair and its .meta twin (exact old->new names), errno 0.
-func commitRename[T any](ctx context.Context, sink renameSink, name string, newParent fs.InodeEmbedder, newName string, spec renameSpec[T]) syscall.Errno {
+func commitRename[T any](ctx context.Context, sink renameSink, name string, newParent fs.InodeEmbedder, newName string, spec renameSpec[T]) (errno syscall.Errno) {
+	start := time.Now()
+	defer func() { recordFuseOp(ctx, "rename", start, errno) }()
+
 	// The _create trigger and the read-only .meta sidecars are not renamable.
 	if name == createTriggerName {
 		return syscall.EPERM
@@ -115,7 +121,8 @@ func commitRename[T any](ctx context.Context, sink renameSink, name string, newP
 
 	target, err := spec.find(ctx)
 	if err != nil {
-		msg, errno := classifyMutationErr(op, err)
+		var msg string
+		msg, errno = classifyMutationErr(op, err)
 		log.Printf("Failed to %s: %v", op, err)
 		sink.SetWriteError(spec.errKey, msg)
 		return errno
@@ -127,7 +134,8 @@ func commitRename[T any](ctx context.Context, sink renameSink, name string, newP
 
 	fresh, err := spec.mutate(ctx, target, parsedName)
 	if err != nil {
-		msg, errno := classifyMutationErr(op, err)
+		var msg string
+		msg, errno = classifyMutationErr(op, err)
 		log.Printf("Failed to %s: %v", op, err)
 		sink.SetWriteError(spec.errKey, msg)
 		return errno
@@ -137,7 +145,7 @@ func commitRename[T any](ctx context.Context, sink renameSink, name string, newP
 	// can't serve fails loud (retry, then EIO) rather than swallowing it. The
 	// rename is already on Linear and idempotent, so the .error says re-saving is
 	// safe (#278). No invalidation on a wedge — the local view is unconfirmed.
-	if errno := persistOrEIO(ctx, sink, spec.errKey,
+	if errno = persistOrEIO(ctx, sink, spec.errKey,
 		func(err error) string { return unconfirmedEditMsg(op, err) },
 		spec.persist, fresh); errno != 0 {
 		return errno

--- a/internal/fs/renamecommit_test.go
+++ b/internal/fs/renamecommit_test.go
@@ -339,6 +339,40 @@ func TestCommitRename_PersistsMutateReturn(t *testing.T) {
 	}
 }
 
+// TestCommitRename_RecordsFuseOp proves commitRename joins the reflection-contract
+// family's telemetry (#294): a completed rename records a "rename" fuse op tagged
+// with the outcome, on both the success and a classified-failure path. Uses a
+// before-after delta because the shared manual reader (metrics_test.go TestMain)
+// also sees rename ops from other cases in this file.
+func TestCommitRename_RecordsFuseOp(t *testing.T) {
+	orig := sqliteRetryBackoff
+	sqliteRetryBackoff = []time.Duration{0}
+	t.Cleanup(func() { sqliteRetryBackoff = orig })
+
+	// Success -> outcome ok.
+	beforeOK := counterValue(t, "linearfs.fuse.ops", map[string]string{"op": "rename", "outcome": "ok"})
+	rec := newRecordingCommitRenameSpec()
+	if errno := commitRename(context.Background(), &renameRecorder{}, "foo.md",
+		&renameParent{}, "bar.md", rec.spec); errno != 0 {
+		t.Fatalf("errno = %v, want 0", errno)
+	}
+	if got := counterValue(t, "linearfs.fuse.ops", map[string]string{"op": "rename", "outcome": "ok"}); got != beforeOK+1 {
+		t.Errorf("ops{op=rename,outcome=ok} = %d, want %d", got, beforeOK+1)
+	}
+
+	// Classified mutate failure -> outcome eio (the op is still recorded).
+	beforeEIO := counterValue(t, "linearfs.fuse.ops", map[string]string{"op": "rename", "outcome": "eio"})
+	recFail := newRecordingCommitRenameSpec()
+	recFail.mutateErr = errors.New("api down")
+	if errno := commitRename(context.Background(), &renameRecorder{}, "foo.md",
+		&renameParent{}, "bar.md", recFail.spec); errno != syscall.EIO {
+		t.Fatalf("errno = %v, want EIO", errno)
+	}
+	if got := counterValue(t, "linearfs.fuse.ops", map[string]string{"op": "rename", "outcome": "eio"}); got != beforeEIO+1 {
+		t.Errorf("ops{op=rename,outcome=eio} = %d, want %d", got, beforeEIO+1)
+	}
+}
+
 // TestCommitRename_SuccessInvalidatesBothPairs pins the exact old->new names for
 // the .md pair and its .meta twin on the success path.
 func TestCommitRename_SuccessInvalidatesBothPairs(t *testing.T) {


### PR DESCRIPTION
`commitRename` (`internal/fs/renamecommit.go`) was the only member of the reflection-contract commit-tail family (`commitCreate`/`commitWriteBack`/`commitDelete`) that emitted no `recordFuseOp` telemetry — so entity renames were invisible in `metrics.jsonl`. A query for rename latency/error rate read as "no renames happen" rather than "renames aren't instrumented". The original "matches `renameSave`" justification was weak: `renameSave` is the atomic-save (edit-family) tail, whereas `commitRename` sits in the reflection-contract family whose other three members all record a fuse op.

## What changed
- **Instrument it as a `"rename"` op**, mirroring the siblings exactly: named `errno` return, `start := time.Now()`, deferred `recordFuseOp` — so every outcome (including the `EPERM`/`EXDEV`/`EINVAL` guard rejections) is counted with its classified errno. The two classified-errno branches switch from a shadowing `:=` to assigning the named return, matching `commitDelete`'s style.
- **No debug entry/success logs re-added.** The sibling tails don't carry them (structured telemetry replaced per-op debug logging), so instrumenting is the family-consistent choice — re-adding logs would diverge `commitRename` the other way, and the `renameSink` seam carries no debug flag.
- **Docs:** filled in the previously-undocumented **serving layer** section of `docs/telemetry.md` (`linearfs.fuse.ops`/`duration` + `embedded_files.fetch`, with `rename` now in the op enum) and added `linearfs/fuse` to the meter-scope list; bumped "three commit tails" → four in `metrics.go` and `docs/ARCHITECTURE.md`.

## Test
`TestCommitRename_RecordsFuseOp` asserts the rename op is recorded on both a success (`ok`) and a classified-failure (`eio`) path, via a before/after delta on the shared manual reader. Full `internal/fs` suite + `go vet ./...` green.

Closes #294