### PR TITLE
docs: add contributor-OSS scaffolding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug report
+description: Something in the filesystem behaves incorrectly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. The single most useful thing you can include is the
+        contents of the relevant `.error` file — LinearFS writes the reason for every
+        failed write there (next to the file you wrote, or in the collection directory).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you do, and what went wrong?
+      placeholder: |
+        I edited `issue.md` to set priority: high and saved, but the write failed with EINVAL.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+  - type: textarea
+    id: error-file
+    attributes:
+      label: .error contents (if a write failed)
+      description: "`cat` the relevant `.error` file and paste it here."
+      render: text
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact filesystem commands (ls / cat / echo > _create / mv / rm …).
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `linearfs version`.
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Platform
+      options:
+        - Linux (systemd)
+        - macOS (launchd)
+        - Linux (manual mount)
+        - macOS (manual mount)
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: "e.g. `journalctl --user -u linearfs -n 50` (Linux). Redact any secrets."
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/jra3/linear-fuse/security/advisories/new
+    about: Please report security issues privately, not as public issues. See SECURITY.md.
+  - name: Question or usage help
+    url: https://github.com/jra3/linear-fuse/discussions
+    about: For questions and usage help, open a discussion (or read README.md / the mount's own README.md).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Feature request
+description: Suggest a filesystem surface, mapping, or capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem / use case
+      description: What are you trying to do that LinearFS doesn't support today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed filesystem behavior
+      description: |
+        LinearFS maps filesystem operations to Linear actions. Describe the surface you'd want —
+        a path, a file, and what reading/writing/`mkdir`/`rm` on it should do.
+      placeholder: |
+        `cat teams/ENG/issues/ENG-1/attachments/report.pdf` should stream the attachment bytes.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!--
+Title format: type(scope): summary   e.g. fix(fs): bound kernel-notify tail steps
+Keep the PR to one logical change.
+-->
+
+## What & why
+
+<!-- What does this change do, and what problem does it solve? -->
+
+## How it was verified
+
+<!-- Tests added/updated? `make test && make lint && make staticcheck` green? Manual check? -->
+
+## Checklist
+
+- [ ] `make test` passes (unit tests run offline, no API key needed)
+- [ ] `make lint` and `make staticcheck` are clean
+- [ ] New behavior has a test — ideally a pure-projection unit test, not mount-only
+- [ ] Updated `CONTEXT.md` / `docs/ARCHITECTURE.md` if a seam, data flow, or filesystem surface changed
+- [ ] Linked related issues (`Closes #NN` / `Part of #NN`)
+
+<!--
+New to the codebase? Read the relevant section of CONTEXT.md first — it names the concepts
+this project uses (edit path, WriteBack tail, persist gate, …). See CONTRIBUTING.md.
+-->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  # Go module dependencies
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,22 @@ jobs:
       - name: staticcheck
         run: make staticcheck
 
+  govulncheck:
+    name: Vulnerability scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
   integration-tests-read:
     name: Integration Tests (Read-Only)
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ docs/*
 !docs/telemetry.md
 !docs/ARCHITECTURE.md
 coverage.out
+
+# stray root build artifacts (goreleaser uses dist/)
+/linearfs
+dist/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Contributor Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and maintainers pledge to make participation in the LinearFS
+project a harassment-free experience for everyone, regardless of age, body size, visible or
+invisible disability, ethnicity, sex characteristics, gender identity and expression, level
+of experience, education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Focusing on what is best for the project and community
+- Showing empathy toward other community members
+
+Examples of unacceptable behavior:
+
+- Harassment, insults, or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the
+maintainer at **github@porcnick.com**. All complaints will be reviewed and investigated
+promptly and fairly. The maintainer is obligated to respect the privacy and security of the
+reporter of any incident.
+
+Maintainers have the right to remove, edit, or reject comments, commits, code, issues, and
+other contributions that are not aligned with this Code of Conduct.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing to LinearFS
+
+Thanks for your interest — contributions are welcome. This document explains how the
+project works so your time is well spent and your PR lands smoothly.
+
+## What this project is (and how it's built)
+
+LinearFS is a FUSE filesystem that exposes [Linear](https://linear.app) as editable
+markdown files. It is **actively developed with heavy AI assistance** (Claude Code), which
+shapes a few things you should know up front:
+
+- **Commits are squash-merged**, one logical change per PR, titled
+  `type(scope): summary (#NN)` (e.g. `fix(fs): bound kernel-notify tail steps`). The history
+  is the changelog.
+- **The design is written down, not just implied.** Two living documents are load-bearing:
+  - [`CONTEXT.md`](CONTEXT.md) — the **domain & architecture vocabulary**. It names every
+    load-bearing concept (the *edit path*, the *WriteBack tail*, the *persist gate*, the
+    *sync reconcile tail*, …). Read the relevant section before touching an area; use its
+    terms in your PR so reviews share one language.
+  - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — the verified orientation map (data flow,
+    package seams, the two governing rules).
+- **Docs are part of the diff.** If your change reshapes a package seam, a data flow, or a
+  filesystem surface, update `CONTEXT.md` / `docs/ARCHITECTURE.md` **in the same PR**. The
+  generated mount README (`internal/fs`) and `docs/ARCHITECTURE.md` can silently lie about
+  behavior otherwise — see the discipline notes in [`CLAUDE.md`](CLAUDE.md).
+
+You do **not** need to use AI to contribute. Human PRs are equally welcome; the docs above
+are just how the codebase stays navigable.
+
+> **Stability:** this is a `v0` tool — breaking changes are acceptable and expected. Don't
+> let that stop you; it just means we optimize for the right design over backward
+> compatibility.
+
+## Getting set up
+
+Requirements: **Go 1.25+** and FUSE (`fuse3`/`libfuse3-dev` on Linux, macFUSE on macOS —
+see [`INSTALL.md`](INSTALL.md)).
+
+```bash
+git clone https://github.com/jra3/linear-fuse
+cd linear-fuse
+make build          # build ./bin/linearfs
+make test           # unit tests (no API key, no mount needed)
+make lint           # golangci-lint
+make staticcheck    # staticcheck (pinned version)
+make fmt            # gofmt
+```
+
+Unit tests run fully offline — no Linear API key, no FUSE mount. **Integration tests**
+default to SQLite fixtures (also offline); a live-API mode exists but is optional and
+budget-hungry:
+
+```bash
+go test ./internal/integration/...                              # fixtures (default)
+LINEARFS_LIVE_API=1 LINEAR_API_KEY=xxx go test ./internal/integration/...   # live, read-only
+```
+
+## The testing philosophy (important)
+
+The codebase testing strategy is **pure-projection extraction**: instead of mocking under
+FUSE node methods (which need a live inode tree), we extract the branchy decision logic into
+a **pure function or a small module behind a seam**, and unit-test *that* with fakes — no
+mount, no SQLite, no API. See `editflush.go`, `manifest.go`, the listing modules, and their
+`_test.go` twins for the pattern.
+
+When you add logic, prefer to put the decision in a pure surface and test it directly. A PR
+that adds branchy behavior only testable through a mounted filesystem will usually be asked
+to extract the decision first.
+
+## Submitting a change
+
+1. **Fork** and create a branch off `main` (any descriptive name — the `john/…` convention
+   in `CLAUDE.md` is the maintainer's personal one, not required of you).
+2. Make the change. Keep it **one logical unit** — smaller PRs review faster.
+3. Ensure green: `make test && make lint && make staticcheck`. Add tests for new behavior.
+4. Update `CONTEXT.md` / `docs/ARCHITECTURE.md` if you moved a seam or changed a surface.
+5. Open a PR against `main` with a `type(scope): summary` title and a body explaining
+   **what** and **why**. Link issues with `Closes #NN` / `Part of #NN`.
+
+CI runs unit tests under `-race`, staticcheck, `govulncheck`, and read-only integration
+tests. Write-integration tests run only on manual dispatch (they mutate real Linear data).
+
+## Reporting bugs & proposing features
+
+Use the [issue templates](https://github.com/jra3/linear-fuse/issues/new/choose). For bugs,
+the single most useful thing you can include is the contents of the relevant `.error` file
+(LinearFS writes the reason for every failed write there) plus `linearfs version` output.
+
+## Security
+
+Please **do not** file security issues as public GitHub issues. See [`SECURITY.md`](SECURITY.md).
+
+## License
+
+By contributing, you agree that your contributions are licensed under the project's
+[MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 Mount your Linear workspace as a FUSE filesystem. Browse and edit issues as markdown files.
 
+## Project status
+
+**LinearFS is a `v0` tool — capable and daily-usable, but with no stability guarantees.**
+Breaking changes are acceptable and expected. It is solo-maintained with heavy AI assistance,
+and **contributions are welcome** — see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+- **For:** CLI-first people who'd rather `ls`/`cat`/`grep`/`vim` their issues than click a UI,
+  and anyone scripting against Linear through ordinary file operations.
+- **Not for:** real-time collaboration (sync is eventually consistent) or production tooling
+  that needs a stable API — use Linear's [official API](https://developers.linear.app) for that.
+- **Handling secrets?** Read [SECURITY.md](SECURITY.md) before mounting, especially on a shared machine.
+- **Known limitations** are tracked in [KNOWN_ISSUES.md](KNOWN_ISSUES.md).
+
 ## Features
 
 - Browse teams, issues, projects, initiatives, and labels as directories/files
@@ -28,7 +41,7 @@ make install
 
 ### Requirements
 
-- **Go 1.21+**
+- **Go 1.25+**
 - **FUSE filesystem:**
   - **macOS:** macFUSE (`brew install --cask macfuse`)
     - ⚠️ Apple Silicon requires enabling kernel extensions in Recovery Mode
@@ -463,7 +476,10 @@ Lower values = fresher data but more API calls. Higher values = better performan
 
 - **No real-time sync**: Linear's WebSocket-based sync engine is internal only; the public API offers webhooks (requires HTTP server) but not subscriptions
 - **Eventual consistency**: Changes by teammates appear after TTL expiry
-- **Rate limits**: Linear allows 1,500 requests/hour with API key auth
+- **Rate limits**: Linear meters API keys on two axes — request count and query *complexity* —
+  and reports both on every response. LinearFS governs itself against the live limits from
+  those headers (a priority ladder sheds background detail fetches first). Bulk reads over a
+  large workspace can still exhaust the hourly budget; reads then fall back to the local cache.
 
 ## Configuration
 
@@ -511,6 +527,15 @@ systemctl --user start linearfs.service
 
 See [INSTALL.md](INSTALL.md#running-as-a-systemd-user-service-linux) for details.
 
+## Contributing
+
+Contributions are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md) — it explains the
+development workflow, the testing philosophy, and the two living design docs
+([`CONTEXT.md`](CONTEXT.md) and [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)) that keep the
+codebase navigable. Bugs and feature ideas go through the
+[issue templates](https://github.com/jra3/linear-fuse/issues/new/choose); security reports
+go through [SECURITY.md](SECURITY.md).
+
 ## License
 
-MIT
+[MIT](LICENSE) © John Allen

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not report security issues through public GitHub issues.**
+
+Report privately through
+[**GitHub's private vulnerability reporting**](https://github.com/jra3/linear-fuse/security/advisories/new)
+("Report a vulnerability" under the repository's **Security** tab). If that is unavailable,
+email **github@porcnick.com** with details.
+
+Please include a description, reproduction steps, and the impact you foresee. You can expect
+an initial acknowledgement within a few days. As a solo-maintained `v0` project, fix
+timelines are best-effort — but reports are taken seriously and credited unless you prefer
+otherwise.
+
+## Supported versions
+
+Only the latest `main` / most recent release is supported. There are no backported fixes.
+
+## Handling your Linear API key
+
+LinearFS acts entirely on behalf of your Linear API key, so the key **is** the security
+boundary. Treat it like a password:
+
+- **A LinearFS API key can read and write everything your Linear account can** — issues,
+  projects, comments, documents, labels — across every team you belong to. It cannot change
+  workspace settings, manage users, or see billing.
+- **Provide it via environment (`LINEAR_API_KEY`) or `~/.config/linearfs/config.yaml`.**
+  If you use the config file, restrict its permissions: `chmod 600 ~/.config/linearfs/config.yaml`.
+- **Never commit a key.** Keep it out of dotfiles you publish and out of shell history where
+  possible.
+- Rotate the key in Linear's settings if you suspect exposure; LinearFS picks up the new key
+  on restart.
+
+LinearFS does not log the API key (only operation names and variables are logged at debug
+level, never the `Authorization` header). If you find a path where a secret is logged,
+please report it as a vulnerability.
+
+## Mounted-filesystem exposure
+
+The mount inherits your user's umask. On a **shared machine**, other local users with
+filesystem access could read your Linear data through the mount depending on permissions.
+Mount with a restrictive umask (`umask 0077`) if this is a concern, and prefer a personal
+machine for sensitive workspaces.
+
+## Local cache
+
+LinearFS mirrors your workspace into a local SQLite database (default
+`~/.config/linearfs/cache.db`). It contains your Linear data in plaintext and is protected
+only by filesystem permissions — treat it with the same care as the mount. Deleting it is
+safe; it is a disposable cache and re-syncs on next start.


### PR DESCRIPTION
Positions the project for outside contributors — the first wave of a broader
project-maturity push (governance now; releases and testing/observability to follow).

## What's here
- **CONTRIBUTING.md** — dev setup, the pure-projection testing philosophy, PR flow, and an honest account of the AI-assisted workflow + the `CONTEXT.md`/`docs/ARCHITECTURE.md` "docs are part of the diff" discipline.
- **SECURITY.md** — private disclosure via GitHub advisories; frames the API key, the plaintext `cache.db`, and the mount umask as the real risk surfaces.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1.
- **Issue & PR templates** — the bug form asks for the `.error` file and `linearfs version`; questions/security route away from public issues.
- **Dependabot** — weekly gomod + actions updates.
- **CI** — a `govulncheck` job.
- **README** — a Project-status block (v0, who it's for/not) and a Contributing section; fixed two stale facts (Go 1.21→1.25; the old "1,500 requests/hour" line → the real two-axis, header-governed rate model).
- Removed a stray root build artifact; gitignored `/linearfs` and `dist/`.

## Manual follow-ups (repo settings, can't be done in a PR)
- Enable **private vulnerability reporting** (Security settings) — `SECURITY.md` links the advisory form.
- Enable **Discussions** — the issue-template config points questions there.
- Set repo **topics**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)