### PR TITLE
fix(fs): create tail records the deduplicated name Lookup serves

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -851,11 +851,11 @@ embedded files (CDN-backed bytes, named by filename) and external attachments
 (`.link` files, named by sanitized title). `attachmentListing{embedded,
 external}` (`internal/fs/attachmentlisting.go`) exposes `entries()` (Readdir)
 and `find(name)` (Lookup) returning a tagged entry, and owns
-`deduplicateFilename`, `sanitizeFilename`, and `linkName` (the `.link`
-derivation the create surface's `.last` path and kernel-entry name reuse —
-formerly restated at four sites). Before it, Readdir and Lookup each rebuilt
-the dedup map independently, duplicate-titled externals emitted *duplicate
-dirents* (kernel-collapsed shadowing), and the dedup algorithm had zero tests.
+`deduplicateFilename`, `sanitizeFilename`, and `linkName` (the *pre-dedup*
+`.link` derivation, written exactly once — formerly restated at four sites).
+Before it, Readdir and Lookup each rebuilt the dedup map independently,
+duplicate-titled externals emitted *duplicate dirents* (kernel-collapsed
+shadowing), and the dedup algorithm had zero tests.
 
 **Collisions are deduplicated (`foo (2).link`) — deliberately the opposite of
 [[named-listing]]'s first-match/shadow policy, licensed by that policy's own
@@ -875,6 +875,25 @@ distinguishes not-found (`ENOENT`) from couldn't-look (`EIO`) via the
 `listing(ctx, &fetchErr)` seam. Pure of the repo; unit-tested on literal
 slices (`TestAttachmentListing*`: round-trip, cross-family dedup, extension
 edges, linkName), no mount.
+
+**The create tail derives its name through the listing, never from the base
+(#333).** `AttachmentsNode.listedName` — and its `linkListing` twin
+`LinksNode.listedName` — finds the just-created entity by ID in the
+post-persist listing (`persist` runs before `result`/`entryName` in the
+[[create-tail]], so it is already visible) and returns `entries()`'
+deduplicated name, so the `.last` `path` and the kernel-notify entry name are
+the *same* name Readdir/Lookup serve; the pre-dedup `linkName`/
+`externalLinkName` is the fallback only when a re-list can't place the item
+(fetch error, or not yet visible). Recording the pre-dedup base
+stranded a colliding create at a name the reader could not open, and
+invalidated the sibling's entry instead. One memoized closure feeds both
+consumers, so they cannot derive two lists that disagree.
+`TestCreateAttachmentCollisionRecordsDedupedName` /
+`TestCreateLinkCollisionRecordsDedupedName` pin the round-trip. The
+heterogeneous collections can do this precisely because they dedup;
+[[named-listing]]'s first-match surfaces keep recording the derived name (the
+adversarial shadow/strand there is an accepted low risk — see
+`docs/THREAT-MODEL.md` TB1).
 
 ### Relation listing (`relationListing`)
 The **deep module** owning the `{type}-{ID}.rel` filenames of the relations

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -92,6 +92,20 @@ mangled name that resolves elsewhere is worse than a broken one, so `safeName`
 is deterministic (same raw+id → same output) and does not deduplicate (collision
 policy is unchanged; see `namedListing`).
 
+**Accepted collision risk (P1, #333).** Linear permits duplicate label/document/
+milestone names, so a hostile member can *deliberately* forge a name that collides
+with a victim's to **shadow** it (their entity resolves first) or **strand** it
+(the victim's is visible in `readdir`, but Lookup serves the other). The
+first-match/emit-once policy holds anyway: the bound is low — confined to the
+name-addressed projection (no traversal, no arbitrary write), and Linear itself
+shadows same-named entities in-product — and disambiguating (`Bug (2).md`) would
+resolve *nowhere*, since `ResolveMilestoneID`/`GetLabelByName` match the raw entity
+name; the whole name→entity stack is assume-first. The heterogeneous collections
+(attachments/links) *do* deduplicate, because nothing name-resolves them by title;
+#333 also aligned their create tail to record and invalidate the **same**
+deduplicated name Lookup serves, closing a round-trip strand where a colliding
+create landed at a name the reader could not open.
+
 Note the in-scope sliver of the "malicious server" idea lives here too: the
 GraphQL/CDN transport must stay HTTPS and must not follow redirects to non-Linear
 hosts, because that is the difference between "P1 sends hostile data" (in scope)

--- a/internal/fs/attachmentlisting.go
+++ b/internal/fs/attachmentlisting.go
@@ -45,9 +45,11 @@ type attachmentEntry struct {
 	external *api.Attachment
 }
 
-// linkName derives an external attachment's base filename (before dedup).
-// The create surface reuses it for its .last path and kernel-entry name, so
-// the derivation is written exactly once.
+// linkName derives an external attachment's base filename (before dedup) — the
+// pre-dedup input to entries(). It is written exactly once here; the create tail
+// resolves its final .last path and kernel-entry name through the listing
+// (AttachmentsNode.listedName) so it agrees with Readdir/Lookup on collisions
+// (#333), falling back to this base name only when the item can't be placed.
 func linkName(att api.Attachment) string {
 	return sanitizeFilename(att.Title, att.ID) + ".link"
 }

--- a/internal/fs/attachments.go
+++ b/internal/fs/attachments.go
@@ -106,8 +106,7 @@ func (n *AttachmentsNode) listing(ctx context.Context, fetchErr *error) attachme
 // records/invalidates the name the item is actually reachable at, not the base
 // that first-matches a sibling (#333).
 func (n *AttachmentsNode) listedName(ctx context.Context, att api.Attachment) string {
-	var ferr error
-	for _, e := range n.listing(ctx, &ferr).entries() {
+	for _, e := range n.listing(ctx, nil).entries() {
 		if e.external != nil && e.external.ID == att.ID {
 			return e.name
 		}
@@ -388,6 +387,8 @@ func (n *AttachmentsNode) upsertAttachment(ctx context.Context, att api.Attachme
 		Url:        att.URL,
 		SourceType: sql.NullString{String: att.SourceType, Valid: att.SourceType != ""},
 		Metadata:   json.RawMessage("{}"),
+		CreatedAt:  sql.NullTime{Time: att.CreatedAt, Valid: !att.CreatedAt.IsZero()},
+		UpdatedAt:  sql.NullTime{Time: att.UpdatedAt, Valid: !att.UpdatedAt.IsZero()},
 		SyncedAt:   db.Now(),
 		Data:       data,
 	})

--- a/internal/fs/attachments.go
+++ b/internal/fs/attachments.go
@@ -98,6 +98,23 @@ func (n *AttachmentsNode) listing(ctx context.Context, fetchErr *error) attachme
 	return attachmentListing{embedded: files, external: attachments}
 }
 
+// listedName returns the deduplicated on-disk name the attachments listing
+// resolves for att (matched by ID) — the same name Readdir/Lookup serve — or the
+// pre-dedup base name when a re-list can't place it (fetch error, or not yet
+// visible). The create tail derives its .last path and kernel-notify name through
+// this so a title collision (with another attachment or an embedded file)
+// records/invalidates the name the item is actually reachable at, not the base
+// that first-matches a sibling (#333).
+func (n *AttachmentsNode) listedName(ctx context.Context, att api.Attachment) string {
+	var ferr error
+	for _, e := range n.listing(ctx, &ferr).entries() {
+		if e.external != nil && e.external.ID == att.ID {
+			return e.name
+		}
+	}
+	return linkName(att)
+}
+
 // trio declares the attachments collection's writable surfaces.
 func (n *AttachmentsNode) trio() collectionTrio {
 	return collectionTrio{kind: "attachments", parentID: n.issueID, onFlush: n.createAttachment}
@@ -292,6 +309,23 @@ func (n *AttachmentsNode) createAttachment(ctx context.Context, raw []byte) sysc
 		}
 	}
 
+	// #333: record the .last path and invalidate the kernel entry under the SAME
+	// deduplicated name Readdir/Lookup resolve — not the pre-dedup base. On a title
+	// collision (with another attachment or an embedded file) the base first-matches
+	// a sibling, so recording it strands this attachment at a name the reader can't
+	// open (and invalidates the wrong entry). persist (in commitCreate) runs before
+	// result/entryName, so the listing already includes this attachment; deriving
+	// through it keeps create and Lookup on one name. Memoized so .last and the
+	// kernel-notify entry never derive two lists that could disagree.
+	var cachedName string
+	var haveName bool
+	nameFor := func(a *api.Attachment) string {
+		if !haveName {
+			haveName, cachedName = true, n.listedName(ctx, *a)
+		}
+		return cachedName
+	}
+
 	_, errno := commitCreate(ctx, n.lfs, createSpec[api.Attachment]{
 		op:  "create attachment",
 		key: collectionErrorKey("attachments", n.issueID),
@@ -324,7 +358,7 @@ func (n *AttachmentsNode) createAttachment(ctx context.Context, raw []byte) sysc
 		result: func(a *api.Attachment) WriteResult {
 			return WriteResult{
 				URL:   a.URL,
-				Path:  linkName(*a),
+				Path:  nameFor(a),
 				Title: a.Title,
 			}
 		},
@@ -332,7 +366,7 @@ func (n *AttachmentsNode) createAttachment(ctx context.Context, raw []byte) sysc
 			return n.upsertAttachment(ctx, *a)
 		},
 		dir:       attachmentsDirIno(n.issueID),
-		entryName: func(a *api.Attachment) string { return linkName(*a) },
+		entryName: func(a *api.Attachment) string { return nameFor(a) },
 	})
 	return errno
 }

--- a/internal/fs/attachments_test.go
+++ b/internal/fs/attachments_test.go
@@ -86,6 +86,57 @@ func TestCreateAttachmentIdempotentOnDuplicate(t *testing.T) {
 	}
 }
 
+// TestCreateAttachmentCollisionRecordsDedupedName is the #333 Gap-2 regression for
+// the attachments surface (twin of the links test): a new external attachment whose
+// title collides with an existing one must record (in .last) and invalidate the
+// DEDUPLICATED name Readdir/Lookup resolve (`Docs (2).link`), not the pre-dedup base
+// (`Docs.link`) that first-matches the other attachment. .last's path and the
+// kernel-notify name share one derivation, so .last stands in for both.
+func TestCreateAttachmentCollisionRecordsDedupedName(t *testing.T) {
+	lfs, store := linkTestLFS(t)
+	ctx := context.Background()
+
+	const issueID = "issue-collide"
+	dir := &AttachmentsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}, issueID: issueID}
+	key := collectionErrorKey("attachments", issueID)
+
+	// Seed an existing "Docs" attachment that sorts FIRST. The create path leaves
+	// created_at NULL, and so does this seed, so ORDER BY created_at,id tie-breaks on
+	// id: the "aaa-" prefix sorts before the mock's "mock-attachment-N", forcing the
+	// new colliding attachment into the "(2)" slot deterministically.
+	seed := api.Attachment{ID: "aaa-seed-docs", Title: "Docs", URL: "https://example.com/seed"}
+	data, _ := json.Marshal(seed)
+	if err := store.Queries().UpsertAttachment(ctx, db.UpsertAttachmentParams{
+		ID: seed.ID, IssueID: issueID, Title: seed.Title, Url: seed.URL,
+		Metadata: json.RawMessage("{}"), SyncedAt: time.Now(), Data: data,
+	}); err != nil {
+		t.Fatalf("seed UpsertAttachment: %v", err)
+	}
+
+	// Create a second "Docs" attachment with a distinct URL, so it is a real create
+	// and not an idempotent URL-match skip.
+	const newURL = "https://example.com/new-docs"
+	if errno := dir.createAttachment(ctx, []byte(newURL+" Docs")); errno != 0 {
+		t.Fatalf("createAttachment: errno = %v, want 0", errno)
+	}
+
+	got := lfs.GetWriteSuccess(key)
+	if len(got) != 1 {
+		t.Fatalf("want 1 .last entry, got %d: %+v", len(got), got)
+	}
+	recorded := got[0].Path
+
+	// The recorded name must resolve — through the shared listing derivation — back
+	// to the attachment that was actually created (matched by its unique URL).
+	entry, ok := dir.listing(ctx, nil).find(recorded)
+	if !ok {
+		t.Fatalf(".last recorded name %q is not resolvable by the listing", recorded)
+	}
+	if entry.external == nil || entry.external.URL != newURL {
+		t.Errorf(".last recorded %q, which does not resolve to the created attachment %q (#333 strand)", recorded, newURL)
+	}
+}
+
 // TestCreateAttachmentPersistFailureFailsLoud is the #284 regression (twin of
 // #283): an attachment link whose SQLite reflection fails must fail loud (EIO)
 // with a de-dupe .error, not report success. The bug was that the persist closure

--- a/internal/fs/attachments_test.go
+++ b/internal/fs/attachments_test.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"path/filepath"
@@ -100,15 +101,19 @@ func TestCreateAttachmentCollisionRecordsDedupedName(t *testing.T) {
 	dir := &AttachmentsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}, issueID: issueID}
 	key := collectionErrorKey("attachments", issueID)
 
-	// Seed an existing "Docs" attachment that sorts FIRST. The create path leaves
-	// created_at NULL, and so does this seed, so ORDER BY created_at,id tie-breaks on
-	// id: the "aaa-" prefix sorts before the mock's "mock-attachment-N", forcing the
-	// new colliding attachment into the "(2)" slot deterministically.
-	seed := api.Attachment{ID: "aaa-seed-docs", Title: "Docs", URL: "https://example.com/seed"}
+	// Seed an existing "Docs" attachment that sorts FIRST the way production data
+	// does: an already-synced sibling carries a real, EARLIER created_at (the mock
+	// mutator stamps its creates at a fixed 2026-01-01), so ORDER BY created_at,id
+	// puts the seed first and the new colliding attachment in the "(2)" slot.
+	seedCreated := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	seed := api.Attachment{ID: "seed-docs", Title: "Docs", URL: "https://example.com/seed", CreatedAt: seedCreated, UpdatedAt: seedCreated}
 	data, _ := json.Marshal(seed)
 	if err := store.Queries().UpsertAttachment(ctx, db.UpsertAttachmentParams{
 		ID: seed.ID, IssueID: issueID, Title: seed.Title, Url: seed.URL,
-		Metadata: json.RawMessage("{}"), SyncedAt: time.Now(), Data: data,
+		Metadata:  json.RawMessage("{}"),
+		CreatedAt: sql.NullTime{Time: seedCreated, Valid: true},
+		UpdatedAt: sql.NullTime{Time: seedCreated, Valid: true},
+		SyncedAt:  time.Now(), Data: data,
 	}); err != nil {
 		t.Fatalf("seed UpsertAttachment: %v", err)
 	}
@@ -134,6 +139,12 @@ func TestCreateAttachmentCollisionRecordsDedupedName(t *testing.T) {
 	}
 	if entry.external == nil || entry.external.URL != newURL {
 		t.Errorf(".last recorded %q, which does not resolve to the created attachment %q (#333 strand)", recorded, newURL)
+	}
+	// The created attachment sorts second only because the create path persisted its
+	// real created_at; a NULL one would sort first and silently flip the suffix on
+	// the next sync.
+	if recorded != "Docs (2).link" {
+		t.Errorf(".last recorded %q, want %q — the newer attachment must take the deduped slot", recorded, "Docs (2).link")
 	}
 }
 

--- a/internal/fs/linklisting.go
+++ b/internal/fs/linklisting.go
@@ -47,9 +47,11 @@ type linkEntry struct {
 	link *api.EntityExternalLink
 }
 
-// externalLinkName derives an external link's base filename (before dedup). The
-// create surface reuses it for its .last path and kernel-entry name, so the
-// derivation is written exactly once.
+// externalLinkName derives an external link's base filename (before dedup) — the
+// pre-dedup input to entries(). It is written exactly once here; the create tail
+// resolves its final .last path and kernel-entry name through the listing
+// (LinksNode.listedName) so it agrees with Readdir/Lookup on collisions (#333),
+// falling back to this base name only when the item can't be placed.
 func externalLinkName(link api.EntityExternalLink) string {
 	return sanitizeFilename(link.Label, link.ID) + ".link"
 }

--- a/internal/fs/links.go
+++ b/internal/fs/links.go
@@ -130,6 +130,22 @@ func (n *LinksNode) listing(ctx context.Context, fetchErr *error) linkListing {
 	return linkListing{links: links}
 }
 
+// listedName returns the deduplicated on-disk name the links listing resolves for
+// link (matched by ID) — the same name Readdir/Lookup serve — or the pre-dedup
+// base name when a re-list can't place it (fetch error, or not yet visible). The
+// create tail derives its .last path and kernel-notify name through this so a
+// label collision records/invalidates the name the item is actually reachable at,
+// not the base that first-matches a sibling (#333).
+func (n *LinksNode) listedName(ctx context.Context, link api.EntityExternalLink) string {
+	var ferr error
+	for _, e := range n.listing(ctx, &ferr).entries() {
+		if e.link != nil && e.link.ID == link.ID {
+			return e.name
+		}
+	}
+	return externalLinkName(link)
+}
+
 // trio declares the links collection's writable surfaces.
 func (n *LinksNode) trio() collectionTrio {
 	return collectionTrio{kind: "links", parentID: n.parentID(), onFlush: n.createLink}
@@ -217,6 +233,22 @@ func (n *LinksNode) createLink(ctx context.Context, raw []byte) syscall.Errno {
 		}
 	}
 
+	// #333: record the .last path and invalidate the kernel entry under the SAME
+	// deduplicated name Readdir/Lookup resolve — not the pre-dedup base. On a label
+	// collision the base first-matches a sibling, so recording it strands this link
+	// at a name the reader can't open (and invalidates the wrong entry). persist (in
+	// commitCreate) runs before result/entryName, so the listing already includes
+	// this link; deriving through it keeps create and Lookup on one name. Memoized so
+	// .last and the kernel-notify entry never derive two lists that could disagree.
+	var cachedName string
+	var haveName bool
+	nameFor := func(l *api.EntityExternalLink) string {
+		if !haveName {
+			haveName, cachedName = true, n.listedName(ctx, *l)
+		}
+		return cachedName
+	}
+
 	_, errno := commitCreate(ctx, n.lfs, createSpec[api.EntityExternalLink]{
 		op:  "create link",
 		key: collectionErrorKey("links", n.parentID()),
@@ -250,13 +282,13 @@ func (n *LinksNode) createLink(ctx context.Context, raw []byte) syscall.Errno {
 			return nil, err
 		},
 		result: func(l *api.EntityExternalLink) WriteResult {
-			return WriteResult{URL: l.URL, Path: externalLinkName(*l), Title: l.Label}
+			return WriteResult{URL: l.URL, Path: nameFor(l), Title: l.Label}
 		},
 		persist: func(ctx context.Context, l *api.EntityExternalLink) error {
 			return n.upsertLink(ctx, *l)
 		},
 		dir:       linksDirIno(n.parentID()),
-		entryName: func(l *api.EntityExternalLink) string { return externalLinkName(*l) },
+		entryName: func(l *api.EntityExternalLink) string { return nameFor(l) },
 	})
 	return errno
 }

--- a/internal/fs/links.go
+++ b/internal/fs/links.go
@@ -137,8 +137,7 @@ func (n *LinksNode) listing(ctx context.Context, fetchErr *error) linkListing {
 // label collision records/invalidates the name the item is actually reachable at,
 // not the base that first-matches a sibling (#333).
 func (n *LinksNode) listedName(ctx context.Context, link api.EntityExternalLink) string {
-	var ferr error
-	for _, e := range n.listing(ctx, &ferr).entries() {
+	for _, e := range n.listing(ctx, nil).entries() {
 		if e.link != nil && e.link.ID == link.ID {
 			return e.name
 		}

--- a/internal/fs/links_test.go
+++ b/internal/fs/links_test.go
@@ -115,6 +115,62 @@ func (m recheckMutator) GetIssueAttachments(ctx context.Context, issueID string)
 	return m.atts, nil
 }
 
+// TestCreateLinkCollisionRecordsDedupedName is the #333 Gap-2 regression: when a
+// new external link's label collides with an existing one, the create tail must
+// record (in .last) and invalidate the DEDUPLICATED name Readdir/Lookup resolve
+// (`Docs (2).link`), not the pre-dedup base (`Docs.link`). The base name resolves
+// — by the listing's first match — to the OTHER link, so recording it strands the
+// new link at a name the reader can't open (and invalidates the wrong kernel
+// entry). .last's path and the kernel-notify name share one derivation, so the
+// user-visible .last path stands in for both.
+func TestCreateLinkCollisionRecordsDedupedName(t *testing.T) {
+	lfs, store := linkTestLFS(t)
+
+	const projectID = "proj-collide"
+	dir := &LinksNode{attrNode: attrNode{BaseNode: BaseNode{lfs: lfs}}, projectID: projectID}
+	key := collectionErrorKey("links", dir.parentID())
+
+	// Seed an existing link labelled "Docs" that sorts FIRST — sort_order -1 is
+	// below the mock create's default 0, so ORDER BY sort_order,id forces the new
+	// colliding link into the "(2)" slot deterministically (ID string-sort aside).
+	seed := api.EntityExternalLink{
+		ID: "aaa-seed-docs", Label: "Docs", URL: "https://example.com/seed",
+		SortOrder: -1, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	params, err := db.APIEntityExternalLinkToDB(seed, projectID, "")
+	if err != nil {
+		t.Fatalf("APIEntityExternalLinkToDB: %v", err)
+	}
+	if err := store.Queries().UpsertEntityExternalLink(context.Background(), params); err != nil {
+		t.Fatalf("seed upsert: %v", err)
+	}
+
+	// Create a second "Docs" link with a distinct URL, so it is a real create and
+	// not an idempotent URL-match skip.
+	const newURL = "https://example.com/new-docs"
+	if errno := dir.createLink(context.Background(), []byte(newURL+" Docs")); errno != 0 {
+		t.Fatalf("createLink: errno = %v, want 0", errno)
+	}
+
+	got := lfs.GetWriteSuccess(key)
+	if len(got) != 1 {
+		t.Fatalf("want 1 .last entry, got %d: %+v", len(got), got)
+	}
+	recorded := got[0].Path
+
+	// The recorded name must resolve — through the shared listing derivation — back
+	// to the link that was actually created (matched by its unique URL), not the seed.
+	listing := dir.listing(context.Background(), nil)
+	entry, ok := listing.find(recorded)
+	if !ok {
+		t.Fatalf(".last recorded name %q is not resolvable by the listing", recorded)
+	}
+	if entry.link.URL != newURL {
+		t.Errorf(".last recorded %q, which resolves to link URL %q; want it to resolve to the created link %q (#333 strand)",
+			recorded, entry.link.URL, newURL)
+	}
+}
+
 // TestCreateLinkMutateFailureRechecksLive covers links.go's post-mutation
 // re-check: CreateEntityExternalLink fails, yet the authoritative live list
 // already has the URL, so createLink adopts the live link as an idempotent success

--- a/internal/fs/namedlisting.go
+++ b/internal/fs/namedlisting.go
@@ -31,6 +31,14 @@ import (
 // *policy*: a disambiguated name like "Bug (2).md" would resolve nowhere, since
 // ResolveMilestoneID and GetLabelByName match the raw entity name — the whole
 // name->entity stack is already assume-first. See CONTEXT.md "Named listing".
+//
+// The *adversarial* case — a hostile workspace member deliberately forging a
+// colliding name to shadow or strand a victim's entity — is an accepted LOW risk
+// for the same reasons (first-match is bounded to this name-addressed projection;
+// disambiguation would break the assume-first resolution). See #333 and
+// docs/THREAT-MODEL.md TB1 "Accepted collision risk". The heterogeneous
+// collections deduplicate instead (attachmentListing/linkListing) because nothing
+// name-resolves them by title.
 type namedListing[T any] struct {
 	items  []T
 	nameOf func(T) string

--- a/internal/integration/issue333_collision_test.go
+++ b/internal/integration/issue333_collision_test.go
@@ -1,0 +1,142 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// linkFileURL returns the `url:` field of a *.link file read through the mount,
+// i.e. the entity a given on-disk name actually resolves to.
+func linkFileURL(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if rest, ok := strings.CutPrefix(line, "url: "); ok {
+			return strings.TrimSpace(rest)
+		}
+	}
+	t.Fatalf("%s has no url: field:\n%s", path, data)
+	return ""
+}
+
+// recordedPathsByURL maps a collection's .last entries from the created entity's
+// URL to the on-disk name the create recorded for it.
+func recordedPathsByURL(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	byURL := map[string]string{}
+	for _, e := range parseLastSidecar(t, filepath.Join(dir, ".last")) {
+		byURL[e["url"]] = e["path"]
+	}
+	return byURL
+}
+
+// removeAllWithPrefix deletes every entry in dir whose name starts with prefix,
+// re-listing between removals because a deduplicated name is positional.
+func removeAllWithPrefix(dir, prefix string) {
+	for {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return
+		}
+		victim := ""
+		for _, e := range entries {
+			if strings.HasPrefix(e.Name(), prefix) {
+				victim = e.Name()
+				break
+			}
+		}
+		if victim == "" {
+			return
+		}
+		if err := os.Remove(filepath.Join(dir, victim)); err != nil {
+			return
+		}
+	}
+}
+
+// assertRecordedNamesRoundTrip is the shared #333 Gap-2 assertion: for every
+// created URL, the name the create recorded in .last must open THAT entity
+// through the mount — not a same-named sibling. It also insists a "(2)" name is
+// among them, so the check can't pass vacuously on a run where no collision
+// actually happened.
+func assertRecordedNamesRoundTrip(t *testing.T, dir string, urls []string) {
+	t.Helper()
+	recorded := recordedPathsByURL(t, dir)
+	deduped := false
+	for _, url := range urls {
+		name, ok := recorded[url]
+		if !ok {
+			t.Fatalf(".last has no entry for created URL %q (entries: %v)", url, recorded)
+		}
+		if strings.Contains(name, " (2)") {
+			deduped = true
+		}
+		if got := linkFileURL(t, filepath.Join(dir, name)); got != url {
+			t.Errorf("created %s but .last recorded %q, which opens %s (#333: the create landed at a name the reader can't open)",
+				url, name, got)
+		}
+	}
+	if !deduped {
+		t.Errorf("no deduplicated name among %v — the two creates did not collide, so this proves nothing", recorded)
+	}
+}
+
+// TestIssue333_CreateTailRecordsNameLookupServes is the mount-level regression
+// for #333 Gap 2, exercised the way a user/agent actually experiences it: write
+// two same-titled entries to _create, read the collection's .last to learn where
+// they landed, then open those paths. Because the listing deduplicates
+// ("Docs (2).link") while the create tail used to record the pre-dedup base
+// ("Docs.link"), one of the two creates was recorded at a name that opens the
+// OTHER entity — visible in readdir, unopenable by identity. Both surfaces that
+// deduplicate (issue attachments, project/initiative links) are covered.
+func TestIssue333_CreateTailRecordsNameLookupServes(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode offline write-path check; uses the mock mutator")
+	}
+	enableMockMutations(t)
+
+	t.Run("attachments", func(t *testing.T) {
+		// A throwaway issue (unique per run), never shared TST-1, so repeated runs
+		// don't accumulate into the fixture attachment counts.
+		issue := createRefreshTestIssue(t, "Issue333 Attachment Collision Probe")
+		dir := attachmentsPath(testTeamKey, issue)
+
+		urls := []string{
+			"https://example.com/issue333/attachment/first",
+			"https://example.com/issue333/attachment/second",
+		}
+		for _, url := range urls {
+			// Same title, distinct URLs: a real second create (the URL-match
+			// idempotency skip would otherwise swallow it) that collides on name.
+			if err := writeToWriteOnly(t, filepath.Join(dir, "_create"), url+" Docs"); err != nil {
+				t.Fatalf("create attachment %s: %v", url, err)
+			}
+		}
+		assertRecordedNamesRoundTrip(t, dir, urls)
+	})
+
+	t.Run("project links", func(t *testing.T) {
+		dir := filepath.Join(projectsPath(testTeamKey), "test-project", "links")
+
+		urls := []string{
+			"https://example.com/issue333/link/first",
+			"https://example.com/issue333/link/second",
+		}
+		for _, url := range urls {
+			if err := writeToWriteOnly(t, filepath.Join(dir, "_create"), url+" Issue333 Link Probe"); err != nil {
+				t.Fatalf("create link %s: %v", url, err)
+			}
+		}
+		// The shared fixture project outlives this test; drop both probes so a
+		// -count rerun starts clean. Re-list after every removal: deleting one of a
+		// deduplicated pair renames the survivor back to the base name, so a
+		// snapshot of both names would leave one behind.
+		t.Cleanup(func() { removeAllWithPrefix(dir, "Issue333 Link Probe") })
+		assertRecordedNamesRoundTrip(t, dir, urls)
+	})
+}


### PR DESCRIPTION
## Intent

Implement GitHub issue #333 (security, sev:low, area:fs; Part of #319): two name-collision gaps in the FUSE name-addressed collections.

GAP 2 (the code fix). On an attachment/external-link create, the .last success entry and the kernel-notify invalidation recorded the UN-deduplicated base name (linkName / externalLinkName), while Readdir/Lookup resolve the DEDUPLICATED name (deduplicateFilename, e.g. 'Docs (2).link'). On a title/label collision the two diverge: the create lands at a name the reader cannot open (the base first-matches a sibling) and the wrong kernel entry is invalidated. Fix: route the create tail through the SAME listing derivation Readdir/Lookup use. New AttachmentsNode/LinksNode.listedName finds the created entity by ID in the post-persist listing (persist runs before result/entryName in commitCreate, so the entity is already visible via SQLite) and returns entries()' deduplicated name, falling back to the base name only when it cannot be placed. A memoized nameFor closure feeds both the .last path and the kernel-notify entryName so they never derive two lists that could disagree.

GAP 1 (documentation — DELIBERATELY NOT a behavior change). The namedListing first-match/emit-once policy for docs/labels/milestones STAYS. The maintainer explicitly decided this on the issue: 'collision policy stays first-match; this is a separate thin follow-up.' The adversarial case (a hostile workspace member forcing a colliding name to shadow/strand a victim) is documented as an ACCEPTED LOW risk in docs/THREAT-MODEL.md TB1 and the namedListing.go comment. Do NOT flag keeping first-match as a bug, and do NOT flag the THREAT-MODEL.md / namedlisting.go doc edits as scope creep — documenting the accepted risk IS the literal Gap-1 deliverable, and the THREAT-MODEL.md update is also required by CLAUDE.md's trust-boundary-doc rule (this change reshapes how a remote string becomes the reachable on-disk name under adversarial collision, TB1).

Deliberate decisions a reviewer reading only the diff would not know: (1) ARCHITECTURE.md and the generated README were intentionally NOT updated — the fix makes the create tail CONFORM to an already-documented invariant ('a name you can ls you can also open and rm'), and .last's 'path' field semantics are unchanged (merely made correct), so no seam/flow/contract moved and no README surface changed. (2) The ~8-line memoization (nameFor closure + listedName method) is near-duplicated across attachments.go and links.go on purpose: the entity types and entries() field access differ (attachmentEntry.external / api.Attachment vs linkEntry.link / api.EntityExternalLink), so unifying would need generics plus an accessor — more ceremony than the small dupe costs. (3) listedName does one extra listing per create; creates are low-frequency user-blocking writes, so this is fine. (4) On the persist-failure path result() re-lists a possibly-wedged store and falls back to the base name, which is benign because unconfirmedReflectionMsg uses only Identifier/Title, never Path, and .last is not appended on that path.

Tests: two round-trip regressions (TestCreateLinkCollisionRecordsDedupedName, TestCreateAttachmentCollisionRecordsDedupedName) assert a colliding create's recorded .last name resolves back to the CREATED entity, not the collided sibling. Both were RED before the fix and GREEN after; the full suite passes. Scope is strictly the two gaps; nothing else.

## What Changed

- Attachment and external-link creates now derive the `.last` `path` and the kernel-notify entry name through the collection listing instead of the pre-dedup base name. New `AttachmentsNode.listedName` / `LinksNode.listedName` find the just-created entity by ID in the post-persist listing (`persist` runs before `result`/`entryName` in `commitCreate`) and return `entries()`' deduplicated name, falling back to `linkName`/`externalLinkName` only when a re-list can't place the item. A memoized `nameFor` closure feeds both consumers so they can't derive two disagreeing lists. Previously a title/label collision recorded a name that first-matched a sibling, stranding the create at a path the reader couldn't open and invalidating the wrong kernel entry.
- `upsertAttachment` now persists `CreatedAt`/`UpdatedAt` from the API response, so a freshly created attachment sorts in `ListIssueAttachments` (`ORDER BY created_at, id`) the same way it will after the next sync — without this the dedup suffix flipped one sync cycle later.
- Documented the unchanged `namedListing` first-match/emit-once policy for docs/labels/milestones as an accepted low risk under adversarial collision, in `docs/THREAT-MODEL.md` TB1 and the `namedlisting.go` comment, plus a CONTEXT.md section on the dedup-aware create tail. Test coverage: two node-level regressions (`TestCreateAttachmentCollisionRecordsDedupedName`, `TestCreateLinkCollisionRecordsDedupedName`) and a mount-level round trip (`internal/integration/issue333_collision_test.go`) that writes two same-titled entries, reads `.last`, and opens each recorded path.

## Risk Assessment

✅ Low: The change is well-bounded — a name-derivation fix confined to two create tails plus two persisted attachment timestamp columns whose only consumer is the ORDER BY the fix targets — with round-trip regression tests on both surfaces and all three prior review findings verified as correctly resolved.

## Testing

Ran the full Go suite (green before and after adding a test), the two shipped node-level regressions, and a new mount-level regression I wrote that exercises the user-visible round trip on a real FUSE mount: create two same-titled attachments/links, read the collection's `.last`, then open the recorded paths. To prove it is a real fix I reverted attachments.go/links.go to the base commit and both the unit and mount checks failed exactly as the issue describes — `.last` recorded `Docs.link`, which opens the previously-created attachment — then restored the files. The reviewer-visible artifact is a live-mount CLI transcript captured before and after the fix showing `path: Docs.link` becoming `path: Docs (2).link` and that name opening (and rm-ing) the correct entity; there is no UI surface here, the product's end-user surface is the mounted filesystem, so a shell transcript against the mount is the closest equivalent to a screenshot. No failures or flakiness remain; the new test is stable across repeated runs on the shared fixture mount.

<details>
<summary>Evidence: Live-mount CLI transcript AFTER the fix (attachments + project links round trip)</summary>

```text
=== RUN   TestZZEvidenceTranscript

===== #333 attachments round trip (mount=/home/john/tmp/linearfs-test-1964474426 issue=TST-1001) =====

# 1. attach a URL titled "Docs"
$ /bin/sh -c 'printf 'https://example.com/docs/handbook Docs' > '/home/john/tmp/linearfs-test-1964474426/teams/TST/issues/TST-1001/attachments/_create''

# 2. attach a DIFFERENT URL, colliding on the same title "Docs"
$ /bin/sh -c 'printf 'https://example.com/docs/runbook Docs' > '/home/john/tmp/linearfs-test-1964474426/teams/TST/issues/TST-1001/attachments/_create''

# 3. what the directory looks like to a reader
$ /bin/ls -1 /home/john/tmp/linearfs-test-1964474426/teams/TST/issues/TST-1001/attachments
_create
Docs (2).link
Docs.link

# 4. what the create tail told the caller (attachments/.last)
$ /bin/cat /home/john/tmp/linearfs-test-1964474426/teams/TST/issues/TST-1001/attachments/.last
- identifier: ""
  url: https://example.com/docs/handbook
  path: Docs.link
  title: Docs
  status: ""
- identifier: ""
  url: https://example.com/docs/runbook
  path: Docs (2).link
  title: Docs
  status: ""

# 5. open each recorded path -- each must be the entity that create returned
$ /bin/cat /home/john/tmp/linearfs-test-1964474426/teams/TST/issues/TST-1001/attachments/Docs.link
title: Docs
url: https://example.com/docs/handbook

$ /bin/cat '/home/john/tmp/linearfs-test-1964474426/teams/TST/issues/TST-1001/attachments/Docs (2).link'
title: Docs
url: https://example.com/docs/runbook

# 6. the recorded name is also the name you can rm
$ /bin/rm '/home/john/tmp/linearfs-test-1964474426/teams/TST/issues/TST-1001/attachments/Docs (2).link'

$ /bin/ls -1 /home/john/tmp/linearfs-test-1964474426/teams/TST/issues/TST-1001/attachments
_create
Docs.link

$ /bin/cat /home/john/tmp/linearfs-test-1964474426/teams/TST/issues/TST-1001/attachments/Docs.link
title: Docs
url: https://example.com/docs/handbook


===== #333 project links round trip (/home/john/tmp/linearfs-test-1964474426/teams/TST/projects/test-project/links) =====

# 1+2. two external links sharing the label "Runbook"
$ /bin/sh -c 'printf 'https://example.com/links/one Runbook' > '/home/john/tmp/linearfs-test-1964474426/teams/TST/projects/test-project/links/_create''

$ /bin/sh -c 'printf 'https://example.com/links/two Runbook' > '/home/john/tmp/linearfs-test-1964474426/teams/TST/projects/test-project/links/_create''

# 3. listing / .last / open the recorded names
$ /bin/sh -c '/bin/ls -1 '/home/john/tmp/linearfs-test-1964474426/teams/TST/projects/test-project/links' | grep Runbook'
Runbook (2).link
Runbook.link

$ /bin/cat /home/john/tmp/linearfs-test-1964474426/teams/TST/projects/test-project/links/.last
- identifier: ""
  url: https://example.com/links/one
  path: Runbook.link
  title: Runbook
  status: ""
- identifier: ""
  url: https://example.com/links/two
  path: Runbook (2).link
  title: Runbook
  status: ""

$ /bin/cat /home/john/tmp/linearfs-test-1964474426/teams/TST/projects/test-project/links/Runbook.link
label: Runbook
url: https://example.com/links/one

$ /bin/cat '/home/john/tmp/linearfs-test-1964474426/teams/TST/projects/test-project/links/Runbook (2).link'
label: Runbook
url: https://example.com/links/two

--- PASS: TestZZEvidenceTranscript (0.02s)
PASS
ok  	github.com/jra3/linear-fuse/internal/integration	0.126s
```
</details>
<details>
<summary>Evidence: Live-mount CLI transcript BEFORE the fix (same steps, source reverted to base 8ef8209)</summary>

```text
=== RUN   TestZZEvidenceTranscript

===== #333 attachments round trip (mount=/home/john/tmp/linearfs-test-2590254966 issue=TST-1001) =====

# 1. attach a URL titled "Docs"
$ /bin/sh -c 'printf 'https://example.com/docs/handbook Docs' > '/home/john/tmp/linearfs-test-2590254966/teams/TST/issues/TST-1001/attachments/_create''

# 2. attach a DIFFERENT URL, colliding on the same title "Docs"
$ /bin/sh -c 'printf 'https://example.com/docs/runbook Docs' > '/home/john/tmp/linearfs-test-2590254966/teams/TST/issues/TST-1001/attachments/_create''

# 3. what the directory looks like to a reader
$ /bin/ls -1 /home/john/tmp/linearfs-test-2590254966/teams/TST/issues/TST-1001/attachments
_create
Docs (2).link
Docs.link

# 4. what the create tail told the caller (attachments/.last)
$ /bin/cat /home/john/tmp/linearfs-test-2590254966/teams/TST/issues/TST-1001/attachments/.last
- identifier: ""
  url: https://example.com/docs/handbook
  path: Docs.link
  title: Docs
  status: ""
- identifier: ""
  url: https://example.com/docs/runbook
  path: Docs.link
  title: Docs
  status: ""

# 5. open each recorded path -- each must be the entity that create returned
$ /bin/cat /home/john/tmp/linearfs-test-2590254966/teams/TST/issues/TST-1001/attachments/Docs.link
title: Docs
url: https://example.com/docs/handbook

$ /bin/cat '/home/john/tmp/linearfs-test-2590254966/teams/TST/issues/TST-1001/attachments/Docs (2).link'
title: Docs
url: https://example.com/docs/runbook

# 6. the recorded name is also the name you can rm
$ /bin/rm '/home/john/tmp/linearfs-test-2590254966/teams/TST/issues/TST-1001/attachments/Docs (2).link'

$ /bin/ls -1 /home/john/tmp/linearfs-test-2590254966/teams/TST/issues/TST-1001/attachments
_create
Docs.link

$ /bin/cat /home/john/tmp/linearfs-test-2590254966/teams/TST/issues/TST-1001/attachments/Docs.link
title: Docs
url: https://example.com/docs/handbook


===== #333 project links round trip (/home/john/tmp/linearfs-test-2590254966/teams/TST/projects/test-project/links) =====

# 1+2. two external links sharing the label "Runbook"
$ /bin/sh -c 'printf 'https://example.com/links/one Runbook' > '/home/john/tmp/linearfs-test-2590254966/teams/TST/projects/test-project/links/_create''

$ /bin/sh -c 'printf 'https://example.com/links/two Runbook' > '/home/john/tmp/linearfs-test-2590254966/teams/TST/projects/test-project/links/_create''

# 3. listing / .last / open the recorded names
$ /bin/sh -c '/bin/ls -1 '/home/john/tmp/linearfs-test-2590254966/teams/TST/projects/test-project/links' | grep Runbook'
Runbook (2).link
Runbook.link

$ /bin/cat /home/john/tmp/linearfs-test-2590254966/teams/TST/projects/test-project/links/.last
- identifier: ""
  url: https://example.com/links/one
  path: Runbook.link
  title: Runbook
  status: ""
- identifier: ""
  url: https://example.com/links/two
  path: Runbook.link
  title: Runbook
  status: ""

$ /bin/cat /home/john/tmp/linearfs-test-2590254966/teams/TST/projects/test-project/links/Runbook.link
label: Runbook
url: https://example.com/links/one

$ /bin/cat '/home/john/tmp/linearfs-test-2590254966/teams/TST/projects/test-project/links/Runbook (2).link'
label: Runbook
url: https://example.com/links/two

--- PASS: TestZZEvidenceTranscript (0.02s)
PASS
ok  	github.com/jra3/linear-fuse/internal/integration	0.123s
```
</details>
<details>
<summary>Evidence: Before/after diff of the two mount transcripts — the only behavioral delta is the .last path</summary>

<code>@@ attachments/.last @@&#10;- identifier: &#34;&#34;&#10;url: https://example.com/docs/runbook&#10;- path: Docs.link&#10;+ path: Docs (2).link&#10;@@ project links/.last @@&#10;- identifier: &#34;&#34;&#10;url: https://example.com/links/two&#10;- path: Runbook.link&#10;+ path: Runbook (2).link</code>

```text
--- norm-before-fix-mount-transcript.txt	2026-07-28 12:24:28.843460355 -0400
+++ norm-after-fix-mount-transcript.txt	2026-07-28 12:24:28.844460371 -0400
@@ -23,7 +23,7 @@
   status: ""
 - identifier: ""
   url: https://example.com/docs/runbook
-  path: Docs.link
+  path: Docs (2).link
   title: Docs
   status: ""
 
@@ -68,7 +68,7 @@
   status: ""
 - identifier: ""
   url: https://example.com/links/two
-  path: Runbook.link
+  path: Runbook (2).link
   title: Runbook
   status: ""
 
@@ -82,4 +82,4 @@
 
 --- PASS: TestZZEvidenceTranscript (0.02s)
 PASS
-ok  	github.com/jra3/linear-fuse/internal/integration	0.123s
+ok  	github.com/jra3/linear-fuse/internal/integration	0.126s
```
</details>
<details>
<summary>Evidence: Regression tests RED against the pre-fix code (unit + mount level)</summary>

<code>created https://example.com/issue333/attachment/second but .last recorded &#34;Docs.link&#34;, which opens https://example.com/issue333/attachment/first (#333: the create landed at a name the reader can&#39;t open)&#10;created https://example.com/issue333/link/second but .last recorded &#34;Issue333 Link Probe.link&#34;, which opens https://example.com/issue333/link/first</code>

```text
### BEFORE THE FIX (internal/fs/attachments.go + links.go reverted to base 8ef8209)

$ go test ./internal/integration/ -run TestIssue333_CreateTailRecordsNameLookupServes -v
=== RUN   TestIssue333_CreateTailRecordsNameLookupServes
=== RUN   TestIssue333_CreateTailRecordsNameLookupServes/attachments
    issue333_collision_test.go:96: created https://example.com/issue333/attachment/second but .last recorded "Docs.link", which opens https://example.com/issue333/attachment/first (#333: the create landed at a name the reader can't open)
    issue333_collision_test.go:96: no deduplicated name among map[https://example.com/issue333/attachment/first:Docs.link https://example.com/issue333/attachment/second:Docs.link] — the two creates did not collide, so this proves nothing
=== RUN   TestIssue333_CreateTailRecordsNameLookupServes/project_links
    issue333_collision_test.go:119: created https://example.com/issue333/link/second but .last recorded "Issue333 Link Probe.link", which opens https://example.com/issue333/link/first (#333: the create landed at a name the reader can't open)
    issue333_collision_test.go:119: no deduplicated name among map[https://example.com/issue333/link/first:Issue333 Link Probe.link https://example.com/issue333/link/second:Issue333 Link Probe.link] — the two creates did not collide, so this proves nothing
--- FAIL: TestIssue333_CreateTailRecordsNameLookupServes (0.01s)
    --- FAIL: TestIssue333_CreateTailRecordsNameLookupServes/attachments (0.01s)
    --- FAIL: TestIssue333_CreateTailRecordsNameLookupServes/project_links (0.00s)
FAIL
FAIL	github.com/jra3/linear-fuse/internal/integration	0.129s
FAIL

$ go test ./internal/fs/ -run 'Collision' -v
=== RUN   TestCreateAttachmentCollisionRecordsDedupedName
    attachments_test.go:147: .last recorded "Docs.link", want "Docs (2).link" — the newer attachment must take the deduped slot
--- FAIL: TestCreateAttachmentCollisionRecordsDedupedName (0.05s)
=== RUN   TestCreateLinkCollisionRecordsDedupedName
    links_test.go:169: .last recorded "Docs.link", which resolves to link URL "https://example.com/seed"; want it to resolve to the created link "https://example.com/new-docs" (#333 strand)
--- FAIL: TestCreateLinkCollisionRecordsDedupedName (0.05s)
FAIL
FAIL	github.com/jra3/linear-fuse/internal/fs	0.101s
FAIL
```
</details>
<details>
<summary>Evidence: Regression tests GREEN at HEAD (including -count=3 rerun stability)</summary>

```text
### AFTER THE FIX (HEAD 638f38b) — the #333 regressions

$ go test ./internal/fs/ -run 'CollisionRecordsDedupedName' -v
=== RUN   TestCreateAttachmentCollisionRecordsDedupedName
--- PASS: TestCreateAttachmentCollisionRecordsDedupedName (0.06s)
=== RUN   TestCreateLinkCollisionRecordsDedupedName
--- PASS: TestCreateLinkCollisionRecordsDedupedName (0.05s)
PASS
ok  	github.com/jra3/linear-fuse/internal/fs	0.114s

$ go test ./internal/integration/ -run TestIssue333_CreateTailRecordsNameLookupServes -count=3 -v
=== RUN   TestIssue333_CreateTailRecordsNameLookupServes
=== RUN   TestIssue333_CreateTailRecordsNameLookupServes/attachments
=== RUN   TestIssue333_CreateTailRecordsNameLookupServes/project_links
--- PASS: TestIssue333_CreateTailRecordsNameLookupServes (0.01s)
    --- PASS: TestIssue333_CreateTailRecordsNameLookupServes/attachments (0.00s)
    --- PASS: TestIssue333_CreateTailRecordsNameLookupServes/project_links (0.00s)
=== RUN   TestIssue333_CreateTailRecordsNameLookupServes
=== RUN   TestIssue333_CreateTailRecordsNameLookupServes/attachments
=== RUN   TestIssue333_CreateTailRecordsNameLookupServes/project_links
--- PASS: TestIssue333_CreateTailRecordsNameLookupServes (0.01s)
    --- PASS: TestIssue333_CreateTailRecordsNameLookupServes/attachments (0.00s)
    --- PASS: TestIssue333_CreateTailRecordsNameLookupServes/project_links (0.00s)
=== RUN   TestIssue333_CreateTailRecordsNameLookupServes
=== RUN   TestIssue333_CreateTailRecordsNameLookupServes/attachments
=== RUN   TestIssue333_CreateTailRecordsNameLookupServes/project_links
--- PASS: TestIssue333_CreateTailRecordsNameLookupServes (0.01s)
    --- PASS: TestIssue333_CreateTailRecordsNameLookupServes/attachments (0.00s)
    --- PASS: TestIssue333_CreateTailRecordsNameLookupServes/project_links (0.00s)
PASS
ok  	github.com/jra3/linear-fuse/internal/integration	0.107s
```
</details>
- Outcome: ⚠️ 1 info across 1 run (12m15s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `internal/fs/attachments.go:108` - The attachments half of the fix is only durable until the next sync. `listedName` derives the dedup suffix from `ListIssueAttachments` (`ORDER BY created_at, id`), but `upsertAttachment` (internal/fs/attachments.go:383) hand-rolls its `UpsertAttachmentParams` and omits `CreatedAt`/`UpdatedAt` — unlike the links path, which goes through `db.APIEntityExternalLinkToDB` and persists the API&#39;s real `sortOrder`. `attachmentLinkURL` does return `createdAt` (AttachmentFields fragment, queries.go:250), so the value is available and simply dropped.

Failure scenario: issue already has attachment A titled &#34;Docs&#34; (created_at=T1, set by reconcile/details.go via `APIAttachmentToDBAttachment`). User creates B titled &#34;Docs&#34; via `_create`. B&#39;s row lands with created_at NULL, which sorts first in SQLite, so `listedName` returns &#34;Docs.link&#34; for B and A silently becomes &#34;Docs (2).link&#34;; `.last` records &#34;Docs.link&#34; and that kernel entry is invalidated — correct at that instant. On the next issue-details sync, `UpsertAttachment`&#39;s `ON CONFLICT ... created_at = excluded.created_at` fills B&#39;s created_at=T2, the order flips, and &#34;Docs.link&#34; now resolves to A while B moves to &#34;Docs (2).link&#34;. `.last`&#39;s recorded path resolves to the wrong attachment — the exact #333 strand, reintroduced one sync cycle later.

Fix would be to populate the params from `db.APIAttachmentToDBAttachment(att, n.issueID)` (which also carries the creator and metadata fields the hand-rolled copy drops). Flagged as ask-user because the author declared &#34;Scope is strictly the two gaps; nothing else&#34; and this touches persistence outside that boundary.
- ℹ️ `internal/fs/attachments_test.go:103` - `TestCreateAttachmentCollisionRecordsDedupedName` forces its RED state by giving the seed a NULL created_at and an &#34;aaa-&#34; ID so it sorts ahead of &#34;mock-attachment-N&#34;. That is the reverse of production ordering: a real pre-existing attachment carries a non-NULL created_at (set by reconcile/details.go), so the newly created one — with its NULL created_at — sorts first and takes the base name. Under production-shaped data this test would pass even against the pre-fix code, because `linkName()` and `listedName()` would both return &#34;Docs.link&#34;. The invariant it asserts is still the right one, but the coverage does not exercise the ordering users actually hit. Seeding the sibling with a real created_at (and persisting created_at on create, per the finding above) would make it representative. The links twin does not have this problem — its seed uses sort_order -1 vs the create&#39;s 0, matching how Linear appends new links.
- ℹ️ `internal/fs/links.go:140` - `var ferr error` is declared and passed to `listing(ctx, &amp;ferr)` but never read, in both copies (internal/fs/links.go:140-141 and internal/fs/attachments.go:109-110). `listing` accepts a nil `fetchErr` (the test at attachments_test.go:131 and the tests already call it that way), and the base-name fallback is exactly the desired behavior on a fetch error, so `n.listing(ctx, nil).entries()` expresses the same intent without the dead variable.

🔧 Fix: persist attachment timestamps; production-shaped dedup test
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `internal/integration/issue333_collision_test.go` - new test file written by agent: internal/integration/issue333_collision_test.go
- <code>`go test ./...` — full suite, green at base of testing and again with the new integration test added</code>
- <code>`go test ./internal/fs/ -run &#39;TestCreateLinkCollisionRecordsDedupedName|TestCreateAttachmentCollisionRecordsDedupedName&#39; -v` — the two shipped node-level regressions</code>
- <code>Red-before-fix check: `git checkout 8ef8209 -- internal/fs/attachments.go internal/fs/links.go`, reran the unit + mount regressions (both FAIL with the strand), then `git checkout HEAD --` to restore</code>
- <code>New test `go test ./internal/integration/ -run TestIssue333_CreateTailRecordsNameLookupServes -count=3 -v` — mount-level round trip: write two same-titled entries to `_create`, read `.last`, open each recorded path; covers issue attachments and project links</code>
- <code>Manual live-mount CLI transcript (throwaway harness in the integration package, since the mount is owned by TestMain; harness deleted afterward): `sh -c &#39;printf &#34;&lt;url&gt; Docs&#34; &gt; attachments/_create&#39;`, `ls -1 attachments/`, `cat attachments/.last`, `cat &#39;attachments/Docs (2).link&#39;`, `rm &#39;attachments/Docs (2).link&#39;` — captured against both the fixed and the reverted code</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/ARCHITECTURE.md:756` - Pre-existing (not caused by this change) stale Known-gaps bullet: &#34;Three `SyncedAt` stamps bypass `db.Now()` and bind local-zone `time.Now()` values&#34; naming `fs/attachments.go`, `fs/relations.go`, and the history cache. All three now stamp via `db.Now()` (UTC): `internal/fs/attachments.go:392`, `internal/fs/relations.go:193`, `internal/repo/sqlite.go:1370`. Noticed because this change edits the very `UpsertAttachmentParams` literal cited, but the drift predates the base commit, so I left it alone under scope discipline. Worth a one-line follow-up correction (or deletion of the bullet) in a separate change.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `internal/fs/editbuffer_test.go:40` - `golangci-lint run` reports 5 pre-existing errcheck findings in this file (lines 40, 65, 99, 177, 219 — unchecked `b.Write`/`b.Setattr`/`kept.Open` returns). Untouched by this change, and the repo&#39;s CI lint gate is staticcheck + check-safename (both clean), not golangci-lint. Left unfixed because the rules bar modifying tests.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
