### PR TITLE
fix(api): treat a local budget deferral as skip-cycle, not a server rate limit

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -222,8 +222,12 @@ Operational guards:
   request (op, vars, duration, outcome, complexity) to
   `~/.config/linearfs/requests.jsonl`, for offline diagnosis.
 - **Error predicates** (`errors.go`): `IsRateLimited`, `IsNotFound`,
-  `IsFieldTooLong` — the vocabulary the fs layer's error classifier maps to
-  errnos.
+  `IsFieldTooLong`, `IsDeferred` — the vocabulary the fs layer's error classifier
+  maps to errnos. `IsDeferred` (a local budget deferral: `ErrDeferred` or the
+  pagination `ErrBudget`) is deliberately *excluded* from `IsRateLimited`: a
+  server rate limit warrants a long pause until the window resets, but a local
+  admission-ladder defer clears next cycle, so the sync worker skips-this-cycle
+  on a defer instead of entering the hour-long rate-limit backoff (#257).
 
 **Consumed by:** Sync Worker (reads), Repository (SWR refreshes and its
 reconcile pass), LinearFS (mutations plus the interactive-tier synchronous

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -168,7 +168,11 @@ func (c *Client) query(ctx context.Context, query string, variables map[string]a
 		adm, dec = c.budget.admit(opName, tier)
 	}
 	if adm == nil {
-		return fmt.Errorf("rate limit: query %s deferred (%s)", opName, dec.reason)
+		// Typed as ErrDeferred: the LOCAL admission ladder declined this, which
+		// clears next cycle — not a server rate limit that warrants a long pause
+		// (#257). The "rate limit:" prefix was dropped precisely because it made
+		// IsRateLimited's message fallback misclassify this as a server 429.
+		return fmt.Errorf("query %s deferred by budget ladder (%s): %w", opName, dec.reason, ErrDeferred)
 	}
 	// The admission must be settled exactly once. The success and
 	// rate-limited paths settle explicitly below (observe/rateLimited);

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -5,6 +5,23 @@ import (
 	"strings"
 )
 
+// ErrDeferred marks an error as the client's OWN admission ladder deferring a
+// request — the local rate budget said "not right now". It is deliberately
+// distinct from a server rate limit (IsRateLimited): a defer clears on the
+// ladder's minute-scale timescale (retry next cycle), whereas a server
+// RATELIMITED warrants a long pause until the window resets. Conflating them
+// cost an hour of detail-sync latency on deploy day when the worker paused for a
+// full hour on a local defer (#257). The pagination-preflight ErrBudget is the
+// same class; IsDeferred recognizes both.
+var ErrDeferred = errors.New("request deferred: rate-limit budget low")
+
+// IsDeferred reports whether err is a local budget deferral (ErrDeferred or the
+// pagination-preflight ErrBudget) rather than a server rate limit. Callers that
+// back off hard on a server rate limit must treat a defer as skip-this-cycle.
+func IsDeferred(err error) bool {
+	return errors.Is(err, ErrDeferred) || errors.Is(err, ErrBudget)
+}
+
 // Error predicates: the package-level classification of Linear API failures.
 //
 // Every layer above the client (fs mutation handlers, the repo's orphan
@@ -29,6 +46,13 @@ import (
 // callers that retry on both (retryableCreateErr) check it separately.
 func IsRateLimited(err error) bool {
 	if err == nil {
+		return false
+	}
+	// A local budget deferral is NOT a server rate limit — it clears on the
+	// admission ladder's own timescale, so it must not trip a long server-rate-
+	// limit backoff (#257). The typed check takes precedence over the message
+	// fallback below.
+	if IsDeferred(err) {
 		return false
 	}
 	var gqlErr *GraphQLError

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -34,9 +34,18 @@ func TestIsRateLimited(t *testing.T) {
 			true,
 		},
 		{
-			"client-side deferred rate limit message",
-			errors.New("rate limit: query GetIssue deferred (reserve)"),
-			true,
+			// A local budget deferral (typed ErrDeferred) is NOT a server rate
+			// limit — the whole point of #257. The typed exclusion must win even
+			// when the message literally says "rate limit" (the historical
+			// phrasing that caused the misclassification).
+			"client-side budget deferral is not a server rate limit",
+			fmt.Errorf("rate limit: query GetIssue deferred (reserve): %w", ErrDeferred),
+			false,
+		},
+		{
+			"pagination-preflight ErrBudget is not a server rate limit",
+			fmt.Errorf("paginate: %w", ErrBudget), // ErrBudget's own message contains "rate-limit"
+			false,
 		},
 		{
 			"circuit breaker is NOT rate limiting",
@@ -54,6 +63,30 @@ func TestIsRateLimited(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := IsRateLimited(tc.err); got != tc.want {
 				t.Errorf("IsRateLimited(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsDeferred(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"ErrDeferred sentinel", ErrDeferred, true},
+		{"ErrDeferred wrapped via %w", fmt.Errorf("query X deferred (reserve): %w", ErrDeferred), true},
+		{"pagination ErrBudget", ErrBudget, true},
+		{"ErrBudget wrapped via %w", fmt.Errorf("paginate: %w", ErrBudget), true},
+		{"server RATELIMITED is not a defer", &GraphQLError{Code: "RATELIMITED"}, false},
+		{"plain rate-limit string is not a defer", errors.New("Rate limit exceeded"), false},
+		{"unrelated error", errors.New("boom"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsDeferred(tc.err); got != tc.want {
+				t.Errorf("IsDeferred(%v) = %v, want %v", tc.err, got, tc.want)
 			}
 		})
 	}

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -180,8 +180,11 @@ func retryableCreateErr(err error) bool {
 	}
 	// Rate-limit detection is the shared predicate's job; the circuit breaker
 	// stays here — it is a client-side connectivity transient (worth retrying),
-	// not the server rate limiting us, so api.IsRateLimited excludes it.
-	return api.IsRateLimited(err) || strings.Contains(err.Error(), "circuit breaker")
+	// not the server rate limiting us, so api.IsRateLimited excludes it. A local
+	// budget deferral (api.IsDeferred) is also transient — it clears next cycle,
+	// so a deferred write should retry (EAGAIN), not fail hard (#257). Now that
+	// IsRateLimited excludes deferrals, it must be checked explicitly.
+	return api.IsRateLimited(err) || api.IsDeferred(err) || strings.Contains(err.Error(), "circuit breaker")
 }
 
 // Mkdir creates a new issue from a directory name

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -1408,8 +1408,16 @@ func (w *Worker) syncDetails(ctx context.Context, issues []issueRef) detailOutco
 	// Fetch all details in one API call
 	detailsMap, err := w.client.GetIssueDetailsBatch(ctx, ids)
 	if err != nil {
+		if api.IsDeferred(err) {
+			// Gate 3a: our OWN admission ladder deferred this batch — a local,
+			// minute-scale condition that clears next cycle, NOT the server rate
+			// limiting us. Skip this cycle (the issues survive in the pending
+			// queue) WITHOUT the long setRateLimited pause (#257).
+			log.Printf("[sync] detail batch deferred by budget ladder, retrying next cycle: %v", err)
+			return deferAll()
+		}
 		if isRateLimitError(err) {
-			// Gate 3: rate limited mid-fetch.
+			// Gate 3: server rate limited mid-fetch.
 			w.setRateLimited()
 			return deferAll()
 		}

--- a/internal/sync/worker_test.go
+++ b/internal/sync/worker_test.go
@@ -1017,6 +1017,46 @@ func TestPendingDetailSyncQueueAndDrain(t *testing.T) {
 	}
 }
 
+// TestDeferredDetailBatchDoesNotRateLimit is the #257 regression guard: when the
+// detail-batch fetch fails with a LOCAL budget deferral (api.ErrDeferred), the
+// worker must skip this cycle (queue the issues) WITHOUT entering the long
+// server-rate-limit backoff. Before the fix, the deferral message matched
+// api.IsRateLimited and the worker paused detail sync for a full hour.
+func TestDeferredDetailBatchDoesNotRateLimit(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	mock := newMockAPIClient()
+	// A local admission-ladder deferral. The message deliberately contains
+	// "rate limit" — the historical phrasing that tripped the misclassification —
+	// so this proves the TYPED ErrDeferred wins over the string fallback, not
+	// merely that the message was reworded.
+	mock.simulateError = fmt.Errorf("rate limit: query IssueDetailsBatch deferred (reserve): %w", api.ErrDeferred)
+
+	worker := NewWorker(mock, store, Config{Interval: time.Hour})
+	issues := []issueRef{{ID: "issue-1", Identifier: "TST-1"}, {ID: "issue-2", Identifier: "TST-2"}}
+
+	outcome := worker.syncDetails(ctx, issues)
+	if !outcome.gated {
+		t.Error("a deferred fetch should gate the outcome (issues survive in the pending queue)")
+	}
+	// The crux: a LOCAL defer must NOT set the server-rate-limit pause.
+	if worker.isRateLimited() {
+		t.Error("worker entered the rate-limit backoff on a local budget deferral (#257 regression)")
+	}
+
+	// The issues must still be queued for the next cycle (same as a rate limit).
+	pending, err := store.Queries().ListPendingDetailSync(ctx)
+	if err != nil {
+		t.Fatalf("ListPendingDetailSync: %v", err)
+	}
+	if len(pending) != 2 {
+		t.Errorf("pending = %d, want 2 (deferred issues must survive)", len(pending))
+	}
+}
+
 // TestDetailsSyncPrunesStaleRows: the details sync must delete rows Linear no
 // longer returns — a comment deleted in Linear, or a phantom left by a delete
 // whose SQLite forget failed (the store is the listing source of truth, so an


### PR DESCRIPTION
Observed live on the first #247 deploy: `drainPendingDetailSync` hit the client's **local** budget-deferral error and classified it as a **server** rate limit — pausing detail sync for a full hour (`backoff=1h0m5s`) for a condition that clears on the admission ladder's own minute-scale timescale.

## Cause
The client's deferral was a plain `fmt.Errorf` whose `rate limit: query X deferred` message matched `api.IsRateLimited`'s case-insensitive `"rate limit"` string fallback. So the worker's `isRateLimitError` couldn't distinguish "the server 429'd us" (long pause appropriate) from "our own ladder said not right now" (retry next cycle). The #232/#233 typed-error work structured the server case (`GraphQLError{Code: RATELIMITED}`); the local defer was the one path that slipped through as a bare string.

## Fix — make the defer typed
- New **`api.ErrDeferred`** sentinel + **`IsDeferred`** predicate (covers `ErrDeferred` and the pagination-preflight `ErrBudget` — the same local-defer class).
- **`IsRateLimited` now excludes `IsDeferred`** (typed check ahead of the message fallback), so a defer is never a server rate limit anywhere.
- The client's deferral **wraps `ErrDeferred`** and drops the misleading `"rate limit:"` prefix (message still contains `"deferred"`).
- The sync worker gets an **explicit deferral branch**: skip this cycle (issues survive in the pending queue) **without** `setRateLimited`'s hour-long pause.
- `retryableCreateErr` adds `IsDeferred` so a deferred **write** still retries (`EAGAIN`), now that `IsRateLimited` no longer covers it.

## Tests
True red→green guards: the `errors_test` defer case and the new `TestDeferredDetailBatchDoesNotRateLimit` both use a message that **literally says "rate limit"** wrapped in `ErrDeferred`, proving the **typed exclusion wins over the string fallback** (they fail if either fix point is reverted — verified). Plus `TestIsDeferred`, and `ErrBudget` is now correctly excluded too.

`go vet ./...`, `staticcheck`, and the api/sync/fs suites are clean. `ARCHITECTURE.md`'s error-predicate note records the split.

Closes #257