### PR TITLE
test: quick follow-ups — dirNames helper (#364), assignee-shadow test (#363), CDN host corpus (#362)

### DIFF
--- a/internal/integration/assignee_shadow_test.go
+++ b/internal/integration/assignee_shadow_test.go
@@ -1,0 +1,79 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAssigneeUnassignedNotShadowed is the #363 receipt (TB1 residual, pairs
+// with #332/#333): the assembled, mount-level proof that a team member whose
+// DisplayName is literally "unassigned" cannot hijack the synthetic
+// by/assignee/unassigned bucket.
+//
+// The unit layer already covers the escape itself (safeName maps the exact
+// collision to "unassigned-<id>", and internal/fs/safename_test.go drives the
+// assigneeHandle builder through the hostile corpus). What only the mount
+// exercises is that the two buckets stay distinct end to end: the assignee-less
+// issues route through GetUnassignedIssues into unassigned/, while the hostile
+// member's issues route through resolveAssigneeID into the escaped
+// unassigned-user-shadow/.
+//
+// Fixture data lives in integration_test.go's populateTestFixtures: user-shadow
+// (DisplayName "unassigned"), TST-90 assigned to it, TST-91 genuinely
+// unassigned.
+func TestAssigneeUnassignedNotShadowed(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode: asserts the seeded hostile 'unassigned' member")
+	}
+
+	const (
+		escapedBucket   = "unassigned-user-shadow" // safeName("unassigned", "user-shadow")
+		hostileIssue    = "TST-90"                 // assigned to the hostile member
+		unassignedIssue = "TST-91"                 // genuinely assignee-less
+	)
+
+	// Both buckets exist side by side: the escape produced a distinct directory
+	// rather than collapsing onto the reserved "unassigned" literal.
+	buckets := dirNames(t, byAssigneePath(testTeamKey))
+	if !buckets["unassigned"] {
+		t.Errorf("by/assignee missing the synthetic unassigned bucket (got %v)", buckets)
+	}
+	if !buckets[escapedBucket] {
+		t.Errorf("by/assignee missing the escaped %q bucket for the hostile member (got %v)", escapedBucket, buckets)
+	}
+
+	// The synthetic unassigned/ bucket lists the assignee-less issue and is NOT
+	// shadowed by the hostile member's issue.
+	unassigned := dirNames(t, filepath.Join(byAssigneePath(testTeamKey), "unassigned"))
+	if !unassigned[unassignedIssue] {
+		t.Errorf("by/assignee/unassigned missing genuinely-unassigned %s (got %v)", unassignedIssue, unassigned)
+	}
+	if unassigned[hostileIssue] {
+		t.Errorf("by/assignee/unassigned leaked hostile-assigned %s — the synthetic bucket IS shadowed (got %v)", hostileIssue, unassigned)
+	}
+
+	// The escaped bucket lists the hostile member's issue and not the
+	// assignee-less one — the two do not bleed into each other.
+	escaped := dirNames(t, filepath.Join(byAssigneePath(testTeamKey), escapedBucket))
+	if !escaped[hostileIssue] {
+		t.Errorf("by/assignee/%s missing hostile-assigned %s (got %v)", escapedBucket, hostileIssue, escaped)
+	}
+	if escaped[unassignedIssue] {
+		t.Errorf("by/assignee/%s leaked unassigned %s (got %v)", escapedBucket, unassignedIssue, escaped)
+	}
+
+	// The hostile member's issue is reachable through the escaped bucket symlink
+	// and correctly attributed (issue.md's assignee renders the member's email).
+	content, err := os.ReadFile(filepath.Join(byAssigneePath(testTeamKey), escapedBucket, hostileIssue, "issue.md"))
+	if err != nil {
+		t.Fatalf("read %s via escaped bucket: %v", hostileIssue, err)
+	}
+	doc, err := parseFrontmatter(content)
+	if err != nil {
+		t.Fatalf("parse %s frontmatter: %v", hostileIssue, err)
+	}
+	if got, _ := doc.Frontmatter["assignee"].(string); got != "shadow@example.com" {
+		t.Errorf("%s assignee = %q, want the hostile member's email shadow@example.com", hostileIssue, got)
+	}
+}

--- a/internal/integration/cache_test.go
+++ b/internal/integration/cache_test.go
@@ -361,7 +361,7 @@ func TestStatusChangeByDirectoryVisibility(t *testing.T) {
 
 	// Verify issue appears in initial status directory
 	fromStatusPath := byStatusPath(testTeamKey, fromState.Name)
-	if !dirContains(fromStatusPath, issue.Identifier) {
+	if !dirContains(t, fromStatusPath, issue.Identifier) {
 		t.Fatalf("Issue not found in initial status directory %s", fromState.Name)
 	}
 
@@ -385,12 +385,12 @@ func TestStatusChangeByDirectoryVisibility(t *testing.T) {
 	toStatusPath := byStatusPath(testTeamKey, toState.Name)
 
 	// Issue should now be in the new status directory
-	if !dirContains(toStatusPath, issue.Identifier) {
+	if !dirContains(t, toStatusPath, issue.Identifier) {
 		t.Errorf("Issue not immediately visible in new status directory %s", toState.Name)
 	}
 
 	// Issue should no longer be in the old status directory
-	if dirContains(fromStatusPath, issue.Identifier) {
+	if dirContains(t, fromStatusPath, issue.Identifier) {
 		t.Errorf("Issue still visible in old status directory %s after status change", fromState.Name)
 	}
 }
@@ -434,7 +434,7 @@ func TestIssueArchiveImmediateVisibility(t *testing.T) {
 	}
 
 	// Verify issue is in the listing
-	if !dirContains(issuesDir, issueIdentifier) {
+	if !dirContains(t, issuesDir, issueIdentifier) {
 		t.Fatalf("Issue not visible in issues directory before archive")
 	}
 
@@ -445,7 +445,7 @@ func TestIssueArchiveImmediateVisibility(t *testing.T) {
 	}
 
 	// Immediately check listing - NO wait needed after filesystem write
-	if dirContains(issuesDir, issueIdentifier) {
+	if dirContains(t, issuesDir, issueIdentifier) {
 		t.Errorf("Issue still visible in issues directory immediately after archive")
 	}
 }

--- a/internal/integration/fixture_parity_test.go
+++ b/internal/integration/fixture_parity_test.go
@@ -288,14 +288,7 @@ func TestFixtureByAssigneeMembers(t *testing.T) {
 		t.Skip("fixture-mode: asserts the seeded synthetic membership")
 	}
 
-	entries, err := os.ReadDir(byAssigneePath(testTeamKey))
-	if err != nil {
-		t.Fatalf("read by/assignee: %v", err)
-	}
-	names := make(map[string]bool, len(entries))
-	for _, e := range entries {
-		names[e.Name()] = true
-	}
+	names := dirNames(t, byAssigneePath(testTeamKey))
 	// assigneeHandle prefers DisplayName; see FixtureAPIUsers.
 	for _, want := range []string{"unassigned", "Test User", "Jane", "Bob"} {
 		if !names[want] {

--- a/internal/integration/fixture_read_test.go
+++ b/internal/integration/fixture_read_test.go
@@ -607,21 +607,12 @@ func TestFixtureByStatusListing(t *testing.T) {
 
 func TestFixtureByStatusContainsIssues(t *testing.T) {
 	// "In Progress" should contain TST-1, TST-4, TST-6
-	inProgressPath := byStatusPath(testTeamKey, "In Progress")
-	entries, err := os.ReadDir(inProgressPath)
-	if err != nil {
-		t.Fatalf("Failed to read by/status/In Progress: %v", err)
-	}
-
-	found := make(map[string]bool)
-	for _, entry := range entries {
-		found[entry.Name()] = true
-	}
+	found := dirNames(t, byStatusPath(testTeamKey, "In Progress"))
 
 	expectedIssues := []string{"TST-1", "TST-4", "TST-6"}
 	for _, id := range expectedIssues {
 		if !found[id] {
-			t.Errorf("Expected %s in by/status/In Progress", id)
+			t.Errorf("Expected %s in by/status/In Progress (got %v)", id, found)
 		}
 	}
 }

--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -298,7 +298,7 @@ const defaultWaitTime = 500 * time.Millisecond
 // never needs. Use dirHas where the entry SHOULD now appear and dirLacks where
 // it SHOULD now be gone; the one-shot dirContains stays for pre-existing
 // fixture entries that never raced a mutation.
-func dirHas(path, name string) bool  { return waitForDirEntry(path, name, defaultWaitTime) == nil }
+func dirHas(path, name string) bool   { return waitForDirEntry(path, name, defaultWaitTime) == nil }
 func dirLacks(path, name string) bool { return waitForNoDirEntry(path, name, defaultWaitTime) == nil }
 
 // waitForCacheExpiry waits for the internal cache to expire.
@@ -340,16 +340,31 @@ func removeFrontmatterField(content []byte, field string) ([]byte, error) {
 
 // Directory listing helpers
 
-func dirContains(path, name string) bool {
+// dirNames reads path and returns the set of entry names, failing the test
+// loudly (with the ReadDir error) if the directory can't be read. Use it for
+// one-shot listing assertions on fixture/pre-existing entries: it collapses the
+// hand-rolled `names := make(map[string]bool)` + range loop, and the returned
+// set gives callers a `got %v` diagnostic for free. For post-mutation listings
+// that race async kernel-cache invalidation, use the polling dirHas/dirLacks.
+func dirNames(t *testing.T, path string) map[string]bool {
+	t.Helper()
 	entries, err := os.ReadDir(path)
 	if err != nil {
-		return false
+		t.Fatalf("read dir %s: %v", path, err)
 	}
-
+	names := make(map[string]bool, len(entries))
 	for _, e := range entries {
-		if e.Name() == name {
-			return true
-		}
+		names[e.Name()] = true
 	}
-	return false
+	return names
+}
+
+// dirContains reports whether path has an entry named name. It routes through
+// dirNames, so a ReadDir failure is a loud t.Fatalf rather than a silent false
+// (the old error-swallowing form was strictly worse than a hand-rolled loop
+// when the assertion failed — it hid the failure). For entries that may race a
+// just-issued mutation, use the polling dirHas/dirLacks instead.
+func dirContains(t *testing.T, path, name string) bool {
+	t.Helper()
+	return dirNames(t, path)[name]
 }

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -22,19 +22,19 @@ import (
 )
 
 var (
-	mountPoint  string
-	stateDir    string // fixture mode: holds the SQLite db, OUTSIDE the mount (see setupSQLiteFixtures)
-	server      *fuse.Server
-	lfs         *fs.LinearFS
-	testStore   *db.Store // fixture mode: the store behind the mount, for tests simulating sync-side writes
-	apiClient   *api.Client
+	mountPoint string
+	stateDir   string // fixture mode: holds the SQLite db, OUTSIDE the mount (see setupSQLiteFixtures)
+	server     *fuse.Server
+	lfs        *fs.LinearFS
+	testStore  *db.Store // fixture mode: the store behind the mount, for tests simulating sync-side writes
+	apiClient  *api.Client
 
 	// offlineAPIServer is where fixture-mode's real client is pointed so an
 	// un-mocked mutation/verify call fails instantly and locally instead of
 	// reaching api.linear.app with the dummy key and 401-ing (#197).
 	offlineAPIServer *httptest.Server
-	testTeamID  string
-	testTeamKey string
+	testTeamID       string
+	testTeamKey      string
 
 	// liveAPIMode indicates if tests are running against real Linear API
 	liveAPIMode bool
@@ -234,6 +234,22 @@ func populateTestFixtures(ctx context.Context, store *db.Store) error {
 	labels := fixtures.FixtureAPILabels()
 	users := fixtures.FixtureAPIUsers()
 
+	// #363 (TB1 residual): a hostile team member whose DisplayName is literally
+	// "unassigned" must NOT shadow the synthetic by/assignee/unassigned bucket.
+	// safeName escapes the exact-collision handle to "unassigned-<id>", so this
+	// member surfaces under by/assignee/unassigned-user-shadow/ while the
+	// assignee-less issues keep the plain unassigned/ bucket. Added to the shared
+	// fixture set (user + team member + two issues below); the assembled,
+	// mount-level behavior is asserted in TestAssigneeUnassignedNotShadowed.
+	shadowUser := api.User{
+		ID:          "user-shadow",
+		Name:        "Shadow User",
+		Email:       "shadow@example.com",
+		DisplayName: "unassigned",
+		Active:      true,
+	}
+	users = append(users, shadowUser)
+
 	// Create a project, pre-labeled with a group child + a retired label (the
 	// carried-through case: labelIds is a full-set write, so a save that keeps
 	// Legacy must re-send it and pass validation).
@@ -313,6 +329,25 @@ func populateTestFixtures(ctx context.Context, store *db.Store) error {
 			fixtures.WithDescription("This issue is in a sprint/cycle"),
 			fixtures.WithState(fixtures.FixtureAPIState("started")),
 			fixtures.WithCycle(&api.IssueCycle{ID: "cycle-1", Name: "Sprint 42", Number: 42}),
+		),
+		// #363: issue assigned to the hostile "unassigned"-named user. It must
+		// route to the escaped by/assignee/unassigned-user-shadow/ bucket, never
+		// the synthetic unassigned/ one.
+		fixtures.FixtureAPIIssue(
+			fixtures.WithIssueID("issue-shadow-assigned", "TST-90"),
+			fixtures.WithTitle("Assigned to the unassigned-named user"),
+			fixtures.WithDescription("Assignee DisplayName is literally \"unassigned\""),
+			fixtures.WithState(fixtures.FixtureAPIState("unstarted")),
+			fixtures.WithAssignee(&shadowUser),
+		),
+		// #363: a genuinely assignee-less issue. It must stay in the synthetic
+		// by/assignee/unassigned/ bucket (proving the bucket is not shadowed).
+		fixtures.FixtureAPIIssue(
+			fixtures.WithIssueID("issue-shadow-unassigned", "TST-91"),
+			fixtures.WithTitle("Genuinely unassigned issue"),
+			fixtures.WithDescription("No assignee; belongs in the synthetic unassigned bucket"),
+			fixtures.WithState(fixtures.FixtureAPIState("unstarted")),
+			fixtures.WithAssignee(nil),
 		),
 	}
 

--- a/internal/integration/read_test.go
+++ b/internal/integration/read_test.go
@@ -138,20 +138,12 @@ func TestTeamsListing(t *testing.T) {
 }
 
 func TestTeamDirectoryContents(t *testing.T) {
-	entries, err := os.ReadDir(teamPath(testTeamKey))
-	if err != nil {
-		t.Fatalf("Failed to read team directory: %v", err)
-	}
-
 	expected := []string{"team.md", "states.md", "labels.md", "by", "issues", "cycles", "projects"}
-	entryNames := make(map[string]bool)
-	for _, e := range entries {
-		entryNames[e.Name()] = true
-	}
+	entryNames := dirNames(t, teamPath(testTeamKey))
 
 	for _, name := range expected {
 		if !entryNames[name] {
-			t.Errorf("Expected %q in team directory", name)
+			t.Errorf("Expected %q in team directory (got %v)", name, entryNames)
 		}
 	}
 }
@@ -448,20 +440,12 @@ func TestIssueWithNoAssignee(t *testing.T) {
 // =============================================================================
 
 func TestMyDirectoryContents(t *testing.T) {
-	entries, err := os.ReadDir(myPath())
-	if err != nil {
-		t.Fatalf("Failed to read my directory: %v", err)
-	}
-
 	expected := []string{"assigned", "created", "active"}
-	entryNames := make(map[string]bool)
-	for _, e := range entries {
-		entryNames[e.Name()] = true
-	}
+	entryNames := dirNames(t, myPath())
 
 	for _, name := range expected {
 		if !entryNames[name] {
-			t.Errorf("Expected %q in /my/ directory", name)
+			t.Errorf("Expected %q in /my/ directory (got %v)", name, entryNames)
 		}
 	}
 }

--- a/internal/integration/t5_recent_test.go
+++ b/internal/integration/t5_recent_test.go
@@ -48,7 +48,7 @@ func TestT5_RecentViewOrdered(t *testing.T) {
 	}
 
 	// recent/ appears in the team listing.
-	if !dirContains(teamPath(testTeamKey), "recent") {
+	if !dirContains(t, teamPath(testTeamKey), "recent") {
 		t.Fatal("recent/ not listed in team directory")
 	}
 

--- a/internal/reconcile/extract_test.go
+++ b/internal/reconcile/extract_test.go
@@ -321,3 +321,150 @@ https://uploads.linear.app/ws1/i1/design-spec.pdf.`
 		t.Errorf("want no specs for plain content, got %d", len(got))
 	}
 }
+
+// legitCDNURL is a genuine Linear CDN URL used as the "must not over-reject"
+// control alongside each hostile lookalike below.
+const legitCDNURL = "https://uploads.linear.app/ws/f/good.png"
+
+// TestLinearCDNPatternAdversarialHosts is the #362 receipt (TB2 residual): the
+// bare-URL fallback regex is the host pin — only https://uploads.linear.app/…
+// URLs ever become embedded-file fetch specs, so a P1-controlled attachment URL
+// in a markdown body can never point CDNClient.Get/Size at another host. The
+// pin is sound by construction (the char after "app" must be "/", and "\." only
+// matches a literal dot), but before this the only negative case was a plain
+// example.com. This corpus drives the crafted lookalikes that a suffix/userinfo/
+// separator/scheme trick would exploit if the regex were loose, asserting each
+// yields NOTHING — while a legitimate URL adjacent to each still extracts, so
+// the pin doesn't over-reject. Pure regex-level, no I/O (guards the first line
+// of TB2 defense; the CheckRedirect refusal from #348 is the second).
+func TestLinearCDNPatternAdversarialHosts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		content  string
+		expected []string
+	}{
+		// Suffix-extended host: "app" is followed by ".", not "/", so
+		// uploads.linear.app.evil.com never satisfies the "app/" anchor.
+		{"suffix-extended host", "https://uploads.linear.app.evil.com/x/y/z.png", nil},
+		{"suffix-extended host + legit adjacent",
+			"hostile https://uploads.linear.app.evil.com/x/y/z.png legit " + legitCDNURL,
+			[]string{legitCDNURL}},
+
+		// Userinfo trick: the "@evil.com" authority is likewise gated out — "app"
+		// is followed by "@", not "/".
+		{"userinfo authority", "https://uploads.linear.app@evil.com/x.png", nil},
+		{"userinfo authority + legit adjacent",
+			"hostile https://uploads.linear.app@evil.com/x.png legit " + legitCDNURL,
+			[]string{legitCDNURL}},
+
+		// Separator lookalikes: the escaped "\." matches only a literal dot, so a
+		// dash (or any other char) between "uploads" and "linear" fails to match.
+		{"dash separator lookalike", "https://uploads-linear.app/x.png", nil},
+		{"non-dot separator lookalike", "https://uploadsXlinear.app/x.png", nil},
+
+		// Scheme downgrade: the pattern requires https://, so plain http:// to the
+		// real host is not extracted (and a real CDN https URL beside it still is).
+		{"scheme downgrade to http", "http://uploads.linear.app/x.png", nil},
+		{"scheme downgrade + legit https",
+			"http://uploads.linear.app/x.png then " + legitCDNURL,
+			[]string{legitCDNURL}},
+
+		// Pin string embedded mid-URL. The bare fallback DOES match the inner,
+		// genuine CDN URL here (leftmost scan finds it) — assessed benign: the
+		// EXTRACTED host is uploads.linear.app, so CDNClient fetches the real CDN,
+		// never evil.com. The pin is about where the fetch lands, and it lands on
+		// the CDN. (markdownLinkPattern, "(" -anchored, does not match this — see
+		// TestMarkdownLinkPatternAdversarialHosts.)
+		{"pin string in path (mid-URL)",
+			"https://evil.com/https://uploads.linear.app/x.png",
+			[]string{"https://uploads.linear.app/x.png"}},
+
+		// All hostile lookalikes at once → nothing; add one legit → only it.
+		{"all hostile, no legit",
+			"https://uploads.linear.app.evil.com/a.png " +
+				"https://uploads.linear.app@evil.com/b.png " +
+				"https://uploads-linear.app/c.png " +
+				"http://uploads.linear.app/d.png",
+			nil},
+		{"all hostile + one legit",
+			"https://uploads.linear.app.evil.com/a.png " +
+				"https://uploads.linear.app@evil.com/b.png " +
+				"https://uploads-linear.app/c.png " +
+				"http://uploads.linear.app/d.png " + legitCDNURL,
+			[]string{legitCDNURL}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := linearCDNPattern.FindAllString(tt.content, -1)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("matched %d URLs, want %d\n got:  %v\n want: %v", len(got), len(tt.expected), got, tt.expected)
+			}
+			for i, want := range tt.expected {
+				if got[i] != want {
+					t.Errorf("URL[%d] = %q, want %q", i, got[i], want)
+				}
+			}
+		})
+	}
+}
+
+// TestMarkdownLinkPatternAdversarialHosts is the markdown-syntax companion to
+// TestLinearCDNPatternAdversarialHosts: markdownLinkPattern is the other half of
+// the #362 host pin. Its URL group is anchored right after the link's "(", which
+// gates out the same lookalike families AND the mid-URL trick the bare fallback
+// tolerates — the URL must BEGIN with https://uploads.linear.app/. This asserts
+// the captured URL (group 2) is empty for each hostile link and the genuine URL
+// for the legit control.
+func TestMarkdownLinkPatternAdversarialHosts(t *testing.T) {
+	t.Parallel()
+
+	extractURLs := func(content string) []string {
+		var urls []string
+		for _, m := range markdownLinkPattern.FindAllStringSubmatch(content, -1) {
+			if len(m) >= 3 {
+				urls = append(urls, m[2])
+			}
+		}
+		return urls
+	}
+
+	tests := []struct {
+		name     string
+		content  string
+		expected []string
+	}{
+		{"suffix-extended host", "![shot](https://uploads.linear.app.evil.com/x.png)", nil},
+		{"userinfo authority", "![shot](https://uploads.linear.app@evil.com/x.png)", nil},
+		{"dash separator lookalike", "![shot](https://uploads-linear.app/x.png)", nil},
+		{"scheme downgrade to http", "![shot](http://uploads.linear.app/x.png)", nil},
+		// Anchored "(" defeats the mid-URL trick that the bare fallback matched:
+		// the URL group must start immediately after "(", and here it starts with
+		// https://evil.com.
+		{"pin string in path (mid-URL)", "![shot](https://evil.com/https://uploads.linear.app/x.png)", nil},
+		// Legit control, and a legit link beside a hostile one — neither
+		// over-rejected nor tricked.
+		{"legit link (control)", "![shot](" + legitCDNURL + ")", []string{legitCDNURL}},
+		{"legit link beside hostile",
+			"![a](https://uploads.linear.app.evil.com/x.png) ![b](" + legitCDNURL + ")",
+			[]string{legitCDNURL}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := extractURLs(tt.content)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("captured %d URLs, want %d\n got:  %v\n want: %v", len(got), len(tt.expected), got, tt.expected)
+			}
+			for i, want := range tt.expected {
+				if got[i] != want {
+					t.Errorf("URL[%d] = %q, want %q", i, got[i], want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Three related test/quality follow-ups flagged by the #355/#341/#342 spec
reviews. Test-only — no product surface, contract, or trust boundary changes.

## #364 — `dirNames` helper + error-aware `dirContains`

The integration suite hand-rolled the ReadDir-and-build-a-name-set shape in
several places, and kept doing so because the old `dirContains` swallowed the
ReadDir error (returned `false`) — strictly worse than the loop when an
assertion failed, since it hid the failure.

- `dirNames(t, path) map[string]bool` — ReadDir with `t.Fatalf` on error,
  returns the entry-name set (`got %v` diagnostics for free).
- `dirContains(t, path, name)` reimplemented through `dirNames`, so a ReadDir
  failure is now loud instead of a silent false.
- Swept the four verbatim set-builds onto `dirNames`; updated `dirContains`
  call sites to the new signature. Polling `dirHas`/`dirLacks` left as-is
  (they intentionally tolerate transient errors).

## #363 — `unassigned`-named user can't shadow the `by/assignee` bucket (TB1)

The unit layer covered the escape (`safeName` → `unassigned-<id>`). This adds
the assembled, mount-level proof. Extends the shared fixture set with a hostile
member (DisplayName literally `unassigned`), an issue assigned to it (TST-90),
and a genuinely assignee-less issue (TST-91). `TestAssigneeUnassignedNotShadowed`
asserts:

- `by/assignee/unassigned/` lists the assignee-less issue and **not** the
  hostile member's issue;
- `by/assignee/unassigned-user-shadow/` lists the hostile member's issue,
  reachable and correctly attributed.

(Dogfoods the `dirNames` helper from #364.)

## #362 — adversarial lookalike-host corpus for the CDN URL pin (TB2)

Pure regex-level table tests over crafted lookalikes of the
`uploads.linear.app` host pin: suffix-extended host, userinfo trick, separator
lookalikes (the `\.`-escaping guard), scheme downgrade → all extract nothing;
pin-string-in-path → the bare fallback matches the inner **genuine** CDN URL
(asserted, assessed benign — the fetch lands on the real CDN), the `(`-anchored
markdown pattern matches nothing; a legit URL adjacent to each hostile one still
extracts (no over-rejection).

## Verification

- `internal/reconcile` — the new corpus passes.
- Full `internal/integration` suite (mounts real FUSE) — passes, so the shared
  fixture additions broke no exact-count assertions.
- `go build ./...`, `go vet`, `gofmt` clean.

Closes #364
Closes #363
Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)
