### PR TITLE
test: fuzz the listing filename round-trips and SQLite time parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ go.work.sum
 .claude/settings.local.json
 docs/*
 !docs/plans/
+!docs/adr/
 !docs/telemetry.md
 !docs/ARCHITECTURE.md
 coverage.out

--- a/docs/adr/0001-filename-sanitization-is-per-entity.md
+++ b/docs/adr/0001-filename-sanitization-is-per-entity.md
@@ -1,0 +1,33 @@
+# Filename sanitization is per-entity, not unified
+
+Each collection derives its filenames with its own small function — `labelFilename`,
+`documentFilename`, `milestoneFilename` (all `internal/fs`), and attachments' `linkName`
+(via the shared `sanitizeFilename`). Only `sanitizeFilename` has a full safety floor
+(strips NUL, trims dots, maps empty → `untitled`); the other three only replace path
+separators. We deliberately keep them separate rather than routing all four through one
+sanitizer.
+
+## Why
+
+The four derivations differ in **style**, not just safety: labels and documents hyphenate
+spaces, documents lowercase, milestones and attachments keep spaces, documents short-circuit
+to the unique `SlugID`, and the extension is `.md` vs `.link`. A single sanitizer would have
+to carry all that variation as parameters — interface width for four callers.
+
+The safety gap is **not reachable in practice**: these are *virtual FUSE names* used only as
+Lookup-matching keys (`entries()` and `find()` re-derive through the same function, and entity
+resolution goes through the raw `Name`, never the filename), so a weird-but-deterministic name
+is never stranded — it round-trips. The only inputs the missing floor would change are NUL
+bytes, all-dots, and empty names, which Linear entity names essentially never are. Unifying
+would be near-zero-real-behavior-change hardening that nonetheless churns existing filenames
+for the pathological cases and adds a filename-round-trip test obligation across all four.
+
+## Consequences
+
+- The `FuzzSanitizeFilename` target holds **only `sanitizeFilename`** to the path-safety bar
+  (no `/` `\` NUL, never `""` / `.` / `..`). The entity derivations are fuzzed for
+  `listed ⇒ openable` and emit-once only — the invariants they actually uphold.
+- If a real need for uniform path-safety appears (e.g. Linear starts permitting control
+  characters in names), the unification is a standalone production PR: extract a `safeName`
+  floor, compose each entity's existing style on top, and pin every derivation with a
+  filename-round-trip test. This ADR is the license to do it then, not now.

--- a/internal/db/timeparse_fuzz_test.go
+++ b/internal/db/timeparse_fuzz_test.go
@@ -1,0 +1,78 @@
+package db
+
+import (
+	"testing"
+	"time"
+)
+
+// timeparseSeedCorpus seeds the no-panic target with one example of each of the
+// 7 layouts ParseSQLiteTime knows, plus garbage the parser must reject cleanly
+// (return the zero time, never panic).
+var timeparseSeedCorpus = []string{
+	"2026-01-02T15:04:05Z",                  // RFC3339
+	"2026-01-02T15:04:05.017Z",              // RFC3339Nano
+	"2026-01-02 15:04:05.999999999-07:00",   // SQLite w/ tz, nanos
+	"2026-01-02 15:04:05.999999999Z07:00",   // SQLite w/ Z-form tz, nanos
+	"2026-01-02 15:04:05-07:00",             // SQLite w/ tz
+	"2026-01-02 15:04:05Z07:00",             // SQLite Z-form tz
+	"2026-01-02 15:04:05",                   // SQLite no tz
+	"",                                      // empty
+	"not a time",                            // garbage
+	"2026-13-45 99:99:99",                   // out-of-range fields
+	"9999999999999999999999999999999999999", // overflow-ish
+	"\x00\x00\x00",                          // NUL bytes
+	"0000-00-00 00:00:00",                   // zero-ish
+}
+
+// FuzzParseSQLiteTimeNoPanic asserts ParseSQLiteTime survives arbitrary input:
+// it parses these strings straight out of SQLite and the API, so the contract is
+// "a time or the zero time, never a panic."
+func FuzzParseSQLiteTimeNoPanic(f *testing.F) {
+	for _, s := range timeparseSeedCorpus {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		_ = ParseSQLiteTime(s) // contract: no panic
+	})
+}
+
+// FuzzParseSQLiteTimeRoundTrip asserts the string-fixpoint property per layout:
+// for a time built from clamped components, formatting it with a layout and
+// re-parsing must format back to the identical string. This is a STRING fixpoint,
+// not a time-equality one — a layout that drops the zone or sub-seconds still
+// passes, because we compare the re-formatted string to the original formatted
+// string under the same layout.
+func FuzzParseSQLiteTimeRoundTrip(f *testing.F) {
+	f.Add(int64(1767366245), int64(17000000), 0)     // 2026-01-02T15:04:05.017Z, UTC
+	f.Add(int64(0), int64(0), 0)                     // epoch
+	f.Add(int64(4102444800), int64(999999999), -420) // 2100, -07:00
+	f.Add(int64(1000000000), int64(500000000), 330)  // +05:30 (half-hour zone)
+	f.Fuzz(func(t *testing.T, sec, nsec int64, offMin int) {
+		// Clamp components to the ranges a real timestamp inhabits.
+		if sec < 0 {
+			sec = -sec
+		}
+		sec %= 4102444801 // [0, 4102444800] -> ~1970..2100
+		if nsec < 0 {
+			nsec = -nsec
+		}
+		nsec %= 1_000_000_000 // [0, 1e9)
+		// offMin into [-840, 840] (UTC-14 .. UTC+14).
+		if offMin < 0 {
+			offMin = -offMin
+		}
+		offMin = offMin%1681 - 840 // [-840, 840]
+
+		zone := time.FixedZone("fuzz", offMin*60)
+		base := time.Unix(sec, nsec).In(zone)
+
+		for _, layout := range sqliteTimeFormats {
+			s := base.Format(layout)
+			got := ParseSQLiteTime(s)
+			if got.Format(layout) != s {
+				t.Fatalf("string-fixpoint broken for layout %q:\n formatted=%q\n reparsed =%q",
+					layout, s, got.Format(layout))
+			}
+		}
+	})
+}

--- a/internal/fs/listing_fuzz_test.go
+++ b/internal/fs/listing_fuzz_test.go
@@ -1,0 +1,344 @@
+package fs
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jra3/linear-fuse/internal/api"
+)
+
+// listingSeedCorpus is shared by the listing fuzz targets: realistic entity
+// names plus the adversarial inputs that break a name->file->name round trip —
+// path separators (`/`, `\`), NUL, all-dots (`.`, `..`, `...`), unicode, empty,
+// duplicate names, a very long name, and leading/trailing spaces/dots. Each
+// target splits these on `\n` into a set of item names, so a single seed doubles
+// as both a realistic single name and a duplicate-heavy multi-item list.
+var listingSeedCorpus = []string{
+	"",
+	"Bug",
+	"Backend\nFrontend\nBug",
+	"Bug\nBug\nBug", // duplicate names -> exercises emit-once / dedup
+	"a/b/c",
+	"a\\b\\c",
+	"with\x00nul",
+	".",
+	"..",
+	"...",
+	"   ",
+	" leading and trailing dots. ",
+	"...leading.dots...",
+	"café ☃ 日本語",
+	"Q3: Bets",
+	"has\nnewline\nembedded",
+	strings.Repeat("x", 4096), // very long name
+	"foo.png\nfoo.png\nfoo",   // attachment-style collision across extensions
+	"blocks\nduplicate\nrelated\nsimilar",
+}
+
+// splitNames turns a `\n`-separated fuzz string into the item names a listing is
+// built from. It intentionally keeps empty segments — an empty name is a real
+// input the derivations must survive.
+func splitNames(s string) []string {
+	return strings.Split(s, "\n")
+}
+
+// assertListedImpliesOpenable is the core listing contract shared by every
+// name-derived listing: every name entries() emits, find() must resolve. A
+// stranded name (listed but unopenable) is a broken readdir/lookup pair.
+func assertListedImpliesOpenable[E any](t *testing.T, label string, names []string, find func(string) (E, bool)) {
+	t.Helper()
+	for _, name := range names {
+		if _, ok := find(name); !ok {
+			t.Fatalf("%s: listed name %q not openable via find()", label, name)
+		}
+	}
+}
+
+// assertEmitOnce asserts entries() never emits the same name twice — the
+// first-wins/emit-once contract of namedListing and relationListing.
+func assertEmitOnce(t *testing.T, label string, names []string) {
+	t.Helper()
+	seen := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if _, dup := seen[name]; dup {
+			t.Fatalf("%s: entries() emitted duplicate name %q", label, name)
+		}
+		seen[name] = struct{}{}
+	}
+}
+
+// FuzzNamedListing drives the three real entity->filename derivations (labels,
+// documents, milestones) through namedListing. For each derivation it asserts
+// listed⇒openable and emit-once. Per ADR-0001, path-safety is NOT asserted on
+// these derivations — only on sanitizeFilename (FuzzSanitizeFilename). The
+// derivations only uphold listed⇒openable and emit-once, because entries() and
+// find() re-derive through the same function, so a weird-but-deterministic name
+// round-trips even without a full safety floor.
+func FuzzNamedListing(f *testing.F) {
+	for _, s := range listingSeedCorpus {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, raw string) {
+		names := splitNames(raw)
+
+		labels := make([]api.Label, len(names))
+		docs := make([]api.Document, len(names))
+		milestones := make([]api.ProjectMilestone, len(names))
+		for i, n := range names {
+			labels[i] = api.Label{Name: n}
+			// SlugID="" forces the title-sanitization path in documentFilename
+			// (the slug shortcut would bypass the derivation under test).
+			docs[i] = api.Document{Title: n, SlugID: ""}
+			milestones[i] = api.ProjectMilestone{Name: n}
+		}
+
+		labelListing := namedListing[api.Label]{items: labels, nameOf: labelFilename}
+		docListing := namedListing[api.Document]{items: docs, nameOf: documentFilename}
+		msListing := namedListing[api.ProjectMilestone]{items: milestones, nameOf: milestoneFilename}
+
+		// entries()/emit-once and listed⇒openable per derivation.
+		{
+			entries := labelListing.entries()
+			emitted := make([]string, len(entries))
+			for i, e := range entries {
+				emitted[i] = e.Name
+			}
+			assertEmitOnce(t, "labels", emitted)
+			assertListedImpliesOpenable(t, "labels", emitted, labelListing.find)
+		}
+		{
+			entries := docListing.entries()
+			emitted := make([]string, len(entries))
+			for i, e := range entries {
+				emitted[i] = e.Name
+			}
+			assertEmitOnce(t, "documents", emitted)
+			assertListedImpliesOpenable(t, "documents", emitted, docListing.find)
+		}
+		{
+			entries := msListing.entries()
+			emitted := make([]string, len(entries))
+			for i, e := range entries {
+				emitted[i] = e.Name
+			}
+			assertEmitOnce(t, "milestones", emitted)
+			assertListedImpliesOpenable(t, "milestones", emitted, msListing.find)
+		}
+	})
+}
+
+// FuzzIndexedListing drives indexedListing with position-derived names
+// (updateEntryName). Names are index-derived so they must be pairwise distinct;
+// the target also assigns synthetic (and deliberately colliding) timestamps to
+// exercise equal-lessKey ties, and asserts entries()/find() agree under those
+// ties.
+func FuzzIndexedListing(f *testing.F) {
+	for _, s := range listingSeedCorpus {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, raw string) {
+		names := splitNames(raw)
+
+		// synthUpdate carries a name (used as the "health" segment), plus a
+		// timestamp that intentionally collides across items (i/2) to force
+		// equal-lessKey ties.
+		type synthUpdate struct {
+			health string
+			at     time.Time
+		}
+		base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		items := make([]synthUpdate, len(names))
+		for i, n := range names {
+			items[i] = synthUpdate{
+				health: n,
+				at:     base.Add(time.Duration(i/2) * time.Hour), // ties every two items
+			}
+		}
+
+		l := indexedListing[synthUpdate]{
+			items:   items,
+			lessKey: func(u synthUpdate) time.Time { return u.at },
+			nameOf: func(i int, u synthUpdate) string {
+				return updateEntryName(i, u.at, u.health)
+			},
+		}
+
+		entries := l.entries()
+		emitted := make([]string, len(entries))
+		for i, e := range entries {
+			emitted[i] = e.Name
+		}
+
+		// Names are position-derived (the %04d index prefix), so they must be
+		// pairwise distinct regardless of duplicate healths or tied timestamps.
+		seen := make(map[string]struct{}, len(emitted))
+		for _, name := range emitted {
+			if _, dup := seen[name]; dup {
+				t.Fatalf("indexed: entries() emitted duplicate name %q (names must be position-distinct)", name)
+			}
+			seen[name] = struct{}{}
+		}
+
+		// listed⇒openable, and entries()/find() agree even under equal-lessKey
+		// ties: sorted() is stable, so both surfaces share one order.
+		assertListedImpliesOpenable(t, "indexed", emitted, l.find)
+	})
+}
+
+// FuzzAttachmentListing drives attachmentListing with both item families —
+// embedded files (named by Filename) and external attachments (named by
+// linkName(Title)). It asserts listed⇒openable and the dedup contract: every
+// name entries() emits is pairwise unique across BOTH families (one counter
+// spans embedded then external).
+func FuzzAttachmentListing(f *testing.F) {
+	for _, s := range listingSeedCorpus {
+		f.Add(s, "")
+	}
+	// A couple of seeds that cross the two families deliberately.
+	f.Add("foo.link", "foo")
+	f.Add("image.png\nimage.png", "image.png")
+	f.Fuzz(func(t *testing.T, embeddedRaw, externalRaw string) {
+		embNames := splitNames(embeddedRaw)
+		extNames := splitNames(externalRaw)
+
+		embedded := make([]api.EmbeddedFile, len(embNames))
+		for i, n := range embNames {
+			embedded[i] = api.EmbeddedFile{Filename: n}
+		}
+		external := make([]api.Attachment, len(extNames))
+		for i, n := range extNames {
+			external[i] = api.Attachment{Title: n}
+		}
+
+		l := attachmentListing{embedded: embedded, external: external}
+		entries := l.entries()
+		emitted := make([]string, len(entries))
+		for i, e := range entries {
+			emitted[i] = e.name
+		}
+
+		// Dedup contract: all emitted names pairwise unique.
+		seen := make(map[string]struct{}, len(emitted))
+		for _, name := range emitted {
+			if _, dup := seen[name]; dup {
+				t.Fatalf("attachments: entries() emitted duplicate name %q (dedup contract violated)", name)
+			}
+			seen[name] = struct{}{}
+		}
+
+		// listed⇒openable: every emitted name replays through find().
+		for _, name := range emitted {
+			if _, ok := l.find(name); !ok {
+				t.Fatalf("attachments: listed name %q not openable via find()", name)
+			}
+		}
+	})
+}
+
+// FuzzRelationListing drives relationListing with both directions. Outgoing
+// relations derive from Type + RelatedIssue.Identifier; inverse from
+// inverseRelationType(Type) + Issue.Identifier. It asserts listed⇒openable and
+// emit-once, and that nil-issue / empty-identifier entries are correctly
+// skipped (never emitted, never resolvable).
+func FuzzRelationListing(f *testing.F) {
+	for _, s := range listingSeedCorpus {
+		f.Add(s, "")
+	}
+	f.Add("blocks\nduplicate\nrelated\nsimilar", "blocks\nrelated")
+	relTypes := []string{"blocks", "duplicate", "related", "similar", "custom"}
+	f.Fuzz(func(t *testing.T, outgoingRaw, inverseRaw string) {
+		outNames := splitNames(outgoingRaw)
+		invNames := splitNames(inverseRaw)
+
+		// Build outgoing relations. Every 4th item gets a nil RelatedIssue or an
+		// empty identifier to exercise the skip path.
+		outgoing := make([]api.IssueRelation, 0, len(outNames))
+		for i, ident := range outNames {
+			rel := api.IssueRelation{Type: relTypes[i%len(relTypes)]}
+			switch i % 4 {
+			case 0:
+				rel.RelatedIssue = nil // skip: nil issue
+			case 1:
+				rel.RelatedIssue = &api.ParentIssue{Identifier: ""} // skip: empty identifier
+			default:
+				rel.RelatedIssue = &api.ParentIssue{Identifier: ident}
+			}
+			outgoing = append(outgoing, rel)
+		}
+
+		inverse := make([]api.IssueRelation, 0, len(invNames))
+		for i, ident := range invNames {
+			rel := api.IssueRelation{Type: relTypes[i%len(relTypes)]}
+			switch i % 4 {
+			case 0:
+				rel.Issue = nil // skip: nil issue
+			case 1:
+				rel.Issue = &api.ParentIssue{Identifier: ""} // skip: empty identifier
+			default:
+				rel.Issue = &api.ParentIssue{Identifier: ident}
+			}
+			inverse = append(inverse, rel)
+		}
+
+		l := relationListing{outgoing: outgoing, inverse: inverse}
+		entries := l.entries()
+		emitted := make([]string, len(entries))
+		for i, e := range entries {
+			emitted[i] = e.name
+		}
+
+		assertEmitOnce(t, "relations", emitted)
+		for _, name := range emitted {
+			if _, ok := l.find(name); !ok {
+				t.Fatalf("relations: listed name %q not openable via find()", name)
+			}
+		}
+
+		// Skipped entries (nil issue / empty identifier) never appear. A name
+		// derived from an empty identifier would end in "-.rel"; assert none of
+		// the *skipped* shapes leaked. We can't reconstruct exact skipped names
+		// cheaply, but we can assert the count: entries() must not exceed the
+		// number of non-skipped inputs.
+		nonSkipped := 0
+		for i := range outgoing {
+			if outgoing[i].RelatedIssue != nil && outgoing[i].RelatedIssue.Identifier != "" {
+				nonSkipped++
+			}
+		}
+		for i := range inverse {
+			if inverse[i].Issue != nil && inverse[i].Issue.Identifier != "" {
+				nonSkipped++
+			}
+		}
+		if len(entries) > nonSkipped {
+			t.Fatalf("relations: entries()=%d exceeds non-skipped inputs=%d (skip path leaked)", len(entries), nonSkipped)
+		}
+	})
+}
+
+// FuzzSanitizeFilename holds sanitizeFilename — and only sanitizeFilename, per
+// ADR-0001 — to the path-safety bar: the output never contains `/`, `\`, or NUL,
+// and is never "", ".", or "..". These are the properties a name used as a
+// virtual filename must have; the per-entity derivations deliberately do not
+// carry this floor (see ADR-0001 and FuzzNamedListing).
+func FuzzSanitizeFilename(f *testing.F) {
+	for _, s := range listingSeedCorpus {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		out := sanitizeFilename(s)
+		if strings.Contains(out, "/") {
+			t.Errorf("sanitizeFilename(%q) = %q contains '/'", s, out)
+		}
+		if strings.Contains(out, "\\") {
+			t.Errorf("sanitizeFilename(%q) = %q contains '\\'", s, out)
+		}
+		if strings.Contains(out, "\x00") {
+			t.Errorf("sanitizeFilename(%q) = %q contains NUL", s, out)
+		}
+		if out == "" || out == "." || out == ".." {
+			t.Errorf("sanitizeFilename(%q) = %q is not a usable filename", s, out)
+		}
+	})
+}


### PR DESCRIPTION
Second fuzz batch (after the marshal parse/render seam), extending fuzzing to the other pure input-shaping surfaces. **Test-only — no production code changed.** Design was grilled to a locked spec before building.

## `internal/fs/listing_fuzz_test.go` — 5 targets over the *real* derivations
| Target | Asserts |
|---|---|
| `FuzzNamedListing` | labels/docs/milestones through the real `*Filename` funcs — `listed ⇒ openable` + emit-once |
| `FuzzIndexedListing` | position-derived names pairwise distinct; `entries()`/`find()` agree under equal-lessKey ties |
| `FuzzAttachmentListing` | dedup contract — every emitted name pairwise unique across embedded + external |
| `FuzzRelationListing` | emit-once, `listed ⇒ openable`, nil-issue/empty-identifier entries skipped |
| `FuzzSanitizeFilename` | path-safety (no `/` `\` NUL, never `""`/`.`/`..`) — on `sanitizeFilename` **only** (ADR-0001) |

## `internal/db/timeparse_fuzz_test.go` — 2 targets
- `FuzzParseSQLiteTimeNoPanic` — arbitrary strings, no-panic.
- `FuzzParseSQLiteTimeRoundTrip` — per-layout **string-fixpoint** (`format→parse→format`) across all 7 `sqliteTimeFormats`, components clamped to ~1970–2100 / ±14h so findings are reachable, not year-10000 formatting noise.

## Result
~60s/target locally (1.8M–4M execs each), **no crashers, no findings** — the derivations round-trip by construction (`entries()`/`find()` re-derive through the same function) and `ParseSQLiteTime` is a clean fixpoint. Seeds run in the normal `-race` job as a regression corpus; no dedicated fuzz CI job.

## Docs
- **ADR-0001** records the load-bearing scoping decision — *filename sanitization stays per-entity; path-safety is only `sanitizeFilename`'s contract* — so a future round (or the fuzzer) doesn't re-litigate it. This is the repo's first ADR.
- `.gitignore`: un-ignore `docs/adr/` so ADRs are tracked (the repo whitelists `docs/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)