### PR TITLE
test(integration): point fixture-mode client at a local offline endpoint (no live 401s)

### DIFF
--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -833,7 +833,9 @@ func (lfs *LinearFS) GetStore() *db.Store {
 // (create/edit reach ClearWriteError/AppendWriteSuccess instead of failing at the
 // network). Reads/infrastructure continue to use the real client. Pass nil to
 // restore the default (mutations hit the real client and fail without an API key,
-// which the loud-failure tests rely on).
+// which the loud-failure tests rely on — the fixture harness points that client
+// at a local offline endpoint via SetTestAPIURL so the failure is instant and
+// local instead of a real-network 401, #197).
 // If mc also implements verifyReader (as the mockmutation fake does), the
 // read-your-writes verify fetch is routed to it too, so the edit-commit tail
 // runs against fake state offline instead of taking the "unverified" branch.
@@ -857,6 +859,16 @@ func (lfs *LinearFS) InjectTestMutationClient(mc MutationClient) {
 	} else {
 		lfs.liveReaderImpl = lfs.client
 	}
+}
+
+// SetTestAPIURL points the real client's HTTP endpoint at url — a test seam so
+// the fixture harness can aim any un-mocked mutation/verify/liveReader call at a
+// local offline server instead of the real api.linear.app. Without it, a
+// fixture-mode write with no mock injected reaches the real API with the dummy
+// key and 401s (network noise, non-hermetic, burns real budget — #197). Call at
+// setup, before the mount serves; it is not concurrency-guarded.
+func (lfs *LinearFS) SetTestAPIURL(url string) {
+	lfs.client.SetAPIURL(url)
 }
 
 // mutator returns the current mutation client under a read lock, so a FUSE

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,6 +28,11 @@ var (
 	lfs         *fs.LinearFS
 	testStore   *db.Store // fixture mode: the store behind the mount, for tests simulating sync-side writes
 	apiClient   *api.Client
+
+	// offlineAPIServer is where fixture-mode's real client is pointed so an
+	// un-mocked mutation/verify call fails instantly and locally instead of
+	// reaching api.linear.app with the dummy key and 401-ing (#197).
+	offlineAPIServer *httptest.Server
 	testTeamID  string
 	testTeamKey string
 
@@ -177,6 +184,18 @@ func setupSQLiteFixtures() error {
 	}
 
 	testStore = store
+
+	// Point the real client at a local endpoint that always fails with a
+	// distinctive offline error. Fixture-mode reads come from the store, but the
+	// mutator/verify/liveReader default to this client, so any write path with no
+	// mock injected (the deliberate loud-failure tests, and incidental
+	// post-teardown writes) fails locally and instantly here instead of hitting
+	// api.linear.app with the dummy key (#197).
+	offlineAPIServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"linearfs fixture mode: offline, no mock mutator injected for this write path (#197)"}]}`))
+	}))
+	lfs.SetTestAPIURL(offlineAPIServer.URL)
 
 	// Inject the store and create repository (no API client for fetching)
 	if err := lfs.InjectTestStore(store); err != nil {
@@ -492,6 +511,9 @@ func cleanup() {
 	}
 	if lfs != nil {
 		lfs.Close()
+	}
+	if offlineAPIServer != nil {
+		offlineAPIServer.Close()
 	}
 	if mountPoint != "" {
 		os.RemoveAll(mountPoint)


### PR DESCRIPTION
In fixture mode (no `LINEARFS_LIVE_API`), any write path exercised **without** `enableMockMutations` — the deliberate loud-failure tests (`TestT4_ValidSpecFailsAtAPILoudly`) and incidental post-teardown/validation writes — reached the real `api.linear.app` with the dummy key and **401'd**. That's network noise that obscures real failures, makes those paths non-hermetic (different behavior offline), and burns a slice of real rate-limit budget.

## Root cause
Fixture-mode reads come from the store, but the mutator/verify/liveReader default to `lfs.client` (a real `api.Client`), and `InjectTestMutationClient(nil)` — the mock-teardown restore — resets to that real client. So an un-mocked write hits the live API.

## Fix
A small `LinearFS.SetTestAPIURL` test seam lets the fixture harness point that client at a local `httptest` server that always returns a distinctive offline error (`503 "linearfs fixture mode: offline ... (#197)"`). Reads are unaffected (they come from the store); only the un-mocked write/verify calls change — they now fail instantly and locally instead of over the network.

## Verification
- `TestT4` still passes (it only asserts the create fails loudly and `.error` carries the op label — both hold against the local failure).
- Full integration suite (`-v`): **0** `401 / Authentication required` lines (down from the reported noise), **11** offline-marker hits where un-mocked writes fire, **0** failures.
- `go vet ./...`, `staticcheck`, fs suite clean.

Closes #197