### PR TITLE
docs,ci: drop vestigial user_allow_other setup (#359)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,7 +31,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y fuse3 libfuse3-dev
-          sudo sed -i 's/#user_allow_other/user_allow_other/' /etc/fuse.conf
 
       - name: Build
         run: make build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y fuse3 libfuse3-dev
-          sudo sed -i 's/#user_allow_other/user_allow_other/' /etc/fuse.conf
 
       - name: Build
         run: make build

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -271,23 +271,14 @@ sudo apt update
 sudo apt install fuse3 libfuse3-dev
 ```
 
-### 2. Configure FUSE (Optional)
-
-To allow non-root users to mount FUSE filesystems:
-
-```bash
-sudo nano /etc/fuse.conf
-# Uncomment the line: user_allow_other
-```
-
-### 3. Add User to fuse Group
+### 2. Add User to fuse Group
 
 ```bash
 sudo usermod -aG fuse $USER
 # Log out and back in for group change to take effect
 ```
 
-### 4. Install Go
+### 3. Install Go
 
 ```bash
 # Option 1: From official repo (may be outdated)
@@ -302,7 +293,7 @@ echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
 source ~/.bashrc
 ```
 
-### 5. Build and Install LinearFS
+### 4. Build and Install LinearFS
 
 ```bash
 git clone https://github.com/jra3/linear-fuse.git
@@ -316,7 +307,7 @@ make install  # Copies binary to ~/bin
 > echo 'export PATH="$HOME/bin:$PATH"' >> ~/.bashrc
 > ```
 
-### 6. Configure
+### 5. Configure
 
 ```bash
 mkdir -p ~/.config/linearfs
@@ -330,7 +321,7 @@ Or set the environment variable:
 export LINEAR_API_KEY="lin_api_YOUR_KEY_HERE"
 ```
 
-### 7. Mount
+### 6. Mount
 
 ```bash
 linearfs mount ~/linear
@@ -342,7 +333,7 @@ linearfs mount ~/linear
 |-------|----------|
 | "fusermount3: command not found" | `sudo apt install fuse3` |
 | "fuse: device not found" | `sudo modprobe fuse` |
-| "Permission denied" | Add user to `fuse` group and edit `/etc/fuse.conf` |
+| "Permission denied" | Add user to `fuse` group, or run with sudo |
 | Mount point busy | `fusermount3 -uz ~/linear` to force unmount |
 
 ---


### PR DESCRIPTION
## What

`user_allow_other` in `/etc/fuse.conf` only gates the `allow_other` mount
option, which LinearFS never requests — the mount is always owner-only,
doubly so since the `allow_other` config knob was removed in #355. The setup
that enabled it was therefore vestigial in both places that carried it:

- **INSTALL.md** — removed the "Configure FUSE (Optional)" step that told
  Ubuntu/Debian users to uncomment `user_allow_other`; renumbered the
  remaining steps and dropped the `/etc/fuse.conf` reference from the
  troubleshooting table.
- **CI** — removed the `sed` line that enabled `user_allow_other` on the
  runner in `test.yml` and `integration.yml` (a needless widening of the
  runner's FUSE policy).

## Verification

Ran the FUSE-mounting suites locally with `user_allow_other` **disabled** in
`/etc/fuse.conf` (clean-room):

- `internal/fs` — pass
- `internal/integration` — pass

Confirms owner-only mounts never needed it.

Left untouched: `config.go` / `config_test.go` / `THREAT-MODEL.md` references
to `allow_other`, which document the invariant that it's *never* set — not
vestigial setup.

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)
