### PR TITLE
fix(#370): frontmatter quoting hint + .last outcome log for failing batches

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -623,8 +623,13 @@ gate above.
   instead.
 - **`.error` / `.last` sidecars** (read-only, backed by `writeFeedback`): every
   writable surface exposes the last failure's reason in `.error` (cleared on
-  success) and, where the surface mints an entity, the created identity/URL in
-  `.last` — so scripts and LLMs never have to parse an errno.
+  success) and, where the surface mints an entity, a per-create outcome log in
+  `.last` — the created identity/URL on success, an `outcome: failed` entry on a
+  clean create failure — so a scripted batch reads back how many of N creates
+  succeeded and scripts and LLMs never have to parse an errno. The one exception
+  is the persist-failure branch (#276): a create Linear accepted but that we
+  cannot cache locally is *not* logged to `.last` (as success or failure), since
+  the entity is live — it fails loud in `.error` instead.
 - **`.meta` sidecars:** editable files hold *only* editable fields; the
   server-managed fields (id, url, timestamps, …) render into a read-only
   `<name>.meta` twin. Editing a server field is impossible by construction.

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -227,7 +227,9 @@ Mitigations, in order of load-bearing-ness:
    REDACTION block: the errno and the `.error` reason line with any echoed field
    *value* elided; paths with the team key and issue identifier replaced by
    placeholders (`teams/<TEAM>/issues/<ID>/issue.md`); from `.last`, only whether
-   the entity is present; never titles, bodies, assignee names or emails,
+   the entity is present and its outcome (created / failed) — a failed entry's
+   `error:` line is workspace-derived and its echoed field values are elided
+   exactly like the `.error` reason; never titles, bodies, assignee names or emails,
    project/initiative/milestone/label names, or URLs into the workspace; and
    never a verbatim quote of text the agent did not author — summarize it, or
    skip filing. `internal/fs/readme_test.go` pins the rule so it cannot silently

--- a/internal/fs/createcommit.go
+++ b/internal/fs/createcommit.go
@@ -43,6 +43,7 @@ const createTimeout = 30 * time.Second
 type createSink interface {
 	errorSink
 	AppendWriteSuccess(key string, r WriteResult)
+	AppendWriteFailure(key, msg string)
 	InvalidateCreated(dirIno uint64, name string)
 }
 
@@ -117,6 +118,14 @@ func commitCreate[T any](ctx context.Context, sink createSink, spec createSpec[T
 		msg, errno = classifyMutationErr(spec.op, err)
 		log.Printf("Failed to %s: %v", spec.op, err)
 		sink.SetWriteError(spec.key, msg)
+		// Also append a compact failure entry to .last so a scripted batch of
+		// failing _create writes leaves N countable outcomes instead of .error
+		// collapsing to only the last one (#370). Note this is the *clean*
+		// failure branch — the mutation never took effect. The persist-failure
+		// branch below deliberately does NOT append: that create SUCCEEDED on
+		// Linear and is only unconfirmed locally, so logging it as a .last
+		// failure would misreport a live entity as failed (#276).
+		sink.AppendWriteFailure(spec.key, msg)
 		return nil, errno
 	}
 

--- a/internal/fs/createcommit_test.go
+++ b/internal/fs/createcommit_test.go
@@ -16,6 +16,9 @@ type fakeCreateSink struct {
 	appendKey     string
 	appendResult  WriteResult
 	appends       int
+	failAppendKey string
+	failAppendMsg string
+	failAppends   int
 	invalidateDir uint64
 	invalidateNam string
 	invalidates   int
@@ -24,6 +27,11 @@ type fakeCreateSink struct {
 func (f *fakeCreateSink) AppendWriteSuccess(key string, r WriteResult) {
 	f.appendKey, f.appendResult = key, r
 	f.appends++
+}
+
+func (f *fakeCreateSink) AppendWriteFailure(key, msg string) {
+	f.failAppendKey, f.failAppendMsg = key, msg
+	f.failAppends++
 }
 
 func (f *fakeCreateSink) InvalidateCreated(dirIno uint64, name string) {
@@ -70,6 +78,9 @@ func TestCommitCreate_Success(t *testing.T) {
 	}
 	if sink.appends != 1 || sink.appendKey != "K" || sink.appendResult.Title != "made" {
 		t.Errorf(".last append: calls=%d key=%q result=%+v", sink.appends, sink.appendKey, sink.appendResult)
+	}
+	if sink.failAppends != 0 {
+		t.Errorf("AppendWriteFailure ran on success: calls=%d, want 0", sink.failAppends)
 	}
 	if persists != 1 {
 		t.Errorf("persist calls = %d, want 1", persists)
@@ -144,6 +155,12 @@ func TestCommitCreate_Classification(t *testing.T) {
 				(tc.wantErrno == syscall.EAGAIN || tc.wantErrno == syscall.EIO) {
 				t.Errorf(".error = %q, want the op name in API-failure messages", sink.setMsg)
 			}
+			// A clean failure appends one countable outcome to .last (#370),
+			// carrying the same reason .error got.
+			if sink.failAppends != 1 || sink.failAppendKey != "K" || sink.failAppendMsg != sink.setMsg {
+				t.Errorf("AppendWriteFailure: calls=%d key=%q msg=%q, want 1 on K carrying the .error msg",
+					sink.failAppends, sink.failAppendKey, sink.failAppendMsg)
+			}
 			// The failure path must not run any of the success tail.
 			if sink.clears != 0 || sink.appends != 0 || persists != 0 || sink.invalidates != 0 || extras != 0 {
 				t.Errorf("success tail ran on failure: clears=%d appends=%d persists=%d invalidates=%d extras=%d",
@@ -177,10 +194,12 @@ func TestCommitCreate_PersistFailureFailsLoud(t *testing.T) {
 			t.Errorf(".error = %q, want it to contain %q", sink.setMsg, want)
 		}
 	}
-	// A create the local cache can't serve must not be advertised or cohered.
-	if sink.appends != 0 || sink.clears != 0 || sink.invalidates != 0 || extras != 0 {
-		t.Errorf("success tail ran on unconfirmed reflection: appends=%d clears=%d invalidates=%d extras=%d",
-			sink.appends, sink.clears, sink.invalidates, extras)
+	// A create the local cache can't serve must not be advertised or cohered —
+	// and, crucially, must not be logged to .last as a failure either: it
+	// SUCCEEDED on Linear (#276), so a failure entry would misreport it.
+	if sink.appends != 0 || sink.failAppends != 0 || sink.clears != 0 || sink.invalidates != 0 || extras != 0 {
+		t.Errorf("success/failure tail ran on unconfirmed reflection: appends=%d failAppends=%d clears=%d invalidates=%d extras=%d",
+			sink.appends, sink.failAppends, sink.clears, sink.invalidates, extras)
 	}
 }
 

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -231,6 +231,11 @@ milestone: "Phase 1"                [milestone within project]
 cycle: "Sprint 42"
 ---
 Description body (editable)
+
+Quote any value that starts with a YAML indicator ([ ] { } * & ! | > %% @ #
+, or a leading -), or YAML reads it as structure and the write fails — e.g.
+title: "[1] Verify" not title: [1] Verify. On failure .error names the field
+and echoes the quoting hint. (Same rule for project.md / initiative.md.)
 </issue_frontmatter>
 
 <project_frontmatter>

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -104,7 +104,7 @@ teams/{KEY}/
   issues/                           [mkdir "Title" for quick create]
     _create                         [write full frontmatter+body to create one issue with all fields]
     .error                          [read-only: last failed issue creation]
-    .last                           [read-only: YAML list of recent creations {identifier,url,path,title,status}]
+    .last                           [read-only: YAML outcome log; success={identifier,url,path,title,status}, failure={outcome: failed, error}]
   recent/                           [read-only: issue symlinks, newest-first by updatedAt (ls recent/ | head)]
   issues/{ID}/
     issue.md                        [read/write: editable fields + body ONLY]
@@ -300,8 +300,11 @@ _create is a write-only trigger file (like /proc/sysrq-trigger):
 - Use piped output: echo "text" > _create, cat file > _create
 - Created items appear as separate files (e.g., 001-2025-01-15.md). Every create
   surface (issues, children, comments, docs, labels, projects, milestones,
-  attachments, relations, updates) exposes a sibling .last with the new identity;
-  read .error for a failure.
+  attachments, relations, updates) exposes a sibling .last outcome log: a success
+  appends the new identity, a failed create appends an "outcome: failed" entry,
+  and .error holds the full reason for the most recent failure. So a scripted
+  batch of N _create writes can read .last back to count how many of N succeeded
+  and which failed, instead of .error collapsing to only the last failure.
 - Each open-write-close cycle creates one item: writing to _create again creates
   another item, so a repeated identical write creates a duplicate. After a failed
   write (.error explains it), simply write the corrected content again.
@@ -450,7 +453,9 @@ SHAPE, not the payload:
 - errors: the errno, plus the .error reason line — the validation message itself,
   with any echoed field VALUE elided (Field: state, Error: unknown state, value
   elided)
-- .last: whether the entity you just created is present or absent. Nothing else
+- .last: whether the entity you just created is present or absent, and the
+  outcome (created / failed). A failed entry's error: line is workspace-derived —
+  elide any echoed field VALUE exactly as for the .error reason. Nothing else
   from it, ever.
 - NEVER paste: issue, comment, or document titles or bodies; assignee names or
   emails; project, initiative, milestone, or label names; URLs into the Linear
@@ -463,8 +468,8 @@ skip filing it. A skipped report costs less than a leaked one.
 REPORT BODY — include all five, redacted per the rule above:
 - what you were doing: the operation and the placeholder form of the path
 - what this README / the contract implied would happen
-- what actually happened: the errno, the .error reason line, and whether .last
-  carried the entity — summarized, never a raw paste of mount content
+- what actually happened: the errno, the .error reason line, and the .last
+  outcome (present/created or failed) — summarized, never a raw paste of mount content
 - expected vs actual, one line each
 - which README section you were following (e.g. <_create_behavior>)
 

--- a/internal/fs/successfile.go
+++ b/internal/fs/successfile.go
@@ -21,30 +21,46 @@ import (
 // It is a create-scoped append log: each create appends one entry (capped to the
 // most recent maxWriteResults), and it is keyed identically to `.error`
 // (collectionSuccessKey shares the "kind:parentID" string with collectionErrorKey).
-// Edits report success via read-your-writes (writeback.go), not `.last`.
+// A create records its *outcome*: a success appends the resulting identity, a
+// failed create appends an `outcome: failed` entry (#370). So a scripted batch
+// that writes `_create` N times — where every write shares a latent bug and all
+// N fail — leaves N countable failure entries here instead of `.error`
+// collapsing to only the last one; `.error` still holds the full most-recent
+// reason. Edits report success via read-your-writes (writeback.go), not `.last`.
 
 // maxWriteResults caps the append log so a long-lived mount doesn't grow it
 // unbounded; the newest entries are kept (last in the slice).
 const maxWriteResults = 50
 
-// WriteResult is one successful create, surfaced as a YAML list entry in `.last`.
-// It captures what *persisted* (from the returned entity), never what was sent.
+// WriteResult is one create's outcome, surfaced as a YAML list entry in `.last`.
+// A success captures what *persisted* (from the returned entity), never what was
+// sent; a failure (Error != "") captures a compact reason and leaves the
+// identity fields empty.
 type WriteResult struct {
 	Identifier string // e.g. "ENG-1234" (issues); entity name/slug for others
 	URL        string // Linear URL, where the entity has one
 	Path       string // the addressable on-disk name (cures typed-name != slug)
 	Title      string // human title/name
 	Status     string // workflow state name, where applicable
+	Error      string // non-empty marks a failed create; identity fields are empty
 	Timestamp  time.Time
 }
 
-// writeResultYAML is the on-disk projection of a WriteResult (no timestamp).
+// writeResultYAML is the on-disk projection of a successful WriteResult (no timestamp).
 type writeResultYAML struct {
 	Identifier string `yaml:"identifier"`
 	URL        string `yaml:"url"`
 	Path       string `yaml:"path"`
 	Title      string `yaml:"title"`
 	Status     string `yaml:"status"`
+}
+
+// writeFailureYAML is the on-disk projection of a failed create in `.last`. The
+// distinct `outcome: failed` shape lets a scripted batch count failures
+// (grep -c 'outcome: failed') without mistaking one for a created entity.
+type writeFailureYAML struct {
+	Outcome string `yaml:"outcome"` // always "failed"
+	Error   string `yaml:"error"`   // the distilled reason (see failureReason)
 }
 
 // firstLine returns the first non-empty line of s, trimmed, capped to 80 runes —
@@ -64,6 +80,21 @@ func firstLine(s string) string {
 	return ""
 }
 
+// failureReason distills a multi-line `.error` message (Field:/Value:/Error: or
+// Operation:/Error:) to the single most informative line for a `.last` failure
+// entry: the "Error:" line's content where present, else the first non-empty
+// line. Capped like firstLine so the log stays scannable; the full reason still
+// lives in `.error`.
+func failureReason(msg string) string {
+	for _, line := range strings.Split(msg, "\n") {
+		line = strings.TrimSpace(line)
+		if after, ok := strings.CutPrefix(line, "Error: "); ok {
+			return firstLine(after)
+		}
+	}
+	return firstLine(msg)
+}
+
 // collectionSuccessKey returns the `.last` store key for a collection directory.
 // It intentionally returns the SAME string as collectionErrorKey so a surface's
 // success and failure sidecars share one namespace (distinct maps and inodes).
@@ -75,29 +106,59 @@ func collectionSuccessKey(kind, parentID string) string {
 // most maxWriteResults newest entries, and refreshes the `.last` file's cached
 // size so the next read reflects it.
 func (wf *writeFeedback) AppendWriteSuccess(key string, r WriteResult) {
+	wf.appendOutcome(key, &r)
+}
+
+// AppendWriteFailure records a failed create for a collection key in the same
+// capped, newest-last `.last` log. It exists so a scripted batch of failing
+// `_create` writes leaves N countable `outcome: failed` entries rather than a
+// single overwritten `.error` (#370); msg is the same reason `.error` carries.
+func (wf *writeFeedback) AppendWriteFailure(key, msg string) {
+	wf.appendOutcome(key, &WriteResult{Error: msg})
+}
+
+// appendOutcome is the shared append tail for AppendWriteSuccess/Failure: stamp
+// the time if unset, append newest-last under the cap, and drop the `.last`
+// inode so the next read reflects it.
+func (wf *writeFeedback) appendOutcome(key string, r *WriteResult) {
 	if r.Timestamp.IsZero() {
 		r.Timestamp = time.Now()
 	}
-	wf.successesMu.Lock()
-	if wf.successes == nil {
-		wf.successes = make(map[string][]*WriteResult)
+	wf.outcomesMu.Lock()
+	if wf.outcomes == nil {
+		wf.outcomes = make(map[string][]*WriteResult)
 	}
-	list := append(wf.successes[key], &r)
+	list := append(wf.outcomes[key], r)
 	if len(list) > maxWriteResults {
 		list = list[len(list)-maxWriteResults:]
 	}
-	wf.successes[key] = list
-	wf.successesMu.Unlock()
+	wf.outcomes[key] = list
+	wf.outcomesMu.Unlock()
 	wf.invalidate(successIno(key))
 }
 
-// GetWriteSuccess returns a copy of the recorded successes for a collection key
-// (nil if none). A copy — not the internal slice — so a caller can't race a
-// concurrent AppendWriteSuccess that re-slices/appends under the write lock.
+// GetWriteSuccess returns a copy of the recorded *successful* creates for a key
+// (failures excluded), nil if none. A copy — not the internal slice — so a
+// caller can't race a concurrent append that re-slices under the write lock.
+// See GetWriteOutcomes for the full success+failure log that `.last` renders.
 func (wf *writeFeedback) GetWriteSuccess(key string) []*WriteResult {
-	wf.successesMu.RLock()
-	defer wf.successesMu.RUnlock()
-	src := wf.successes[key]
+	wf.outcomesMu.RLock()
+	defer wf.outcomesMu.RUnlock()
+	var out []*WriteResult
+	for _, r := range wf.outcomes[key] {
+		if r.Error == "" {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// GetWriteOutcomes returns a copy of the full ordered create log for a key —
+// successes and failures, as rendered into `.last` — or nil if empty.
+func (wf *writeFeedback) GetWriteOutcomes(key string) []*WriteResult {
+	wf.outcomesMu.RLock()
+	defer wf.outcomesMu.RUnlock()
+	src := wf.outcomes[key]
 	if len(src) == 0 {
 		return nil
 	}
@@ -106,26 +167,32 @@ func (wf *writeFeedback) GetWriteSuccess(key string) []*WriteResult {
 	return out
 }
 
-// ClearWriteSuccess drops the recorded successes for a collection key (used by tests).
+// ClearWriteSuccess drops the recorded outcomes for a collection key (used by tests).
 func (wf *writeFeedback) ClearWriteSuccess(key string) {
-	wf.successesMu.Lock()
-	_, had := wf.successes[key]
-	delete(wf.successes, key)
-	wf.successesMu.Unlock()
+	wf.outcomesMu.Lock()
+	_, had := wf.outcomes[key]
+	delete(wf.outcomes, key)
+	wf.outcomesMu.Unlock()
 	if had {
 		wf.invalidate(successIno(key))
 	}
 }
 
-// renderWriteSuccess renders the recorded successes for a key as a YAML list.
-// Returns empty (size 0) when there are none, mirroring an empty `.error`.
+// renderWriteSuccess renders the recorded create outcomes for a key as a YAML
+// list — a success as its identity fields, a failure as `outcome: failed` plus
+// the reason's first line. Returns empty (size 0) when there are none, mirroring
+// an empty `.error`.
 func (lfs *LinearFS) renderWriteSuccess(key string) []byte {
-	results := lfs.GetWriteSuccess(key)
+	results := lfs.GetWriteOutcomes(key)
 	if len(results) == 0 {
 		return nil
 	}
-	projected := make([]writeResultYAML, len(results))
+	projected := make([]any, len(results))
 	for i, r := range results {
+		if r.Error != "" {
+			projected[i] = writeFailureYAML{Outcome: "failed", Error: failureReason(r.Error)}
+			continue
+		}
 		projected[i] = writeResultYAML{
 			Identifier: r.Identifier,
 			URL:        r.URL,
@@ -153,7 +220,7 @@ func (lfs *LinearFS) lookupSuccessFile(ctx context.Context, parent fs.InodeEmbed
 			return nil, time.Time{}, time.Time{}
 		}
 		var latest time.Time
-		for _, r := range lfs.GetWriteSuccess(key) {
+		for _, r := range lfs.GetWriteOutcomes(key) {
 			if r.Timestamp.After(latest) {
 				latest = r.Timestamp
 			}

--- a/internal/fs/successfile_test.go
+++ b/internal/fs/successfile_test.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -85,5 +86,55 @@ func TestRenderWriteSuccessYAML(t *testing.T) {
 		if _, ok := entries[0][k]; !ok {
 			t.Errorf("rendered entry missing key %q", k)
 		}
+	}
+}
+
+// TestAppendWriteFailureOutcome: a failed create appends a typed `outcome: failed`
+// entry to .last so a scripted batch can count failures (#370). Successes and
+// failures interleave in order; GetWriteSuccess stays successes-only while
+// GetWriteOutcomes and the rendered .last carry both.
+func TestAppendWriteFailureOutcome(t *testing.T) {
+	lfs := newSuccessTestFS()
+	key := collectionSuccessKey("issues", "team-1")
+
+	lfs.AppendWriteSuccess(key, WriteResult{Identifier: "TST-1", Path: "TST-1", Title: "ok one"})
+	lfs.AppendWriteFailure(key, "Field: frontmatter\nError: yaml: did not find expected key")
+	lfs.AppendWriteFailure(key, "Field: frontmatter\nError: yaml: did not find expected key")
+
+	// GetWriteSuccess excludes failures; GetWriteOutcomes is the full log.
+	if got := lfs.GetWriteSuccess(key); len(got) != 1 || got[0].Identifier != "TST-1" {
+		t.Fatalf("GetWriteSuccess = %+v, want the one success TST-1", got)
+	}
+	if got := lfs.GetWriteOutcomes(key); len(got) != 3 {
+		t.Fatalf("GetWriteOutcomes len = %d, want 3 (1 success + 2 failures)", len(got))
+	}
+
+	var entries []map[string]string
+	if err := yaml.Unmarshal(lfs.renderWriteSuccess(key), &entries); err != nil {
+		t.Fatalf("render is not a YAML list: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("want 3 rendered entries, got %d", len(entries))
+	}
+	// Newest-last order: the success is first, the two failures follow.
+	if entries[0]["identifier"] != "TST-1" {
+		t.Errorf("entry 0 identifier = %q, want TST-1 (success first)", entries[0]["identifier"])
+	}
+	failed := 0
+	for _, e := range entries {
+		if e["outcome"] != "failed" {
+			continue
+		}
+		failed++
+		if !strings.Contains(e["error"], "did not find expected key") {
+			t.Errorf("failure entry error = %q, want the yaml reason (first line)", e["error"])
+		}
+		// The reason is the compact first line, not the multi-line .error blob.
+		if strings.Contains(e["error"], "\n") {
+			t.Errorf("failure entry error is multi-line %q, want firstLine only", e["error"])
+		}
+	}
+	if failed != 2 {
+		t.Errorf("counted %d `outcome: failed` entries in .last, want 2", failed)
 	}
 }

--- a/internal/fs/writefeedback.go
+++ b/internal/fs/writefeedback.go
@@ -23,9 +23,10 @@ type writeFeedback struct {
 	errorsMu gosync.RWMutex
 	errors   map[string]*WriteError
 
-	// successes holds recent creates per collection key (capped, newest-last).
-	successesMu gosync.RWMutex
-	successes   map[string][]*WriteResult
+	// outcomes holds recent create outcomes per collection key (successes and
+	// failures, capped, newest-last); surfaced at `.last`.
+	outcomesMu gosync.RWMutex
+	outcomes   map[string][]*WriteResult
 }
 
 // newWriteFeedback builds an initialized feedback store. invalidate is the
@@ -38,6 +39,6 @@ func newWriteFeedback(invalidate func(ino uint64)) writeFeedback {
 	return writeFeedback{
 		invalidate: invalidate,
 		errors:     make(map[string]*WriteError),
-		successes:  make(map[string][]*WriteResult),
+		outcomes:   make(map[string][]*WriteResult),
 	}
 }

--- a/internal/fs/writefeedback_test.go
+++ b/internal/fs/writefeedback_test.go
@@ -36,6 +36,19 @@ func TestWriteFeedbackInvalidateSeam(t *testing.T) {
 	if len(dropped) != 3 || dropped[2] != successIno(key) {
 		t.Fatalf("append dropped = %v, want successIno(key)", dropped)
 	}
+
+	// Append failure drops the same .last inode, is excluded from GetWriteSuccess,
+	// but is present in the full GetWriteOutcomes log (#370).
+	wf.AppendWriteFailure(key, "boom")
+	if len(dropped) != 4 || dropped[3] != successIno(key) {
+		t.Fatalf("append-failure dropped = %v, want one more successIno(key)", dropped)
+	}
+	if got := wf.GetWriteSuccess(key); len(got) != 1 {
+		t.Fatalf("GetWriteSuccess = %+v, want still one (failure not counted as success)", got)
+	}
+	if got := wf.GetWriteOutcomes(key); len(got) != 2 {
+		t.Fatalf("GetWriteOutcomes len = %d, want 2 (success + failure)", len(got))
+	}
 }
 
 // TestWriteFeedbackNilInvalidate: a nil seam degrades to a no-op, so a bare

--- a/internal/integration/readme_test.go
+++ b/internal/integration/readme_test.go
@@ -41,7 +41,10 @@ func TestGeneratedReadmeMatchesBehavior(t *testing.T) {
 	// swallowed the second write, so nothing documented it).
 	// "targeted catalog refresh" pins the stale-catalog self-healing doc (#246):
 	// a local name→ID miss refreshes the catalog once and retries before .error.
-	for _, want := range []string{".last", "issue.meta", "initiative.meta", "recent/", "recent created updates", "relations, updates", "creates one item", "targeted catalog refresh"} {
+	// "outcome: failed" pins the .last outcome-log contract (#370): a failed
+	// create appends a countable failure entry rather than .error collapsing to
+	// only the last failure of a batch.
+	for _, want := range []string{".last", "issue.meta", "initiative.meta", "recent/", "recent created updates", "relations, updates", "creates one item", "targeted catalog refresh", "outcome: failed"} {
 		if !strings.Contains(readme, want) {
 			t.Errorf("README does not mention %q", want)
 		}

--- a/internal/integration/t6_conformance_test.go
+++ b/internal/integration/t6_conformance_test.go
@@ -215,12 +215,24 @@ func TestWriteContractLastSidecarShape(t *testing.T) {
 	if !liveAPIMode && len(entries) == 0 {
 		t.Fatal("expected at least one .last entry after a create")
 	}
+	// .last is an outcome log: success entries carry the identity shape, failure
+	// entries carry `outcome: failed` + a reason (#370). Validate the success
+	// shape and require at least one — failure entries (seeded by other tests'
+	// invalid creates on the shared mount) are a legitimate distinct shape.
+	successes := 0
 	for _, e := range entries {
+		if e["outcome"] == "failed" {
+			continue
+		}
+		successes++
 		for _, k := range []string{"identifier", "url", "path", "title", "status"} {
 			if _, ok := e[k]; !ok {
-				t.Errorf(".last entry missing key %q: %v", k, e)
+				t.Errorf(".last success entry missing key %q: %v", k, e)
 			}
 		}
+	}
+	if !liveAPIMode && successes == 0 {
+		t.Fatal("expected at least one success entry in .last after a create")
 	}
 }
 
@@ -511,15 +523,46 @@ func TestWriteContractAgentLoop(t *testing.T) {
 		noopByteStable(t, filepath.Join(initDir, "initiative.md"), initDir)
 	}
 
-	// (d) A subsequent EINVAL create must not wipe the earlier successes from .last.
-	before := len(parseLastSidecar(t, issuesLastPath(testTeamKey)))
-	if err := writeCreateSpec(t, "---\ntitle: Doomed\npriority: critical\n---\nx\n"); err == nil {
-		t.Fatal("expected EINVAL for invalid priority")
+	// (d) A batch of failing creates must not wipe the earlier successes from
+	// .last, and each failure appends a countable `outcome: failed` entry so a
+	// scripted loop can read back how many of N failed instead of .error
+	// collapsing to only the last one (#370).
+	before := parseLastSidecar(t, issuesLastPath(testTeamKey))
+	failuresBefore := countFailedOutcomes(before)
+	const doomed = 2
+	for i := 0; i < doomed; i++ {
+		if err := writeCreateSpec(t, "---\ntitle: Doomed\npriority: critical\n---\nx\n"); err == nil {
+			t.Fatal("expected EINVAL for invalid priority")
+		}
 	}
 	after := parseLastSidecar(t, issuesLastPath(testTeamKey))
-	if len(after) < before {
-		t.Errorf(".last shrank after a failed create: %d -> %d (append log should survive)", before, len(after))
+	if len(after) < len(before) {
+		t.Errorf(".last shrank after failed creates: %d -> %d (append log should survive)", len(before), len(after))
 	}
+	if got := countFailedOutcomes(after) - failuresBefore; got != doomed {
+		t.Errorf(".last gained %d `outcome: failed` entries, want %d (batch failures must each be countable)", got, doomed)
+	}
+	// The prior successes are still there (failures are additive, not replacing).
+	stillFound := 0
+	for _, e := range after {
+		if strings.HasPrefix(e["title"], marker) {
+			stillFound++
+		}
+	}
+	if stillFound < found {
+		t.Errorf("successes lost after failed creates: %d -> %d", found, stillFound)
+	}
+}
+
+// countFailedOutcomes tallies the failure entries in a parsed .last log (#370).
+func countFailedOutcomes(entries []map[string]string) int {
+	n := 0
+	for _, e := range entries {
+		if e["outcome"] == "failed" {
+			n++
+		}
+	}
+	return n
 }
 
 // TestWriteContractEditVerifiesOffline proves the edit-commit tail runs against

--- a/internal/marshal/frontmatter.go
+++ b/internal/marshal/frontmatter.go
@@ -40,6 +40,9 @@ func Parse(content []byte) (*Document, error) {
 
 	var frontmatter map[string]any
 	if err := yaml.Unmarshal([]byte(fmYAML), &frontmatter); err != nil {
+		if hint := quotingHint(fmYAML); hint != "" {
+			return nil, fmt.Errorf("failed to parse frontmatter: %w (%s)", err, hint)
+		}
 		return nil, fmt.Errorf("failed to parse frontmatter: %w", err)
 	}
 
@@ -51,6 +54,49 @@ func Parse(content []byte) (*Document, error) {
 		Frontmatter: frontmatter,
 		Body:        body,
 	}, nil
+}
+
+// yamlIndicatorChars are characters that begin YAML structure — flow
+// collections, aliases/anchors, tags, block scalars, directives, comments. An
+// unquoted scalar starting with one of these is read as syntax rather than a
+// string; the classic trap is a title like `[1] Do the thing`, which YAML
+// parses as a flow sequence and rejects.
+const yamlIndicatorChars = "[]{}*&!|>%@`#,-"
+
+// quotingHint inspects raw frontmatter YAML after a parse failure and, when a
+// top-level value begins with a YAML indicator character, returns a short hint
+// telling the user to quote it. It returns "" when no such value is found, so
+// callers only append the hint to genuinely indicator-triggered failures.
+func quotingHint(fmYAML string) string {
+	for line := range strings.SplitSeq(fmYAML, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		key, value, found := strings.Cut(trimmed, ": ")
+		if !found {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		first := value[0]
+		if strings.IndexByte(yamlIndicatorChars, first) < 0 {
+			continue
+		}
+		// A balanced flow collection ([a, b] or {a: b}) is valid YAML — don't
+		// flag it; the failure is elsewhere in the document.
+		last := value[len(value)-1]
+		if (first == '[' && last == ']') || (first == '{' && last == '}') {
+			continue
+		}
+		return fmt.Sprintf(
+			"hint: quote the value for %q — it starts with %q, which YAML reads as syntax; e.g. %s: %q",
+			strings.TrimSpace(key), string(first), strings.TrimSpace(key), value,
+		)
+	}
+	return ""
 }
 
 // Render combines frontmatter and body into a markdown document

--- a/internal/marshal/frontmatter_test.go
+++ b/internal/marshal/frontmatter_test.go
@@ -142,6 +142,67 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestParseQuotingHint(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		content  string
+		wantErr  bool
+		wantHint bool   // error mentions quoting
+		hintKey  string // substring the hint should name (when wantHint)
+	}{
+		{
+			name:     "unquoted flow-sequence title",
+			content:  "---\ntitle: [1] Verify auto context-file generation\n---\nBody",
+			wantErr:  true,
+			wantHint: true,
+			hintKey:  "title",
+		},
+		{
+			name:     "unquoted alias value",
+			content:  "---\nname: *ref\n---\nBody",
+			wantErr:  true,
+			wantHint: true,
+			hintKey:  "name",
+		},
+		{
+			name:    "quoted flow-sequence title parses",
+			content: "---\ntitle: \"[1] Verify auto context-file generation\"\n---\nBody",
+			wantErr: false,
+		},
+		{
+			name:    "balanced flow sequence is valid",
+			content: "---\nlabels: [Bug, Backend]\n---\nBody",
+			wantErr: false,
+		},
+		{
+			name:     "non-indicator parse error carries no quoting hint",
+			content:  "---\nkey:\n\tnested: 1\n---\nBody", // tab indentation is illegal YAML
+			wantErr:  true,
+			wantHint: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse([]byte(tt.content))
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("Parse() err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				return
+			}
+			msg := err.Error()
+			mentionsQuote := strings.Contains(msg, "quote")
+			if mentionsQuote != tt.wantHint {
+				t.Fatalf("Parse() error = %q; quoting hint present = %v, want %v", msg, mentionsQuote, tt.wantHint)
+			}
+			if tt.wantHint && !strings.Contains(msg, tt.hintKey) {
+				t.Errorf("Parse() hint = %q, want it to name key %q", msg, tt.hintKey)
+			}
+		})
+	}
+}
+
 func TestRender(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
Closes #370. Two commits, both parts of the ticket.

## (a) Quoting hint on frontmatter parse errors — `63df931`

A frontmatter value beginning with a YAML indicator (`[ { * & ! | > % @ \``, a leading `-`) is read as structure, not a string — the classic trap is a title like `[1] Do the thing`, which parses as a flow sequence and fails with an opaque *"did not find expected key"*. `marshal.Parse` wrapped the raw yaml error with no guidance.

`Parse` is the single chokepoint every entity's unmarshal funnels through, so detecting the offending value there and appending a quoting hint (naming the field, showing the quoted form) surfaces the fix on **every** `_create`/edit surface at once:

```
failed to parse frontmatter: yaml: line 1: did not find expected key
  (hint: quote the value for "title" — it starts with "[", which YAML reads
   as syntax; e.g. title: "[1] Verify auto context-file generation")
```

A balanced flow collection (`labels: [Bug, Backend]`) is left unflagged so valid frontmatter never trips the hint. The README frontmatter block gains the quoting rule with a quoted-title example.

## (b) `.last` becomes a create-outcome log — `864b49f`

A scripted batch of `_create` writes that all fail (every title sharing the latent bug above) left no signal that N/N failed rather than 1: `.error` overwrites on each write and `.last` (successes only) stayed empty.

`.last` now records outcomes. `commitCreate`'s clean mutate-failure branch appends a typed `outcome: failed` + distilled reason entry alongside successes, so a scripted loop can count failures:

```
$ grep -c 'outcome: failed' teams/ENG/issues/.last
```

`.error` still holds the full most-recent reason. The `#276` persist-failure branch deliberately does **not** log — that create succeeded on Linear and is only unconfirmed locally, so a failure entry would misreport a live entity.

Docs moved in lockstep: README (`.last` legend, `<_create_behavior>`, feedback-protocol redaction), `ARCHITECTURE.md` (the `.last` contract + the `#276` carve-out), `THREAT-MODEL.md` (the failure `error:` line is workspace-derived and redacted like the `.error` reason).

## Tests
- TDD at both seams: `marshal.Parse` (indicator detection + balanced-collection guard, 2M-exec fuzz clean), `writeFeedback`/`commitCreate` (failure appends one countable outcome; success and the `#276` branch append none).
- `TestGeneratedReadmeMatchesBehavior` pins `outcome: failed`.
- A t6 end-to-end case writes two failing creates and asserts two countable failure entries survive alongside the prior successes.
- Full `-race` suite green, staticcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)