### PR TITLE
security follow-ups: drop dead allow_other, refuse API-client redirects

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -161,12 +161,15 @@ traffic has one auth header, one timeout policy, and one set of OTEL instruments
 (`linearfs.cdn.*`) instead of each wiring its own invisible `http.Client`:
 `internal/fs`'s `embeddedFileCache` calls `CDNClient.Get` for bytes on read, and
 `internal/reconcile`'s `Extractor` calls `CDNClient.Size` (a HEAD) for embedded-file
-sizes during sync. Its transport is hardened: it **refuses every redirect**
-(`CheckRedirect`) because the uploads CDN serves attachment bytes directly, so a
-3xx would only leak the Authorization key onward (SSRF / http-downgrade), and it
-**caps each GET body at 100 MiB** (`maxCDNBytes`), erroring rather than caching a
-truncated entry. Its only internal dependency is the small `internal/telemetry`
-instrument-constructor helpers. Exposes 26 query methods (`GetTeamIssuesPage`,
+sizes during sync. Both transports are hardened: **each client refuses every
+redirect** (`CheckRedirect` — `errCDNRedirect` and `errAPIRedirect`), because a
+3xx is never legitimate (the uploads CDN serves attachment bytes directly; the
+GraphQL endpoint is a pinned constant) and following one would only replay the
+Authorization key onto the redirect target (SSRF / http-downgrade). The CDN
+client additionally **caps each GET body at 100 MiB** (`maxCDNBytes`), erroring
+rather than caching a truncated entry. The package's only internal dependency
+is the small `internal/telemetry` instrument-constructor helpers. It exposes
+26 query methods (`GetTeamIssuesPage`,
 `GetTeamMetadata`, `GetInitiativesProbe`, `GetIssueDetailsBatch`, …) backed by
 31 named GraphQL operations — combined fetches like `GetTeamMetadata` issue
 several (metadata query + drain-page twins) — and ~30 mutation methods

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -118,8 +118,9 @@ Alongside the secret, the whole cached workspace lands on disk: the SQLite cache
 DB (`os.UserConfigDir()/linearfs/cache.db`), embedded-file bytes, and the
 optional telemetry/request logs. Their file and parent-directory modes decide
 whether another local user can read a colleague's entire issue tracker. The
-`allow_other` config option, when enabled, widens who can traverse the mount
-itself and is part of this boundary.
+mount itself is always owner-only: FUSE denies other users by default, and
+LinearFS never sets `fuse.MountOptions.AllowOther` (the `allow_other` config
+key that once suggested otherwise was a dead knob, removed in #355).
 
 **At-rest posture (enforced).** Every on-disk artifact LinearFS writes is
 owner-only: `0700` directories, `0600` files. The mode constants and the
@@ -136,8 +137,8 @@ is logged and swallowed rather than blocking the mount. Separately, `internal/co
 **hard-refuses** to load when the API key's source is `config.yaml` and that file
 is group/other-accessible (`mode & 0o077 != 0`), naming the fix (`chmod 600`);
 the `LINEAR_API_KEY` env path is the escape hatch and is unaffected. The
-mountpoint itself stays `0755` — the FUSE mount is owner-only regardless without
-`allow_other`, so tightening it is cosmetic.
+mountpoint itself stays `0755` — the FUSE mount is owner-only regardless
+(AllowOther is never set), so tightening it is cosmetic.
 
 ### TB4 — Build & release (P4)
 

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -91,7 +91,10 @@ policy is unchanged; see `namedListing`).
 Note the in-scope sliver of the "malicious server" idea lives here too: the
 GraphQL/CDN transport must stay HTTPS and must not follow redirects to non-Linear
 hosts, because that is the difference between "P1 sends hostile data" (in scope)
-and a network attacker injecting it (which the transport must prevent).
+and a network attacker injecting it (which the transport must prevent). Enforced:
+both network callers refuse every redirect via `CheckRedirect` (`errCDNRedirect`
+in the CDN client, #348; `errAPIRedirect` in the GraphQL client, #353), so no
+request carrying the API key ever makes a second hop.
 
 ### TB2 — Linear CDN → local bytes on disk (P2)
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -35,6 +35,18 @@ const (
 // and the sync worker's queues retry it.
 const maxWriteWait = 30 * time.Second
 
+// errAPIRedirect refuses every GraphQL-endpoint redirect — the API-client twin
+// of the CDN's errCDNRedirect (#353, symmetry with #336/#337). The endpoint is
+// the pinned https constant defaultAPIURL, so a 3xx can only come from the real
+// Linear server misbehaving or a forged TLS peer — no in-scope persona can
+// inject one. But Go's default redirect handling would replay the Authorization
+// header (the raw lin_api_ key) onto whatever target a redirect names, so
+// refusing all redirects makes "no Linear secret ever rides a redirect" a
+// property of both network callers, not just the CDN.
+func errAPIRedirect(req *http.Request, _ []*http.Request) error {
+	return fmt.Errorf("api: refusing redirect to %s (the graphql endpoint is pinned; a redirect is not trusted)", req.URL)
+}
+
 type Client struct {
 	apiKey     string
 	apiURL     string
@@ -80,7 +92,7 @@ func NewClient(apiKey string) *Client {
 	return &Client{
 		apiKey:     apiKey,
 		apiURL:     defaultAPIURL,
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: &http.Client{Timeout: 30 * time.Second, CheckRedirect: errAPIRedirect},
 		metrics:    newAPIMetrics(),
 		budget:     newRateBudget(time.Now),
 		limiter:    limiter,

--- a/internal/api/redirect_test.go
+++ b/internal/api/redirect_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestClientRefusesRedirect proves the GraphQL client's redirect policy (#353,
+// the API-client twin of the CDN's #336/#337 hardening): the client follows NO
+// redirect, at every redirect status. The endpoint is a pinned https constant,
+// so a 3xx can only come from the real Linear server misbehaving or a forged
+// TLS peer — either way, following it would replay the raw lin_api_ key in the
+// Authorization header onto the redirect target. As in the CDN test, each case
+// points the redirect at a REACHABLE recording sink so a regression that starts
+// following redirects is observed as sinkReached, not masked by a dial failure.
+func TestClientRefusesRedirect(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// A reachable sink that records whether it was ever reached / saw the key.
+	var sinkReached, sinkSawAuth bool
+	sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sinkReached = true
+		if r.Header.Get("Authorization") != "" {
+			sinkSawAuth = true
+		}
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	defer sink.Close()
+
+	// Every redirect status must be refused — Go treats 301/302/303/307/308 all
+	// as follow-worthy by default, so each must be independently blocked.
+	for _, code := range []int{
+		http.StatusMovedPermanently,  // 301
+		http.StatusFound,             // 302
+		http.StatusSeeOther,          // 303
+		http.StatusTemporaryRedirect, // 307
+		http.StatusPermanentRedirect, // 308
+	} {
+		code := code
+		redir := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Location", sink.URL+"/leak")
+			w.WriteHeader(code)
+		}))
+
+		t.Run(fmt.Sprintf("query-%d", code), func(t *testing.T) {
+			sinkReached, sinkSawAuth = false, false
+			c := NewClient("lin_api_test")
+			c.SetAPIURL(redir.URL)
+
+			var out struct{}
+			err := c.query(ctx, `query Probe { viewer { id } }`, nil, &out)
+			if err == nil {
+				t.Fatal("query should refuse the redirect")
+			}
+			if !strings.Contains(err.Error(), "refusing redirect") {
+				t.Errorf("error = %q, want it to name the redirect refusal", err)
+			}
+			if sinkReached {
+				t.Error("redirect target was followed — should have been refused")
+			}
+			if sinkSawAuth {
+				t.Error("Authorization key leaked to redirect target")
+			}
+		})
+		redir.Close()
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,9 +22,12 @@ type CacheConfig struct {
 	MaxEntries int           `yaml:"max_entries"`
 }
 
+// MountConfig configures the mount. The allow_other key that used to live
+// here was a dead knob (never wired to fuse.MountOptions — the mount is
+// always owner-only) and is gone (#355); yaml.v3 ignores unknown keys, so
+// old config files carrying it still parse.
 type MountConfig struct {
 	DefaultPath string `yaml:"default_path"`
-	AllowOther  bool   `yaml:"allow_other"`
 }
 
 // LogConfig configures logging. The api_stats key that used to live here is
@@ -72,7 +75,6 @@ func DefaultConfig() *Config {
 		},
 		Mount: MountConfig{
 			DefaultPath: "",
-			AllowOther:  false,
 		},
 		Log: LogConfig{
 			Level: "info",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -38,9 +38,6 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.Mount.DefaultPath != "" {
 		t.Errorf("DefaultConfig() Mount.DefaultPath = %q, want empty", cfg.Mount.DefaultPath)
 	}
-	if cfg.Mount.AllowOther != false {
-		t.Error("DefaultConfig() Mount.AllowOther should be false")
-	}
 
 	// Check default log level
 	if cfg.Log.Level != "info" {
@@ -228,7 +225,6 @@ cache:
   max_entries: 5000
 mount:
   default_path: ~/linear
-  allow_other: true
 log:
   level: debug
   file: /var/log/linearfs.log
@@ -262,9 +258,6 @@ log:
 	if cfg.Mount.DefaultPath != "~/linear" {
 		t.Errorf("LoadWithEnv() Mount.DefaultPath = %q, want %q", cfg.Mount.DefaultPath, "~/linear")
 	}
-	if cfg.Mount.AllowOther != true {
-		t.Error("LoadWithEnv() Mount.AllowOther should be true")
-	}
 	if cfg.Log.Level != "debug" {
 		t.Errorf("LoadWithEnv() Log.Level = %q, want %q", cfg.Log.Level, "debug")
 	}
@@ -273,10 +266,11 @@ log:
 	}
 }
 
-// TestLoadToleratesRemovedAPIStatsKey: existing user config files may still
-// carry log.api_stats (the field died with APIStats); yaml.v3 ignores
-// unknown keys, so such a file must keep parsing.
-func TestLoadToleratesRemovedAPIStatsKey(t *testing.T) {
+// TestLoadToleratesRemovedKeys: existing user config files may still carry
+// keys whose fields have been removed — log.api_stats (died with APIStats)
+// and mount.allow_other (dead knob removed in #355; the mount was always
+// owner-only). yaml.v3 ignores unknown keys, so such a file must keep parsing.
+func TestLoadToleratesRemovedKeys(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 	configDir := filepath.Join(tmpDir, "linearfs")
@@ -285,6 +279,8 @@ func TestLoadToleratesRemovedAPIStatsKey(t *testing.T) {
 	}
 	configContent := `
 api_key: "key_with_stale_field"
+mount:
+  allow_other: true
 log:
   level: debug
   api_stats: true


### PR DESCRIPTION
Two small follow-ups from the #319 audit backlog, one commit each:

**Remove the dead `allow_other` mount option (#355).** `MountConfig.AllowOther` was never wired to `fuse.MountOptions` — the mount has always been owner-only, so `allow_other: true` in config.yaml was a silent no-op that lied to the user. Removed rather than wired (the issue's lean); old config files carrying the key keep parsing (yaml.v3 ignores unknown keys, guarded by `TestLoadToleratesRemovedKeys`), and THREAT-MODEL TB3 no longer describes the option as a real widening lever.

**Refuse redirects on the GraphQL client (#353).** The API client's `http.Client` had no `CheckRedirect`, so Go's default handling would follow a 3xx and replay the raw `lin_api_` Authorization header onto the redirect target. Not reachable by any in-scope persona (the endpoint is a pinned https constant), but the CDN client already refuses all redirects (#348) — this gives the API client the same policy, making "no Linear secret ever rides a redirect" a property of both network callers. `TestClientRefusesRedirect` mirrors the CDN twin: all five 3xx statuses refused, with a reachable recording sink proving the second hop is never made and the key never leaks. THREAT-MODEL TB1 and ARCHITECTURE's `internal/api` section state the now-two-sided enforcement.

Full suite (including integration) and staticcheck green on the stack.

Closes #355, closes #353