### PR TITLE
refactor(fs): extract parseLinkInput, then fuzz the _create command parsers

### DIFF
--- a/internal/fs/attachments.go
+++ b/internal/fs/attachments.go
@@ -281,7 +281,7 @@ func (n *AttachmentsNode) createAttachment(ctx context.Context, raw []byte) sysc
 	// cache pre-check returns 0 without a .last entry (nothing was created);
 	// the authoritative post-failure re-check inside mutate treats a stale-cache
 	// miss as the created attachment.
-	if url := strings.SplitN(content, " ", 2)[0]; url != "" {
+	if url, _ := parseLinkInput(content); url != "" {
 		if existing, err := n.lfs.repo.GetIssueAttachments(ctx, n.issueID); err == nil {
 			for _, att := range existing {
 				if attachmentURLsEqual(att.URL, url) {
@@ -299,14 +299,7 @@ func (n *AttachmentsNode) createAttachment(ctx context.Context, raw []byte) sysc
 			if content == "" {
 				return nil, &FieldError{Field: "content", Message: `empty content. Write "<url> [title]".`}
 			}
-			// Parse the content: "url [title]" or just "url" (title defaults
-			// to the URL).
-			parts := strings.SplitN(content, " ", 2)
-			url := parts[0]
-			title := url
-			if len(parts) > 1 {
-				title = parts[1]
-			}
+			url, title := parseLinkInput(content)
 
 			att, err := n.lfs.mutator().LinkURL(ctx, n.issueID, url, title)
 			if err == nil {

--- a/internal/fs/createparse_fuzz_test.go
+++ b/internal/fs/createparse_fuzz_test.go
@@ -1,0 +1,85 @@
+package fs
+
+import (
+	"strings"
+	"testing"
+)
+
+// createParseSeedCorpus feeds the two write-only _create command parsers
+// (parseLinkInput, parseRelationInput). These parse arbitrary bytes a user
+// writes into relations/_create, links/_create, or attachments/_create through
+// the mount, so the contract is "structured result or clean error, never a
+// crash." The corpus mixes realistic commands with adversarial whitespace,
+// bare tokens, unicode, NUL, and an oversized input.
+var createParseSeedCorpus = []string{
+	"",
+	" ",
+	"   ",
+	"\t\n ",
+	"https://example.com",
+	"https://example.com Label here",
+	"https://example.com [Bracketed Label]",
+	"blocks ENG-123",
+	"related",
+	"duplicate TEAM-1",
+	"similar\tPROJ-9", // tab: Fields splits it (relations), SplitN(" ") does not (links)
+	"blocks",          // a bare type name — becomes the identifier for relations
+	"  leading spaces then url",
+	"url\nwith\nnewlines",
+	"a b c d e",
+	"nospaceurl",
+	"café ☃ 日本語",
+	"has\x00nul url",
+	strings.Repeat("x", 4096),
+}
+
+// FuzzParseLinkInput asserts parseLinkInput never panics and honors its
+// contract: whitespace-only content yields empty url and label; any other
+// content yields a non-empty url that is a single space-free token (the first
+// field) and a non-empty label (the rest, or the url itself).
+func FuzzParseLinkInput(f *testing.F) {
+	for _, s := range createParseSeedCorpus {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, content string) {
+		url, label := parseLinkInput(content)
+		if strings.TrimSpace(content) == "" {
+			if url != "" || label != "" {
+				t.Fatalf("whitespace content %q must yield empty url/label, got url=%q label=%q", content, url, label)
+			}
+			return
+		}
+		if url == "" {
+			t.Fatalf("non-empty content %q yielded an empty url", content)
+		}
+		if strings.Contains(url, " ") {
+			t.Fatalf("url %q contains a space (must be the first space-delimited token)", url)
+		}
+		if label == "" {
+			t.Fatalf("content %q yielded an empty label (must default to the url)", content)
+		}
+	})
+}
+
+// FuzzParseRelationInput asserts parseRelationInput never panics and honors its
+// contract: it returns either a FieldError, or a valid relation type
+// (blocks/duplicate/related/similar) with a non-empty identifier. A nil error
+// paired with an invalid type or empty identifier is a broken contract.
+func FuzzParseRelationInput(f *testing.F) {
+	for _, s := range createParseSeedCorpus {
+		f.Add(s)
+	}
+	validTypes := map[string]bool{"blocks": true, "duplicate": true, "related": true, "similar": true}
+	f.Fuzz(func(t *testing.T, content string) {
+		relType, identifier, err := parseRelationInput(content)
+		if err != nil {
+			return // a clean FieldError is a valid outcome
+		}
+		if !validTypes[relType] {
+			t.Fatalf("content %q: nil error but invalid relation type %q", content, relType)
+		}
+		if identifier == "" {
+			t.Fatalf("content %q: nil error but empty identifier", content)
+		}
+	})
+}

--- a/internal/fs/linklisting.go
+++ b/internal/fs/linklisting.go
@@ -1,8 +1,27 @@
 package fs
 
 import (
+	"strings"
+
 	"github.com/jra3/linear-fuse/internal/api"
 )
+
+// parseLinkInput parses a links/attachments _create command — "<url> [label]",
+// or just "<url>" (label defaults to the url) — into its two fields. Whitespace
+// is trimmed off the whole command first; the empty-content guard stays with
+// each caller, which keeps its own "[label]"/"[title]" help text. Pure and
+// mount-free, so it is the fuzz seam for the write-only link/attachment create
+// surface — the command-syntax sibling of parseRelationInput.
+func parseLinkInput(content string) (url, label string) {
+	content = strings.TrimSpace(content)
+	parts := strings.SplitN(content, " ", 2)
+	url = parts[0]
+	label = url
+	if len(parts) > 1 {
+		label = parts[1]
+	}
+	return url, label
+}
 
 // linkListing owns the filenames of a links/ directory — the project/initiative
 // "Links / Resources" surface. Unlike attachmentListing it holds one item family

--- a/internal/fs/links.go
+++ b/internal/fs/links.go
@@ -203,7 +203,7 @@ func (n *LinksNode) createLink(ctx context.Context, raw []byte) syscall.Errno {
 	// against Linear before skipping; a phantom (not live) falls through to a real
 	// create. If the verify itself fails we keep the cache-trust skip — protecting
 	// against a duplicate is the safer default when we cannot confirm.
-	if url := strings.SplitN(content, " ", 2)[0]; url != "" {
+	if url, _ := parseLinkInput(content); url != "" {
 		if existing, err := n.getLinks(ctx); err == nil {
 			for _, l := range existing {
 				if linkURLsEqual(l.URL, url) {
@@ -224,13 +224,7 @@ func (n *LinksNode) createLink(ctx context.Context, raw []byte) syscall.Errno {
 			if content == "" {
 				return nil, &FieldError{Field: "content", Message: `empty content. Write "<url> [label]".`}
 			}
-			// Parse "url [label]" or just "url" (label defaults to the URL).
-			parts := strings.SplitN(content, " ", 2)
-			url := parts[0]
-			label := url
-			if len(parts) > 1 {
-				label = parts[1]
-			}
+			url, label := parseLinkInput(content)
 
 			input := map[string]any{"url": url, "label": label}
 			if n.projectID != "" {


### PR DESCRIPTION
Third fuzz batch — the write-only `_create` **command parsers**: the bytes a user writes into `relations/_create`, `links/_create`, and `attachments/_create` through the mount (untrusted input → a Linear mutation). The command-syntax counterpart to the marshal markdown parsers.

## Production extraction (behavior-preserving)
The `"<url> [label]"` parse was hand-copied byte-for-byte in `LinksNode.createLink` and `AttachmentsNode.createAttachment` — the `SplitN` + label-defaults-to-url dance, plus a bare url-token extract in each idempotency pre-check (**four sites**). `parseLinkInput` (in `linklisting.go`, the symmetric home to `parseRelationInput` in `relationlisting.go`) owns it once.

The empty-content guard stays with each caller, so their distinct `"[label]"`/`"[title]"` help text is preserved verbatim — **zero observable change**. The link/attachment/relation integration tests pass unchanged, confirming faithfulness.

## Fuzz (`createparse_fuzz_test.go`)
- **`FuzzParseLinkInput`** — never panics; whitespace-only → empty url/label; any other content → a non-empty, space-free url (first token) + non-empty label (rest, or the url).
- **`FuzzParseRelationInput`** — never panics; returns a `FieldError`, or a valid type (`blocks`/`duplicate`/`related`/`similar`) with a non-empty identifier.

~30s/target locally (~1.1M execs each), **no crashers, no findings.** Seeds run in the normal `-race` job.

This completes the fuzz frontier we mapped: marshal (#313), listing + timeparse (#316), and now the `_create` command surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)