### PR TITLE
security: at-rest permissions — refuse loose key file, tighten to 0600/0700, self-heal

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -365,6 +365,15 @@ Design conventions:
   Durability is `busy_timeout` plus single-statement upserts, with the
   reconcile clean-guard providing prune safety; a `Store.WithTx` helper was
   deleted after accruing zero production callers.
+- **At-rest posture:** `cache.db` and its dir are owner-only (`0600`/`0700`).
+  The SQLite driver creates the db file, so `Open` chmods it *after* open (the
+  MkdirAll mode cannot reach it); the `-wal`/`-shm` sidecars are tightened
+  alongside and otherwise live inside the `0700` dir. The mode constants and the
+  best-effort self-heal chmod are shared with every other on-disk artifact via
+  `internal/atrest` (see the threat model's TB3). This is one of three
+  artifact-creating sites — the others are the embedded-file byte cache
+  (`internal/fs/embeddedfilecache.go`) and the telemetry/request logs
+  (`internal/telemetry/rotate.go`).
 - **Time-format gotcha (read side):** the driver uses `_time_format=sqlite`, so
   timestamps come back space-separated, not RFC3339 `T`, and
   `time.Parse(time.RFC3339, …)` fails silently. Always use `ParseSQLiteTime` /
@@ -647,7 +656,10 @@ degrades to summary-only — telemetry must never take the mount down.
 
 1. `config.Load()` — reads `LINEAR_API_KEY` (env overrides file) and
    `~/.config/linearfs/config.yaml` (or `$XDG_CONFIG_HOME`); loading itself
-   succeeds without a key.
+   succeeds without a key. One hard refusal: if the key's source is the config
+   file (not the env escape hatch) and the file is group/other-accessible
+   (`mode & 0o077 != 0`), load fails and names the fix (`chmod 600`) — see the
+   threat model's TB3.
 2. `fs.PreflightMountpoint(...)` — detects and heals a wedged/stale FUSE mount
    at the target before mounting over it.
 3. `telemetry.Init(...)` — metrics pipeline up before anything records.

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -121,6 +121,24 @@ whether another local user can read a colleague's entire issue tracker. The
 `allow_other` config option, when enabled, widens who can traverse the mount
 itself and is part of this boundary.
 
+**At-rest posture (enforced).** Every on-disk artifact LinearFS writes is
+owner-only: `0700` directories, `0600` files. The mode constants and the
+best-effort `Chmod` self-heal live in one place, `internal/atrest`, and every
+artifact-creating site routes through it — the SQLite dir + `cache.db` (chmodded
+*after* open, since the driver creates the file; its `-wal`/`-shm` sidecars are
+tightened alongside and otherwise sit inside the `0700` dir), the embedded-file
+cache dir + byte files (`internal/fs/embeddedfilecache.go`), and the
+telemetry/request logs + their rotated `.1` sidecars (`internal/telemetry/rotate.go`).
+The chmod runs at startup on every known artifact regardless of creator, so a
+`0644` file an older binary left is tightened on the next start (self-heal) and
+future drift self-corrects; a chmod that fails (foreign owner, removed under us)
+is logged and swallowed rather than blocking the mount. Separately, `internal/config`
+**hard-refuses** to load when the API key's source is `config.yaml` and that file
+is group/other-accessible (`mode & 0o077 != 0`), naming the fix (`chmod 600`);
+the `LINEAR_API_KEY` env path is the escape hatch and is unaffected. The
+mountpoint itself stays `0755` — the FUSE mount is owner-only regardless without
+`allow_other`, so tightening it is cosmetic.
+
 ### TB4 — Build & release (P4)
 
 The path from source to running binary: the `linearfs-bin` AUR package (PKGBUILD

--- a/internal/atrest/atrest.go
+++ b/internal/atrest/atrest.go
@@ -1,0 +1,35 @@
+// Package atrest centralizes the at-rest permission posture for every on-disk
+// artifact LinearFS writes (the SQLite cache, the embedded-file byte cache, the
+// telemetry/request JSONL logs). All of these hold a local mirror of the user's
+// private Linear data, so they are owner-only: 0700 dirs, 0600 files.
+//
+// The helpers are best-effort by design. They are called at startup on every
+// known artifact regardless of who created it, so an artifact an older binary
+// left 0644 is tightened on the next start (self-heal) and future drift is
+// corrected for free. A chmod that fails (e.g. the artifact is owned by another
+// user, or was removed under us) must not block a mount or a write — the failure
+// is logged and swallowed; the 0700 parent dir still bounds group/other reach.
+package atrest
+
+import (
+	"log"
+	"os"
+)
+
+// Mode constants for the two artifact kinds. Use these instead of bare octal at
+// each call site so the posture lives in one place.
+const (
+	// DirMode is the mode for a directory holding LinearFS state.
+	DirMode os.FileMode = 0o700
+	// FileMode is the mode for a file holding LinearFS state.
+	FileMode os.FileMode = 0o600
+)
+
+// Chmod tightens path to mode, best-effort. A missing file is not an error (the
+// artifact simply does not exist yet); any other failure is logged and
+// swallowed so it never blocks a mount or a write.
+func Chmod(path string, mode os.FileMode) {
+	if err := os.Chmod(path, mode); err != nil && !os.IsNotExist(err) {
+		log.Printf("[atrest] warning: could not tighten %s to %04o: %v", path, mode, err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -140,9 +140,11 @@ func LoadWithEnv(getenv func(string) string) (*Config, error) {
 func loadPath(getenv func(string) string, path string, explicit bool) (*Config, error) {
 	cfg := DefaultConfig()
 
+	fileRead := false
 	data, err := os.ReadFile(path)
 	switch {
 	case err == nil:
+		fileRead = true
 		if err := yaml.Unmarshal(data, cfg); err != nil {
 			return nil, fmt.Errorf("failed to parse config file %s: %w", path, err)
 		}
@@ -150,12 +152,45 @@ func loadPath(getenv func(string) string, path string, explicit bool) (*Config, 
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
 
+	// The api_key came from the file unless the env var overrides it below.
+	keyFromFile := fileRead && cfg.APIKey != ""
+
 	// Environment variables override config file
 	if apiKey := getenv("LINEAR_API_KEY"); apiKey != "" {
 		cfg.APIKey = apiKey
+		keyFromFile = false
+	}
+
+	// #338: when the API key's source is the config file (not the env-var
+	// escape hatch), the file must be owner-only — group or other access to a
+	// file holding a secret is refused, ssh StrictModes style. The env path is
+	// deliberately untouched: the systemd EnvironmentFile is systemd's to
+	// protect, and an operator exporting LINEAR_API_KEY has opted out of the
+	// on-disk key entirely.
+	if keyFromFile {
+		if err := requireOwnerOnly(path); err != nil {
+			return nil, err
+		}
 	}
 
 	return cfg, nil
+}
+
+// requireOwnerOnly refuses a config file that holds the API key and is
+// accessible to group or other (mode & 0o077 != 0). The error names the fix so
+// an operator can act on it directly.
+func requireOwnerOnly(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat config file %s: %w", path, err)
+	}
+	if perm := info.Mode().Perm(); perm&0o077 != 0 {
+		return fmt.Errorf(
+			"config file %s is group/other-accessible (mode %04o) but holds an api_key; "+
+				"refusing to load — run: chmod 600 %s",
+			path, perm, path)
+	}
+	return nil
 }
 
 func getConfigPathWithEnv(getenv func(string) string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -231,7 +233,9 @@ log:
   level: debug
   file: /var/log/linearfs.log
 `
-	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+	// 0600: a config.yaml carrying an api_key must be owner-only, else Load
+	// refuses it (see TestLoadRefusesLooseKeyFile).
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
 		t.Fatalf("Failed to write config file: %v", err)
 	}
 
@@ -285,7 +289,7 @@ log:
   level: debug
   api_stats: true
 `
-	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0600); err != nil {
 		t.Fatalf("Failed to write config file: %v", err)
 	}
 
@@ -462,7 +466,11 @@ cache:
 func TestLoadFrom(t *testing.T) {
 	t.Run("explicit file loads", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "custom.yaml")
-		if err := os.WriteFile(path, []byte("api_key: from-file\n"), 0644); err != nil {
+		// 0600: a key-bearing config file must be owner-only or Load refuses it.
+		if err := os.WriteFile(path, []byte("api_key: from-file\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(path, 0600); err != nil {
 			t.Fatal(err)
 		}
 		t.Setenv("LINEAR_API_KEY", "")
@@ -496,6 +504,116 @@ func TestLoadFrom(t *testing.T) {
 		}
 		if cfg.APIKey != "from-env" {
 			t.Errorf("LoadFrom() APIKey = %q, want %q", cfg.APIKey, "from-env")
+		}
+	})
+}
+
+// TestLoadRefusesLooseKeyFile guards #338: a config.yaml that carries an
+// api_key and is group- or world-accessible (mode & 0o077 != 0) is refused at
+// load with a message that names the fix (chmod 600). An owner-only (0600)
+// file is accepted, and — the escape hatch — a loose file whose key is
+// overridden by LINEAR_API_KEY is unaffected (the env is the key source, so
+// the file's mode is irrelevant).
+func TestLoadRefusesLooseKeyFile(t *testing.T) {
+	// group/world-readable modes that must all be refused when a key is present.
+	looseModes := []os.FileMode{0640, 0604, 0644, 0660, 0666, 0700 | 0044}
+	for _, mode := range looseModes {
+		mode := mode
+		t.Run(fmt.Sprintf("refuse mode %04o", mode), func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configDir := filepath.Join(tmpDir, "linearfs")
+			if err := os.MkdirAll(configDir, 0700); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(configDir, "config.yaml")
+			if err := os.WriteFile(path, []byte("api_key: secret\n"), mode); err != nil {
+				t.Fatal(err)
+			}
+			// os.WriteFile is subject to umask; force the intended loose bits.
+			if err := os.Chmod(path, mode); err != nil {
+				t.Fatal(err)
+			}
+			_, err := LoadWithEnv(mockEnv(map[string]string{"XDG_CONFIG_HOME": tmpDir}))
+			if err == nil {
+				t.Fatalf("LoadWithEnv() with %04o key file: want refusal, got nil", mode)
+			}
+			if !strings.Contains(err.Error(), "chmod 600") {
+				t.Errorf("refusal error %q: want it to name the fix (chmod 600)", err.Error())
+			}
+			if !strings.Contains(err.Error(), path) {
+				t.Errorf("refusal error %q: want it to name the file %q", err.Error(), path)
+			}
+		})
+	}
+
+	t.Run("accepts 0600 key file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configDir := filepath.Join(tmpDir, "linearfs")
+		if err := os.MkdirAll(configDir, 0700); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(configDir, "config.yaml")
+		if err := os.WriteFile(path, []byte("api_key: secret\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(path, 0600); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadWithEnv(mockEnv(map[string]string{"XDG_CONFIG_HOME": tmpDir}))
+		if err != nil {
+			t.Fatalf("LoadWithEnv() with 0600 key file: %v", err)
+		}
+		if cfg.APIKey != "secret" {
+			t.Errorf("APIKey = %q, want %q", cfg.APIKey, "secret")
+		}
+	})
+
+	t.Run("env override makes loose file irrelevant", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configDir := filepath.Join(tmpDir, "linearfs")
+		if err := os.MkdirAll(configDir, 0700); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(configDir, "config.yaml")
+		if err := os.WriteFile(path, []byte("api_key: file-secret\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(path, 0644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadWithEnv(mockEnv(map[string]string{
+			"XDG_CONFIG_HOME": tmpDir,
+			"LINEAR_API_KEY":  "env-secret",
+		}))
+		if err != nil {
+			t.Fatalf("LoadWithEnv() with env override of loose file: %v", err)
+		}
+		if cfg.APIKey != "env-secret" {
+			t.Errorf("APIKey = %q, want env-secret (env is the source)", cfg.APIKey)
+		}
+	})
+
+	t.Run("loose file with no api_key is fine", func(t *testing.T) {
+		// A config.yaml that carries only non-secret settings never triggers
+		// the refusal — the check keys on a present api_key, not the file.
+		tmpDir := t.TempDir()
+		configDir := filepath.Join(tmpDir, "linearfs")
+		if err := os.MkdirAll(configDir, 0700); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(configDir, "config.yaml")
+		if err := os.WriteFile(path, []byte("log:\n  level: debug\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(path, 0644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadWithEnv(mockEnv(map[string]string{"XDG_CONFIG_HOME": tmpDir}))
+		if err != nil {
+			t.Fatalf("LoadWithEnv() with keyless loose file: %v", err)
+		}
+		if cfg.Log.Level != "debug" {
+			t.Errorf("Log.Level = %q, want debug", cfg.Log.Level)
 		}
 	})
 }

--- a/internal/db/perm_test.go
+++ b/internal/db/perm_test.go
@@ -1,0 +1,100 @@
+package db
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// withZeroUmask forces a 0 umask for the duration of a test so a mode
+// assertion reflects the mode the code requested, not the ambient umask (which
+// on a dev box or CI runner is usually 022 and would mask group/other bits the
+// test is not exercising). It restores the prior umask on cleanup. Tests using
+// it must NOT be t.Parallel() — umask is process-global.
+func withZeroUmask(t *testing.T) {
+	t.Helper()
+	prev := syscall.Umask(0)
+	t.Cleanup(func() { syscall.Umask(prev) })
+}
+
+// assertMode fails if path's permission bits differ from want.
+func assertMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Errorf("%s mode = %04o, want %04o", path, got, want)
+	}
+}
+
+// TestOpenTightensArtifacts guards #339: the cache dir is 0700 and the created
+// cache.db (plus its WAL/SHM sidecars) are 0600. The SQLite driver creates the
+// db file, so Open must chmod it after open — the MkdirAll mode alone can't
+// reach it.
+func TestOpenTightensArtifacts(t *testing.T) {
+	withZeroUmask(t)
+
+	dir := filepath.Join(t.TempDir(), "state")
+	dbPath := filepath.Join(dir, "cache.db")
+
+	store, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+
+	// A write forces the WAL/SHM sidecars into existence so we can check them.
+	if _, err := store.DB().ExecContext(context.Background(),
+		"CREATE TABLE IF NOT EXISTS _permcheck (x INTEGER)"); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+
+	assertMode(t, dir, 0700)
+	assertMode(t, dbPath, 0600)
+	for _, sfx := range []string{"-wal", "-shm"} {
+		p := dbPath + sfx
+		if _, err := os.Stat(p); err == nil {
+			assertMode(t, p, 0600)
+		}
+	}
+}
+
+// TestOpenSelfHealsLooseArtifacts guards the self-heal contract: a pre-existing
+// 0644 cache.db and 0755 dir left by an older binary are tightened to
+// 0600/0700 on the next Open, with no manual chmod.
+func TestOpenSelfHealsLooseArtifacts(t *testing.T) {
+	withZeroUmask(t)
+
+	dir := filepath.Join(t.TempDir(), "state")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(dir, "cache.db")
+
+	// First open creates the db; loosen everything to simulate an old binary.
+	store, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open (seed): %v", err)
+	}
+	store.Close()
+	if err := os.Chmod(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dbPath, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-open: the loose artifacts must self-heal.
+	store2, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open (reopen): %v", err)
+	}
+	defer store2.Close()
+
+	assertMode(t, dir, 0700)
+	assertMode(t, dbPath, 0600)
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jra3/linear-fuse/internal/atrest"
 	_ "modernc.org/sqlite"
 )
 
@@ -55,11 +56,15 @@ func Open(dbPath string) (*Store, error) {
 
 // openDB is the internal function that opens the database
 func openDB(dbPath string) (*Store, error) {
-	// Ensure parent directory exists
+	// Ensure parent directory exists. 0700: the SQLite cache holds a full local
+	// copy of the user's Linear data (issue bodies, comments, ...) and must be
+	// owner-only (#339). atrest.Chmod self-heals an existing loose dir that an
+	// older binary created 0755.
 	dir := filepath.Dir(dbPath)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, atrest.DirMode); err != nil {
 		return nil, fmt.Errorf("create db directory: %w", err)
 	}
+	atrest.Chmod(dir, atrest.DirMode)
 
 	// Use file: URI format to properly handle paths with spaces and query params
 	// Escape spaces in path for URI format
@@ -93,12 +98,27 @@ func openDB(dbPath string) (*Store, error) {
 		return nil, fmt.Errorf("migrate schema: %w", err)
 	}
 
+	// Tighten the db file to 0600 (#339). The SQLite driver creates cache.db —
+	// so the dir's 0700 does not reach it and the MkdirAll mode arg cannot; an
+	// explicit chmod after open is the only lever. This also self-heals a
+	// pre-existing 0644 db from an older binary. The WAL/SHM sidecars exist by
+	// now (journal_mode=WAL + the schema exec above), so tighten them too; any
+	// created later are still inside the 0700 dir, out of group/other reach.
+	tightenDBFiles(dbPath)
+
 	qdb := ctxDetachDBTX{inner: db}
 	return &Store{
 		db:      db,
 		queries: New(qdb),
 		qdb:     qdb,
 	}, nil
+}
+
+// tightenDBFiles chmods cache.db and its WAL/SHM sidecars to 0600, best-effort.
+func tightenDBFiles(dbPath string) {
+	atrest.Chmod(dbPath, atrest.FileMode)
+	atrest.Chmod(dbPath+"-wal", atrest.FileMode)
+	atrest.Chmod(dbPath+"-shm", atrest.FileMode)
 }
 
 // migrateSchema applies idempotent bootstrap-ALTER migrations to a database

--- a/internal/fs/embeddedfilecache.go
+++ b/internal/fs/embeddedfilecache.go
@@ -9,6 +9,7 @@ import (
 	gosync "sync"
 
 	"github.com/jra3/linear-fuse/internal/api"
+	"github.com/jra3/linear-fuse/internal/atrest"
 )
 
 // embeddedFileCache owns the bytes of embedded attachment files (the *.png/*.pdf
@@ -49,6 +50,14 @@ func embeddedFileCacheDir() string {
 // on-disk path and size (best-effort), a late-bound closure because the repo it
 // reaches is wired after the LinearFS exists.
 func newEmbeddedFileCache(dir string, cdn *api.CDNClient, persist func(ctx context.Context, fileID, path string, size int64) error) *embeddedFileCache {
+	// The byte cache holds a local copy of the user's attachment files and is
+	// owner-only (#339). Create the dir 0700 and self-heal a loose pre-existing
+	// one (an older binary made it 0755). Best-effort: a failure here does not
+	// block a mount — the 0700 dir bounds reach and a fetch simply re-downloads.
+	if err := os.MkdirAll(dir, atrest.DirMode); err != nil {
+		log.Printf("[cache] Warning: failed to create cache dir %s: %v", dir, err)
+	}
+	atrest.Chmod(dir, atrest.DirMode)
 	return &embeddedFileCache{
 		dir:     dir,
 		cdn:     cdn,
@@ -89,11 +98,16 @@ func (c *embeddedFileCache) FetchEmbeddedFile(ctx context.Context, file api.Embe
 	// source of truth. `content` is returned this call regardless, and a cache
 	// miss next time simply re-fetches from the CDN — so a failed write self-
 	// corrects with no divergence to surface. (#278)
-	if err := os.WriteFile(diskPath, content, 0644); err != nil {
+	if err := os.WriteFile(diskPath, content, atrest.FileMode); err != nil {
 		log.Printf("[cache] Warning: failed to cache file %s: %v", file.Filename, err)
-	} else if c.persist != nil {
-		if err := c.persist(ctx, file.ID, diskPath, int64(len(content))); err != nil {
-			log.Printf("[cache] Warning: failed to update cache path: %v", err)
+	} else {
+		// Self-heal an existing byte file an older binary wrote 0644; WriteFile
+		// leaves an existing file's mode untouched, so tighten explicitly (#339).
+		atrest.Chmod(diskPath, atrest.FileMode)
+		if c.persist != nil {
+			if err := c.persist(ctx, file.ID, diskPath, int64(len(content))); err != nil {
+				log.Printf("[cache] Warning: failed to update cache path: %v", err)
+			}
 		}
 	}
 

--- a/internal/fs/embeddedfilecache_test.go
+++ b/internal/fs/embeddedfilecache_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/jra3/linear-fuse/internal/api"
@@ -85,6 +86,49 @@ func TestEmbeddedFileCacheTiers(t *testing.T) {
 	}
 	if served != 1 {
 		t.Errorf("disk tier hit the CDN: served=%d", served)
+	}
+}
+
+// TestEmbeddedFileCacheTightensArtifacts guards #339: the on-disk byte cache is
+// owner-only. newEmbeddedFileCache creates its dir 0700 (self-healing a loose
+// pre-existing one), and a downloaded byte file lands 0600. Run under a zero
+// umask so the assertion reflects the requested mode, not the ambient umask.
+func TestEmbeddedFileCacheTightensArtifacts(t *testing.T) {
+	prev := syscall.Umask(0)
+	defer syscall.Umask(prev)
+
+	ctx := context.Background()
+	// Pre-create the dir 0755 to prove the self-heal tightens an existing dir.
+	dir := filepath.Join(t.TempDir(), "files")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("PNGDATA"))
+	}))
+	defer srv.Close()
+
+	cdn := api.NewCDNClient(func() string { return "" })
+	cdn.SetHTTPClient(srv.Client())
+	c := newEmbeddedFileCache(dir, cdn, nil)
+
+	if info, err := os.Stat(dir); err != nil {
+		t.Fatalf("stat cache dir: %v", err)
+	} else if got := info.Mode().Perm(); got != 0o700 {
+		t.Errorf("cache dir mode = %04o, want 0700", got)
+	}
+
+	file := api.EmbeddedFile{ID: "f1", URL: srv.URL + "/f1.png", Filename: "f1.png"}
+	if _, err := c.FetchEmbeddedFile(ctx, file); err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(dir, "f1"))
+	if err != nil {
+		t.Fatalf("stat cached byte file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("cached byte file mode = %04o, want 0600", got)
 	}
 }
 

--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -121,11 +121,9 @@ func NewLinearFS(cfg *config.Config, debug bool) (*LinearFS, error) {
 		requestLog = w
 	}
 
-	// Initialize file cache directory
+	// The embedded-file cache dir is created (and tightened to 0700) by
+	// newEmbeddedFileCache below, which owns its own at-rest posture (#339).
 	cacheDir := embeddedFileCacheDir()
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
-		log.Printf("[linearfs] Warning: failed to create cache dir: %v", err)
-	}
 
 	lfs := &LinearFS{
 		uid:            uid,

--- a/internal/telemetry/rotate.go
+++ b/internal/telemetry/rotate.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/jra3/linear-fuse/internal/atrest"
 )
 
 // rotatingWriter is a size-capped io.Writer over a single file with one
@@ -21,10 +23,14 @@ type rotatingWriter struct {
 // newRotatingWriter opens path for appending (creating parent directories as
 // needed) and caps it at maxBytes before rollover.
 func newRotatingWriter(path string, maxBytes int64) (*rotatingWriter, error) {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	// The telemetry/request logs record every GraphQL request (including the
+	// full variables map) and are owner-only (#339): dir 0700, files 0600.
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, atrest.DirMode); err != nil {
 		return nil, err
 	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	atrest.Chmod(dir, atrest.DirMode)
+	f, err := openLog(path)
 	if err != nil {
 		return nil, err
 	}
@@ -34,6 +40,18 @@ func newRotatingWriter(path string, maxBytes int64) (*rotatingWriter, error) {
 		return nil, err
 	}
 	return &rotatingWriter{path: path, max: maxBytes, f: f, size: st.Size()}, nil
+}
+
+// openLog opens path for appending, creating it 0600 and self-healing an
+// existing loose (e.g. 0644) log — O_APPEND leaves an existing file's mode
+// untouched, so tighten explicitly after open.
+func openLog(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, atrest.FileMode)
+	if err != nil {
+		return nil, err
+	}
+	atrest.Chmod(path, atrest.FileMode)
+	return f, nil
 }
 
 func (w *rotatingWriter) Write(p []byte) (int, error) {
@@ -55,11 +73,14 @@ func (w *rotatingWriter) rotateLocked() error {
 	if err := w.f.Close(); err != nil {
 		return err
 	}
-	// os.Rename replaces an existing path.1 — the single-slot rollover.
+	// os.Rename replaces an existing path.1 — the single-slot rollover. The
+	// renamed .1 keeps the original 0600 mode; the fresh path is opened 0600 by
+	// openLog. (After the rename path no longer exists, so O_APPEND creates it
+	// empty — equivalent to the old O_TRUNC create.)
 	if err := os.Rename(w.path, w.path+".1"); err != nil {
 		return err
 	}
-	f, err := os.OpenFile(w.path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	f, err := openLog(w.path)
 	if err != nil {
 		return err
 	}

--- a/internal/telemetry/rotate_test.go
+++ b/internal/telemetry/rotate_test.go
@@ -4,8 +4,81 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
+
+// TestRotatingWriterTightensArtifacts guards #339: the telemetry dir is 0700
+// and both the live log and its rotated .1 sidecar are 0600. Run under a zero
+// umask so the assertion reflects the requested mode, not the ambient umask.
+func TestRotatingWriterTightensArtifacts(t *testing.T) {
+	prev := syscall.Umask(0)
+	defer syscall.Umask(prev)
+
+	// A nested dir the writer must create, pre-loosened to prove self-heal.
+	dir := filepath.Join(t.TempDir(), "state")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "requests.jsonl")
+
+	w, err := newRotatingWriter(path, 4)
+	if err != nil {
+		t.Fatalf("newRotatingWriter: %v", err)
+	}
+	defer w.Close()
+
+	// Two writes past the tiny cap force a rollover, creating path.1.
+	if _, err := w.Write([]byte("aaaa\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if _, err := w.Write([]byte("bbbb\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	check := func(p string, want os.FileMode) {
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("stat %s: %v", p, err)
+		}
+		if got := info.Mode().Perm(); got != want {
+			t.Errorf("%s mode = %04o, want %04o", p, got, want)
+		}
+	}
+	check(dir, 0o700)
+	check(path, 0o600)
+	check(path+".1", 0o600)
+}
+
+// TestRotatingWriterSelfHealsLooseFile guards the self-heal contract: an
+// existing 0644 log left by an older binary is tightened to 0600 when the
+// writer reopens it (O_APPEND leaves an existing file's mode untouched).
+func TestRotatingWriterSelfHealsLooseFile(t *testing.T) {
+	prev := syscall.Umask(0)
+	defer syscall.Umask(prev)
+
+	path := filepath.Join(t.TempDir(), "metrics.jsonl")
+	if err := os.WriteFile(path, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	w, err := newRotatingWriter(path, 1024)
+	if err != nil {
+		t.Fatalf("newRotatingWriter: %v", err)
+	}
+	defer w.Close()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("reopened log mode = %04o, want 0600 (self-heal)", got)
+	}
+}
 
 func TestRotatingWriterAppendsUnderCap(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Remediation Unit 3 from the #319 security audit (grilling-locked). Tightens
on-disk permissions and refuses a group/world-readable API key file.

## What changed

### #338 — config.yaml permission refusal
`internal/config` hard-refuses to load when the API key's **source is
`config.yaml`** (not the env var) and the file is group/other-accessible
(`mode & 0o077 != 0`), ssh `StrictModes` style. The error names the fix
(`chmod 600 <path>`). The `LINEAR_API_KEY` env path is the escape hatch and is
untouched — the systemd `EnvironmentFile` is systemd's to protect.

### #339 — tighten on-disk artifact modes to 0700 dirs / 0600 files
- SQLite cache dir + `cache.db` (chmodded **after** open — the driver creates
  the file, so the MkdirAll mode can't reach it) + its `-wal`/`-shm` sidecars.
- Embedded-file byte-cache dir + byte files (`internal/fs/embeddedfilecache.go`).
- Telemetry/request JSONL logs + their rotated `.1` sidecars
  (`internal/telemetry/rotate.go`).
- Mountpoint left at `0755` — FUSE is owner-only without `allow_other`.

### Self-healing chmod on startup
An idempotent best-effort `Chmod` runs at startup on every known artifact
regardless of creator, so a `0644` file an older binary left (a live daemon's
`cache.db`/`metrics.jsonl`) is tightened on the next start, and future drift
self-corrects. A chmod that fails (foreign owner, removed under us) is logged and
swallowed — it never blocks a mount or a write; the `0700` parent dir still
bounds group/other reach. The mode constants and the self-heal `Chmod` live in
one shared place, `internal/atrest`.

## Tests (#343, red-first)
Under a controlled zero umask (so assertions reflect the requested mode, not the
ambient umask), assert every created dir is `0700` and every file `0600` across
the SQLite cache, embedded cache, and telemetry logs — plus self-heal of
pre-loosened artifacts. Config tests assert refusal of a `0o077` key file (with
the `chmod 600` message), acceptance of a `0600` one, and that the env-var path
is unaffected by a loose file.

`go test -race ./...` and `make test` (incl. the 62s integration suite) green;
gofmt + staticcheck clean.

## Docs
`docs/THREAT-MODEL.md` TB3 records the enforced at-rest posture; `docs/ARCHITECTURE.md`
notes the config refusal in the startup order and the `internal/db` at-rest chmod
seam.

Closes #346, closes #338, closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)