### PR TITLE
ci: drop unused Install FUSE step from the build job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,11 +114,6 @@ jobs:
         with:
           go-version: '1.25'
 
-      - name: Install FUSE
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y fuse3
-
       - name: Build
         run: make build
 


### PR DESCRIPTION
## What

Removes the dead `Install FUSE` step from the **`build`** job in `.github/workflows/test.yml`.

The `build` job runs only `make build` (pure-Go, `CGO_ENABLED=0`, no libfuse linkage) and `./bin/linearfs version` (prints a string). It never mounts a filesystem, so `fuse3`/`fusermount3` is never exercised — the `apt-get update` + install was pure dead weight and a bit of CI time.

## Left untouched

Both jobs that genuinely mount a real FUSE filesystem keep their `Install FUSE` step:
- `integration-tests-read` in `test.yml`
- `integration.yml`

Purely a tidy — no behavior change, the build job already passes.

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)