### PR TITLE
build: add release pipeline (goreleaser) + reproducible build stamping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,92 @@
+# goreleaser configuration — https://goreleaser.com
+# Cut a release by pushing a tag: `git tag -a v0.1.0 -m ... && git push origin v0.1.0`
+# The release workflow (.github/workflows/release.yml) runs this on tag push.
+version: 2
+
+project_name: linearfs
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: linearfs
+    main: ./cmd/linearfs
+    binary: linearfs
+    # go-fuse is pure Go, so cgo is not needed and cross-compilation is clean.
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/jra3/linear-fuse/internal/cmd.Version={{.Version}}
+      - -X github.com/jra3/linear-fuse/internal/cmd.GitCommit={{.ShortCommit}}
+      - -X github.com/jra3/linear-fuse/internal/cmd.BuildDate={{.CommitDate}}
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+archives:
+  - id: linearfs
+    formats: [tar.gz]
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    files:
+      - README.md
+      - LICENSE
+      - INSTALL.md
+      - KNOWN_ISSUES.md
+      - src: contrib/**/*
+        strip_parent: false
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-snapshot-{{ .ShortCommit }}"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - "^test:"
+      - "^chore:"
+      - "^ci:"
+      - "Merge pull request"
+      - "Merge branch"
+  groups:
+    - title: Features
+      regexp: '^feat(\(.+\))?:'
+      order: 0
+    - title: Fixes
+      regexp: '^fix(\(.+\))?:'
+      order: 1
+    - title: Refactors
+      regexp: '^refactor(\(.+\))?:'
+      order: 2
+    - title: Others
+      order: 999
+
+release:
+  github:
+    owner: jra3
+    name: linear-fuse
+  # v0.x tags remain flagged as pre-release until a stable line exists.
+  prerelease: auto
+  header: |
+    ## LinearFS {{ .Tag }}
+
+    A `v0` tool — no stability guarantees; breaking changes are expected.
+    See [README](https://github.com/jra3/linear-fuse#readme) and
+    [INSTALL.md](https://github.com/jra3/linear-fuse/blob/main/INSTALL.md).
+
+    **macOS binaries require [macFUSE](https://osxfuse.github.io) installed at runtime.**
+  footer: |
+    ---
+    Install from source instead: `go install github.com/jra3/linear-fuse/cmd/linearfs@{{ .Tag }}`

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,13 @@
 BINARY=linearfs
 VERSION?=dev
 COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-LDFLAGS=-ldflags "-X github.com/jra3/linear-fuse/internal/cmd.Version=$(VERSION) -X github.com/jra3/linear-fuse/internal/cmd.GitCommit=$(COMMIT)"
+# Commit date (not wall-clock) keeps `make build` reproducible for a given commit.
+DATE=$(shell git show -s --format=%cI HEAD 2>/dev/null || echo "unknown")
+PKG=github.com/jra3/linear-fuse/internal/cmd
+LDFLAGS=-ldflags "-X $(PKG).Version=$(VERSION) -X $(PKG).GitCommit=$(COMMIT) -X $(PKG).BuildDate=$(DATE)"
 
 build:
-	go build $(LDFLAGS) -o bin/$(BINARY) ./cmd/linearfs
+	go build -trimpath $(LDFLAGS) -o bin/$(BINARY) ./cmd/linearfs
 
 install: build
 	mkdir -p ~/.local/bin

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -2,13 +2,16 @@ package cmd
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/spf13/cobra"
 )
 
+// Build-stamped at link time via -ldflags (see Makefile / .goreleaser.yaml).
 var (
 	Version   = "dev"
 	GitCommit = "unknown"
+	BuildDate = "unknown"
 )
 
 var versionCmd = &cobra.Command{
@@ -16,6 +19,9 @@ var versionCmd = &cobra.Command{
 	Short: "Print version information",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("linearfs %s (%s)\n", Version, GitCommit)
+		fmt.Printf("  built:    %s\n", BuildDate)
+		fmt.Printf("  go:       %s\n", runtime.Version())
+		fmt.Printf("  platform: %s/%s\n", runtime.GOOS, runtime.GOARCH)
 	},
 }
 


### PR DESCRIPTION
Wave 2 of the maturity push — makes LinearFS installable without building from source.
(Recreated after #309 was auto-closed when #308's branch was deleted; content unchanged, now based directly on `main`.)

## What's here
- **`.goreleaser.yaml`** — cross-compiles linux+darwin / amd64+arm64 as **pure Go** (go-fuse needs no cgo), stamps version/commit/date, ships `tar.gz` archives with README/LICENSE/INSTALL/KNOWN_ISSUES/contrib, plus a grouped changelog + checksums.
- **`.github/workflows/release.yml`** — runs goreleaser on any `v*` tag push (`contents: write`, stock `GITHUB_TOKEN`).
- **Makefile** — `-trimpath` and a commit-date `BuildDate` stamp (reproducible per commit); new `internal/cmd.BuildDate` ldflag.
- **`linearfs version`** now also prints build date, Go version, and platform.

## Verified locally
- `goreleaser check` passes.
- `goreleaser build --snapshot` produced all four binaries: linux amd64/arm64 (ELF) + darwin amd64/arm64 (Mach-O).

🤖 Generated with [Claude Code](https://claude.com/claude-code)