### PR TITLE
docs: sync ARCHITECTURE.md CLI wiring and drop resolved observations

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -741,20 +741,3 @@ and `mockmutation`, the in-memory fake behind the `MutationClient` seam.
 - **Time handling** is the most common footgun — both directions: parse reads
   via `ParseSQLiteTime*`, stamp writes via `db.Now()` (UTC). Inside the worker,
   scheduling goes through the injected clock seam.
-
-## Observations worth a maintainer's attention
-
-These surfaced while mapping the code and are noted as-is, not as prescriptions:
-
-- **Embedded-file cache path is macOS-only.** `linearfs.go` hardcodes
-  `~/Library/Caches/linearfs/files` even on Linux (where `~/.cache/linearfs`
-  per XDG would be expected). Embedded-file downloads land there regardless of
-  OS. (The SQLite cache DB itself is XDG-correct via `os.UserConfigDir()`.)
-- **`--config` flag is inert.** `root.go` defines `--config`/`-c`, but
-  `mount.go` calls `config.Load()` with no path, so the config location is
-  effectively hardcoded to the XDG default.
-- **Three `SyncedAt` stamps bypass `db.Now()`** and bind local-zone
-  `time.Now()` values: the history cache (`repo/sqlite.go`, benign — never
-  cutoff-pruned) and the attachment/relation write tails (`fs/attachments.go`,
-  `fs/relations.go`), which *do* feed cutoff-compared prunes — latent
-  misorder bugs east of UTC.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -664,14 +664,17 @@ degrades to summary-only — telemetry must never take the mount down.
 
 ### `internal/cmd` + `cmd/linearfs` + `internal/config` — wiring
 
-`cmd/linearfs/main.go` calls `cmd.Execute()` (Cobra). Commands: `mount`
-(with `--foreground`/`-f`, `--debug`/`-d`) and `version`. **Startup order**
-(`mount.go` → `linearfs.go`):
+`cmd/linearfs/main.go` calls `cmd.Execute()` (Cobra). Commands: `mount` (with
+`--foreground`/`-f`), `status` (read-only local health snapshot; never talks to
+the daemon) and `version`; `--config`/`-c` and `--debug`/`-d` are root
+persistent flags. **Startup order** (`mount.go` → `linearfs.go`):
 
 1. `config.Load()` — reads `LINEAR_API_KEY` and `USER_FEEDBACK` (env overrides
    file) and `~/.config/linearfs/config.yaml` (or `$XDG_CONFIG_HOME`); loading
-   itself succeeds without a key. One hard refusal: if the key's source is the
-   config file (not the env escape hatch) and the file is group/other-accessible
+   itself succeeds without a key. `--config` names an exact file instead
+   (`config.LoadFrom`) — unreadable is fatal for `mount`, while `status` falls
+   back to defaults. One hard refusal: if the key's source is the config file
+   (not the env escape hatch) and the file is group/other-accessible
    (`mode & 0o077 != 0`), load fails and names the fix (`chmod 600`) — see the
    threat model's TB3.
 2. `fs.PreflightMountpoint(...)` — detects and heals a wedged/stale FUSE mount


### PR DESCRIPTION
## Intent

Docs-only cleanup: remove the entire 'Observations worth a maintainer's attention' section (the trailing section) from docs/ARCHITECTURE.md because all three observations it listed have since been fixed, so the map was lying. This is deliberate deletion, not a mistake — do NOT flag the removed content as lost information.

Each removed observation is verified resolved:
(1) 'Embedded-file cache path is macOS-only' — FIXED. internal/fs/embeddedfilecache.go:embeddedFileCacheDir() now uses os.UserCacheDir() (XDG ~/.cache/linearfs on Linux, ~/Library/Caches on macOS). Closed as issue #259.
(2) '--config flag is inert' — FIXED. internal/cmd/mount.go:39 and internal/cmd/status.go:42 read the --config flag and pass the path to config.Load(). Closed as issue #260.
(3) 'Three SyncedAt stamps bypass db.Now()' — FIXED. All three synced_at stamps go through db.Now() (UTC): internal/fs/attachments.go, internal/fs/relations.go, internal/repo/sqlite.go.

The section is REMOVED rather than re-pointed at issues because nothing is outstanding to track (the two that ever had issues, #259/#260, are already closed). Per CLAUDE.md, docs/ARCHITECTURE.md is a verified orientation map that must match the code; a section describing three already-fixed gaps as open is exactly the drift that discipline guards against. No code changed; the general 'Time-stamping invariant (write side)' description elsewhere in the doc (which correctly states synced_at writes go through db.Now()) is left intact. Scope is strictly this one stale section.

## What Changed

- Removed the trailing "Observations worth a maintainer's attention" section from `docs/ARCHITECTURE.md`. All three entries described gaps that the code has since closed — the embedded-file cache path now goes through `os.UserCacheDir()`, `--config` is read and passed to config loading, and every persisted `SyncedAt`/`DetailSyncedAt` stamp goes through `db.Now()` — so the section had become drift the map is supposed to guard against.
- Updated the `internal/cmd` + `cmd/linearfs` + `internal/config` wiring section to match the current CLI: `status` is listed alongside `mount` and `version` (read-only local snapshot, never talks to the daemon), and `--config`/`-c` and `--debug`/`-d` are described as root persistent flags rather than `mount`-only.
- Documented the `--config` load path in the startup-order steps: it names an exact file via `config.LoadFrom`, which is fatal for `mount` when unreadable but falls back to defaults for `status`. The existing group/other-accessible refusal (TB3) and the general "Time-stamping invariant (write side)" text elsewhere in the doc are untouched.

## Risk Assessment

✅ Low: Docs-only deletion of one self-contained trailing section whose three claims I verified are all resolved in the current code, with no surviving references, anchors, or code changes.

## Testing

I validated the docs-only deletion by falsifying each of the three removed observations against the running code, not just by reading the diff: a real FUSE-mounting integration run under a sandboxed XDG_CACHE_HOME showed the app creating $XDG_CACHE_HOME/linearfs/files (with this machine's live install on ~/.cache/linearfs/files and the ~/Library path a fossil last written 2026-06-18), a CLI transcript showed a custom --config file's api_key and mount.default_path actually driving `linearfs status` output and a bad path erroring from both status and mount, and the repo's AST-based TestSyncedAtStampsUseDBNow rule confirmed every persisted synced_at stamp goes through db.Now(). I also verified the diff is deletion-only with no dangling TOC entry or anchor, that the preserved "Time-stamping invariant (write side)" text is intact, captured rendered before/after screenshots of the doc tail as the reader-facing surface, and ran the full test suite green. Everything passed; no findings.

- Evidence: Rendered docs/ARCHITECTURE.md tail — BEFORE (base 45e2df8), stale section highlighted (local file: <code>/home/john/tmp/no-mistakes-evidence/01KYMVHFWP1KCNFMXFJ1ZAPGCH/architecture-tail-before.png</code>)
- Evidence: Rendered docs/ARCHITECTURE.md tail — AFTER (4404a9a), ends cleanly on Cross-cutting concerns (local file: <code>/home/john/tmp/no-mistakes-evidence/01KYMVHFWP1KCNFMXFJ1ZAPGCH/architecture-tail-after.png</code>)
<details>
<summary>Evidence: CLI transcript: --config flag is wired (disproves removed observation 2)</summary>

<code>$ linearfs status --config ./custom-config.yaml # flag honored end-to-end&#10;Config:&#10;file: ./custom-config.yaml&#10;api key: set (config file)&#10;&#10;Mount:&#10;/home/john/am/linear [live]&#10;/tmp/evidence-proves-config-flag-is-wired [not mounted (path does not exist)] (configured default)&#10;&#10;$ linearfs status --config ./no-such-file.yaml # the flag path really is opened&#10;Config:&#10;file: ERROR (failed to read config file: open ./no-such-file.yaml: no such file or directory) — using defaults&#10;&#10;$ linearfs mount --config ./no-such-file.yaml # mount.go reads it too&#10;Error: failed to load config: failed to read config file: open ./no-such-file.yaml: no such file or directory</code>

```text
# Observation (2) claimed: "--config flag is inert ... config location effectively hardcoded".
# Below: the flag selects the file AND its values drive behavior.

$ linearfs status            # no --config -> default XDG path
Config:
  file:      ERROR (config file /home/john/.config/linearfs/config.yaml is group/other-accessible (mode 0644) but holds an api_key; refusing to load — run: chmod 600 /home/john/.config/linearfs/config.yaml) — using defaults
  api key:   NOT SET

Mount:
  /home/john/am/linear  [live]

Cache:

$ cat custom-config.yaml
api_key: "lin_api_EVIDENCE_FROM_CUSTOM_CONFIG"
mount:
  default_path: /tmp/evidence-proves-config-flag-is-wired
cache:
  ttl: 60s

$ linearfs status --config ./custom-config.yaml   # flag honored end-to-end
Config:
  file:      ./custom-config.yaml
  api key:   set (config file)

Mount:
  /home/john/am/linear  [live]
  /tmp/evidence-proves-config-flag-is-wired  [not mounted (path does not exist)]  (configured default)


$ linearfs status --config ./no-such-file.yaml    # the flag path really is opened
Config:
  file:      ERROR (failed to read config file: open ./no-such-file.yaml: no such file or directory) — using defaults
  api key:   NOT SET


$ linearfs mount --config ./no-such-file.yaml     # mount.go reads it too (cmd/mount.go:39-46)
Error: failed to load config: failed to read config file: open ./no-such-file.yaml: no such file or directory
```
</details>
<details>
<summary>Evidence: Transcript: embedded-file cache is XDG-correct on Linux (disproves removed observation 1)</summary>

<code>## A. Sandboxed run: where does the app actually create the byte cache?&#10;$ export XDG_CACHE_HOME=/tmp/linearfs-cachehome-vLE9 # fresh empty dir&#10;entries before: 0&#10;$ go test ./internal/integration/ -run TestGeneratedReadmeMatchesBehavior # really mounts FUSE&#10;ok github.com/jra3/linear-fuse/internal/integration 0.121s&#10;$ find $XDG_CACHE_HOME # created by the app -&gt; XDG-correct, and 0700 (#339)&#10;drwx------ $XDG_CACHE_HOME/linearfs&#10;drwx------ $XDG_CACHE_HOME/linearfs/files&#10;&#10;## B. This machine&#39;s real installation: XDG path is live, Library path is a fossil&#10;drwx------ ~/.cache/linearfs/files 2026-07-22 11:27 &lt;- current binary writes here&#10;drwxr-xr-x ~/Library/Caches/linearfs/files 2026-06-18 15:50 &lt;- pre-fix leftover&#10;last byte-file written: 2026-06-18&#10;today: 2026-07-28 -&gt; nothing new lands in the Library path</code>

```text
# Observation (1) claimed: "Embedded-file cache path is macOS-only — linearfs.go hardcodes
# ~/Library/Caches/linearfs/files even on Linux". Verified stale two ways on this Linux box.

## A. Sandboxed run: where does the app actually create the byte cache?
$ export XDG_CACHE_HOME=/tmp/linearfs-cachehome-vLE9      # fresh empty dir
  entries before: 0
$ go test ./internal/integration/ -run TestGeneratedReadmeMatchesBehavior   # really mounts FUSE
ok  	github.com/jra3/linear-fuse/internal/integration	0.121s
$ find $XDG_CACHE_HOME       # created by the app -> XDG-correct, and 0700 (#339)
drwx------ $XDG_CACHE_HOME/linearfs
drwx------ $XDG_CACHE_HOME/linearfs/files

## B. This machine`s real installation: XDG path is live, Library path is a fossil
$ ls -ld ~/.cache/linearfs/files            # current binary writes here
drwx------ 1 john john 64 2026-07-22 11:27 ~/.cache/linearfs/files
$ ls -ld ~/Library/Caches/linearfs/files    # pre-fix leftover; newest cached byte-file:
drwxr-xr-x 1 john john 9472 2026-06-18 15:50 ~/Library/Caches/linearfs/files
  last byte-file written: 2026-06-18
  today: 2026-07-28  -> nothing new lands in the Library path

## C. Source of truth: internal/fs/embeddedfilecache.go
// embeddedFileCacheDir returns the on-disk byte-cache root under the
// platform's user cache dir — ~/.cache/linearfs/files per XDG on Linux,
// ~/Library/Caches/linearfs/files on macOS (identical to the previously
// hardcoded macOS-only path, so existing caches carry over).
func embeddedFileCacheDir() string {
	dir, err := os.UserCacheDir()
	if err != nil {
		dir = filepath.Join(os.Getenv("HOME"), ".cache")
	}
	return filepath.Join(dir, "linearfs", "files")
}
```
</details>
<details>
<summary>Evidence: Diff stat — deletion-only, single file</summary>

<code>docs/ARCHITECTURE.md | 17 -----------------&#10;1 file changed, 17 deletions(-)</code>

```text
 docs/ARCHITECTURE.md | 17 -----------------
 1 file changed, 17 deletions(-)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff 45e2df8 4404a9a` — confirmed deletion-only: docs/ARCHITECTURE.md, 17 deletions, 0 insertions, no other file touched</code>
- <code>`go test ./internal/db/ -run TestSyncedAtStampsUseDBNow -v` — repo-wide AST rule proving every persisted SyncedAt/DetailSyncedAt stamp uses db.Now() (observation 3)</code>
- <code>`XDG_CACHE_HOME=&lt;sandbox&gt; go test ./internal/integration/ -run TestGeneratedReadmeMatchesBehavior` — real FUSE mount; app created $XDG_CACHE_HOME/linearfs/files at 0700, proving os.UserCacheDir() is honored on Linux (observation 1)</code>
- <code>`ls -ld ~/.cache/linearfs/files ~/Library/Caches/linearfs/files` + newest-file timestamps — live XDG path in active use (2026-07-22) vs. pre-fix Library fossil (last byte-file 2026-06-18)</code>
- <code>`go build -trimpath -o /tmp/linearfs-evidence-bin ./cmd/linearfs` then `linearfs status`, `linearfs status --config ./custom-config.yaml`, `linearfs status --config ./no-such-file.yaml`, `linearfs mount --config ./no-such-file.yaml` — CLI transcript proving the --config flag selects the file and its values drive behavior (observation 2)</code>
- <code>`go test ./internal/config/` — LoadFrom, the function the --config flag targets</code>
- <code>`grep -rn &#34;Observations worth|observations-worth&#34; --include=*.md --include=*.go .` — no dangling links or heading anchors to the removed section</code>
- <code>`grep -n -A6 &#34;Time-stamping invariant&#34; docs/ARCHITECTURE.md` — confirmed the preserved write-side invariant text at line 384 is untouched</code>
- `Rendered docs/ARCHITECTURE.md tail before (45e2df8) and after (4404a9a) via pandoc + headless chromium screenshots — reviewer-visible before/after of the doc surface`
- <code>`go test ./...` — full suite green across all 13 packages including the 62s integration suite</code>
- <code>`git status --porcelain` — worktree clean; temp binary, sandbox cache homes, and render intermediates removed</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `internal/cmd/status_test.go:69` - `make lint` (golangci-lint) fails on pre-existing errcheck violations in internal/cmd/status_test.go:69,78,97 (unchecked os.WriteFile). Unrelated to this docs-only change and left alone because lint fixes must not modify tests. CI&#39;s lint job runs `make staticcheck` + `make check-safename` (both pass), so this only affects the local `make lint` target.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
