### PR TITLE
test(integration): make the offline suite -count-safe

### DIFF
--- a/docs/plans/2026-07-18-integration-count-safety.md
+++ b/docs/plans/2026-07-18-integration-count-safety.md
@@ -1,0 +1,93 @@
+# Offline integration suite: `-count` safety
+
+## Problem
+
+The offline integration suite (`internal/integration`, fixture mode) is not safe
+under `go test -count=N` for `N > 1`. A single fresh-process run is reliably green
+(verified: 5/5 separate `go test -count=1` invocations pass), which is why CI —
+one run per fresh process — never sees it. But `-count=3` fails ~9 tests.
+
+This matters because **separate-process repeats are the way you prove the absence
+of flakes** (`for i in $(seq 20); do go test ./internal/integration/...; done`),
+and `-count` is the cheap in-process equivalent. A suite that can't survive
+`-count` can't be load-tested for real flakes, and the pollution it exposes is
+latent order-dependent risk even at `count=1`.
+
+## Root cause
+
+`TestMain` mounts the filesystem **once** over a store seeded with shared
+fixtures (`TST-1`, the `TST` team, `test-project`, …). Every test shares that one
+mount and store. A test that **mutates shared fixture state without restoring it**
+leaves debris that:
+
+1. breaks **itself** on the next in-process iteration (it assumes a clean start), and
+2. breaks later **reader** tests that observe the mutated fixture.
+
+The isolation boundary the suite actually supports is the **process** (fresh
+mount + freshly-seeded store), not the individual test. `-count` reuses the mount,
+so the debris accumulates.
+
+Two debris channels:
+
+- **Store rows** written directly (`testStore.Queries().UpsertIssue/UpsertTeam/UpsertLabel`)
+  or upserted with a mutation — never restored.
+- **Mount node state**: a store restore alone is not enough, because a live node
+  caches adopted content (and its 30s kernel entry timeout), so a later read
+  within the window still serves the polluted value. Cache-coherent restore would
+  need kernel invalidation the tests can't currently reach by inode.
+
+## Taxonomy of the failing tests
+
+| Test | Channel | Mechanism |
+|---|---|---|
+| `TestStaleCatalogWriteSelfHeals` | store label | Upserts label `TeammateFresh`, no cleanup. Rerun: label already present → resolve succeeds with **no refresh** → `refresh calls = []`. |
+| `TestNonexistentNameFailsAfterOneRefresh` | store issues | Creates a probe issue per run (accumulates); rerun records a **double** state refresh. |
+| `TestOffline_AtomicRenameEditPersists` | shared `TST-1` + scratch node | Restores via a mount write, but the consumed-scratch-node (`#280`) makes that restore unreliable across reruns → oscillates pass/fail. |
+| `TestRemoteUpdateVisibleAfterKernelRevalidation` | shared `TST-1` row | Upserts `TST-1` as "Renamed By Remote Sync", never restores. Rerun: `before` no longer contains "Test Issue 1". Also pollutes the `TestFixture*` readers of `TST-1`. |
+| `TestRemoteTeamUpdateVisibleAfterKernelRevalidation` | shared team row | Upserts the `TST` team renamed, never restores. |
+| `TestFixtureIssueFileDescription`, `…CommentsDirectoryListing`, `…CommentFileContents`, `…AttachmentsDirectoryListing`, `TestFixtureIssueMetaRelations` | — (victims) | Read shared `TST-1`; pass in isolation, fail only after a polluter ran. Heal once polluters are fixed. |
+
+## Fix strategy — self-contained tests, no new production seam
+
+The clean fix is to stop mutating **shared** fixtures. Each mutating test operates
+on a **unique-per-run throwaway entity** it creates and cleans up, so there is no
+shared state to pollute and no cross-run collision:
+
+- **`TestRemote*Revalidation`** — instead of renaming shared `TST-1` / the `TST`
+  team, create a throwaway issue / team with a unique id per run
+  (`iso-<name>-<UnixNano>`), upsert it (the mount serves it via store-backed
+  Lookup), pin it, mutate *it*, wait out the timeout, assert revalidation on *it*.
+  The go-fuse node-reuse path under test is identical on a throwaway node.
+  `t.Cleanup` deletes the throwaway rows. Nothing shared is touched.
+- **`TestOffline_AtomicRenameEditPersists`** — do the atomic-save-over-`issue.md`
+  dance on a throwaway issue's `issue.md`, not `TST-1`. The consumed-scratch-node
+  behavior is exercised the same way; the shared fixture is untouched, and there
+  is no cross-run marker to linger.
+- **`TestStaleCatalogWriteSelfHeals`** — the created label is throwaway already;
+  add `t.Cleanup` that deletes it from the store (`DeleteLabel`) so a rerun starts
+  with the local miss the test needs.
+- **`TestNonexistentNameFailsAfterOneRefresh`** — clean up the probe issue and
+  confirm the double-refresh is a consequence of accumulation; if it isn't,
+  diagnose the second refresh directly.
+- **Any remaining shared-fixture polluter** (a comment/attachment created on
+  `TST-1` by `t6_conformance`/others without cleanup) — create it on a throwaway
+  issue, or delete it in `t.Cleanup`.
+
+Where a throwaway isn't practical, delete the injected store rows in `t.Cleanup`
+(the pattern `TestRejectedSaveKeepsDirtyContentReadable` already uses:
+`testStore.DB().Exec("DELETE FROM …")`).
+
+## Verification
+
+1. Each fixed test passes in isolation at `-count=5`.
+2. Full suite passes `go test -count=20 ./internal/integration/...`.
+3. Separate-process repeats stay green (the pre-existing guarantee):
+   `for i in $(seq 10); do go test -count=1 ./internal/integration/...; done`.
+
+## Non-goals / recorded decisions
+
+- **No new production invalidation seam for tests.** The throwaway-entity approach
+  avoids needing cache-coherent restore of shared fixtures, so we don't add a
+  test-only `InvalidateIssueForTest` to `LinearFS`.
+- The process remains the documented isolation boundary; `-count` safety is an
+  additional guarantee this change buys, not a redefinition.

--- a/internal/integration/edit_persist_test.go
+++ b/internal/integration/edit_persist_test.go
@@ -85,14 +85,17 @@ func TestOffline_AtomicRenameEditPersists(t *testing.T) {
 	}
 	enableMockMutations(t)
 
-	path := issueFilePath(testTeamKey, "TST-1")
+	// Operate on a throwaway issue (unique per run), never the shared TST-1
+	// fixture: the atomic save consumes a scratch node (#280), and a mount-write
+	// restore of that reused node is unreliable across -count reruns (it
+	// oscillated pass/fail). A disposable issue needs no restore and cannot
+	// pollute the fixture readers.
+	identifier := createRefreshTestIssue(t, "Atomic Rename Persist Probe")
+	path := issueFilePath(testTeamKey, identifier)
 	orig, err := readFileWithRetry(path, defaultWaitTime)
 	if err != nil {
 		t.Fatalf("read issue.md: %v", err)
 	}
-	// Restore the original content through the mount so the shared fixture issue
-	// is left unchanged for other tests.
-	t.Cleanup(func() { claudeToolWrite(t, path, orig) })
 
 	doc, err := marshal.Parse(orig)
 	if err != nil {

--- a/internal/integration/staleness_test.go
+++ b/internal/integration/staleness_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -27,14 +28,40 @@ import (
 // stale content is the latent bug, confirmed end-to-end.
 func TestRemoteUpdateVisibleAfterKernelRevalidation(t *testing.T) {
 	ctx := context.Background()
-	path := mountPoint + "/teams/TST/issues/TST-1/issue.md"
+	if testStore == nil {
+		t.Skip("store-backed staleness simulation requires fixture mode")
+	}
+
+	// Drive the remote-update dance on a THROWAWAY issue (unique per run), never
+	// the shared TST-1 fixture: mutating TST-1 left the fixture readers — and
+	// every -count rerun's own baseline read — seeing "Renamed By Remote Sync".
+	// A store-upserted issue is served through the mount's dynamic issue Lookup,
+	// and the go-fuse node-reuse path under test is identical on a fresh node.
+	team := fixtures.FixtureAPITeam()
+	uniq := time.Now().UnixNano()
+	issueID := fmt.Sprintf("iso-issue-%d", uniq)
+	identifier := fmt.Sprintf("TST-%d", 90000+uniq%10000)
+	seedRow, err := db.APIIssueToDBIssue(fixtures.FixtureAPIIssue(
+		fixtures.WithIssueID(issueID, identifier),
+		fixtures.WithTitle("Isolation Probe Original"),
+		fixtures.WithTeam(&team),
+	))
+	if err != nil {
+		t.Fatalf("convert seed: %v", err)
+	}
+	if err := testStore.Queries().UpsertIssue(ctx, seedRow.ToUpsertParams()); err != nil {
+		t.Fatalf("seed upsert: %v", err)
+	}
+	t.Cleanup(func() { _ = testStore.Queries().DeleteIssue(context.Background(), issueID) })
+
+	path := mountPoint + "/teams/" + testTeamKey + "/issues/" + identifier + "/issue.md"
 
 	before, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("first read: %v", err)
 	}
-	if !strings.Contains(string(before), "Test Issue 1") {
-		t.Fatalf("fixture issue not served, got:\n%s", before)
+	if !strings.Contains(string(before), "Isolation Probe Original") {
+		t.Fatalf("throwaway issue not served, got:\n%s", before)
 	}
 
 	// Pin the inode chain: an open descriptor keeps the kernel from
@@ -52,9 +79,8 @@ func TestRemoteUpdateVisibleAfterKernelRevalidation(t *testing.T) {
 	// Simulate the sync worker landing a remote edit: same issue, new title,
 	// newer updatedAt — written straight to the store, no kernel notification
 	// (faithful to production sync).
-	team := fixtures.FixtureAPITeam()
 	renamed := fixtures.FixtureAPIIssue(
-		fixtures.WithIssueID("issue-1", "TST-1"),
+		fixtures.WithIssueID(issueID, identifier),
 		fixtures.WithTitle("Renamed By Remote Sync"),
 		fixtures.WithTeam(&team),
 	)
@@ -62,9 +88,6 @@ func TestRemoteUpdateVisibleAfterKernelRevalidation(t *testing.T) {
 	row, err := db.APIIssueToDBIssue(renamed)
 	if err != nil {
 		t.Fatalf("convert: %v", err)
-	}
-	if testStore == nil {
-		t.Skip("store-backed staleness simulation requires fixture mode")
 	}
 	if err := testStore.Queries().UpsertIssue(ctx, row.ToUpsertParams()); err != nil {
 		t.Fatalf("upsert: %v", err)
@@ -103,7 +126,7 @@ func TestRemoteUpdateVisibleAfterKernelRevalidation(t *testing.T) {
 	// every read (the freshestByID pattern) instead of trusting the captured
 	// entity. If .meta is fresh while issue.md is stale, the mechanism is
 	// pinned: go-fuse node reuse + entity captured at first Lookup.
-	meta, err := os.ReadFile(mountPoint + "/teams/TST/issues/TST-1/issue.meta")
+	meta, err := os.ReadFile(mountPoint + "/teams/" + testTeamKey + "/issues/" + identifier + "/issue.meta")
 	if err != nil {
 		t.Fatalf("read issue.meta: %v", err)
 	}
@@ -205,35 +228,51 @@ func TestRejectedSaveKeepsDirtyContentReadable(t *testing.T) {
 // took on when it moved these nodes off auto-assigned inos.
 func TestRemoteTeamUpdateVisibleAfterKernelRevalidation(t *testing.T) {
 	ctx := context.Background()
-	teamDir := mountPoint + "/teams/" + testTeamKey
+	if testStore == nil {
+		t.Skip("store-backed staleness simulation requires fixture mode")
+	}
+
+	// Drive the remote-update dance on a THROWAWAY team (unique key per run),
+	// never the shared TST team: renaming TST left every -count rerun's baseline
+	// read — and any later team.md reader — seeing "Renamed Team By Remote Sync".
+	// TeamsNode.Lookup resolves teams dynamically from the store, so a fresh
+	// upserted team is served, and the node-reuse path under test is identical.
+	uniq := time.Now().UnixNano()
+	teamID := fmt.Sprintf("iso-team-%d", uniq)
+	teamKey := fmt.Sprintf("IS%d", uniq%100000)
+	team := fixtures.FixtureAPITeam()
+	team.ID = teamID
+	team.Key = teamKey
+	team.Name = "Isolation Team Original"
+	if err := testStore.Queries().UpsertTeam(ctx, db.APITeamToDBTeam(team)); err != nil {
+		t.Fatalf("seed team: %v", err)
+	}
+	t.Cleanup(func() { _, _ = testStore.DB().Exec("DELETE FROM teams WHERE id = ?", teamID) })
+
+	teamDir := mountPoint + "/teams/" + teamKey
 	teamFile := teamDir + "/team.md"
 
 	before, err := os.ReadFile(teamFile)
 	if err != nil {
 		t.Fatalf("first read: %v", err)
 	}
-	if !strings.Contains(string(before), "Test Team") {
-		t.Fatalf("fixture team not served, got:\n%s", before)
+	if !strings.Contains(string(before), "Isolation Team Original") {
+		t.Fatalf("throwaway team not served, got:\n%s", before)
 	}
 
 	// Pin the team directory: an open descriptor keeps the kernel from
 	// FORGETting the dir inode and its ancestor dentries, so the post-expiry
-	// re-Lookup of "TST" hits the ALREADY-KNOWN TeamNode — the go-fuse reuse
-	// path this test exists to guard.
+	// re-Lookup hits the ALREADY-KNOWN TeamNode — the go-fuse reuse path this
+	// test exists to guard.
 	pin, err := os.Open(teamDir)
 	if err != nil {
 		t.Fatalf("pin open: %v", err)
 	}
 	defer pin.Close()
 
-	if testStore == nil {
-		t.Skip("store-backed staleness simulation requires fixture mode")
-	}
-
 	// Simulate the sync worker landing a remote team edit: same team, new
 	// name, newer updatedAt — written straight to the store, no kernel
 	// notification (faithful to production sync).
-	team := fixtures.FixtureAPITeam()
 	team.Name = "Renamed Team By Remote Sync"
 	team.UpdatedAt = time.Now()
 	if err := testStore.Queries().UpsertTeam(ctx, db.APITeamToDBTeam(team)); err != nil {

--- a/internal/integration/t6_conformance_test.go
+++ b/internal/integration/t6_conformance_test.go
@@ -294,13 +294,16 @@ func TestWriteContractCreateTrioUniform(t *testing.T) {
 		t.Error("relations/.last has no entry after a relation create")
 	}
 
-	// An attachment create reports its identity to attachments/.last.
+	// An attachment create reports its identity to attachments/.last. Created on
+	// a throwaway issue (unique per run), never shared TST-1, so it doesn't
+	// accumulate into the fixture attachment count on a -count rerun.
+	attIssue := createRefreshTestIssue(t, "T6 Attachment Probe")
 	attURL := "https://example.com/trio-probe/1"
-	if err := os.WriteFile(filepath.Join(attachmentsPath(testTeamKey, "TST-1"), "_create"), []byte(attURL+" Trio Probe"), 0200); err != nil {
+	if err := os.WriteFile(filepath.Join(attachmentsPath(testTeamKey, attIssue), "_create"), []byte(attURL+" Trio Probe"), 0200); err != nil {
 		t.Fatalf("create attachment: %v", err)
 	}
 	afound := false
-	for _, e := range parseLastSidecar(t, filepath.Join(attachmentsPath(testTeamKey, "TST-1"), ".last")) {
+	for _, e := range parseLastSidecar(t, filepath.Join(attachmentsPath(testTeamKey, attIssue), ".last")) {
 		if e["url"] == attURL {
 			afound = true
 		}
@@ -470,13 +473,16 @@ func TestWriteContractAgentLoop(t *testing.T) {
 	}
 
 	// (a2) A non-issue create surface also reports to its .last: create a comment
-	// on TST-1 and confirm comments/.last gains an entry (guards the other five
-	// AppendWriteSuccess producers beyond team-issue creates).
+	// on a throwaway issue (unique per run, not shared TST-1 — else the comment
+	// accumulates into the fixture comment count on a -count rerun) and confirm
+	// comments/.last gains an entry (guards the other five AppendWriteSuccess
+	// producers beyond team-issue creates).
+	commentIssue := createRefreshTestIssue(t, "T6 Comment Probe")
 	commentBody := "agentloop comment marker"
-	if err := os.WriteFile(newCommentPath(testTeamKey, "TST-1"), []byte(commentBody), 0200); err != nil {
+	if err := os.WriteFile(newCommentPath(testTeamKey, commentIssue), []byte(commentBody), 0200); err != nil {
 		t.Fatalf("create comment: %v", err)
 	}
-	commentsLast := filepath.Join(commentsPath(testTeamKey, "TST-1"), ".last")
+	commentsLast := filepath.Join(commentsPath(testTeamKey, commentIssue), ".last")
 	cfound := false
 	for _, e := range parseLastSidecar(t, commentsLast) {
 		if strings.Contains(e["title"], "agentloop comment marker") {

--- a/internal/integration/validation_refresh_test.go
+++ b/internal/integration/validation_refresh_test.go
@@ -3,11 +3,13 @@ package integration
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	gosync "sync"
 	"testing"
+	"time"
 
 	"github.com/jra3/linear-fuse/internal/api"
 	"github.com/jra3/linear-fuse/internal/db"
@@ -51,9 +53,15 @@ func (r *refreshCalls) snapshot() []string {
 }
 
 // createRefreshTestIssue creates a fresh fixture issue via issues/_create (so
-// the shared fixture issues stay untouched) and returns its identifier.
+// the shared fixture issues stay untouched) and returns its identifier. The
+// title is made UNIQUE per call so a later in-process rerun (-count) creates a
+// distinct issue with a fresh node — reusing the same identifier would inherit
+// the prior run's leftover dirty edit buffer (a failed validation write keeps
+// the buffer dirty), which re-flushes on the next write and double-counts
+// resolution/refresh attempts.
 func createRefreshTestIssue(t *testing.T, title string) string {
 	t.Helper()
+	title = fmt.Sprintf("%s %d", title, time.Now().UnixNano())
 	if err := writeCreateSpec(t, "---\ntitle: "+title+"\n---\nrefresh-retry probe body\n"); err != nil {
 		t.Fatalf("create probe issue: %v", err)
 	}
@@ -88,9 +96,16 @@ func TestStaleCatalogWriteSelfHeals(t *testing.T) {
 	enableMockMutations(t)
 	identifier := createRefreshTestIssue(t, "Stale Catalog Self-Heal Probe")
 
+	const freshLabelID = "label-teammate-fresh"
+	// The test's whole premise is a LOCAL MISS on this label; the injected
+	// refresh "discovers" it by upserting it into the store. Delete it on
+	// cleanup so a later in-process rerun (-count) starts from the same miss
+	// instead of resolving immediately and firing no refresh.
+	t.Cleanup(func() { _ = testStore.Queries().DeleteLabel(context.Background(), freshLabelID) })
+
 	rec := catalogRefreshRecorder(t, func(ctx context.Context) error {
 		label := api.Label{
-			ID:    "label-teammate-fresh",
+			ID:    freshLabelID,
 			Name:  "TeammateFresh",
 			Color: "#00ff00",
 			Team:  &api.Team{ID: testTeamID},


### PR DESCRIPTION
Wave 3 (testing maturity). The offline integration suite passed a single fresh-process run — so CI was green — but failed under `go test -count=N` (N>1). That blocked using load runs to *prove* the absence of real flakes, and was latent order-dependent risk even at count=1.

## Root cause
`TestMain` mounts once over a store seeded with shared fixtures (`TST-1`, the `TST` team, catalog labels). Several tests mutated those shared fixtures without restoring them, so in-process reruns — and, order-dependently, later reader tests — saw the debris. The suite's real isolation boundary is the **process**; `-count` reuses the mount.

## Fix — self-contained tests, no new production seam
Each mutating test now operates on a **unique-per-run throwaway entity** it cleans up, instead of a shared fixture:
- **validation_refresh** — `createRefreshTestIssue` mints a unique title per call (a reused issue inherited the prior run's leftover **dirty edit buffer**, which re-flushed and *double-counted the refresh*); `TestStaleCatalogWriteSelfHeals` deletes its injected label on cleanup.
- **edit_persist AtomicRename** — atomic-save dance on a throwaway issue, not `TST-1` (the consumed-scratch-node behavior `#280` made a mount-write restore of the reused node unreliable → oscillated pass/fail).
- **staleness Remote\*Revalidation** — seed a throwaway issue / team and drive the remote-update + 31s kernel-revalidation on it (Lookup resolves dynamically from the store, so a fresh upsert is served).
- **t6_conformance** — the `.last`-reporting comment/attachment probes create on a throwaway issue, so they don't accumulate into the fixture counts the reader tests assert.

## Verified
- full suite `-count=3` green (real 31s waits)
- `-short -count=20` green (fast cross-pollution sweep)
- the two staleness tests `-count=2` green with the real waits
- 3 fresh-process runs green (CI condition unchanged)

Spec (root cause, taxonomy, per-test fix, verification): `docs/plans/2026-07-18-integration-count-safety.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)