### PR TITLE
ci(security): SHA-pin actions, pin govulncheck, add least-privilege perms

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,6 +9,9 @@ on:
         default: 'false'
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   integration-write:
     name: Integration Tests (Write Operations)
@@ -17,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,17 +15,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: '~> v2'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     name: Unit Tests
@@ -13,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
 
@@ -34,10 +37,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
 
@@ -53,15 +56,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
 
       - name: govulncheck
-        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
 
   integration-tests-read:
     name: Integration Tests (Read-Only)
@@ -71,10 +74,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
 
@@ -105,10 +108,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
 


### PR DESCRIPTION
Pins the CI/release supply chain (Remediation Unit 4 from the #319 security audit). CI-config-only — no runtime effect.

## Changes

- **SHA-pin all three actions** across `release.yml`, `test.yml`, `integration.yml` to full 40-char commit SHAs with trailing version comments:
  | Action | SHA | Comment |
  |---|---|---|
  | `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | `# v4.3.1` |
  | `actions/setup-go` | `40f1582b2485089dde7abd97c1529aa768e1baff` | `# v5.6.0` |
  | `goreleaser/goreleaser-action` | `e435ccd777264be153ace6237001ef4d979d3a7a` | `# v6.4.0` |

  Each `vN` tag was resolved via `gh api repos/<owner>/<repo>/git/ref/tags/vN` (all point directly to commit objects), the exact release tag confirmed via the repo's `/tags` list, and each SHA re-verified as a real commit via `/commits/<sha>`. Dependabot (github-actions ecosystem, already configured) bumps these SHA pins going forward.
- **Pin `govulncheck`** in `test.yml`: `@latest` → `@v1.1.4` (latest `golang.org/x/vuln` release) for reproducible scans.
- **Explicit least-privilege**: added top-level `permissions:\n  contents: read` to `test.yml` and `integration.yml` (belt-and-suspenders against an org-default flip). `release.yml` keeps its existing `contents: write` for the goreleaser job.

## Out of scope

SLSA provenance / cosign signing — tracked separately as #354.

## Reviewer note

The whole risk here is SHA authenticity — a wrong SHA silently swaps the action. Each SHA above was resolved from the action's own repo via `git/ref/tags` and re-confirmed to exist as a commit. Worth a spot-check against GitHub's tag pages.

Closes #347, closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)