### PR TITLE
fix(db): detach SQLite ops from FUSE-request cancellation (de-flake offline suite)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -339,6 +339,17 @@ Design conventions:
   pooled connection gets them (a `db.Exec("PRAGMA …")` configures only one
   pooled connection; that gap once caused deletes racing the worker to fail
   instantly and leave phantom rows).
+- **Cancellation-detached queries:** the `Store` runs every SQLite operation
+  through `ctxDetachDBTX`, a `DBTX` wrapper that strips the caller's context
+  cancellation (keeping its values) before delegating. The callers are FUSE
+  request handlers, and under load the kernel cancels a request's context — a
+  spurious interrupt, not an abandoned op. That cancellation reaching SQLite
+  makes the driver return `context.Canceled` regardless of `busy_timeout`,
+  surfacing a clean local read as an EIO listing and a committed mutation's
+  reflection as an EIO on close (the offline-suite flake, #296). A local read is
+  sub-millisecond and a committed mutation MUST reflect, so neither hinges on the
+  liveness of the request that triggered it; the worker still checks its own
+  context between operations, so cooperative shutdown is unaffected.
 - **No transaction wrapper:** multi-table writes are *not* transactional.
   Durability is `busy_timeout` plus single-statement upserts, with the
   reconcile clean-guard providing prune safety; a `Store.WithTx` helper was

--- a/internal/db/ctxdetach.go
+++ b/internal/db/ctxdetach.go
@@ -1,0 +1,49 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+)
+
+// ctxDetachDBTX wraps a DBTX so every SQLite operation detaches from the
+// caller's context cancellation, keeping only its values.
+//
+// The store is a local cache: a query is sub-millisecond and the
+// busy_timeout(5000) DSN pragma already bounds the only legitimate wait (a
+// writer racing the sync worker). Honoring the caller's ctx cancellation buys
+// nothing — but it costs correctness. The callers are FUSE request handlers, and
+// under load the kernel cancels a request's context (a spurious interrupt, not
+// the user abandoning the op). That cancellation, reaching SQLite, makes
+// database/sql return context.Canceled regardless of busy_timeout — surfacing an
+// otherwise-clean read as EIO on a directory listing and an otherwise-committed
+// write's reflection as EIO on close. That was the offline-integration-suite
+// flake (#296): a different unrelated op failed each run because whichever one
+// happened to catch a kernel interrupt returned a spurious EIO.
+//
+// Detaching with context.WithoutCancel keeps the ctx's values (so anything a
+// query reads off ctx still resolves) while dropping only its cancellation and
+// deadline. A mutation Linear already accepted MUST reflect locally, and a local
+// read MUST NOT fail for a reason the data doesn't warrant — neither should hinge
+// on the liveness of the FUSE request that triggered it.
+//
+// There are no long-running SQLite operations (the sync worker's largest writes
+// are still sub-second batch upserts) and the worker checks its own context
+// between operations, so dropping mid-operation cancellation does not impair
+// cooperative shutdown.
+type ctxDetachDBTX struct{ inner DBTX }
+
+func (d ctxDetachDBTX) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	return d.inner.ExecContext(context.WithoutCancel(ctx), query, args...)
+}
+
+func (d ctxDetachDBTX) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	return d.inner.PrepareContext(context.WithoutCancel(ctx), query)
+}
+
+func (d ctxDetachDBTX) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	return d.inner.QueryContext(context.WithoutCancel(ctx), query, args...)
+}
+
+func (d ctxDetachDBTX) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	return d.inner.QueryRowContext(context.WithoutCancel(ctx), query, args...)
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -21,6 +21,12 @@ var schemaSQL string
 type Store struct {
 	db      *sql.DB
 	queries *Queries
+	// qdb is the query executor: the raw *sql.DB wrapped so every SQLite
+	// operation detaches from FUSE-request cancellation (see ctxDetachDBTX).
+	// Both sqlc queries and the hand-written store methods run through it, so no
+	// caller can wedge a local read/write into a spurious EIO on a cancelled
+	// FUSE request (#296). db stays raw for lifecycle (Close) and the test seam.
+	qdb DBTX
 }
 
 // Open opens or creates a SQLite database at the given path.
@@ -87,9 +93,11 @@ func openDB(dbPath string) (*Store, error) {
 		return nil, fmt.Errorf("migrate schema: %w", err)
 	}
 
+	qdb := ctxDetachDBTX{inner: db}
 	return &Store{
 		db:      db,
-		queries: New(db),
+		queries: New(qdb),
+		qdb:     qdb,
 	}, nil
 }
 
@@ -179,7 +187,7 @@ func (s *Store) DB() *sql.DB {
 // while a fresh one has it in schema.sql order — positional scanning over *
 // would misalign on one of them.
 func (s *Store) ListIssuesByLabel(ctx context.Context, teamID, labelName string) ([]Issue, error) {
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.qdb.QueryContext(ctx, `
 		SELECT id, identifier, team_id, title, description,
 			state_id, state_name, state_type,
 			assignee_id, assignee_email, creator_id, creator_email, priority,

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -28,6 +28,36 @@ func TestOpenAndClose(t *testing.T) {
 	}
 }
 
+// TestStoreDetachesContextCancellation is the #296 regression guard: a query run
+// through the store must succeed even when the caller's context is already
+// cancelled. FUSE request handlers pass their request ctx here, and under load
+// the kernel cancels that ctx (a spurious interrupt); if the cancellation reached
+// SQLite the query would return context.Canceled and the handler a spurious EIO.
+// The contrast against the raw *sql.DB (which DOES honor the cancellation) proves
+// the store's ctxDetachDBTX wrapper is what neutralizes it.
+func TestStoreDetachesContextCancellation(t *testing.T) {
+	t.Parallel()
+	store, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer store.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the FUSE request the query rode in on was interrupted
+
+	// Through the store: the wrapper detaches the cancellation, so the query runs.
+	if _, err := store.Queries().CountPendingDetailSync(ctx); err != nil {
+		t.Errorf("store query with cancelled ctx = %v, want nil (ctxDetachDBTX must neutralize FUSE-request cancellation)", err)
+	}
+	// Sanity: the same cancelled ctx straight to the raw *sql.DB DOES fail, so the
+	// test exercises the wrapper rather than a driver that ignores ctx entirely.
+	var n int
+	if err := store.DB().QueryRowContext(ctx, "SELECT COUNT(*) FROM pending_detail_sync").Scan(&n); err == nil {
+		t.Error("raw DB query with cancelled ctx unexpectedly succeeded; the detach test proves nothing")
+	}
+}
+
 // TestConnectionPragmas asserts the DSN-level pragmas reach every pooled
 // connection. busy_timeout in particular is per-connection: configured via a
 // one-off Exec it covered only one pooled conn, and a delete's SQLite forget

--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -262,7 +262,44 @@ func waitForDirEntry(dir, name string, maxWait time.Duration) error {
 	return fmt.Errorf("entry %s not found in %s after %v", name, dir, maxWait)
 }
 
+// waitForNoDirEntry is the negative twin of waitForDirEntry: it polls until name
+// is ABSENT from dir (a delete/rename-away invalidates the kernel cache
+// asynchronously, so the removed entry can linger for a beat under load).
+func waitForNoDirEntry(dir, name string, maxWait time.Duration) error {
+	deadline := time.Now().Add(maxWait)
+
+	for time.Now().Before(deadline) {
+		entries, err := os.ReadDir(dir)
+		if err == nil {
+			present := false
+			for _, e := range entries {
+				if e.Name() == name {
+					present = true
+					break
+				}
+			}
+			if !present {
+				return nil
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return fmt.Errorf("entry %s still present in %s after %v", name, dir, maxWait)
+}
+
 const defaultWaitTime = 500 * time.Millisecond
+
+// dirHas / dirLacks are polling predicates for post-mutation listing checks. A
+// write invalidates the kernel directory cache asynchronously (server.Inode/
+// EntryNotify), so a one-shot os.ReadDir immediately after the mutation races
+// that invalidation — the flake behind #296's "created/renamed X not in
+// listing". These poll up to defaultWaitTime, which a real `ls` a moment later
+// never needs. Use dirHas where the entry SHOULD now appear and dirLacks where
+// it SHOULD now be gone; the one-shot dirContains stays for pre-existing
+// fixture entries that never raced a mutation.
+func dirHas(path, name string) bool  { return waitForDirEntry(path, name, defaultWaitTime) == nil }
+func dirLacks(path, name string) bool { return waitForNoDirEntry(path, name, defaultWaitTime) == nil }
 
 // waitForCacheExpiry waits for the internal cache to expire.
 // Only needed after API-direct operations (createTestIssue, etc.) where

--- a/internal/integration/write_offline_test.go
+++ b/internal/integration/write_offline_test.go
@@ -85,7 +85,7 @@ func TestOffline_ProjectCreateAndArchive(t *testing.T) {
 
 	// The created project directory is present and carries a server-populated
 	// project.meta (proof the mkdir upserted it to SQLite for the listing).
-	if !dirContains(projectsPath(testTeamKey), dir) {
+	if !dirHas(projectsPath(testTeamKey), dir) {
 		t.Fatalf("created project %q not in projects listing", dir)
 	}
 	assertMetaHasFields(t, filepath.Join(projectsPath(testTeamKey), dir, "project.meta"), "id", "url", "status")
@@ -94,7 +94,7 @@ func TestOffline_ProjectCreateAndArchive(t *testing.T) {
 	if err := os.Remove(filepath.Join(projectsPath(testTeamKey), dir)); err != nil {
 		t.Fatalf("rmdir (archive) project should succeed: %v", err)
 	}
-	if dirContains(projectsPath(testTeamKey), dir) {
+	if !dirLacks(projectsPath(testTeamKey), dir) {
 		t.Errorf("archived project %q still in listing (resurrection — forget failed)", dir)
 	}
 }
@@ -115,7 +115,7 @@ func TestOffline_LabelCreateRenameDelete(t *testing.T) {
 		t.Fatalf("create label via _create should succeed with mock mutator: %v", err)
 	}
 	const created = "Offline-Mock-Label-ZZZ.md"
-	if !dirContains(labelsPath(testTeamKey), created) {
+	if !dirHas(labelsPath(testTeamKey), created) {
 		t.Fatalf("created label %q not in labels listing", created)
 	}
 
@@ -125,10 +125,10 @@ func TestOffline_LabelCreateRenameDelete(t *testing.T) {
 	if err := os.Rename(labelFilePath(testTeamKey, created), labelFilePath(testTeamKey, renamed)); err != nil {
 		t.Fatalf("rename label should succeed: %v", err)
 	}
-	if dirContains(labelsPath(testTeamKey), created) {
+	if !dirLacks(labelsPath(testTeamKey), created) {
 		t.Errorf("old label name %q still present after rename", created)
 	}
-	if !dirContains(labelsPath(testTeamKey), renamed) {
+	if !dirHas(labelsPath(testTeamKey), renamed) {
 		t.Errorf("renamed label %q not present after rename", renamed)
 	}
 
@@ -136,7 +136,7 @@ func TestOffline_LabelCreateRenameDelete(t *testing.T) {
 	if err := os.Remove(labelFilePath(testTeamKey, renamed)); err != nil {
 		t.Fatalf("unlink (delete) label should succeed: %v", err)
 	}
-	if dirContains(labelsPath(testTeamKey), renamed) {
+	if !dirLacks(labelsPath(testTeamKey), renamed) {
 		t.Errorf("deleted label %q still in listing (forget failed)", renamed)
 	}
 }
@@ -187,7 +187,7 @@ func TestOffline_IssueLifecycle(t *testing.T) {
 	if err := os.Remove(commentFilePath(testTeamKey, id, commentFile)); err != nil {
 		t.Fatalf("unlink (delete) comment should succeed: %v", err)
 	}
-	if dirContains(commentsPath(testTeamKey, id), commentFile) {
+	if !dirLacks(commentsPath(testTeamKey, id), commentFile) {
 		t.Errorf("deleted comment %q still present", commentFile)
 	}
 
@@ -195,7 +195,7 @@ func TestOffline_IssueLifecycle(t *testing.T) {
 	if err := os.Remove(issueDirPath(testTeamKey, id)); err != nil {
 		t.Fatalf("rmdir (archive) issue should succeed: %v", err)
 	}
-	if dirContains(issuesPath(testTeamKey), id) {
+	if !dirLacks(issuesPath(testTeamKey), id) {
 		t.Errorf("archived issue %q still in listing (resurrection — forget failed)", id)
 	}
 }
@@ -218,7 +218,7 @@ func TestOffline_NamedFileCreate(t *testing.T) {
 	if err := os.WriteFile(labelFilePath(testTeamKey, labelFile), labelSpec, 0o644); err != nil {
 		t.Fatalf("create label via named file should succeed: %v", err)
 	}
-	if !dirContains(labelsPath(testTeamKey), labelFile) {
+	if !dirHas(labelsPath(testTeamKey), labelFile) {
 		t.Fatalf("named-file label %q not in labels listing", labelFile)
 	}
 	_ = os.Remove(labelFilePath(testTeamKey, labelFile)) // best-effort cleanup
@@ -354,7 +354,7 @@ func TestOffline_MilestoneDelete(t *testing.T) {
 	if err := os.Remove(filepath.Join(msDir, file)); err != nil {
 		t.Fatalf("rm milestone should succeed: %v", err)
 	}
-	if dirContains(msDir, file) {
+	if !dirLacks(msDir, file) {
 		t.Errorf("deleted milestone %q still in listing (forget failed / silent no-op)", file)
 	}
 }
@@ -385,7 +385,7 @@ func TestOffline_InitiativeUpdateCreatePersists(t *testing.T) {
 	if last := lastEntryByTitle(t, filepath.Join(updatesDir, ".last"), ""); last != nil && last["url"] == "" {
 		t.Errorf("updates/.last entry missing url: %v", last)
 	}
-	if !dirContains(updatesDir, name) {
+	if !dirHas(updatesDir, name) {
 		t.Errorf("created update %q not in updates listing", name)
 	}
 }
@@ -407,7 +407,7 @@ func TestOffline_DocumentCreate(t *testing.T) {
 	}
 	name := mdFileContaining(t, dir, marker)
 	t.Cleanup(func() { _ = os.Remove(filepath.Join(dir, name)) })
-	if !dirContains(dir, name) {
+	if !dirHas(dir, name) {
 		t.Errorf("created doc %q not in docs listing", name)
 	}
 }
@@ -431,7 +431,7 @@ func TestOffline_DocumentDelete(t *testing.T) {
 	if err := os.Remove(filepath.Join(dir, name)); err != nil {
 		t.Fatalf("rm doc should succeed: %v", err)
 	}
-	if dirContains(dir, name) {
+	if !dirLacks(dir, name) {
 		t.Errorf("deleted doc %q still in listing (forget failed / silent no-op)", name)
 	}
 }
@@ -480,7 +480,7 @@ func TestOffline_ProjectUpdateCreatePersists(t *testing.T) {
 		t.Fatalf("create project update via _create should succeed: %v", err)
 	}
 	name := mdFileContaining(t, updatesDir, marker)
-	if !dirContains(updatesDir, name) {
+	if !dirHas(updatesDir, name) {
 		t.Errorf("created update %q not in updates listing", name)
 	}
 }
@@ -532,7 +532,7 @@ func TestOffline_RelationCreateAndDelete(t *testing.T) {
 		t.Fatalf("create relation via _create should succeed: %v", err)
 	}
 	rel := "blocks-" + dst + ".rel"
-	if !dirContains(relationsDir, rel) {
+	if !dirHas(relationsDir, rel) {
 		t.Fatalf("created relation %q not in relations listing", rel)
 	}
 
@@ -540,13 +540,13 @@ func TestOffline_RelationCreateAndDelete(t *testing.T) {
 	// side; deleting it is EPERM (delete from the owning side).
 	inverseDir := filepath.Join(issueDirPath(testTeamKey, dst), "relations")
 	inverse := "blocked-by-" + src + ".rel"
-	if !dirContains(inverseDir, inverse) {
+	if !dirHas(inverseDir, inverse) {
 		t.Fatalf("inverse relation %q not present on target", inverse)
 	}
 	if err := os.Remove(filepath.Join(inverseDir, inverse)); !os.IsPermission(err) {
 		t.Errorf("rm inverse relation: want EPERM, got %v", err)
 	}
-	if !dirContains(inverseDir, inverse) {
+	if !dirHas(inverseDir, inverse) {
 		t.Errorf("inverse relation %q vanished after a rejected rm", inverse)
 	}
 
@@ -555,10 +555,10 @@ func TestOffline_RelationCreateAndDelete(t *testing.T) {
 	if err := os.Remove(filepath.Join(relationsDir, rel)); err != nil {
 		t.Fatalf("unlink (delete) relation should succeed: %v", err)
 	}
-	if dirContains(relationsDir, rel) {
+	if !dirLacks(relationsDir, rel) {
 		t.Errorf("deleted relation %q still in listing (forget failed / silent no-op)", rel)
 	}
-	if dirContains(inverseDir, inverse) {
+	if !dirLacks(inverseDir, inverse) {
 		t.Errorf("inverse relation %q still present after the edge was deleted", inverse)
 	}
 
@@ -580,14 +580,14 @@ func TestOffline_ProjectLinkCreateAndDelete(t *testing.T) {
 		t.Fatalf("create link via _create should succeed: %v", err)
 	}
 	const link = "Offline Link Probe.link"
-	if !dirContains(linksDir, link) {
+	if !dirHas(linksDir, link) {
 		t.Fatalf("created link %q not in links listing", link)
 	}
 
 	if err := os.Remove(filepath.Join(linksDir, link)); err != nil {
 		t.Fatalf("unlink (delete) link should succeed: %v", err)
 	}
-	if dirContains(linksDir, link) {
+	if !dirLacks(linksDir, link) {
 		t.Errorf("deleted link %q still in listing (forget failed / silent no-op)", link)
 	}
 }
@@ -616,7 +616,7 @@ func TestOffline_ProjectLinkCreateIdempotent(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Remove(filepath.Join(linksDir, link)) })
 
-	if !dirContains(linksDir, link) {
+	if !dirHas(linksDir, link) {
 		t.Fatalf("link %q not created", link)
 	}
 	// A duplicate would surface as a counter-suffixed sibling ("... (2).link").
@@ -641,14 +641,14 @@ func TestOffline_AttachmentCreateAndDelete(t *testing.T) {
 		t.Fatalf("create attachment via _create should succeed: %v", err)
 	}
 	const att = "Offline Att Probe.link"
-	if !dirContains(attDir, att) {
+	if !dirHas(attDir, att) {
 		t.Fatalf("created attachment %q not in attachments listing", att)
 	}
 
 	if err := os.Remove(filepath.Join(attDir, att)); err != nil {
 		t.Fatalf("unlink (delete) attachment should succeed: %v", err)
 	}
-	if dirContains(attDir, att) {
+	if !dirLacks(attDir, att) {
 		t.Errorf("deleted attachment %q still in listing (forget failed / silent no-op)", att)
 	}
 }


### PR DESCRIPTION
The offline integration suite (`TestOffline_*`) flaked ~10% under load — a **different** unrelated test failed each run, either an EIO on a `_create`/edit close or a read, or a `created/renamed X not in listing` readdir race. Pre-existing on base `c0244b6`, so PR #295 merged with the check red.

## Root cause — the issue's stated cause was wrong
#296/#268 blamed background sync/SWR goroutines racing the test's SQLite writes → `SQLITE_BUSY` → EIO. But **in fixture mode there are no background SQLite writers**: `maybeRefreshSWR`/`triggerBackgroundRefresh` short-circuit on a nil client, and the sync worker isn't started. And with `busy_timeout(5000)`, `SQLITE_BUSY` on these tiny writes is nearly impossible.

The real mechanism is **FUSE request-context cancellation**: go-fuse cancels a request's `context.Context` when the kernel interrupts it (common under load), that ctx flows straight into SQLite, and `database/sql` returns `context.Canceled` **regardless of `busy_timeout`** — surfacing a clean read as an EIO listing and a committed mutation's reflection as an EIO on close. Whichever op happened to catch a kernel interrupt failed → a different test broke each run.

## Fix — one seam
`Store` runs every SQLite op through **`ctxDetachDBTX`**, a `DBTX` wrapper that strips the caller's cancellation (keeping its values) via `context.WithoutCancel`. A local read is sub-millisecond and a committed mutation MUST reflect, so neither should hinge on the liveness of the FUSE request that triggered it; the worker still checks its own ctx between ops, so shutdown is unaffected. There are **no transactions**, so wrapping the `New(db)` DBTX plus the one hand-written `ListIssuesByLabel` covers 100% of queries. `TestStoreDetachesContextCancellation` guards it (a cancelled ctx still executes through the store, while the same ctx straight to the raw `*sql.DB` fails — proving the wrapper is what neutralizes it).

## Separately — the "not in listing" class is a test race, not a product bug
A mutation invalidates the kernel dir cache asynchronously (`server.Inode/EntryNotify`), so a one-shot `dirContains` immediately after can read the stale cached listing. The offline write tests now poll via `dirHas`/`dirLacks` (built on the existing `waitForDirEntry` + a new `waitForNoDirEntry`) — a wait a real `ls` a moment later never needs.

## Verification
- Offline suite green at **count=50 ×3** and **count=80** under 6× CPU load (previously failed within a few runs at count=30).
- Full integration suite (63s), db + fs unit suites, `go vet ./...`, and `staticcheck` all clean.

Note: the "wire the offline suite in as a *required* CI check" acceptance item is a branch-protection change left for the maintainer.

Closes #296