### PR TITLE
fs safety chokepoint: route every name/target builder through safeName

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,9 @@ jobs:
       - name: staticcheck
         run: make staticcheck
 
+      - name: safeName chokepoint (no-bypass grep-rule, #345)
+        run: make check-safename
+
   govulncheck:
     name: Vulnerability scan
     runs-on: ubuntu-latest

--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -1,0 +1,14 @@
+# Local project notes
+
+## Issue tracking: GitHub, not Linear
+
+This project does NOT use Linear for its own development, despite being a
+Linear client. All issue tracking — backlog, bugs, wayfinder maps and their
+tickets — lives in GitHub issues on `jra3/linear-fuse`. Fix PRs close issues
+with `Closes #N`.
+
+This overrides the `linear-tracker` / wayfinder default of "Linear via the
+Linear MCP": for this repo, wayfinder maps are GitHub issues (label
+`wayfinder:map`), tickets are issues referenced from the map, and blocking
+uses body convention (`Blocked by #N`) plus native GitHub relationships where
+available via `gh`.

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,12 @@ lint:
 staticcheck:
 	go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 ./...
 
+# The "no bypass" grep-rule guarding the fs name/target safety chokepoint
+# (safeName, #345): fails if a builder returns a raw remote name field without
+# routing through safeName(). CI runs this alongside staticcheck.
+check-safename:
+	./scripts/check-safename.sh
+
 # Pinned so regeneration doesn't churn version comments in generated files
 sqlc:
 	go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0 generate

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -498,6 +498,17 @@ building blocks:
   filename is *not* a resolution key (attachments, links); where it is (labels/
   milestones resolve by name, `.rel` names feed `rm`), collisions shadow
   first-match/emit-once — a suffixed name would resolve nowhere.
+- `safeName(raw, id)` (`safename.go`) — the single name/target **safety
+  chokepoint**. Every name/target builder (the `*DirName`/`*Filename` family,
+  `sanitizeFilename`, the `by/` value names, and every symlink-target component)
+  routes its cosmetically-transformed output through it: `/`\`, NUL, and C0
+  controls become `-`, trailing spaces/dots are trimmed, an empty/`.`/`..` result
+  falls back to the entity id, and an exact collision with a reserved control
+  literal (`_create`/`.error`/`.last`/`.meta`/`current`/`unassigned`) is escaped
+  with `-<id>`. It unifies the safety *invariant*, not cosmetic style (each
+  builder keeps its own casing), and is a non-breaking pass — only pathological
+  names change. A CI grep-rule (`scripts/check-safename.sh`) guards against a new
+  builder bypassing it. This is the TB1 name/target defense in the threat model.
 - `editBuffer` — the read/write buffer under every editable file, and
   `collectionTrio` + `createFileNode` — the writable-collection kit: the trio
   guarantees every writable directory serves `_create`/`.error`/`.last`

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -55,23 +55,38 @@ GraphQL API) and flow, unchanged in trust, through `internal/marshal` (render)
 and into `internal/fs`, where they become **names and targets on a real
 filesystem**:
 
-- **Filenames / directory names** — `sanitizeFilename` (`internal/fs/
-  attachmentlisting.go`) for attachment `.link` and embedded-file names, plus the
-  doc-slug, label-name, milestone-name, and project-slug derivations behind the
-  listing family (`namedListing`, `indexedListing`, `attachmentListing`,
-  `relationListing`, `linkListing`).
+- **Filenames / directory names** — every name/target builder in `internal/fs`
+  routes its output through the single `safeName(raw, id)` chokepoint
+  (`internal/fs/safename.go`, #345): `cycleDirName`, `userDirName`,
+  `sanitizeFilename` (attachment/link `.link` + embedded-file names),
+  `labelFilename`, `documentFilename`, `milestoneFilename`, `projectDirName`,
+  `initiativeDirName`, `initiativeProjectDirName`, and the `by/` status/label/
+  assignee value names. `safeName` replaces `/`, `\`, NUL, and C0 controls with
+  `-`, trims trailing spaces/dots, falls back to the stable entity id when the
+  result is `""`/`.`/`..`, and escapes an exact collision with a reserved control
+  literal (`_create`, `.error`, `.last`, `.meta`, `current`, `unassigned`) by
+  appending `-<id>`. Each builder keeps its own cosmetic transform; `safeName` is
+  the final safety pass layered over it. A CI grep-rule
+  (`scripts/check-safename.sh`, `make check-safename`) flags any builder
+  returning a raw remote name field without it.
 - **Symlink targets** — `symlinkNode` backs every symlink view (`by/`, `cycles/`,
   `recent/`, `users/`, `my/`, `children/`, project issue links, initiative→project
-  links). A target is remote-derived.
+  links). A target is remote-derived; every interpolated component (issue
+  identifier, team key, project dir name) passes through `safeName` so a hostile
+  value cannot traverse out of its directory.
 - **Disk-write paths** — the embedded-file cache writes bytes to a path derived
   from remote data (see also TB2).
 
 The questions this boundary raises: does a title/slug/label containing `..`, `/`,
 a NUL, a leading `-`, an empty string, or a unicode-normalization trick survive
 into a path that escapes the mount or the cache dir, collides with another
-entity, or serves the wrong file? Names that are *resolution keys* (labels and
-milestones resolve by name; `.rel` names feed `rm`) carry extra risk — a
-mangled name that resolves elsewhere is worse than a broken one.
+entity, or serves the wrong file? `safeName` is the answer for the name/target
+surfaces; the corpus test (`internal/fs/safename_test.go`, #341) drives the
+hostile inputs through every builder. Names that are *resolution keys* (labels
+and milestones resolve by name; `.rel` names feed `rm`) carry extra risk — a
+mangled name that resolves elsewhere is worse than a broken one, so `safeName`
+is deterministic (same raw+id → same output) and does not deduplicate (collision
+policy is unchanged; see `namedListing`).
 
 Note the in-scope sliver of the "malicious server" idea lives here too: the
 GraphQL/CDN transport must stay HTTPS and must not follow redirects to non-Linear

--- a/internal/fs/attachmentlisting.go
+++ b/internal/fs/attachmentlisting.go
@@ -49,7 +49,7 @@ type attachmentEntry struct {
 // The create surface reuses it for its .last path and kernel-entry name, so
 // the derivation is written exactly once.
 func linkName(att api.Attachment) string {
-	return sanitizeFilename(att.Title) + ".link"
+	return sanitizeFilename(att.Title, att.ID) + ".link"
 }
 
 // entries derives every entry's final name through one shared dedup counter,
@@ -103,16 +103,10 @@ func deduplicateFilename(name string, nameCount map[string]int) string {
 	return fmt.Sprintf("%s (%d)%s", base, count, ext)
 }
 
-// sanitizeFilename converts a string to a safe filename by replacing problematic characters
-func sanitizeFilename(s string) string {
-	// Replace path separators and null bytes
-	s = strings.ReplaceAll(s, "/", "-")
-	s = strings.ReplaceAll(s, "\\", "-")
-	s = strings.ReplaceAll(s, "\x00", "")
-	// Trim spaces and dots from ends
-	s = strings.Trim(s, " .")
-	if s == "" {
-		return "untitled"
-	}
-	return s
+// sanitizeFilename converts a string to a safe filename. It is a thin wrapper
+// over the shared safeName chokepoint: id (the attachment ID) is the stable
+// fallback when the title sanitizes to empty, replacing the old "untitled"
+// literal so an empty-titled attachment stays addressable and distinct.
+func sanitizeFilename(s, id string) string {
+	return safeName(s, id)
 }

--- a/internal/fs/attachmentlisting_test.go
+++ b/internal/fs/attachmentlisting_test.go
@@ -114,11 +114,13 @@ func TestLinkName(t *testing.T) {
 	cases := []struct{ title, want string }{
 		{"Spec doc", "Spec doc.link"},
 		{"a/b\\c", "a-b-c.link"},
-		{"  trimmed. ", "trimmed.link"},
-		{"", "untitled.link"},
+		// safeName trims TRAILING spaces/dots only (per the #345 spec); an empty
+		// title falls back to the attachment ID (replacing the old "untitled").
+		{"  trailing. ", "  trailing.link"},
+		{"", "att-fallback.link"},
 	}
 	for _, c := range cases {
-		if got := linkName(api.Attachment{Title: c.title}); got != c.want {
+		if got := linkName(api.Attachment{ID: "att-fallback", Title: c.title}); got != c.want {
 			t.Errorf("linkName(%q) = %q, want %q", c.title, got, c.want)
 		}
 	}

--- a/internal/fs/cycles.go
+++ b/internal/fs/cycles.go
@@ -13,13 +13,15 @@ import (
 	"github.com/jra3/linear-fuse/internal/api"
 )
 
-// cycleDirName returns the directory name for a cycle (name with spaces as hyphens)
+// cycleDirName returns the directory name for a cycle (name with spaces as
+// hyphens). The cosmetic transform stays; safeName is the final safety pass
+// (traversal/control chars, and escaping the reserved "current" alias).
 func cycleDirName(cycle api.Cycle) string {
 	name := cycle.Name
 	if name == "" {
 		name = fmt.Sprintf("Cycle %d", cycle.Number)
 	}
-	return strings.ReplaceAll(name, " ", "-")
+	return safeName(strings.ReplaceAll(name, " ", "-"), cycle.ID)
 }
 
 // CyclesNode represents the /teams/{KEY}/cycles directory. It holds a team
@@ -178,8 +180,9 @@ func (c *CycleDirNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 
 	for _, issue := range issues {
 		if issue.Identifier == name {
-			// Path from /teams/ENG/cycles/Cycle-22/ENG-123 to /teams/ENG/issues/ENG-123/
-			target := fmt.Sprintf("../../issues/%s", issue.Identifier)
+			// Path from /teams/ENG/cycles/Cycle-22/ENG-123 to /teams/ENG/issues/ENG-123/.
+			// safeName keeps the interpolated identifier a single path-safe component.
+			target := fmt.Sprintf("../../issues/%s", safeName(issue.Identifier, issue.ID))
 			return c.newSymlinkInode(ctx, out, target, issue.CreatedAt, issue.UpdatedAt), 0
 		}
 	}

--- a/internal/fs/documents.go
+++ b/internal/fs/documents.go
@@ -162,17 +162,18 @@ func (n *DocsNode) Create(ctx context.Context, name string, flags uint32, mode u
 	return n.collection().create(ctx, name, flags, out, n.createDocument(name))
 }
 
-// documentFilename returns the filename for a document
+// documentFilename returns the filename for a document. Cosmetic transform
+// (slugId when present, else lowercased space→hyphen title) stays; safeName is
+// the final safety pass over the base name before the .md suffix
+// (traversal/control chars, empty fallback to document ID).
 func documentFilename(doc api.Document) string {
 	// Use slugId if available, otherwise sanitize title
 	if doc.SlugID != "" {
-		return doc.SlugID + ".md"
+		return safeName(doc.SlugID, doc.ID) + ".md"
 	}
-	// Sanitize title for filename
 	name := strings.ToLower(doc.Title)
 	name = strings.ReplaceAll(name, " ", "-")
-	name = strings.ReplaceAll(name, "/", "-")
-	return name + ".md"
+	return safeName(name, doc.ID) + ".md"
 }
 
 // DocumentFileNode represents a single document file (read-write)

--- a/internal/fs/documents_test.go
+++ b/internal/fs/documents_test.go
@@ -59,7 +59,8 @@ func TestDocumentFilename(t *testing.T) {
 				SlugID: "",
 				Title:  "",
 			},
-			want: ".md",
+			// Empty title + slug + ID → "unnamed" fallback (never a bare ".md").
+			want: "unnamed.md",
 		},
 		{
 			name: "slugId takes precedence",

--- a/internal/fs/filter.go
+++ b/internal/fs/filter.go
@@ -12,19 +12,27 @@ import (
 	"github.com/jra3/linear-fuse/internal/api"
 )
 
-// assigneeHandle returns the handle for an assignee (prefers DisplayName, falls back to email local part)
+// assigneeHandle returns the handle for an assignee (prefers DisplayName, falls
+// back to email local part). safeName is the final safety pass: it strips
+// traversal/control chars from the handle and, critically for #332, escapes a
+// handle that lands exactly on the "unassigned" bucket literal so a real user
+// named "unassigned" cannot shadow the unassigned view. Both the by/assignee
+// value list and resolveAssigneeID derive through this one function, so the
+// sanitized handle stays a consistent resolution key.
 func assigneeHandle(user *api.User) string {
 	if user == nil {
 		return ""
 	}
-	if user.DisplayName != "" {
-		return user.DisplayName
+	handle := user.DisplayName
+	if handle == "" {
+		// Fallback to email local part
+		if idx := strings.Index(user.Email, "@"); idx != -1 {
+			handle = user.Email[:idx]
+		} else {
+			handle = user.Email
+		}
 	}
-	// Fallback to email local part
-	if idx := strings.Index(user.Email, "@"); idx != -1 {
-		return user.Email[:idx]
-	}
-	return user.Email
+	return safeName(handle, user.ID)
 }
 
 // FilterRootNode represents the by/ directory. It holds a team snapshot and
@@ -135,27 +143,30 @@ func (f *FilterCategoryNode) getUniqueValues(ctx context.Context) ([]string, err
 	teamID := f.entity().ID
 	switch f.category {
 	case "status":
-		// Use team states from API - much faster than scanning all issues
+		// Use team states from API - much faster than scanning all issues.
+		// The state name is a remote string, so the directory value is the
+		// safeName of it (traversal/control chars, reserved-literal escape).
 		states, err := f.lfs.repo.GetTeamStates(ctx, teamID)
 		if err != nil {
 			return nil, err
 		}
 		values := make([]string, len(states))
 		for i, state := range states {
-			values[i] = state.Name
+			values[i] = safeName(state.Name, state.ID)
 		}
 		sort.Strings(values)
 		return values, nil
 
 	case "label":
-		// Use team labels from API - much faster than scanning all issues
+		// Use team labels from API - much faster than scanning all issues.
+		// The label name is a remote string; the directory value is its safeName.
 		labels, err := f.lfs.repo.GetTeamLabels(ctx, teamID)
 		if err != nil {
 			return nil, err
 		}
 		values := make([]string, len(labels))
 		for i, label := range labels {
-			values[i] = label.Name
+			values[i] = safeName(label.Name, label.ID)
 		}
 		sort.Strings(values)
 		return values, nil
@@ -224,7 +235,7 @@ func (f *FilterValueNode) Lookup(ctx context.Context, name string, out *fuse.Ent
 	for _, issue := range issues {
 		if issue.Identifier == name {
 			// From by/category/value/ go up 3 levels to team dir, then into issues/
-			target := fmt.Sprintf("../../../issues/%s", issue.Identifier)
+			target := fmt.Sprintf("../../../issues/%s", safeName(issue.Identifier, issue.ID))
 			return f.newSymlinkInode(ctx, out, target, issue.CreatedAt, issue.UpdatedAt), 0
 		}
 	}
@@ -233,12 +244,22 @@ func (f *FilterValueNode) Lookup(ctx context.Context, name string, out *fuse.Ent
 
 func (f *FilterValueNode) getFilteredIssues(ctx context.Context) ([]api.Issue, error) {
 	teamID := f.entity().ID
-	// Use server-side filtering for much better performance
+	// Use server-side filtering for much better performance. f.value is the
+	// safeName'd directory name, so resolve it back to the entity's real name
+	// (GetStateByName/GetLabelByName match the raw remote name) before filtering.
 	switch f.category {
 	case "status":
-		return f.lfs.GetFilteredIssuesByStatus(ctx, teamID, f.value)
+		name, err := f.resolveStateName(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return f.lfs.GetFilteredIssuesByStatus(ctx, teamID, name)
 	case "label":
-		return f.lfs.GetFilteredIssuesByLabel(ctx, teamID, f.value)
+		name, err := f.resolveLabelName(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return f.lfs.GetFilteredIssuesByLabel(ctx, teamID, name)
 	case "assignee":
 		if f.value == "unassigned" {
 			return f.lfs.repo.GetUnassignedIssues(ctx, teamID)
@@ -252,6 +273,38 @@ func (f *FilterValueNode) getFilteredIssues(ctx context.Context) ([]api.Issue, e
 	default:
 		return nil, fmt.Errorf("unknown filter category: %s", f.category)
 	}
+}
+
+// resolveStateName maps the safeName'd status directory value back to a state's
+// real remote name, which the name-keyed filter query matches. An unresolvable
+// value (a state that vanished since the listing) yields the raw value, which
+// GetStateByName then reports as no-match (empty result).
+func (f *FilterValueNode) resolveStateName(ctx context.Context) (string, error) {
+	states, err := f.lfs.repo.GetTeamStates(ctx, f.entity().ID)
+	if err != nil {
+		return "", err
+	}
+	for _, state := range states {
+		if safeName(state.Name, state.ID) == f.value {
+			return state.Name, nil // safename:ok resolution key (feeds GetStateByName, not a path)
+		}
+	}
+	return f.value, nil
+}
+
+// resolveLabelName maps the safeName'd label directory value back to a label's
+// real remote name for the name-keyed filter query, mirroring resolveStateName.
+func (f *FilterValueNode) resolveLabelName(ctx context.Context) (string, error) {
+	labels, err := f.lfs.repo.GetTeamLabels(ctx, f.entity().ID)
+	if err != nil {
+		return "", err
+	}
+	for _, label := range labels {
+		if safeName(label.Name, label.ID) == f.value {
+			return label.Name, nil // safename:ok resolution key (feeds GetLabelByName, not a path)
+		}
+	}
+	return f.value, nil
 }
 
 // resolveAssigneeID converts an assignee handle (display name or email prefix) to user ID

--- a/internal/fs/filter_test.go
+++ b/internal/fs/filter_test.go
@@ -56,7 +56,9 @@ func TestAssigneeHandle(t *testing.T) {
 				DisplayName: "",
 				Email:       "",
 			},
-			want: "",
+			// No name, no email, no ID → safeName never yields "" (invalid dir),
+			// so the ultimate fallback is "unnamed". A real user has an ID.
+			want: "unnamed",
 		},
 	}
 

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -57,17 +57,19 @@ func (i *InitiativesNode) Lookup(ctx context.Context, name string, out *fuse.Ent
 	return nil, syscall.ENOENT
 }
 
-// initiativeDirName returns a safe directory name for an initiative
+// initiativeDirName returns a safe directory name for an initiative. Cosmetic
+// slug-casing transform stays; safeName is the final chokepoint pass, holding
+// for the ID fallback and escaping any reserved-literal collision.
 func initiativeDirName(init api.Initiative) string {
 	// Always derive from name (Linear's slugId for initiatives is not human-readable)
 	name := strings.ToLower(init.Name)
 	name = strings.ReplaceAll(name, " ", "-")
 	name = dirNameUnsafe.ReplaceAllString(name, "")
-	if name != "" {
-		return name
+	if name == "" {
+		// Fallback to ID only if name is empty
+		name = init.ID
 	}
-	// Fallback to ID only if name is empty
-	return init.ID
+	return safeName(name, init.ID)
 }
 
 // InitiativeNode represents a single initiative directory
@@ -404,25 +406,32 @@ func (p *InitiativeProjectsNode) resolveProjectTarget(ctx context.Context, proje
 		return "", time.Time{}, time.Time{}, syscall.ENOENT
 	}
 	// The symlink lives at initiatives/{slug}/projects/{name}, three levels
-	// below the mount root.
-	target := fmt.Sprintf("../../../teams/%s/projects/%s", teamKey, projectDirName(*full))
+	// below the mount root. teamKey and the project dir both come from remote
+	// strings; safeName keeps each a single path-safe component so the target
+	// can never traverse out of teams/. projectDirName is already safe; the
+	// team key is the sibling risk #330 called out.
+	target := fmt.Sprintf("../../../teams/%s/projects/%s", safeName(teamKey, projectID), projectDirName(*full))
 	return target, full.CreatedAt, full.UpdatedAt, 0
 }
 
-// initiativeProjectDirName returns a safe directory name for an initiative project
+// initiativeProjectDirName returns a safe directory name for an initiative
+// project. Cosmetic slug-casing transform stays; safeName is the final
+// chokepoint pass, holding for the slug/ID fallback and escaping any
+// reserved-literal collision.
 func initiativeProjectDirName(proj api.InitiativeProject) string {
 	// Derive from name (not slugId, which is an opaque hash in Linear)
 	name := strings.ToLower(proj.Name)
 	name = strings.ReplaceAll(name, " ", "-")
 	name = dirNameUnsafe.ReplaceAllString(name, "")
-	if name != "" {
-		return name
+	// Fallback to slug/ID only if name sanitizes to empty.
+	fallback := proj.Slug
+	if fallback == "" {
+		fallback = proj.ID
 	}
-	// Fallback to slug/ID only if name sanitizes to empty
-	if proj.Slug != "" {
-		return proj.Slug
+	if name == "" {
+		name = fallback
 	}
-	return proj.ID
+	return safeName(name, fallback)
 }
 
 // InitiativeUpdatesNode represents /initiatives/{slug}/updates/

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -57,8 +57,10 @@ func (lfs *LinearFS) issueCreateSpec(teamID, op, key string, dir uint64, mutate 
 		persist: func(ctx context.Context, i *api.Issue) error {
 			return lfs.UpsertIssue(ctx, *i)
 		},
-		dir:       dir,
-		entryName: func(i *api.Issue) string { return i.Identifier },
+		dir: dir,
+		// Structured Linear identifier (TEAM-NNN), used as a kernel-cache entry
+		// key; the issue-dir listing renders the same identifier verbatim.
+		entryName: func(i *api.Issue) string { return i.Identifier }, // safename:ok structured id
 		invalidateExtra: func(i *api.Issue) {
 			// A fresh issue must appear in recent/ immediately, not after the
 			// dir cache TTL (the #148 design's known staleness bound).
@@ -582,8 +584,9 @@ func (n *ChildrenNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 	for _, child := range children {
 		if child.Identifier == name {
 			// The link lives at issues/{PARENT}/children/{ID}; the sibling
-			// issue dir is two levels up.
-			target := "../../" + child.Identifier
+			// issue dir is two levels up. safeName keeps the interpolated
+			// identifier a single path-safe component.
+			target := "../../" + safeName(child.Identifier, child.ID)
 			return n.newSymlinkInode(ctx, out, target, child.CreatedAt, child.UpdatedAt), 0
 		}
 	}

--- a/internal/fs/labels.go
+++ b/internal/fs/labels.go
@@ -118,12 +118,12 @@ func (n *LabelsNode) Create(ctx context.Context, name string, flags uint32, mode
 	return n.collection().create(ctx, name, flags, out, n.createLabel)
 }
 
-// labelFilename returns the filename for a label
+// labelFilename returns the filename for a label. The cosmetic transform
+// (space→hyphen) stays; safeName is the final safety pass over the base name
+// before the .md suffix (traversal/control chars, empty fallback to label ID).
 func labelFilename(label api.Label) string {
-	// Sanitize name for filename
 	name := strings.ReplaceAll(label.Name, " ", "-")
-	name = strings.ReplaceAll(name, "/", "-")
-	return name + ".md"
+	return safeName(name, label.ID) + ".md"
 }
 
 // LabelFileNode represents a single label file (read-write)

--- a/internal/fs/labels_test.go
+++ b/internal/fs/labels_test.go
@@ -89,7 +89,9 @@ func TestLabelFilename(t *testing.T) {
 		{
 			name:  "empty name",
 			label: api.Label{Name: ""},
-			want:  ".md",
+			// Empty name + empty ID → "unnamed" fallback (never a bare ".md"); a
+			// real label has an ID to fall back to.
+			want: "unnamed.md",
 		},
 	}
 

--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -611,7 +611,7 @@ func (lfs *LinearFS) ResolveStateID(ctx context.Context, teamID string, stateNam
 			return "", err
 		}
 		return resolveByName(states, stateName, "state",
-			func(s api.State) string { return s.Name }, func(s api.State) string { return s.ID })
+			func(s api.State) string { return s.Name /* safename:ok resolution key */ }, func(s api.State) string { return s.ID })
 	})
 }
 
@@ -668,7 +668,7 @@ func (lfs *LinearFS) ResolveProjectID(ctx context.Context, teamID string, projec
 			return "", err
 		}
 		return resolveByName(projects, projectName, "project",
-			func(p api.Project) string { return p.Name }, func(p api.Project) string { return p.ID })
+			func(p api.Project) string { return p.Name /* safename:ok resolution key */ }, func(p api.Project) string { return p.ID })
 	})
 }
 
@@ -705,7 +705,7 @@ func (lfs *LinearFS) ResolveMilestoneID(ctx context.Context, projectID string, m
 			return "", err
 		}
 		return resolveByName(milestones, milestoneName, "milestone",
-			func(m api.ProjectMilestone) string { return m.Name }, func(m api.ProjectMilestone) string { return m.ID })
+			func(m api.ProjectMilestone) string { return m.Name /* safename:ok resolution key */ }, func(m api.ProjectMilestone) string { return m.ID })
 	})
 }
 
@@ -718,7 +718,7 @@ func (lfs *LinearFS) ResolveCycleID(ctx context.Context, teamID string, cycleNam
 			return "", err
 		}
 		return resolveByName(cycles, cycleName, "cycle",
-			func(c api.Cycle) string { return c.Name }, func(c api.Cycle) string { return c.ID })
+			func(c api.Cycle) string { return c.Name /* safename:ok resolution key */ }, func(c api.Cycle) string { return c.ID })
 	})
 }
 
@@ -731,7 +731,7 @@ func (lfs *LinearFS) ResolveInitiativeID(ctx context.Context, initiativeName str
 			return "", err
 		}
 		return resolveByName(initiatives, initiativeName, "initiative",
-			func(i api.Initiative) string { return i.Name }, func(i api.Initiative) string { return i.ID })
+			func(i api.Initiative) string { return i.Name /* safename:ok resolution key */ }, func(i api.Initiative) string { return i.ID })
 	})
 }
 

--- a/internal/fs/linklisting.go
+++ b/internal/fs/linklisting.go
@@ -51,7 +51,7 @@ type linkEntry struct {
 // create surface reuses it for its .last path and kernel-entry name, so the
 // derivation is written exactly once.
 func externalLinkName(link api.EntityExternalLink) string {
-	return sanitizeFilename(link.Label) + ".link"
+	return sanitizeFilename(link.Label, link.ID) + ".link"
 }
 
 // entries derives every entry's final name through one shared dedup counter —

--- a/internal/fs/linklisting_test.go
+++ b/internal/fs/linklisting_test.go
@@ -76,11 +76,13 @@ func TestExternalLinkName(t *testing.T) {
 	cases := []struct{ label, want string }{
 		{"Spec doc", "Spec doc.link"},
 		{"a/b\\c", "a-b-c.link"},
-		{"  trimmed. ", "trimmed.link"},
-		{"", "untitled.link"},
+		// safeName trims TRAILING spaces/dots only (per the #345 spec); an empty
+		// label falls back to the link ID (replacing the old "untitled").
+		{"  trailing. ", "  trailing.link"},
+		{"", "link-fallback.link"},
 	}
 	for _, c := range cases {
-		if got := externalLinkName(api.EntityExternalLink{Label: c.label}); got != c.want {
+		if got := externalLinkName(api.EntityExternalLink{ID: "link-fallback", Label: c.label}); got != c.want {
 			t.Errorf("externalLinkName(%q) = %q, want %q", c.label, got, c.want)
 		}
 	}

--- a/internal/fs/listing_fuzz_test.go
+++ b/internal/fs/listing_fuzz_test.go
@@ -327,7 +327,7 @@ func FuzzSanitizeFilename(f *testing.F) {
 		f.Add(s)
 	}
 	f.Fuzz(func(t *testing.T, s string) {
-		out := sanitizeFilename(s)
+		out := sanitizeFilename(s, "att-fallback-id")
 		if strings.Contains(out, "/") {
 			t.Errorf("sanitizeFilename(%q) = %q contains '/'", s, out)
 		}
@@ -336,6 +336,11 @@ func FuzzSanitizeFilename(f *testing.F) {
 		}
 		if strings.Contains(out, "\x00") {
 			t.Errorf("sanitizeFilename(%q) = %q contains NUL", s, out)
+		}
+		for _, r := range out {
+			if r < 0x20 {
+				t.Errorf("sanitizeFilename(%q) = %q contains C0 control %#x", s, out, r)
+			}
 		}
 		if out == "" || out == "." || out == ".." {
 			t.Errorf("sanitizeFilename(%q) = %q is not a usable filename", s, out)

--- a/internal/fs/milestones.go
+++ b/internal/fs/milestones.go
@@ -3,7 +3,6 @@ package fs
 import (
 	"context"
 	"log"
-	"strings"
 	"syscall"
 	"time"
 
@@ -95,12 +94,12 @@ func (n *MilestonesNode) Unlink(ctx context.Context, name string) syscall.Errno 
 	return n.collection().unlink(ctx, name)
 }
 
-// milestoneFilename returns the filename for a milestone
+// milestoneFilename returns the filename for a milestone. safeName is the final
+// safety pass over the name before the .md suffix (traversal/control chars,
+// empty fallback to milestone ID). The name is otherwise preserved verbatim
+// (milestone names allow spaces).
 func milestoneFilename(m api.ProjectMilestone) string {
-	// Sanitize name for filename
-	name := strings.ReplaceAll(m.Name, "/", "-")
-	name = strings.ReplaceAll(name, "\\", "-")
-	return name + ".md"
+	return safeName(m.Name, m.ID) + ".md"
 }
 
 // MilestoneFileNode represents a single milestone file (read-write)

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -160,17 +160,21 @@ func (p *ProjectsNode) Rmdir(ctx context.Context, name string) syscall.Errno {
 // names (projects, initiatives, initiative projects).
 var dirNameUnsafe = regexp.MustCompile(`[^a-z0-9-]`)
 
-// projectDirName returns a safe directory name for a project
+// projectDirName returns a safe directory name for a project. The cosmetic
+// slug-casing transform (lowercase, space→hyphen, strip non-[a-z0-9-]) stays
+// and already excludes traversal/control chars; safeName is the final chokepoint
+// pass that also holds for the Slug fallback and escapes any reserved-literal
+// collision. Its dirNameUnsafe strip means benign names are unaffected.
 func projectDirName(project api.Project) string {
 	// Sanitize name: lowercase, replace spaces with hyphens, remove special chars
 	name := strings.ToLower(project.Name)
 	name = strings.ReplaceAll(name, " ", "-")
 	name = dirNameUnsafe.ReplaceAllString(name, "")
-	if name != "" {
-		return name
+	if name == "" {
+		// Fallback to slug if name sanitizes to empty
+		name = project.Slug
 	}
-	// Fallback to slug if name sanitizes to empty
-	return project.Slug
+	return safeName(name, project.Slug)
 }
 
 // ProjectNode represents a single project directory
@@ -236,7 +240,7 @@ func (p *ProjectNode) Lookup(ctx context.Context, name string, out *fuse.EntryOu
 	}
 	for _, issue := range issues {
 		if issue.Identifier == name {
-			target := fmt.Sprintf("../../issues/%s", issue.Identifier)
+			target := fmt.Sprintf("../../issues/%s", safeName(issue.Identifier, issue.ID))
 			return p.newSymlinkInode(ctx, out, target, issue.CreatedAt, issue.UpdatedAt), 0
 		}
 	}

--- a/internal/fs/recent.go
+++ b/internal/fs/recent.go
@@ -81,7 +81,7 @@ func (n *RecentNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut
 	}
 	for _, issue := range issues {
 		if issue.Identifier == name {
-			target := fmt.Sprintf("../issues/%s", issue.Identifier)
+			target := fmt.Sprintf("../issues/%s", safeName(issue.Identifier, issue.ID))
 			return n.newSymlinkInode(ctx, out, target, issue.CreatedAt, issue.UpdatedAt), 0
 		}
 	}

--- a/internal/fs/relationlisting.go
+++ b/internal/fs/relationlisting.go
@@ -50,6 +50,10 @@ type relationEntry struct {
 // it for its .last path and kernel-entry name, so the format string exists
 // exactly once.
 func relationFileName(relType, identifier string) string {
+	// relType is a controlled enum (blocks/related/…) and identifier is a
+	// server-assigned issue identifier (TEAM-NNN) — neither can carry a path
+	// separator or control char, so this .rel name (which also feeds rm) needs no
+	// safeName pass. safename:ok structured id
 	return fmt.Sprintf("%s-%s.rel", relType, identifier)
 }
 

--- a/internal/fs/safename.go
+++ b/internal/fs/safename.go
@@ -41,6 +41,12 @@ var reservedNames = map[string]struct{}{
 //   - if the result is "", ".", or ".." → returns id;
 //   - if the result exactly equals a reserved literal → appends "-" + id.
 func safeName(raw, id string) string {
+	// id is both the empty-result fallback and the reserved-literal suffix, so it
+	// must itself be a safe, non-empty component or the invariant leaks (a caller
+	// with an empty slug could otherwise make safeName return "" / "." / "..").
+	if id == "" || id == "." || id == ".." {
+		id = "unnamed"
+	}
 	var b strings.Builder
 	b.Grow(len(raw))
 	for _, r := range raw {

--- a/internal/fs/safename.go
+++ b/internal/fs/safename.go
@@ -1,0 +1,62 @@
+package fs
+
+import "strings"
+
+// reservedNames is the exact set of control literals a rendered fs name must
+// never collide with. They are the collectionTrio triggers (_create), the
+// feedback sidecars (.error, .last), the read-through sidecar suffix (.meta),
+// and the two view aliases (current in cycles/, unassigned in by/assignee/).
+// safeName escapes a sanitized name that lands exactly on one of these by
+// appending -<id>. Exact-match only: a name that merely CONTAINS a dot (e.g.
+// "my.error.log") is left alone — only a shadow that would hijack a control
+// file is escaped.
+var reservedNames = map[string]struct{}{
+	"_create":    {},
+	".error":     {},
+	".last":      {},
+	".meta":      {},
+	"current":    {},
+	"unassigned": {},
+}
+
+// safeName is the single safety chokepoint every fs name/target builder routes
+// its output through. It is a lenient strip-and-replace pass layered over each
+// builder's own cosmetic transform (projectDirName stays slug-cased,
+// cycleDirName stays space-hyphen) — it unifies the safety INVARIANT, not the
+// cosmetic style. A remote Linear string can be arbitrary, so this is the one
+// place that guarantees a rendered name can never escape its directory, carry a
+// control character into a path, collapse to an invalid "" / "." / ".."
+// component, or shadow a reserved control file.
+//
+// raw is the builder's cosmetically-transformed candidate name; id is the
+// entity's stable identifier (or slug) used as the fallback when raw sanitizes
+// to nothing usable, and as the disambiguating suffix when raw would shadow a
+// reserved literal. The fallback/suffix keeps the escape deterministic and
+// unique: two distinct remote names can never both escape into the same slot.
+//
+// The pass:
+//   - replaces /, \, NUL, and every C0 control char (< 0x20) with '-';
+//   - trims trailing spaces and dots (a name ending in '.' or ' ' is a
+//     Windows/path footgun and "foo." collapses to "foo" on some layers);
+//   - if the result is "", ".", or ".." → returns id;
+//   - if the result exactly equals a reserved literal → appends "-" + id.
+func safeName(raw, id string) string {
+	var b strings.Builder
+	b.Grow(len(raw))
+	for _, r := range raw {
+		if r == '/' || r == '\\' || r < 0x20 {
+			b.WriteByte('-')
+			continue
+		}
+		b.WriteRune(r)
+	}
+	s := strings.TrimRight(b.String(), " .")
+
+	if s == "" || s == "." || s == ".." {
+		return id
+	}
+	if _, reserved := reservedNames[s]; reserved {
+		return s + "-" + id
+	}
+	return s
+}

--- a/internal/fs/safename_test.go
+++ b/internal/fs/safename_test.go
@@ -1,0 +1,196 @@
+package fs
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jra3/linear-fuse/internal/api"
+)
+
+// reservedLiterals is the set of control names a rendered fs name must never
+// collide with (the collectionTrio triggers, the sidecar suffixes, and the two
+// view aliases). safeName's exact-match escape guarantees a sanitized name that
+// equals one of these gets an -<id> suffix.
+var reservedLiterals = []string{
+	"_create", ".error", ".last", ".meta", "current", "unassigned",
+}
+
+// hostileNames is the corpus of pathological / malicious raw name inputs fed
+// through every builder. Each must survive sanitization without producing a
+// path-escaping, control-char-carrying, empty, dot, or reserved-literal name.
+var hostileNames = []string{
+	"..",
+	".",
+	"",
+	"/",
+	"\\",
+	"../../etc/passwd",
+	"a/b/c",
+	"foo\x00bar",
+	"\x00",
+	"\x01\x02\x1f",
+	"tab\there",
+	"new\nline",
+	"trailing   ",
+	"trailing...",
+	"  ...  ",
+	"-leadingdash",
+	"_create",
+	".error",
+	".last",
+	".meta",
+	"current",
+	"unassigned",
+	"café",           // unicode should be preserved
+	"日本語",            // unicode should be preserved
+	"normal-name",    // benign control
+	"Normal Name 42", // benign control
+}
+
+// assertSafe checks the universal safety invariant every builder output must
+// satisfy: no path separators, no NUL, no C0 controls, never "", ".", "..",
+// and never exactly equal to a reserved control literal.
+func assertSafe(t *testing.T, builder, raw, got string) {
+	t.Helper()
+	if strings.ContainsAny(got, "/\\\x00") {
+		t.Errorf("%s(%q) = %q: contains path separator or NUL", builder, raw, got)
+	}
+	for _, r := range got {
+		if r < 0x20 {
+			t.Errorf("%s(%q) = %q: contains C0 control char %#x", builder, raw, got, r)
+		}
+	}
+	if got == "" || got == "." || got == ".." {
+		t.Errorf("%s(%q) = %q: is empty/./.. (invalid path component)", builder, raw, got)
+	}
+	// A rendered name must never EXACTLY equal a reserved control file. The
+	// builders that append a suffix (labelFilename etc.) produce e.g.
+	// "_create.md", which is fine — only an exact match is a shadow.
+	for _, res := range reservedLiterals {
+		if got == res {
+			t.Errorf("%s(%q) = %q: shadows reserved literal %q", builder, raw, got, res)
+		}
+	}
+}
+
+func TestSafeName_HostileCorpus(t *testing.T) {
+	const id = "ID-STABLE-123"
+	for _, raw := range hostileNames {
+		got := safeName(raw, id)
+		assertSafe(t, "safeName", raw, got)
+	}
+}
+
+func TestSafeName_ReservedEscapeAppendsID(t *testing.T) {
+	const id = "abc123"
+	for _, res := range reservedLiterals {
+		got := safeName(res, id)
+		if got == res {
+			t.Errorf("safeName(%q, %q) = %q: reserved literal not escaped", res, id, got)
+		}
+		if !strings.HasSuffix(got, "-"+id) {
+			t.Errorf("safeName(%q, %q) = %q: expected -<id> suffix", res, id, got)
+		}
+	}
+}
+
+func TestSafeName_EmptyFallsBackToID(t *testing.T) {
+	const id = "fallback-id"
+	// Only inputs that sanitize to "", ".", or ".." fall back to the id. A raw
+	// "/" becomes "-" (a valid, if ugly, single component) — not a fallback case
+	// per the spec, but still path-safe (asserted by the corpus test).
+	for _, raw := range []string{"", ".", "..", "   ", "...", "  ...  "} {
+		if got := safeName(raw, id); got != id {
+			t.Errorf("safeName(%q, %q) = %q: expected id fallback", raw, id, got)
+		}
+	}
+}
+
+func TestSafeName_ContainingDotNotEscaped(t *testing.T) {
+	// Only EXACT matches escape; a name merely containing a reserved substring
+	// is left alone (no false-positive churn).
+	for _, raw := range []string{"my.error.log", "not_create", ".errorlog", "currentish"} {
+		got := safeName(raw, "id")
+		if strings.HasSuffix(got, "-id") {
+			t.Errorf("safeName(%q) = %q: should not have been reserved-escaped", raw, got)
+		}
+	}
+}
+
+// --- Builder corpus: every name/target builder must produce a safe output for
+// every hostile input. ---
+
+func TestBuilders_HostileCorpus(t *testing.T) {
+	for _, raw := range hostileNames {
+		// cycleDirName
+		assertSafe(t, "cycleDirName", raw, cycleDirName(api.Cycle{ID: "cyc-1", Name: raw}))
+
+		// userDirName (via DisplayName)
+		assertSafe(t, "userDirName", raw, userDirName(api.User{ID: "usr-1", DisplayName: raw}))
+
+		// sanitizeFilename (attachment title component)
+		assertSafe(t, "sanitizeFilename", raw, sanitizeFilename(raw, "att-1"))
+
+		// linkName (external attachment .link name)
+		assertSafe(t, "linkName", raw, linkName(api.Attachment{ID: "att-1", Title: raw}))
+
+		// labelFilename
+		assertSafe(t, "labelFilename", raw, labelFilename(api.Label{ID: "lbl-1", Name: raw}))
+
+		// documentFilename (via title; empty SlugID)
+		assertSafe(t, "documentFilename", raw, documentFilename(api.Document{ID: "doc-1", Title: raw}))
+
+		// milestoneFilename
+		assertSafe(t, "milestoneFilename", raw, milestoneFilename(api.ProjectMilestone{ID: "ms-1", Name: raw}))
+
+		// projectDirName
+		assertSafe(t, "projectDirName", raw, projectDirName(api.Project{ID: "prj-1", Slug: "prj-slug", Name: raw}))
+
+		// initiativeDirName
+		assertSafe(t, "initiativeDirName", raw, initiativeDirName(api.Initiative{ID: "ini-1", Name: raw}))
+
+		// initiativeProjectDirName
+		assertSafe(t, "initiativeProjectDirName", raw, initiativeProjectDirName(api.InitiativeProject{ID: "ip-1", Slug: "ip-slug", Name: raw}))
+
+		// assigneeHandle (by/assignee value)
+		assertSafe(t, "assigneeHandle", raw, assigneeHandle(&api.User{ID: "usr-2", DisplayName: raw}))
+	}
+}
+
+// TestSafeName_NonBreaking pins that benign, already-safe names render
+// identically after the safety pass — the change must not churn the live
+// mount's directory names.
+func TestSafeName_NonBreaking(t *testing.T) {
+	cases := []struct{ builder, raw, want string }{
+		{"cycleDirName", "Sprint 42", "Sprint-42"},
+		{"userDirName", "alice", "alice"},
+		{"labelFilename", "Bug", "Bug.md"},
+		{"labelFilename", "Backend Work", "Backend-Work.md"},
+		{"milestoneFilename", "Phase 1", "Phase 1.md"},
+		{"projectDirName", "API Gateway", "api-gateway"},
+		{"initiativeDirName", "Platform Modernization", "platform-modernization"},
+		{"documentFilename", "Design Notes", "design-notes.md"},
+	}
+	for _, tc := range cases {
+		var got string
+		switch tc.builder {
+		case "cycleDirName":
+			got = cycleDirName(api.Cycle{ID: "c", Name: tc.raw})
+		case "userDirName":
+			got = userDirName(api.User{ID: "u", DisplayName: tc.raw})
+		case "labelFilename":
+			got = labelFilename(api.Label{ID: "l", Name: tc.raw})
+		case "milestoneFilename":
+			got = milestoneFilename(api.ProjectMilestone{ID: "m", Name: tc.raw})
+		case "projectDirName":
+			got = projectDirName(api.Project{ID: "p", Slug: "s", Name: tc.raw})
+		case "initiativeDirName":
+			got = initiativeDirName(api.Initiative{ID: "i", Name: tc.raw})
+		case "documentFilename":
+			got = documentFilename(api.Document{ID: "d", Title: tc.raw})
+		}
+		if got != tc.want {
+			t.Errorf("%s(%q) = %q, want %q (non-breaking regression)", tc.builder, tc.raw, got, tc.want)
+		}
+	}
+}

--- a/internal/fs/safename_test.go
+++ b/internal/fs/safename_test.go
@@ -154,6 +154,20 @@ func TestBuilders_HostileCorpus(t *testing.T) {
 
 		// assigneeHandle (by/assignee value)
 		assertSafe(t, "assigneeHandle", raw, assigneeHandle(&api.User{ID: "usr-2", DisplayName: raw}))
+
+		// teamIssueTarget (symlink target): both remote-derived components — the
+		// team key and the issue identifier — must be safeName'd, so a hostile
+		// value can never inject a path segment into .../teams/<k>/issues/<i>.
+		// Checked prefix-agnostically via the suffix; reverting either component
+		// to a raw field breaks it (a raw '/' would inject extra segments).
+		// An empty team key legitimately ENOENTs (degenerate); only assert the
+		// safe-component invariant when a target is actually produced.
+		if gotTarget, errno := teamIssueTarget(api.Issue{ID: "iss-1", Identifier: raw, Team: &api.Team{ID: "team-1", Key: raw}}); errno == 0 {
+			wantSuffix := "/teams/" + safeName(raw, "team-1") + "/issues/" + safeName(raw, "iss-1")
+			if !strings.HasSuffix(gotTarget, wantSuffix) {
+				t.Errorf("teamIssueTarget(%q) = %q: components must be safeName'd (want suffix %q)", raw, gotTarget, wantSuffix)
+			}
+		}
 	}
 }
 

--- a/internal/fs/symlink.go
+++ b/internal/fs/symlink.go
@@ -87,5 +87,9 @@ func teamIssueTarget(issue api.Issue) (string, syscall.Errno) {
 	if issue.Team == nil || issue.Team.Key == "" {
 		return "", syscall.ENOENT
 	}
-	return fmt.Sprintf("../../teams/%s/issues/%s", issue.Team.Key, issue.Identifier), 0
+	// Team key and identifier are remote strings interpolated into a symlink
+	// target; safeName keeps each a single path-safe component so a hostile
+	// value can never traverse out of teams/.
+	return fmt.Sprintf("../../teams/%s/issues/%s",
+		safeName(issue.Team.Key, issue.Team.ID), safeName(issue.Identifier, issue.ID)), 0
 }

--- a/internal/fs/teams.go
+++ b/internal/fs/teams.go
@@ -30,7 +30,7 @@ func (t *TeamsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	entries := make([]fuse.DirEntry, len(teams))
 	for i, team := range teams {
 		entries[i] = fuse.DirEntry{
-			Name: team.Key,
+			Name: safeName(team.Key, team.ID),
 			Mode: syscall.S_IFDIR,
 		}
 	}

--- a/internal/fs/users.go
+++ b/internal/fs/users.go
@@ -57,17 +57,21 @@ func (u *UsersNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut)
 	return nil, syscall.ENOENT
 }
 
-// userDirName returns the directory name for a user (email without domain)
+// userDirName returns the directory name for a user (display name, or email
+// local part). safeName is the final safety pass over the chosen handle
+// (traversal/control chars, empty fallback to the user ID).
 func userDirName(user api.User) string {
 	// Use DisplayName as directory name (this is the user's handle)
-	if user.DisplayName != "" {
-		return user.DisplayName
+	handle := user.DisplayName
+	if handle == "" {
+		// Fallback to email local part if DisplayName not set
+		if idx := strings.Index(user.Email, "@"); idx != -1 {
+			handle = user.Email[:idx]
+		} else {
+			handle = user.Email
+		}
 	}
-	// Fallback to email local part if DisplayName not set
-	if idx := strings.Index(user.Email, "@"); idx != -1 {
-		return user.Email[:idx]
-	}
-	return user.Email
+	return safeName(handle, user.ID)
 }
 
 // UserNode represents a single user's directory (e.g., /users/alice).

--- a/internal/fs/users_test.go
+++ b/internal/fs/users_test.go
@@ -47,12 +47,16 @@ func TestUserDirName(t *testing.T) {
 			want: "johnny",
 		},
 		{
-			name: "empty displayName and email",
+			// Degenerate: no name, no email, no ID. safeName never yields an
+			// empty directory name (that would be an invalid, un-openable dir),
+			// so the ultimate fallback is "unnamed". In practice a user always
+			// has an ID, so an empty name falls back to that ID, not here.
+			name: "empty displayName, email and id",
 			user: api.User{
 				DisplayName: "",
 				Email:       "",
 			},
-			want: "",
+			want: "unnamed",
 		},
 	}
 

--- a/scripts/check-safename.sh
+++ b/scripts/check-safename.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# check-safename.sh — the "no bypass" grep-rule guarding the fs name/target
+# safety chokepoint (safeName, see internal/fs/safename.go and issue #345).
+#
+# A static proof that every builder routes through safeName is impossible in Go,
+# so this is a lightweight lint: it flags any `return <expr>.<Field>` inside
+# internal/fs where the returned expression is a raw remote name field (Name /
+# Title / Label / Identifier / Key / DisplayName) NOT wrapped in safeName(...).
+# Those are exactly the strings that become directory names, filenames, or
+# symlink-target components; each MUST pass through safeName so a hostile remote
+# value cannot escape its directory or shadow a control file.
+#
+# False positives (a raw field legitimately returned for a non-path use) are
+# suppressed with a trailing `// safename:ok` comment on the line.
+#
+# Exit non-zero (fails CI) if any un-wrapped, un-annotated return is found.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Remote string fields that, when returned as a bare `x.Field`, are candidate
+# path components. Kept deliberately narrow to the fields that actually feed
+# name/target builders.
+FIELDS='Name|Title|Label|Identifier|Key|DisplayName'
+
+# Match:  return <ident-chain>.<Field>   (optionally with a trailing string concat
+# like `+ ".md"`), i.e. a bare field return with no safeName( on the line.
+# We only scan non-test .go files under internal/fs.
+matches="$(
+  grep -rnE "return [A-Za-z_][A-Za-z0-9_.]*\.($FIELDS)\b" internal/fs \
+    --include='*.go' \
+  | grep -v '_test.go:' \
+  | grep -v 'safeName(' \
+  | grep -v 'safename:ok' \
+  || true
+)"
+
+if [ -n "$matches" ]; then
+  echo "check-safename: found name/target builder(s) returning a raw remote name"
+  echo "field without routing through safeName(). Wrap the return in safeName(raw,"
+  echo "id) — or, if the value is not a path component, annotate the line with a"
+  echo "trailing '// safename:ok'."
+  echo
+  echo "$matches"
+  exit 1
+fi
+
+echo "check-safename: OK (no un-wrapped raw-name returns in internal/fs)"

--- a/scripts/check-safename.sh
+++ b/scripts/check-safename.sh
@@ -1,17 +1,28 @@
 #!/usr/bin/env bash
-# check-safename.sh — the "no bypass" grep-rule guarding the fs name/target
-# safety chokepoint (safeName, see internal/fs/safename.go and issue #345).
+# check-safename.sh — a lightweight lint guarding the fs name/target safety
+# chokepoint (safeName, see internal/fs/safename.go and issue #345).
 #
-# A static proof that every builder routes through safeName is impossible in Go,
-# so this is a lightweight lint: it flags any `return <expr>.<Field>` inside
-# internal/fs where the returned expression is a raw remote name field (Name /
-# Title / Label / Identifier / Key / DisplayName) NOT wrapped in safeName(...).
-# Those are exactly the strings that become directory names, filenames, or
-# symlink-target components; each MUST pass through safeName so a hostile remote
-# value cannot escape its directory or shadow a control file.
+# SCOPE (read this — the guard is deliberately partial). A static proof that
+# every builder routes through safeName is impossible in Go. This grep covers
+# only the RETURN-FORM builders: `return <expr>.<Field>` inside internal/fs where
+# the returned expression is a raw remote name field (Name / Title / Label /
+# Identifier / Key / DisplayName) NOT wrapped in safeName(...). Those are the
+# name/dir/file builders (cycleDirName, labelFilename, …); each MUST pass through
+# safeName so a hostile remote value cannot escape its directory or shadow a
+# control file.
 #
-# False positives (a raw field legitimately returned for a non-path use) are
-# suppressed with a trailing `// safename:ok` comment on the line.
+# It deliberately does NOT try to catch the ASSIGNMENT form (`x = ent.Name`) or
+# Sprintf-interpolated SYMLINK TARGETS: builders routinely do `name := ent.Name`
+# as an intermediate step *before* the final safeName, so a grep for those forms
+# is ~all false positives (verified: 13 legitimate intermediate assignments).
+# Those two surfaces — the by/ value lists in filter.go and every
+# `fmt.Sprintf(".../%s", …)` target — are instead guarded by
+# TestBuilders_HostileCorpus, which drives assigneeHandle and teamIssueTarget
+# through the hostile corpus. WHEN YOU ADD a new by/-value or symlink-target
+# surface, add it to that test — the grep will not catch it for you.
+#
+# False positives (a raw field legitimately returned for a non-path use, e.g. a
+# structured TEAM-NNN identifier) are suppressed with a trailing `// safename:ok`.
 #
 # Exit non-zero (fails CI) if any un-wrapped, un-annotated return is found.
 


### PR DESCRIPTION
## Summary

Remediation Unit 2 from the #319 security audit: introduce a single exported
`safeName(raw, id string) string` chokepoint in `internal/fs` that **every**
name/target builder routes its output through — the "B3 safety unification". It
unifies the safety *invariant*, not the cosmetic naming.

`safeName`:
- replaces `/`, `\`, NUL, and every C0 control char (`< 0x20`) with `-`;
- trims trailing spaces and dots;
- if the result is `""`, `.`, or `..` → returns the stable entity `id`/slug;
- if the result exactly equals a reserved control literal (`_create`, `.error`,
  `.last`, `.meta`, `current`, `unassigned`) → appends `-<id>` (exact-match only;
  a name merely containing a dot is left alone).

**Non-breaking.** Each builder keeps its own cosmetic transform (`projectDirName`
stays slug-cased, `cycleDirName` stays space-hyphen); `safeName` is the final
safety pass layered over each. Only pathological/malicious names change. The
collision policy is **unchanged** — `namedListing` stays first-match/no-dedup
(dedup would fabricate names that resolve nowhere). #333 is referenced only, not
in scope.

## Builders routed through `safeName`

`cycleDirName`, `userDirName`, `sanitizeFilename` (attachment + external link
`.link` names), `labelFilename`, `documentFilename`, `milestoneFilename`,
`projectDirName`, `initiativeDirName`, `initiativeProjectDirName`, and the `by/`
status/label/assignee value names (`assigneeHandle` + the status/label value
lists). Plus every symlink-target component that interpolates a remote string:
`teamIssueTarget` (my/, users/), the inline issue-symlink targets in `cycles/`,
`projects/`, `recent/`, `by/`, `children/`, and the initiative→project
`../../../teams/%s/projects/%s` target (team key + project dir).

The `by/status` and `by/label` views resolve the sanitized directory value back
to the entity's real remote name before filtering (the filter queries match by
name), so listing and resolution stay consistent.

## Test-first (#341) + enforcement

- `internal/fs/safename_test.go` — a table-driven hostile-input corpus (`..`,
  `/`, `\`, NUL, C0 controls, empty, leading `-`, the reserved literals, unicode)
  fed through every builder, asserting each output never contains `/`/NUL/control,
  is never `""`/`.`/`..`, and never exactly equals a reserved literal; plus the
  reserved-escape, id-fallback, containing-dot, and non-breaking golden cases.
  Written red-first (build failure), then green.
- `scripts/check-safename.sh` + `make check-safename` (wired into the CI Lint
  job) — a lightweight grep-rule that fails if a builder returns a raw remote
  name field (`.Name`/`.Title`/`.Label`/`.Identifier`/`.Key`/`.DisplayName`)
  without `safeName`. Legitimate non-path returns (resolution keys, structured
  identifiers) carry a `// safename:ok` annotation.

## Verification

- Non-breaking golden test pins benign names render identically (`Sprint 42` →
  `Sprint-42`, `API Gateway` → `api-gateway`, `Bug` → `Bug.md`, `alice` →
  `alice`, `Phase 1` → `Phase 1.md`, etc.).
- `go test -race ./internal/fs/...` green; `make test` green (incl. the ~60s
  offline integration suite); `make staticcheck` clean; `FuzzSanitizeFilename`
  10s clean.
- `docs/ARCHITECTURE.md` (new fs seam) and `docs/THREAT-MODEL.md` (TB1
  name/target defense) updated in the same change per the repo's doc discipline.

Closes #345, closes #330, closes #331, closes #332, closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)