### PR TITLE
feat(observability): count atrest chmod self-heal failures

### DIFF
--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -132,7 +132,8 @@ telemetry/request logs + their rotated `.1` sidecars (`internal/telemetry/rotate
 The chmod runs at startup on every known artifact regardless of creator, so a
 `0644` file an older binary left is tightened on the next start (self-heal) and
 future drift self-corrects; a chmod that fails (foreign owner, removed under us)
-is logged and swallowed rather than blocking the mount. Separately, `internal/config`
+is logged, counted (`linearfs.atrest.chmod_failures{artifact}`, #352), and
+swallowed rather than blocking the mount. Separately, `internal/config`
 **hard-refuses** to load when the API key's source is `config.yaml` and that file
 is group/other-accessible (`mode & 0o077 != 0`), naming the fix (`chmod 600`);
 the `LINEAR_API_KEY` env path is the escape hatch and is unaffected. The

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -60,9 +60,9 @@ documented in its own section below.
 ## Instruments
 
 Naming: `linearfs.<layer>.<what>`; meter scopes are `linearfs/process`,
-`linearfs/fuse`, `linearfs/api`, `linearfs/budget`, `linearfs/sync`,
-`linearfs/swr`. Histograms use the SDK default buckets; durations are in
-**seconds**.
+`linearfs/fuse`, `linearfs/api`, `linearfs/cdn`, `linearfs/budget`,
+`linearfs/sync`, `linearfs/swr`, `linearfs/atrest`. Histograms use the SDK
+default buckets; durations are in **seconds**.
 
 ### Process heartbeats — `internal/telemetry/heartbeat.go`
 
@@ -98,6 +98,16 @@ the journald line merges the per-op series (see below).
 
 `op` is the GraphQL operation name (`extractOpName`, ~30 values — e.g.
 `TeamIssuesByUpdatedAt`, `IssueDetailsBatch`, `GetViewer`).
+
+### CDN layer — `internal/api/cdn.go` (`cdnMetrics`, bound at `NewCDNClient`)
+
+| Instrument | Kind | Attributes | Recorded |
+|---|---|---|---|
+| `linearfs.cdn.requests` | counter | `method` = `get` \| `head`, `outcome` = `ok` \| `error` | at `CDNClient.do` completion, one per CDN request (embedded-file byte GETs, sync HEAD sizes). The CDN has no rate-limit tier of its own, so `outcome` is the two-value form |
+| `linearfs.cdn.duration` | histogram (s) | `method` | same site, wall time of the request |
+
+`method` is not in the summary keep-list, so the journald line merges the
+get/head series; the split is in the JSONL export.
 
 ### Budget layer — `internal/api/metrics.go` (`budgetMetrics` + `registerBudgetGauges`, owned by `rateBudget`)
 
@@ -157,6 +167,18 @@ budget; `api.requests`/`api.complexity` are the spend. Round 18's leak
 `api.requests{op=GetIssueDetails}` growth and `budget.remaining{axis=complexity}`
 decay — on one view.
 
+### At-rest posture — `internal/atrest/atrest.go` (lazy-bound, like `sync.prunes`)
+
+| Instrument | Kind | Attributes | Recorded |
+|---|---|---|---|
+| `linearfs.atrest.chmod_failures` | counter | `artifact` = `db` \| `embedded` \| `logs` | inside `atrest.Chmod` when a tighten **genuinely fails** (#352) — a missing artifact records nothing (it simply does not exist yet). Nonzero means an on-disk artifact silently kept a loose mode (e.g. foreign-owner `EPERM`); the `0700` parent dir still bounds group/other reach, so this is defense-in-depth degradation, not exposure — but it is the drift a dashboard should catch |
+
+`artifact` is a closed enum, never a path (embedded-file paths are unbounded
+remote-derived strings). The instrument binds lazily on the first counted
+failure and is constructed against the bare otel API — `internal/telemetry`
+imports `atrest` (rotate.go tightens the log files), so the shared `Must*`
+helpers would cycle.
+
 ## The journald summary line
 
 Format: `metrics: name{k=v,...}=value ...` — counters/gauges as plain values
@@ -165,7 +187,7 @@ Format: `metrics: name{k=v,...}=value ...` — counters/gauges as plain values
 
 To stay one readable line, attribute sets are **projected onto a keep-list**
 (`summaryAttrKeys`): `outcome`, `decision`, `tier`, `axis`, `kind`,
-`collection`, `version`, `commit`. Keys not in the list (notably the ~30-value
+`collection`, `version`, `commit`, `artifact`. Keys not in the list (notably the ~30-value
 `op`) are dropped and the collided series **merged** (values and
 count/sum summed). Full cardinality is only in the JSONL export — the summary
 is deliberately the compact projection.

--- a/internal/atrest/atrest.go
+++ b/internal/atrest/atrest.go
@@ -8,12 +8,20 @@
 // left 0644 is tightened on the next start (self-heal) and future drift is
 // corrected for free. A chmod that fails (e.g. the artifact is owned by another
 // user, or was removed under us) must not block a mount or a write — the failure
-// is logged and swallowed; the 0700 parent dir still bounds group/other reach.
+// is logged, counted (linearfs.atrest.chmod_failures), and swallowed; the 0700
+// parent dir still bounds group/other reach.
 package atrest
 
 import (
+	"context"
 	"log"
 	"os"
+	"sync"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 )
 
 // Mode constants for the two artifact kinds. Use these instead of bare octal at
@@ -25,11 +33,62 @@ const (
 	FileMode os.FileMode = 0o600
 )
 
+// Artifact names the kind of on-disk artifact a Chmod call is tightening — the
+// only attribute on the failure counter. A closed enum, never a path: paths
+// reaching Chmod include embedded-file names, which are unbounded
+// remote-derived strings (cardinality poison).
+type Artifact string
+
+const (
+	// ArtifactDB is the SQLite state: the linearfs config dir, cache.db, and
+	// its -wal/-shm sidecars (internal/db).
+	ArtifactDB Artifact = "db"
+	// ArtifactEmbedded is the embedded-file byte cache: its dir and the
+	// cached attachment files (internal/fs).
+	ArtifactEmbedded Artifact = "embedded"
+	// ArtifactLogs is the telemetry/request JSONL logs: their dir and the
+	// log files plus rotated .1 sidecars (internal/telemetry).
+	ArtifactLogs Artifact = "logs"
+)
+
+// chmodFailures is the linearfs.atrest.chmod_failures counter (#352) — a
+// genuine tighten failure means an artifact silently stays loose with the only
+// other signal buried in journald, so it is the one thing worth counting here
+// (a missing artifact records nothing; it simply does not exist yet). The
+// package has no construction point, so the instrument binds lazily on the
+// first counted failure, like reconcile's prune counter; without a registered
+// provider the global no-op makes the Add free. Constructed against the bare
+// otel API — telemetry.MustInt64Counter is unavailable here because
+// internal/telemetry imports atrest (rotate.go tightens the log files) — but
+// replicating its contract: a creation failure degrades to a logged no-op,
+// never a panic. Telemetry must never take the process down, and this package
+// doubly so (its whole charter is never blocking a mount or a write).
+var (
+	chmodFailuresOnce sync.Once
+	chmodFailures     metric.Int64Counter
+)
+
+func chmodFailuresCounter() metric.Int64Counter {
+	chmodFailuresOnce.Do(func() {
+		c, err := otel.Meter("linearfs/atrest").Int64Counter(
+			"linearfs.atrest.chmod_failures",
+			metric.WithDescription("Genuine at-rest tighten failures (missing artifacts excluded), by artifact kind"))
+		if err != nil {
+			log.Printf("telemetry: creating linearfs.atrest.chmod_failures: %v", err)
+			c, _ = noop.NewMeterProvider().Meter("noop").Int64Counter("linearfs.atrest.chmod_failures")
+		}
+		chmodFailures = c
+	})
+	return chmodFailures
+}
+
 // Chmod tightens path to mode, best-effort. A missing file is not an error (the
-// artifact simply does not exist yet); any other failure is logged and
-// swallowed so it never blocks a mount or a write.
-func Chmod(path string, mode os.FileMode) {
+// artifact simply does not exist yet); any other failure is logged, counted
+// under the artifact kind, and swallowed so it never blocks a mount or a write.
+func Chmod(path string, mode os.FileMode, artifact Artifact) {
 	if err := os.Chmod(path, mode); err != nil && !os.IsNotExist(err) {
 		log.Printf("[atrest] warning: could not tighten %s to %04o: %v", path, mode, err)
+		chmodFailuresCounter().Add(context.Background(), 1,
+			metric.WithAttributes(attribute.String("artifact", string(artifact))))
 	}
 }

--- a/internal/atrest/atrest_test.go
+++ b/internal/atrest/atrest_test.go
@@ -1,0 +1,108 @@
+package atrest
+
+// Chmod failure-counter tests. Like linearfs.sync.prunes (internal/reconcile),
+// the instrument binds lazily on the first counted failure and the package has
+// no construction point, so ONE manual-reader provider is installed for the
+// whole binary in TestMain, before any test can bind it. Cross-test isolation
+// comes from the artifact attribute: each test asserts on its own unique
+// Artifact value, so other tests' failures can never collide with an assertion.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+var metricsReader *sdkmetric.ManualReader
+
+func TestMain(m *testing.M) {
+	metricsReader = sdkmetric.NewManualReader()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(metricsReader)))
+	os.Exit(m.Run())
+}
+
+// chmodFailuresValue returns the linearfs.atrest.chmod_failures count for one
+// artifact, or 0 when no such datapoint has been recorded.
+func chmodFailuresValue(t *testing.T, artifact Artifact) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := metricsReader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "linearfs.atrest.chmod_failures" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("chmod_failures data is %T, want Sum[int64]", m.Data)
+			}
+			for _, dp := range sum.DataPoints {
+				if v, ok := dp.Attributes.Value("artifact"); ok && v.AsString() == string(artifact) {
+					return dp.Value
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// notADir returns a path whose parent component is a regular file, so any
+// chmod on it fails with ENOTDIR — a genuine failure reachable without root
+// (EPERM would need a foreign-owner file).
+func notADir(t *testing.T) string {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "plainfile")
+	if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return filepath.Join(f, "child")
+}
+
+// TestChmodFailureRecordsMetric: a genuine chmod failure (not missing-file)
+// increments linearfs.atrest.chmod_failures under its artifact.
+func TestChmodFailureRecordsMetric(t *testing.T) {
+	const artifact Artifact = "test-genuine-failure"
+	Chmod(notADir(t), FileMode, artifact)
+	if got := chmodFailuresValue(t, artifact); got != 1 {
+		t.Errorf("chmod_failures{artifact=%s} = %d, want 1", artifact, got)
+	}
+}
+
+// TestChmodMissingFileNotCounted: a missing artifact is not a failure — it
+// simply does not exist yet — so nothing is counted (mirroring the existing
+// swallow of os.IsNotExist).
+func TestChmodMissingFileNotCounted(t *testing.T) {
+	const artifact Artifact = "test-missing-file"
+	Chmod(filepath.Join(t.TempDir(), "does-not-exist"), FileMode, artifact)
+	if got := chmodFailuresValue(t, artifact); got != 0 {
+		t.Errorf("chmod_failures{artifact=%s} = %d, want 0 (missing file is not a failure)", artifact, got)
+	}
+}
+
+// TestChmodSuccessNotCounted: a successful tighten records nothing, and
+// actually tightens.
+func TestChmodSuccessNotCounted(t *testing.T) {
+	const artifact Artifact = "test-success"
+	f := filepath.Join(t.TempDir(), "loose")
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	Chmod(f, FileMode, artifact)
+	info, err := os.Stat(f)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != FileMode {
+		t.Errorf("mode = %04o, want %04o", perm, FileMode)
+	}
+	if got := chmodFailuresValue(t, artifact); got != 0 {
+		t.Errorf("chmod_failures{artifact=%s} = %d, want 0 (success is not a failure)", artifact, got)
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -64,7 +64,7 @@ func openDB(dbPath string) (*Store, error) {
 	if err := os.MkdirAll(dir, atrest.DirMode); err != nil {
 		return nil, fmt.Errorf("create db directory: %w", err)
 	}
-	atrest.Chmod(dir, atrest.DirMode)
+	atrest.Chmod(dir, atrest.DirMode, atrest.ArtifactDB)
 
 	// Use file: URI format to properly handle paths with spaces and query params
 	// Escape spaces in path for URI format
@@ -116,9 +116,9 @@ func openDB(dbPath string) (*Store, error) {
 
 // tightenDBFiles chmods cache.db and its WAL/SHM sidecars to 0600, best-effort.
 func tightenDBFiles(dbPath string) {
-	atrest.Chmod(dbPath, atrest.FileMode)
-	atrest.Chmod(dbPath+"-wal", atrest.FileMode)
-	atrest.Chmod(dbPath+"-shm", atrest.FileMode)
+	atrest.Chmod(dbPath, atrest.FileMode, atrest.ArtifactDB)
+	atrest.Chmod(dbPath+"-wal", atrest.FileMode, atrest.ArtifactDB)
+	atrest.Chmod(dbPath+"-shm", atrest.FileMode, atrest.ArtifactDB)
 }
 
 // migrateSchema applies idempotent bootstrap-ALTER migrations to a database

--- a/internal/fs/embeddedfilecache.go
+++ b/internal/fs/embeddedfilecache.go
@@ -57,7 +57,7 @@ func newEmbeddedFileCache(dir string, cdn *api.CDNClient, persist func(ctx conte
 	if err := os.MkdirAll(dir, atrest.DirMode); err != nil {
 		log.Printf("[cache] Warning: failed to create cache dir %s: %v", dir, err)
 	}
-	atrest.Chmod(dir, atrest.DirMode)
+	atrest.Chmod(dir, atrest.DirMode, atrest.ArtifactEmbedded)
 	return &embeddedFileCache{
 		dir:     dir,
 		cdn:     cdn,
@@ -103,7 +103,7 @@ func (c *embeddedFileCache) FetchEmbeddedFile(ctx context.Context, file api.Embe
 	} else {
 		// Self-heal an existing byte file an older binary wrote 0644; WriteFile
 		// leaves an existing file's mode untouched, so tighten explicitly (#339).
-		atrest.Chmod(diskPath, atrest.FileMode)
+		atrest.Chmod(diskPath, atrest.FileMode, atrest.ArtifactEmbedded)
 		if c.persist != nil {
 			if err := c.persist(ctx, file.ID, diskPath, int64(len(content))); err != nil {
 				log.Printf("[cache] Warning: failed to update cache path: %v", err)

--- a/internal/telemetry/rotate.go
+++ b/internal/telemetry/rotate.go
@@ -29,7 +29,7 @@ func newRotatingWriter(path string, maxBytes int64) (*rotatingWriter, error) {
 	if err := os.MkdirAll(dir, atrest.DirMode); err != nil {
 		return nil, err
 	}
-	atrest.Chmod(dir, atrest.DirMode)
+	atrest.Chmod(dir, atrest.DirMode, atrest.ArtifactLogs)
 	f, err := openLog(path)
 	if err != nil {
 		return nil, err
@@ -50,7 +50,7 @@ func openLog(path string) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	atrest.Chmod(path, atrest.FileMode)
+	atrest.Chmod(path, atrest.FileMode, atrest.ArtifactLogs)
 	return f, nil
 }
 

--- a/internal/telemetry/summary.go
+++ b/internal/telemetry/summary.go
@@ -57,6 +57,7 @@ var summaryAttrKeys = map[string]bool{
 	"collection": true, // phase-3 sync instruments
 	"version":    true, // build.info
 	"commit":     true, // build.info
+	"artifact":   true, // atrest.chmod_failures (#352) — 3 bounded values
 }
 
 // renderSummary is the pure projection from collected metric data to the one


### PR DESCRIPTION
`atrest.Chmod` stays best-effort, but a genuine tighten failure previously left its only signal buried in journald — an artifact could silently keep a loose mode with nothing observable. `Chmod` now records `linearfs.atrest.chmod_failures{artifact}` alongside the log line; missing artifacts still record nothing (they simply don't exist yet), preserving the issue's "genuine failure" distinction.

Design notes:
- The `artifact` attribute is a closed three-value enum (`db` | `embedded` | `logs`) passed as a new required `Chmod` parameter — never a path, since embedded-file paths are unbounded remote-derived strings. All 8 call sites updated.
- The instrument binds lazily like `reconcile`'s prune counter (the package has no construction point) and is built against the bare otel API — `internal/telemetry` imports `atrest` (rotate.go tightens the log files), so the shared `Must*` helpers would cycle. Their degrade-to-logged-no-op contract is replicated, not the panic the first draft had (spec-review catch: telemetry must never take the process down, and this package doubly so).
- `artifact` joins the journald summary keep-list so the always-on line shows the per-artifact split.
- Tests force a real unprivileged failure (ENOTDIR via a file-as-parent path) against a TestMain manual reader, plus missing-file and success non-counting — the reconcile metrics-test pattern.

Also fixes pre-existing `docs/telemetry.md` drift: the `linearfs/cdn` meter (PR #348) was missing from the scope list and instrument inventory entirely; it now has its own section. THREAT-MODEL TB3's "logged and swallowed" clause is updated to "logged, counted, and swallowed."

Full suite (including integration) and staticcheck green.

Closes #352