### PR TITLE
fix(api): reject a null entity on a success:true mutation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -188,7 +188,10 @@ lift each connection through `connAt` / `firstPageThenDrain` (first page +
 `drain` tail), and the batch walks each alias — so a null parent object,
 connection, or alias is an error, not a silent empty result a sync prune would
 read as "everything was removed". Mutations use their own envelope (`exec.go`),
-which gates on the `success` flag before decoding.
+which gates on the `success` flag before decoding and then applies the same
+null-terminal-is-an-error rule (shared `isJSONNull` predicate): a `success:true`
+payload whose entity field is absent or explicitly null is an error, not a
+silent zero-value entity.
 
 Operational guards:
 

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -18,13 +18,23 @@ import (
 
 // execMutation runs a mutation and decodes the entity at
 // data.<opField>.<entityField> into T, failing if success is false or absent.
+//
+// A success:true payload whose entity field is absent or an explicit null is an
+// error, not a silent zero-value T — the same "null terminal is an error" rule
+// the read side enforces via walkPath (#273). Absent already errored on decode
+// ("unexpected end of JSON input"); an explicit null decoded cleanly into a
+// zero value, so it is the case the guard adds.
 func execMutation[T any](ctx context.Context, c *Client, query string, vars map[string]any, opField, entityField string) (*T, error) {
 	payload, err := execEnvelope(ctx, c, query, vars, opField)
 	if err != nil {
 		return nil, err
 	}
+	raw := payload[entityField]
+	if isJSONNull(raw) {
+		return nil, fmt.Errorf("%s: %s missing or null in a success response", opField, entityField)
+	}
 	var entity T
-	if err := json.Unmarshal(payload[entityField], &entity); err != nil {
+	if err := json.Unmarshal(raw, &entity); err != nil {
 		return nil, fmt.Errorf("%s: decode %s: %w", opField, entityField, err)
 	}
 	return &entity, nil

--- a/internal/api/exec_test.go
+++ b/internal/api/exec_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// execThing is a minimal entity for exercising execMutation's decode + null
+// guard without depending on a real api.* type's field set.
+type execThing struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+const execTestMutation = `mutation DoThing($id: String!) { thingUpdate(id: $id) { success thing { id name } } }`
+
+// TestExecMutation_NullEntityIsError is the #273 guard: a success:true payload
+// whose entity field is an explicit null must error, not decode into a silent
+// zero-value entity (json.Unmarshal([]byte("null")) succeeds and yields one).
+func TestExecMutation_NullEntityIsError(t *testing.T) {
+	mock, c := fetchTestClient(t)
+	mock.SetResponse("DoThing", map[string]any{
+		"thingUpdate": map[string]any{"success": true, "thing": nil},
+	})
+	_, err := execMutation[execThing](context.Background(), c, execTestMutation,
+		map[string]any{"id": "t1"}, "thingUpdate", "thing")
+	if err == nil || !strings.Contains(err.Error(), "thingUpdate: thing missing or null in a success response") {
+		t.Fatalf("err = %v, want a missing-or-null guard error", err)
+	}
+}
+
+// TestExecMutation_MissingEntityIsError covers the absent-field case: it errored
+// before (decode of a nil RawMessage) and now errors through the same guard, so
+// both faces of "no entity" report the same reason.
+func TestExecMutation_MissingEntityIsError(t *testing.T) {
+	mock, c := fetchTestClient(t)
+	mock.SetResponse("DoThing", map[string]any{
+		"thingUpdate": map[string]any{"success": true},
+	})
+	_, err := execMutation[execThing](context.Background(), c, execTestMutation,
+		map[string]any{"id": "t1"}, "thingUpdate", "thing")
+	if err == nil || !strings.Contains(err.Error(), "thingUpdate: thing missing or null in a success response") {
+		t.Fatalf("err = %v, want a missing-or-null guard error", err)
+	}
+}
+
+// TestExecMutation_DecodesEntity is the happy path: a present, non-null entity
+// decodes into T.
+func TestExecMutation_DecodesEntity(t *testing.T) {
+	mock, c := fetchTestClient(t)
+	mock.SetResponse("DoThing", map[string]any{
+		"thingUpdate": map[string]any{
+			"success": true,
+			"thing":   map[string]any{"id": "t1", "name": "One"},
+		},
+	})
+	got, err := execMutation[execThing](context.Background(), c, execTestMutation,
+		map[string]any{"id": "t1"}, "thingUpdate", "thing")
+	if err != nil {
+		t.Fatalf("execMutation: %v", err)
+	}
+	if got.ID != "t1" || got.Name != "One" {
+		t.Errorf("entity = %+v, want t1/One", got)
+	}
+}
+
+// TestExecMutation_SuccessFalseIsError pins that the envelope's success check
+// still fires ahead of the entity decode.
+func TestExecMutation_SuccessFalseIsError(t *testing.T) {
+	mock, c := fetchTestClient(t)
+	mock.SetResponse("DoThing", map[string]any{
+		"thingUpdate": map[string]any{
+			"success": false,
+			"thing":   map[string]any{"id": "t1", "name": "One"},
+		},
+	})
+	_, err := execMutation[execThing](context.Background(), c, execTestMutation,
+		map[string]any{"id": "t1"}, "thingUpdate", "thing")
+	if err == nil || !strings.Contains(err.Error(), "mutation reported failure") {
+		t.Fatalf("err = %v, want a success-false error", err)
+	}
+}

--- a/internal/api/fetch.go
+++ b/internal/api/fetch.go
@@ -26,6 +26,15 @@ import (
 //
 // The helpers never mutate the caller's vars map.
 
+// isJSONNull reports whether a raw JSON value is absent or an explicit null —
+// the single definition of the envelope's "null terminal is an error" rule,
+// shared by walkPath (read side) and execMutation (mutation side). A map miss
+// yields a nil RawMessage (len 0); an explicit JSON null is the four bytes
+// "null". Both fail the policy; a present, non-null value passes.
+func isJSONNull(raw json.RawMessage) bool {
+	return len(raw) == 0 || string(raw) == "null"
+}
+
 // walkPath descends path from the decoded data root and returns the raw
 // terminal value. A missing or null element errors naming the path walked so
 // far. Errors carry no module prefix — callers wrap ("fetch: %w" here,
@@ -36,8 +45,8 @@ func walkPath(root map[string]json.RawMessage, path []string) (json.RawMessage, 
 	}
 	cur := root
 	for i, elem := range path {
-		raw, ok := cur[elem]
-		if !ok || string(raw) == "null" {
+		raw := cur[elem]
+		if isJSONNull(raw) {
 			return nil, fmt.Errorf("%q missing or null in response", strings.Join(path[:i+1], "."))
 		}
 		if i == len(path)-1 {


### PR DESCRIPTION
Followup from #263 (fetch-envelope bypass review).

`execMutation` (`internal/api/exec.go`) decoded `payload[entityField]` into the entity **after** the `success` check. A mutation reporting `success: true` with a null/absent entity field decoded into a **silent zero-value `T`** — the same class #263 closed on the read side. An absent field already errored (`unexpected end of JSON input`), but an explicit `null` did not: `json.Unmarshal([]byte("null"), &entity)` returns no error and yields a zero value. `exec.go` was the one envelope that didn't enforce the "null terminal is an error" rule.

## Change
- Extract the rule into a shared `isJSONNull(json.RawMessage)` predicate (absent → nil/len 0, or explicit `"null"`), single-sourced in `fetch.go` where the null policy is documented.
- Reuse it in **`walkPath`** (read side — behavior identical, since a map miss is already a nil `RawMessage`) and in **`execMutation`**'s new guard.

## Notes
- **Purely theoretical today** — a successful create/update always returns its entity — so no behavior change in practice; it closes the envelope philosophy's one remaining gap.
- Tests (`exec_test.go`, new) cover null, absent, valid, and `success:false`; the null guard is verified as a real red→green (bypassing it makes the null case decode to a silent zero value). `ARCHITECTURE.md`'s mutation-envelope note now records the shared rule.
- Full `go vet ./...`, `staticcheck`, and the `internal/api` suite are clean.

Closes #273