### PR TITLE
feat(fs): bound kernel-notify tail steps against a wedge

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -558,7 +558,12 @@ a layer above the commit-tail primitives) and no telemetry (matching
    `InvalidateUpdated` / `InvalidateDeleted` / `InvalidateRenamed`. Handlers
    never hand-pick the raw `InodeNotify`/`EntryNotify` primitives; hand-picked
    combinations drifted (missed dir inodes, un-notified unlinks) before the
-   policy module existed.
+   policy module existed. Each intent runs its notify sequence under a 5s
+   deadline (`boundedNotify`): the raw primitives do not honor a context and can
+   wedge, so on the deadline the stuck goroutine is leaked and control returns to
+   the handler — a wedged notify degrades to "handler completes, that dir's cache
+   is briefly stale" plus a `linearfs.fuse.notify_timeouts` count, instead of
+   hanging the write until a manual restart (#277).
 
 **Delete flow:** `rm` of a comment/doc/label/relation/… or `rmdir`-archive of
 an issue/project goes through `commitDelete`: API delete first, then a

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -77,6 +77,7 @@ Naming: `linearfs.<layer>.<what>`; meter scopes are `linearfs/process`,
 |---|---|---|---|
 | `linearfs.fuse.ops` | counter | `op`, `outcome` = `ok` \| `einval` \| `eio` \| `eagain` \| `enoent` \| `eperm` \| `exdev` \| `eacces` \| `other` | one per completed op at the cheap choke points — the **four** commit tails (`op` = `create` \| `delete` \| `flush` \| `rename`; `rename` added in #294 so entity renames stop reading as "no renames happen") plus the editBuffer `read`/`write` and renderFile `read` entry points. `outcome` is `outcomeForErrno` — a closed enum so cardinality stays bounded |
 | `linearfs.fuse.duration` | histogram (s) | `op` | same sites, wall time of the op |
+| `linearfs.fuse.notify_timeouts` | counter | `intent` = `created` \| `deleted` \| `updated` \| `renamed` | one per kernel-cache invalidation abandoned after the `kernelNotifyTimeout` (5s) guard — a wedged `InodeNotify`/`EntryNotify` (#277). Nonzero means a leaked notify goroutine and possibly-stale cache for that intent's directory; a growing count is a persistent wedge warranting a restart |
 | `linearfs.embedded_files.fetch` | counter | `source` = `memory` \| `disk` \| `cdn` | one per embedded-file byte fetch, by the tier that served it |
 
 Coverage is deliberately the shared tails, not every node type: Lookup and

--- a/internal/fs/invalidate.go
+++ b/internal/fs/invalidate.go
@@ -1,6 +1,51 @@
 package fs
 
-import "github.com/hanwen/go-fuse/v2/fuse"
+import (
+	"log"
+	"time"
+
+	"github.com/hanwen/go-fuse/v2/fuse"
+)
+
+// kernelNotifyTimeout bounds one kernel-cache invalidation intent. A package var
+// so a test can lower it (the sqliteRetryBackoff seam idiom). 5s is ~1000x a
+// healthy notify's sub-millisecond latency, so a false trip is nearly impossible
+// while a real wedge still returns control promptly.
+var kernelNotifyTimeout = 5 * time.Second
+
+// boundedNotify runs one kernel-cache invalidation intent under a deadline.
+//
+// server.InodeNotify / EntryNotify do not honor a context and can wedge — on an
+// internal go-fuse lock, or a backed-up kernel-notify queue — with no way to
+// interrupt them. A create's write-back once hung the whole FUSE handler that
+// way until a manual `systemctl restart` (#277). Running the intent in a
+// goroutine and selecting on kernelNotifyTimeout bounds it: on a wedge the stuck
+// goroutine is LEAKED (unavoidable — the call is uninterruptible) and control
+// returns to the caller, so the handler completes instead of hanging forever.
+// The abandoned directory's kernel cache stays stale until its TTL;
+// recordNotifyTimeout + a WARN log make that legible.
+//
+// A persistent wedge leaks one goroutine per mutation. That is accepted
+// deliberately — no circuit breaker (grilled 2026-07-17): mutations are
+// interactive-rate so the leak grows slowly, and the counter names the condition
+// for an operator restart, which a truly wedged notify warrants anyway. Trading
+// the leak for a breaker would only swap it for silent permanent staleness.
+func boundedNotify(intent string, run func()) {
+	// Buffered so the goroutine's send never blocks after a timeout moved on.
+	done := make(chan struct{}, 1)
+	go func() {
+		run()
+		done <- struct{}{}
+	}()
+	timer := time.NewTimer(kernelNotifyTimeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+	case <-timer.C:
+		recordNotifyTimeout(intent)
+		log.Printf("Warning: kernel-notify %q exceeded %s and was abandoned; the guard goroutine is leaked and this directory's cache may be stale until its TTL — restart linearfs if this persists (#277)", intent, kernelNotifyTimeout)
+	}
+}
 
 // kernelNotify owns the filesystem's one coupling to the FUSE server: the two
 // raw kernel-cache primitives (InodeNotify / EntryNotify) and the intent
@@ -32,16 +77,33 @@ func (k *kernelNotify) InvalidateKernelEntry(parent uint64, name string) {
 
 // InvalidateCreated / Deleted / Updated / Renamed name what happened; the
 // coherence policy (below) picks the correct notifies. fileIno/name may be zero
-// where the policy allows.
+// where the policy allows. Each runs its notify sequence through boundedNotify,
+// so a wedged InodeNotify/EntryNotify can no longer hang the calling handler
+// (#277). The nil-server short-circuit keeps the pre-mount / fixture no-op AND
+// avoids spawning a guard goroutine when there is nothing to notify.
 func (k *kernelNotify) InvalidateCreated(dirIno uint64, name string) {
-	invalidateCreated(k, dirIno, name)
+	if k.server == nil {
+		return
+	}
+	boundedNotify("created", func() { invalidateCreated(k, dirIno, name) })
 }
 func (k *kernelNotify) InvalidateDeleted(dirIno uint64, name string) {
-	invalidateDeleted(k, dirIno, name)
+	if k.server == nil {
+		return
+	}
+	boundedNotify("deleted", func() { invalidateDeleted(k, dirIno, name) })
 }
-func (k *kernelNotify) InvalidateUpdated(fileIno uint64) { invalidateUpdated(k, fileIno) }
+func (k *kernelNotify) InvalidateUpdated(fileIno uint64) {
+	if k.server == nil {
+		return
+	}
+	boundedNotify("updated", func() { invalidateUpdated(k, fileIno) })
+}
 func (k *kernelNotify) InvalidateRenamed(dirIno uint64, oldName, newName string, fileIno uint64) {
-	invalidateRenamed(k, dirIno, oldName, newName, fileIno)
+	if k.server == nil {
+		return
+	}
+	boundedNotify("renamed", func() { invalidateRenamed(k, dirIno, oldName, newName, fileIno) })
 }
 
 // Kernel-cache coherence policy.

--- a/internal/fs/invalidate_test.go
+++ b/internal/fs/invalidate_test.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 // recordingNotifier captures the notify calls the coherence policy makes, in
@@ -69,4 +70,52 @@ func TestInvalidateRenamed(t *testing.T) {
 		invalidateRenamed(r, 3, "Old.md", "New.md", 0)
 		eq(t, r.calls, []string{`entry(3,"Old.md")`, `entry(3,"New.md")`})
 	})
+}
+
+// TestBoundedNotify_FastPathRunsSynchronously: a notify that returns promptly is
+// run to completion before boundedNotify returns — the guard adds only a
+// goroutine hop on the happy path, so callers still see synchronous coherence.
+func TestBoundedNotify_FastPathRunsSynchronously(t *testing.T) {
+	ran := make(chan struct{}, 1)
+	boundedNotify("created", func() { ran <- struct{}{} })
+	select {
+	case <-ran:
+	default:
+		t.Fatal("intent did not run before boundedNotify returned (happy path must be synchronous)")
+	}
+}
+
+// TestBoundedNotify_TimesOutLeaksAndCounts is the #277 guard: a wedged notify
+// must NOT hang the caller. boundedNotify returns after the deadline, records the
+// timeout, and leaves the stuck intent goroutine parked (leaked). Deterministic:
+// a block-forever intent + a lowered timeout always trips.
+func TestBoundedNotify_TimesOutLeaksAndCounts(t *testing.T) {
+	saved := kernelNotifyTimeout
+	kernelNotifyTimeout = 10 * time.Millisecond
+	t.Cleanup(func() { kernelNotifyTimeout = saved })
+
+	before := counterValue(t, "linearfs.fuse.notify_timeouts", map[string]string{"intent": "updated"})
+
+	block := make(chan struct{})
+	t.Cleanup(func() { close(block) }) // release the leaked goroutine when the test ends
+	started := make(chan struct{})
+	returned := make(chan struct{})
+	go func() {
+		boundedNotify("updated", func() {
+			close(started)
+			<-block // wedge: never completes until cleanup
+		})
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("boundedNotify hung on a wedged intent (10ms guard) — the whole point of #277 is that it must not")
+	}
+	<-started // the intent did start and is now leaked, still blocked on `block`
+
+	if after := counterValue(t, "linearfs.fuse.notify_timeouts", map[string]string{"intent": "updated"}); after != before+1 {
+		t.Errorf("notify_timeouts{intent=updated} = %d, want %d", after, before+1)
+	}
 }

--- a/internal/fs/metrics.go
+++ b/internal/fs/metrics.go
@@ -31,9 +31,10 @@ import (
 )
 
 type fuseMetrics struct {
-	ops      metric.Int64Counter     // linearfs.fuse.ops {op, outcome}
-	duration metric.Float64Histogram // linearfs.fuse.duration {op}, seconds
-	embedded metric.Int64Counter     // linearfs.embedded_files.fetch {source}
+	ops            metric.Int64Counter     // linearfs.fuse.ops {op, outcome}
+	duration       metric.Float64Histogram // linearfs.fuse.duration {op}, seconds
+	embedded       metric.Int64Counter     // linearfs.embedded_files.fetch {source}
+	notifyTimeouts metric.Int64Counter     // linearfs.fuse.notify_timeouts {intent}
 }
 
 var (
@@ -52,6 +53,8 @@ func fuseMetricsInstance() fuseMetrics {
 				metric.WithDescription("FUSE operation duration by op")),
 			embedded: telemetry.MustInt64Counter(m, "linearfs.embedded_files.fetch",
 				metric.WithDescription("Embedded-file byte fetches, by serving tier (memory|disk|cdn)")),
+			notifyTimeouts: telemetry.MustInt64Counter(m, "linearfs.fuse.notify_timeouts",
+				metric.WithDescription("Kernel-cache invalidations abandoned after the guard deadline, by intent (created|deleted|updated|renamed) — a wedged InodeNotify/EntryNotify; nonzero means a leaked notify goroutine and possibly-stale cache")),
 		}
 	})
 	return fuseMetricsInst
@@ -98,4 +101,13 @@ func recordFuseOp(ctx context.Context, op string, start time.Time, errno syscall
 func recordEmbeddedFetch(ctx context.Context, source string) {
 	fuseMetricsInstance().embedded.Add(ctx, 1,
 		metric.WithAttributes(attribute.String("source", source)))
+}
+
+// recordNotifyTimeout counts one kernel-cache invalidation abandoned after the
+// guard deadline (a wedged InodeNotify/EntryNotify), by intent. It uses a
+// background context: the notify runs after the FUSE handler's request ctx is
+// out of scope (#277).
+func recordNotifyTimeout(intent string) {
+	fuseMetricsInstance().notifyTimeouts.Add(context.Background(), 1,
+		metric.WithAttributes(attribute.String("intent", intent)))
 }


### PR DESCRIPTION
Design was grilled with @jra3 (2026-07-17) — full decision log below.

The confirmed-reflection contract (#276) closed the persist-wedge path, but a **post-persist tail step could still hang the FUSE handler forever**: `server.InodeNotify` / `EntryNotify` do not honor a context and can wedge on an internal go-fuse lock or a backed-up kernel-notify queue. A create's write-back hit exactly that, and only `systemctl restart` cleared it.

## Fix
Bound each `kernelNotify` intent (`InvalidateCreated/Deleted/Updated/Renamed`) with a 5s deadline via `boundedNotify`: the notify sequence runs in a goroutine and the caller selects on `kernelNotifyTimeout`. On a wedge the stuck goroutine is **leaked** (the call is uninterruptible — there is no other option) and control returns to the handler, so the write completes instead of hanging. The failure degrades to *"handler returns, that dir's kernel cache is briefly stale until its TTL"*, made legible by a `linearfs.fuse.notify_timeouts{intent}` counter + a WARN log.

## Grilled decisions
- **Scope: tail-bound fix only** — no liveness watchdog, no in-process self-heal. A truly wedged process is `systemd Restart=on-failure`'s job; a self-heal that misfires would reset a healthy process mid-write. (#257, a named wedge trigger, is already fixed.)
- **Grain: per intent** — one guard goroutine per mutation; coherence completes-or-abandons whole.
- **No circuit breaker** on the leak — mutations are interactive-rate so it grows slowly, and the counter names the condition for a restart. Capping it would only trade the leak for silent permanent staleness.
- **5s timeout** — ~1000× a healthy notify's latency, so a false trip (which would abandon coherence → stale cache) is nearly impossible.

## Behavior + tests
The happy path stays synchronous (caller blocks on the goroutine's completion), so healthy notifies are unchanged; existing coherence-policy tests (free functions + fake recorder) are untouched. New tests cover the fast path and the timeout-leaks-and-counts contract (block-forever intent + lowered timeout = deterministic). Full fs suite green **under `-race`**; vet + staticcheck clean.

Closes #277