### PR TITLE
fix(telemetry): stop journald dropping metrics dumps; guard uptime gauge

### DIFF
--- a/contrib/systemd/linearfs.service
+++ b/contrib/systemd/linearfs.service
@@ -22,6 +22,13 @@ ExecStop=/usr/bin/fusermount3 -uz ${LINEARFS_MOUNT}
 Restart=on-failure
 RestartSec=5
 SyslogIdentifier=linearfs
+# Don't let journald's per-service rate limiter drop our logs. The always-on
+# metrics summary is one line every 5 minutes, but a cold-start burst of sync
+# logs can trip journald's default RateLimitBurst and silently suppress
+# subsequent lines — including the summary — leaving stale/sparse metrics in the
+# journal (#256: only 2 metrics dumps landed in 93 minutes). This service is
+# low-volume in steady state, so disabling the limiter is safe.
+LogRateLimitIntervalSec=0
 # Deliberately NO sandboxing directives (ProtectHome/ProtectSystem/
 # PrivateTmp/...): the mount lives in $HOME and the config + SQLite cache
 # live under ~/.config/linearfs — hardening those away breaks the service.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -167,7 +167,17 @@ To stay one readable line, attribute sets are **projected onto a keep-list**
 `collection`, `version`, `commit`. Keys not in the list (notably the ~30-value
 `op`) are dropped and the collided series **merged** (values and
 count/sum summed). Full cardinality is only in the JSONL export — the summary
-is deliberately the compact projection. Source:
+is deliberately the compact projection.
+
+**journald rate-limiting caveat:** the summary is one `log.Printf` line every 5
+minutes, but journald rate-limits per service, so a cold-start burst of sync
+logs can trip the default `RateLimitBurst` and silently drop later lines —
+including the summary — leaving stale/sparse metrics in the journal (#256: only
+2 dumps landed in 93 minutes, and the surviving early dump's honest
+`uptime_seconds≈300` read as a bug at 93 min wall-clock). The systemd unit sets
+`LogRateLimitIntervalSec=0` so this service's logs are never dropped; a
+free-standing run should either disable the limiter or read metrics from the
+JSONL export instead. Source:
 `internal/telemetry/summary.go`.
 
 ## The JSONL file

--- a/internal/telemetry/heartbeat_test.go
+++ b/internal/telemetry/heartbeat_test.go
@@ -1,0 +1,60 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// readUptime collects the manual reader and returns the single
+// linearfs.process.uptime_seconds gauge value, or -1 if absent.
+func readUptime(t *testing.T, r *sdkmetric.ManualReader) float64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := r.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == "linearfs.process.uptime_seconds" {
+				g, ok := m.Data.(metricdata.Gauge[float64])
+				if !ok || len(g.DataPoints) == 0 {
+					t.Fatalf("uptime is %T with %d points", m.Data, len(g.DataPoints))
+				}
+				return g.DataPoints[0].Value
+			}
+		}
+	}
+	return -1
+}
+
+// TestUptimeTracksTimeSinceStart is the #256 regression guard: the uptime gauge
+// must report seconds since the process (registration) start and keep growing
+// across collects — NOT time-since-last-collect or a per-collect reset, which
+// would peg it near one export interval forever (the field symptom: 300.001s at
+// ~93min real uptime). Two collects across a real sleep: the value must advance
+// by at least the slept duration, proving `start` is captured once and never
+// reset by a collect.
+func TestUptimeTracksTimeSinceStart(t *testing.T) {
+	r := sdkmetric.NewManualReader()
+	p := sdkmetric.NewMeterProvider(sdkmetric.WithReader(r))
+	if err := registerHeartbeat(p, "v", "c"); err != nil {
+		t.Fatalf("registerHeartbeat: %v", err)
+	}
+
+	const sleep = 120 * time.Millisecond
+	v0 := readUptime(t, r)
+	time.Sleep(sleep)
+	v1 := readUptime(t, r)
+
+	if v0 < 0 || v1 < 0 {
+		t.Fatalf("uptime gauge not found (v0=%.4f v1=%.4f)", v0, v1)
+	}
+	// The second collect must reflect the elapsed sleep, not restart from ~0.
+	if delta := v1 - v0; delta < sleep.Seconds()*0.75 {
+		t.Errorf("uptime advanced %.4fs across a %.3fs sleep — gauge is measuring time-since-collect, not since start (#256)", delta, sleep.Seconds())
+	}
+}


### PR DESCRIPTION
Field report (#247 verification): `linearfs.process.uptime_seconds` read `300.001s` (~one export interval) at ~93 min real uptime, and only **2** `metrics:` dumps appeared in the journal over 93 minutes.

## Investigation — the uptime gauge is correct
It captures `start` once at registration (`telemetry.Init` runs exactly once, at mount) and observes `time.Since(start)`. A `ManualReader` probe across two collects confirms it tracks true elapsed time and never resets per-collect. Added as **`TestUptimeTracksTimeSinceStart`** (the #256 regression guard): the hypothesized per-collect-reset bug would peg the value near one interval and fail this test.

## The real defect — journald dropped the dumps
The summary is one `log.Printf` every 5 minutes to journald, and **journald rate-limits per service**. A cold-start burst of sync logs trips the default `RateLimitBurst` and silently drops later lines — including the summary. The surviving dump was an early one (t≈300s, uptime honestly ≈300); read at 93 min wall-clock during a counter-heavy cold-start deploy, that stale-but-honest value looked like a misreport (the counters were already large because a cold start front-loads work).

## Fix
Set **`LogRateLimitIntervalSec=0`** on the systemd unit so this low-volume service's logs (and thus every 5-min metrics summary) are never dropped. `docs/telemetry.md` records the journald caveat and the mitigation.

vet + staticcheck + telemetry suite clean.

Closes #256