### PR TITLE
build(aur): add linearfs-bin AUR package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ coverage.out
 # stray root build artifacts (goreleaser uses dist/)
 /linearfs
 dist/
+
+# AUR package build artifacts
+contrib/aur/src/
+contrib/aur/pkg/
+contrib/aur/*.pkg.tar.*
+contrib/aur/*.tar.gz

--- a/contrib/aur/.SRCINFO
+++ b/contrib/aur/.SRCINFO
@@ -1,0 +1,20 @@
+pkgbase = linearfs-bin
+	pkgdesc = Mount your Linear workspace as a FUSE filesystem — browse and edit issues as markdown (prebuilt binary)
+	pkgver = 0.1.0
+	pkgrel = 1
+	url = https://github.com/jra3/linear-fuse
+	install = linearfs-bin.install
+	arch = x86_64
+	arch = aarch64
+	license = MIT
+	depends = fuse3
+	provides = linearfs
+	conflicts = linearfs
+	options = !strip
+	options = !debug
+	source_x86_64 = linearfs-0.1.0-x86_64.tar.gz::https://github.com/jra3/linear-fuse/releases/download/v0.1.0/linearfs_0.1.0_linux_amd64.tar.gz
+	sha256sums_x86_64 = 12be306b356a8b7b678833ab3a598182363e3ffcd464960522082ae29ac1ae1b
+	source_aarch64 = linearfs-0.1.0-aarch64.tar.gz::https://github.com/jra3/linear-fuse/releases/download/v0.1.0/linearfs_0.1.0_linux_arm64.tar.gz
+	sha256sums_aarch64 = 9d7e208902b4680bf0e84a995ac0f21c25a525dc61726a62e1a4f2974e1c10d7
+
+pkgname = linearfs-bin

--- a/contrib/aur/PKGBUILD
+++ b/contrib/aur/PKGBUILD
@@ -1,0 +1,37 @@
+# Maintainer: John Allen <github@porcnick.com>
+pkgname=linearfs-bin
+pkgver=0.1.0
+pkgrel=1
+pkgdesc="Mount your Linear workspace as a FUSE filesystem — browse and edit issues as markdown (prebuilt binary)"
+arch=('x86_64' 'aarch64')
+url="https://github.com/jra3/linear-fuse"
+license=('MIT')
+depends=('fuse3')
+provides=('linearfs')
+conflicts=('linearfs')
+# The release binary is already stripped (goreleaser -s -w); re-stripping a Go
+# binary can drop its build info, so leave it as shipped. !debug because there
+# are no debug symbols to split out of a stripped prebuilt binary.
+options=('!strip' '!debug')
+install="$pkgname.install"
+source_x86_64=("linearfs-$pkgver-x86_64.tar.gz::$url/releases/download/v$pkgver/linearfs_${pkgver}_linux_amd64.tar.gz")
+source_aarch64=("linearfs-$pkgver-aarch64.tar.gz::$url/releases/download/v$pkgver/linearfs_${pkgver}_linux_arm64.tar.gz")
+sha256sums_x86_64=('12be306b356a8b7b678833ab3a598182363e3ffcd464960522082ae29ac1ae1b')
+sha256sums_aarch64=('9d7e208902b4680bf0e84a995ac0f21c25a525dc61726a62e1a4f2974e1c10d7')
+
+package() {
+	install -Dm755 linearfs "$pkgdir/usr/bin/linearfs"
+
+	# Ship the systemd *user* service, repointed at the packaged binary. The
+	# in-repo unit runs from %h/.local/bin (the from-source install location);
+	# a pacman-installed binary lives in /usr/bin. Everything else (the
+	# %h/.config/linearfs/env EnvironmentFile, the mount preflight) is unchanged.
+	sed 's|%h/.local/bin/linearfs|/usr/bin/linearfs|' \
+		contrib/systemd/linearfs.service > linearfs.service.pkg
+	install -Dm644 linearfs.service.pkg "$pkgdir/usr/lib/systemd/user/linearfs.service"
+
+	install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+	for doc in README.md INSTALL.md KNOWN_ISSUES.md; do
+		install -Dm644 "$doc" "$pkgdir/usr/share/doc/$pkgname/$doc"
+	done
+}

--- a/contrib/aur/README.md
+++ b/contrib/aur/README.md
@@ -1,0 +1,55 @@
+# AUR package — `linearfs-bin`
+
+A prebuilt-binary [AUR](https://aur.archlinux.org) package for Arch Linux: it
+downloads the GitHub release tarball for your architecture, verifies its
+checksum, and installs the binary (`/usr/bin/linearfs`), the systemd **user**
+service (repointed at `/usr/bin/linearfs`), the license, and the docs.
+
+Covers `x86_64` and `aarch64`. Depends on `fuse3`.
+
+## Install locally (from this directory)
+
+```bash
+cd contrib/aur
+makepkg -si          # build + install with pacman
+```
+
+Then follow the post-install notes (set your API key; optionally enable the
+user service — the unit reads `~/.config/linearfs/env`, which must set
+`LINEARFS_MOUNT`).
+
+## Publishing / updating the AUR package
+
+The AUR is a separate git repo (`ssh://aur@aur.archlinux.org/linearfs-bin.git`).
+The files here (`PKGBUILD`, `.SRCINFO`, `linearfs-bin.install`) are the source of
+truth; publishing copies them into that repo.
+
+First-time publish:
+
+```bash
+git clone ssh://aur@aur.archlinux.org/linearfs-bin.git /tmp/aur-linearfs
+cp PKGBUILD .SRCINFO linearfs-bin.install /tmp/aur-linearfs/
+cd /tmp/aur-linearfs && git add -A && git commit -m 'Initial import: linearfs-bin 0.1.0' && git push
+```
+
+## Bumping to a new release (the checklist)
+
+When a new `vX.Y.Z` is tagged and its release assets exist:
+
+1. Set `pkgver=X.Y.Z` and reset `pkgrel=1` in `PKGBUILD`.
+2. Update **both** `sha256sums_x86_64` and `sha256sums_aarch64` from the
+   release's `checksums.txt`:
+   ```bash
+   curl -fsSL https://github.com/jra3/linear-fuse/releases/download/vX.Y.Z/checksums.txt
+   ```
+   (Match `linearfs_X.Y.Z_linux_amd64.tar.gz` → `_x86_64`, `_linux_arm64` → `_aarch64`.)
+3. Regenerate the metadata: `makepkg --printsrcinfo > .SRCINFO`.
+4. Test the build end-to-end: `makepkg -f` (downloads, verifies checksum, packages).
+5. Commit `PKGBUILD` + `.SRCINFO` here, then copy all three files into the AUR
+   repo and `git push` there.
+
+Bump only `pkgrel` (not `pkgver`) if you change packaging without a new upstream
+release.
+
+> Build artifacts (`src/`, `pkg/`, `*.pkg.tar.*`, the downloaded `*.tar.gz`) are
+> gitignored — never commit them.

--- a/contrib/aur/linearfs-bin.install
+++ b/contrib/aur/linearfs-bin.install
@@ -1,0 +1,32 @@
+post_install() {
+	cat <<'EOF'
+==> linearfs installed to /usr/bin/linearfs
+
+    Finish setup:
+
+    1. Provide your Linear API key (either works):
+         mkdir -p ~/.config/linearfs
+         printf 'api_key: lin_api_xxxxx\n' > ~/.config/linearfs/config.yaml
+         chmod 600 ~/.config/linearfs/config.yaml
+
+    2. Try it interactively:
+         linearfs mount ~/linear
+         linearfs status
+
+    3. Or run it as a systemd *user* service (auto-mount on login). The unit
+       reads ~/.config/linearfs/env, which must set at least LINEARFS_MOUNT:
+         mkdir -p ~/.config/linearfs
+         printf 'LINEARFS_MOUNT=%s/linear\nLINEAR_API_KEY=lin_api_xxxxx\n' "$HOME" \
+             > ~/.config/linearfs/env
+         chmod 600 ~/.config/linearfs/env
+         systemctl --user enable --now linearfs.service
+
+    Docs: /usr/share/doc/linearfs-bin/   Security: keep the key file chmod 600.
+EOF
+}
+
+post_upgrade() {
+	if systemctl --user is-active --quiet linearfs.service 2>/dev/null; then
+		echo "==> Restart to pick up the new binary: systemctl --user restart linearfs.service"
+	fi
+}


### PR DESCRIPTION
A prebuilt-binary [AUR](https://aur.archlinux.org) package so a fresh Arch box installs with `yay -S linearfs-bin` (one command, pacman-integrated, tracks releases) instead of building from source.

## What it does
Downloads the `vX.Y.Z` release tarball for the host arch (`x86_64`/`aarch64`), verifies its sha256 against the release `checksums.txt`, and installs:
- `/usr/bin/linearfs`
- the systemd **user** unit at `/usr/lib/systemd/user/linearfs.service`, with `ExecStart` repointed from `%h/.local/bin/linearfs` → `/usr/bin/linearfs` (the rest — the `%h/.config/linearfs/env` EnvironmentFile, the mount preflight — unchanged)
- the MIT license + README/INSTALL/KNOWN_ISSUES docs

`depends=(fuse3)`, `provides`/`conflicts` `linearfs`. A `.install` post-message walks the user through the API key + optional user-service setup.

## Verified end-to-end
Built with `makepkg -f` against the **real v0.1.0** release: checksum matches, package builds clean (`!strip`/`!debug` for the already-stripped Go binary), the packaged binary reports `linearfs 0.1.0 (bf9e3bb)`, and the packaged unit's `ExecStart` is `/usr/bin/linearfs`.

## Contents of `contrib/aur/`
`PKGBUILD`, `.SRCINFO` (makepkg-generated), `linearfs-bin.install`, and a `README.md` with the publish steps and a per-release version-bump checklist. Build artifacts are gitignored.

## Follow-up (not in this PR)
Actually publishing to the AUR is a manual push to `aur@aur.archlinux.org` (maintainer action) — the README has the exact steps. Ideally the release workflow eventually auto-bumps `pkgver` + checksums on tag, but that's a separate enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)