### PR TITLE
fix(fs): serve written bytes back across the atomic-save re-Lookup

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -101,7 +101,8 @@ canonical files aren't renamable) → target-name guard (`.error` names the one
 writable target, `ENOTSUP`) → flush the bytes through the file's normal edit
 path (a transient file node with a dirty edit buffer, so frontmatter
 validation, read-your-writes verification, and `.error` handling all apply) →
-**adopt + consume + `InvalidateRenamed`, all on {0, EIO}**. The adopt-on-EIO
+**adopt + consume + `InvalidateRenamed`, all on {0, EIO}, plus the
+[[authored-pin]] of the written bytes on a committed clean save**. The adopt-on-EIO
 line is the policy, now written once: `Flush` returns `EIO` only on a fatal
 read-your-writes divergence, by which point the write has already reached
 Linear — refusing to adopt would keep serving stale content while `.error`
@@ -114,11 +115,14 @@ that can no longer persist. A consumed scratch node now returns `ESTALE` from
 `ESTALE` on `Open` drives the VFS to re-Lookup the real node (`LOOKUP_REVAL`).
 Lives in `internal/fs/renamesave.go`; each directory hands it a small spec
 (target name, error key, dir/file inos, scratch/flush/adopt closures — the
-scratch closure also returns the per-node consume). It depends only on the `renameSink` seam
-(ErrorSink + `InvalidateRenamed`, satisfied by `*LinearFS` through the
-writeFeedback and kernelNotify promotions), and the scratch lookup is a spec
-closure, so it is unit-tested with a recording sink — no FUSE mount, inode
-tree, SQLite, or API.
+scratch closure also returns the per-node consume, and the flush closure reports
+whether it actually **committed** alongside its errno, since a save that resolved
+to no changes returns 0 too and must not pin). It depends only on the
+`renameSaveSink` seam (the `renameSink` surface — ErrorSink +
+`InvalidateRenamed` — plus `PinWritten`, all satisfied by `*LinearFS` through the
+writeFeedback, kernelNotify, and authoredPins promotions; `commitRename` keeps
+the narrower `renameSink`), and the scratch lookup is a spec closure, so it is
+unit-tested with a recording sink — no FUSE mount, inode tree, SQLite, or API.
 
 ### Create tail (`commitCreate`)
 The **deep module** that owns the invariant tail of every create (`_create` writes and
@@ -676,7 +680,10 @@ async refresh. It is deliberately NOT armed on a fatal read-your-writes divergen
 (a silent revert or truncation, where `commitWriteBack` returns EIO) — serving the
 written bytes there would mask the loss from the very re-read the `.error` asks for.
 A fresh `Open` clears it, so independent later readers converge to what persisted.
-See [[node-refresh]]. Each of the seven editable file
+The flag is also the atomic-save path's **commit signal**: `editBuffer.committedWrite`
+reads it back off the transient node [[rename-save]] flushes through, so the
+[[authored-pin]] arms on exactly the outcome that arms `authored` here rather than
+on a bare errno 0. See [[node-refresh]]. Each of the seven editable file
 nodes (`IssueFileNode`, `ProjectInfoNode`, `InitiativeInfoNode`, `CommentNode`,
 `LabelFileNode`, `MilestoneFileNode`, `DocumentFileNode`) embeds it and keeps
 only its **`Getattr`** (a one-liner: `fileAttr(n.size(), created, updated).fill`
@@ -697,6 +704,39 @@ regenerate on first Read — a live double-compute this fix removed by seeding.
 carry no `CreatedAt`/`UpdatedAt`, so `Getattr` reports `now()` — see
 [[attr-construction]]). Unit-tested directly (write-expands, in-place,
 truncate-grow/shrink, read-clamps-at-EOF), no FUSE mount.
+
+### Authored-write pin (`authoredPins`)
+The **deep module** that carries serve-your-own-writes across a node boundary the
+[[edit-buffer]] cannot cross (#379). `authored` pins the written bytes *in the
+buffer they were written through*, which covers in-place edits only — and editors
+never write in place: they rename a scratch temp file onto the canonical `.md`, so
+[[rename-save]] flushes through a **transient** node (its buffer, and its
+`authored` flag, are discarded a line later) and then deliberately drops the
+canonical file's inode so it re-Looks-up and re-renders what *persisted*. The
+written bytes were therefore never served back, and any server-side reformat that
+moved the byte count reached the client as a size mismatch on a fully successful
+write — which editors report as a possibly truncated write.
+`authoredPins` (`internal/fs/authoredpin.go`) is a mount-wide `ino → {bytes,
+deadline}` store embedded on `LinearFS` by value (zero value ready, no constructor
+wiring). Its invariant: **a Lookup that finds a pin serves the pinned bytes as the
+buffer's content *and* as the size it publishes** — `manifest.file` reports
+`len(content)` in the `EntryOut`, and publishing the render's length while serving
+the pin would clamp the client's own read to the wrong size, which is the mismatch
+the module exists to remove. The pin is armed **only on a committed clean save**
+(`committed && errno == 0`, the same rule that arms `authored`): not on `EIO`,
+where the write did not persist as written and hiding that would mask real loss;
+not on a save that committed nothing, where echoing the bytes back would report a
+dropped edit as a byte-for-byte success. It is bounded by **time** (`pinTTL`),
+**not consumed by the first Lookup** — a client's verification is several syscalls
+(stat, then open+read), each able to drive its own Lookup after the rename
+invalidation, so all of them must answer alike; the TTL is also a tighter staleness
+bound than the in-place path's "until the next `Open`", and it is what bounds the
+one gap left open (a later *in-place* edit inside the window does not supersede an
+existing pin). Wired at all three atomic-save sites (`issue.md`, `project.md`,
+`initiative.md`) via the `renameSaveSink` seam; unit-tested directly (window,
+expiry, sweep, unaliased copies, seed-beats-render) plus one deterministic
+mount-level test — the rename itself forces the re-Lookup, so no timeout wait is
+needed.
 
 ### Render file (`renderFile`)
 The **deep module** owning every read-only *generated* file — the render-through

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -734,9 +734,10 @@ bound than the in-place path's "until the next `Open`", and it is what bounds th
 one gap left open (a later *in-place* edit inside the window does not supersede an
 existing pin). Wired at all three atomic-save sites (`issue.md`, `project.md`,
 `initiative.md`) via the `renameSaveSink` seam; unit-tested directly (window,
-expiry, sweep, unaliased copies, seed-beats-render) plus one deterministic
-mount-level test — the rename itself forces the re-Lookup, so no timeout wait is
-needed.
+expiry, sweep, unaliased copies, seed-beats-render) plus deterministic
+mount-level tests over all three files, the reformat-note shape, and the EIO
+no-pin rule (`internal/integration/atomicsave_pin_test.go`) — the rename itself
+forces the re-Lookup, so no timeout wait is needed.
 
 ### Render file (`renderFile`)
 The **deep module** owning every read-only *generated* file — the render-through

--- a/README.md
+++ b/README.md
@@ -289,7 +289,10 @@ Error: invalid priority "critical": must be none, low, medium, high, or urgent
 
 **Reference files:** Check `states.md` for valid workflow states, `labels.md` for valid labels.
 
-The `.error` file is cleared on successful writes.
+The `.error` file is cleared on successful writes, with one exception: a save whose
+body Linear reformatted server-side leaves an informational note there ("saved, but
+Linear reformatted the markdown server-side") — the write succeeded and no text was
+lost.
 
 ## File Operations
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -465,7 +465,7 @@ than silently treated as body text.
 
 **Consumed by** `internal/fs` only. Depends on `yaml.v3` and `api` types.
 
-### `internal/fs` — the FUSE filesystem (the core, ~54 non-test files)
+### `internal/fs` — the FUSE filesystem (the core, ~64 non-test files)
 
 The serving end and the largest package, built on `go-fuse/v2`. The root struct
 `LinearFS` (`linearfs.go`) is sectioned:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -539,6 +539,17 @@ building blocks:
   refresh, while persistence (SQLite and the entity) already holds Linear's
   normalized render. It is not armed on a fatal read-your-writes divergence (a
   revert or truncation, EIO), so a real loss is never masked from a re-read.
+- `authoredPins` — the same guarantee across the **atomic-save** path, where the
+  buffer that was written cannot carry it (#379): `renameSave` flushes through a
+  transient node and then drops the canonical file's inode, so the re-Lookup
+  renders what persisted and the written bytes would be lost. It pins them under
+  the file's inode (clean commits only, same `errno == 0` rule) and the Lookup
+  seeds the new buffer — content *and* the size it publishes — from the pin
+  instead of the render. Bounded by time (`pinTTL`), not by one Lookup: a client's
+  verification is several syscalls, each able to drive its own Lookup, so all of
+  them must answer alike. Without it a server-side reformat that changed the byte
+  count reached the client as a size mismatch, which editors report as a possibly
+  truncated write on a save that fully succeeded.
 - `resolveByName` — collapses the five regular single-name→ID resolvers
   (state, project, milestone, cycle, initiative); user, issue-identifier,
   label, and project-slug resolution remain bespoke.
@@ -557,7 +568,8 @@ a layer above the commit-tail primitives) and no telemetry (matching
 1. `Write` buffers bytes in the `editBuffer`; `Flush` parses the markdown via
    `marshal`. Editor save-via-rename (temp file + `rename`) is caught by a
    scratch node and routed through the same path (`atomicwrite.go`,
-   `renamesave.go`).
+   `renamesave.go`), pinning the written bytes for the re-Lookup that path forces
+   (`authoredPins`).
 2. The fs layer **resolves names to IDs** (status→stateId, assignee
    email→userId, labels→labelIds, project/milestone/cycle/parent→IDs). A local
    catalog miss self-heals: a typed unknown-name error triggers exactly **one**

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -543,8 +543,10 @@ building blocks:
   buffer that was written cannot carry it (#379): `renameSave` flushes through a
   transient node and then drops the canonical file's inode, so the re-Lookup
   renders what persisted and the written bytes would be lost. It pins them under
-  the file's inode (clean commits only, same `errno == 0` rule) and the Lookup
-  seeds the new buffer — content *and* the size it publishes — from the pin
+  the file's inode (only when the flush actually committed a write and returned
+  `errno == 0` — the same rule that arms `authored`, so neither a fatal divergence
+  nor a save that changed nothing is echoed back as a byte-for-byte success) and
+  the Lookup seeds the new buffer — content *and* the size it publishes — from the pin
   instead of the render. Bounded by time (`pinTTL`), not by one Lookup: a client's
   verification is several syscalls, each able to drive its own Lookup, so all of
   them must answer alike. Without it a server-side reformat that changed the byte

--- a/internal/fs/authoredpin.go
+++ b/internal/fs/authoredpin.go
@@ -1,0 +1,115 @@
+package fs
+
+import (
+	"sync"
+	"time"
+)
+
+// Serve-your-own-writes across the atomic-save path (#379).
+//
+// #365 pins the bytes a client wrote into the editBuffer it wrote them through,
+// so a write→verify re-read sees its own bytes instead of Linear's normalized
+// render. That covers the in-place write path only, and editors don't use it:
+// they write a sibling scratch file and rename(2) it over the canonical .md
+// (atomicwrite.go, #145). On that path renameSave flushes the bytes through a
+// TRANSIENT file node — issues.go/projects.go/initiatives.go build one just to
+// run Flush — so editFlush arms `authored` on a buffer that is discarded a line
+// later, and renameSave then deliberately drops the canonical file's inode so it
+// re-Looks-up and re-renders what PERSISTED. The written bytes were therefore
+// never served back, and any server-side reformat that changed the byte count
+// reached the client as a size mismatch on a write that fully succeeded: editors
+// report that as "the filesystem may have silently truncated the write" (#379).
+//
+// authoredPins carries the pin across the node boundary the rename path crosses.
+// renameSave records the written bytes under the canonical file's inode, and a
+// Lookup that builds that file seeds its editBuffer with them — marked authored,
+// so a background refresh leaves them alone — instead of the fresh render.
+//
+// The pin is bounded by TIME, not by one Lookup: a client's verification is
+// several syscalls (stat, then open+read), each of which can drive its own
+// Lookup after the rename invalidation, and a pin consumed by the first would
+// leave the second answering from the render again — which is the bug. Every
+// Lookup inside the window therefore reads the same pinned bytes, and once the
+// window closes reads converge to what Linear stored. pinTTL is what keeps a pin
+// nobody ever looked up from becoming a stale read minutes later; it is a
+// tighter bound than the in-place path's "until the next Open" (#365).
+const pinTTL = 10 * time.Second
+
+// authoredPin is one pinned write: the exact bytes a client wrote through the
+// atomic-save path, and the deadline past which they must not be served.
+type authoredPin struct {
+	content  []byte
+	deadline time.Time
+}
+
+// authoredPins is the mount-wide store of pinned writes, keyed by the canonical
+// file's inode. Embedded in LinearFS (zero value ready to use), so PinWritten
+// promotes onto it for the renameSink seam.
+type authoredPins struct {
+	mu   sync.Mutex
+	pins map[uint64]authoredPin
+}
+
+// PinWritten records content as the bytes a client just wrote to the file at
+// fileIno through an atomic save, for the next Lookup of that file to serve.
+// Called only on a clean commit — see renameSave.
+func (p *authoredPins) PinWritten(fileIno uint64, content []byte) {
+	if len(content) == 0 {
+		return
+	}
+	now := time.Now()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.pins == nil {
+		p.pins = make(map[uint64]authoredPin)
+	}
+	// Sweep here rather than from a goroutine: pins are few (one per file being
+	// edited) and a write is the only thing that grows the map, so the write is
+	// also the right place to drop what expired unread.
+	for ino, pin := range p.pins {
+		if now.After(pin.deadline) {
+			delete(p.pins, ino)
+		}
+	}
+	p.pins[fileIno] = authoredPin{
+		content:  append([]byte(nil), content...),
+		deadline: now.Add(pinTTL),
+	}
+}
+
+// writtenBytes returns the pinned write for fileIno, or nil when there is none or
+// its window has closed. It does NOT consume the pin — every Lookup in the window
+// must answer alike (see above) — but it does drop one that expired, so the store
+// never holds bytes it can no longer serve.
+func (p *authoredPins) writtenBytes(fileIno uint64) []byte {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	pin, ok := p.pins[fileIno]
+	if !ok {
+		return nil
+	}
+	if time.Now().After(pin.deadline) {
+		delete(p.pins, fileIno)
+		return nil
+	}
+	return pin.content
+}
+
+// seedAuthored fills a freshly-built editable node's buffer and reports the bytes
+// its Lookup must publish as the file's size: the rendered content normally, or
+// a pinned atomic-save write when one is waiting for this inode. The two must be
+// the same bytes — a Lookup that published the render's length while the buffer
+// served the pin would clamp the client's own read to the wrong size, which is
+// the very mismatch this module exists to remove.
+func (p *authoredPins) seedAuthored(b *editBuffer, fileIno uint64, rendered []byte) []byte {
+	pinned := p.writtenBytes(fileIno)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if pinned == nil {
+		b.content = rendered
+		return rendered
+	}
+	b.content = pinned
+	b.authored = true
+	return pinned
+}

--- a/internal/fs/authoredpin.go
+++ b/internal/fs/authoredpin.go
@@ -33,6 +33,16 @@ import (
 // window closes reads converge to what Linear stored. pinTTL is what keeps a pin
 // nobody ever looked up from becoming a stale read minutes later; it is a
 // tighter bound than the in-place path's "until the next Open" (#365).
+//
+// The TTL is also what bounds the one case where a pin outlives its truth: a
+// successful IN-PLACE edit of the same file inside the window does not drop the
+// pin (editFlush invalidates the inode, which usually leaves the node — and the
+// unread pin — alive), so if that inode is forgotten and re-Looked-up before the
+// window closes, the Lookup serves the older atomic-save bytes rather than the
+// newer in-place ones. It needs a dentry forget inside the window to happen at
+// all, and it converges on expiry; making an in-place write supersede a pin would
+// mean plumbing the file's inode through editFlush, which is deliberately out of
+// scope here.
 const pinTTL = 10 * time.Second
 
 // authoredPin is one pinned write: the exact bytes a client wrote through the
@@ -101,6 +111,11 @@ func (p *authoredPins) writtenBytes(fileIno uint64) []byte {
 // the same bytes — a Lookup that published the render's length while the buffer
 // served the pin would clamp the client's own read to the wrong size, which is
 // the very mismatch this module exists to remove.
+//
+// The buffer gets its own copy of the pin: the pin is not consumed, so every
+// Lookup in the window is handed the same bytes, and editBuffer.Write mutates a
+// buffer in place whenever the write fits — one node's edit would otherwise
+// rewrite what the next Lookup serves.
 func (p *authoredPins) seedAuthored(b *editBuffer, fileIno uint64, rendered []byte) []byte {
 	pinned := p.writtenBytes(fileIno)
 	b.mu.Lock()
@@ -109,7 +124,8 @@ func (p *authoredPins) seedAuthored(b *editBuffer, fileIno uint64, rendered []by
 		b.content = rendered
 		return rendered
 	}
-	b.content = pinned
+	owned := append([]byte(nil), pinned...)
+	b.content = owned
 	b.authored = true
-	return pinned
+	return owned
 }

--- a/internal/fs/authoredpin.go
+++ b/internal/fs/authoredpin.go
@@ -54,7 +54,7 @@ type authoredPin struct {
 
 // authoredPins is the mount-wide store of pinned writes, keyed by the canonical
 // file's inode. Embedded in LinearFS (zero value ready to use), so PinWritten
-// promotes onto it for the renameSink seam.
+// promotes onto it for the renameSaveSink seam.
 type authoredPins struct {
 	mu   sync.Mutex
 	pins map[uint64]authoredPin

--- a/internal/fs/authoredpin_test.go
+++ b/internal/fs/authoredpin_test.go
@@ -1,6 +1,7 @@
 package fs
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -135,6 +136,29 @@ func TestSeedAuthored_PinnedWriteWinsOverRender(t *testing.T) {
 	}
 	if !b.authored {
 		t.Error("a pin-seeded buffer must be authored, or a refresh can drop the client's bytes mid-verify")
+	}
+}
+
+// TestSeedAuthored_BufferWriteCannotCorruptThePin: the pin is not consumed, so a
+// node seeded from it must own its bytes — editBuffer.Write rewrites a buffer in
+// place whenever the write fits, and the next Lookup in the same window still has
+// to serve the bytes the client actually saved.
+func TestSeedAuthored_BufferWriteCannotCorruptThePin(t *testing.T) {
+	var p authoredPins
+	written := []byte("body the client wrote")
+	p.PinWritten(13, written)
+
+	var first editBuffer
+	p.seedAuthored(&first, 13, []byte("what Linear stored"))
+	if _, errno := first.Write(context.Background(), nil, []byte("MANGLED"), 0); errno != 0 {
+		t.Fatalf("write through the seeded buffer = %v, want 0", errno)
+	}
+
+	var second editBuffer
+	served := p.seedAuthored(&second, 13, []byte("what Linear stored"))
+	if string(served) != string(written) || string(second.content) != string(written) {
+		t.Errorf("second lookup served %q / buffer %q, want the pinned write %q",
+			served, second.content, written)
 	}
 }
 

--- a/internal/fs/authoredpin_test.go
+++ b/internal/fs/authoredpin_test.go
@@ -1,0 +1,154 @@
+package fs
+
+import (
+	"testing"
+	"time"
+)
+
+// TestAuthoredPins_ServesEveryLookupInTheWindow is the core contract, and the
+// reason the pin is not consume-once: a client's verification is several syscalls
+// (stat, then open+read), each able to drive its own Lookup after the rename
+// invalidation. A pin the first Lookup consumed would leave the second answering
+// from the render again — exactly the mismatch this fixes.
+func TestAuthoredPins_ServesEveryLookupInTheWindow(t *testing.T) {
+	var p authoredPins
+	p.PinWritten(42, []byte("written bytes"))
+
+	for i, want := range []string{"written bytes", "written bytes", "written bytes"} {
+		if got := string(p.writtenBytes(42)); got != want {
+			t.Errorf("lookup %d served %q, want the pinned write %q", i+1, got, want)
+		}
+	}
+}
+
+func TestAuthoredPins_UnpinnedInodes(t *testing.T) {
+	var p authoredPins
+	// Zero value, no map allocated yet: a read must not panic.
+	if got := p.writtenBytes(1); got != nil {
+		t.Fatalf("read from an empty store = %q, want nil", got)
+	}
+	p.PinWritten(1, []byte("one"))
+	if got := p.writtenBytes(2); got != nil {
+		t.Errorf("read of an unpinned inode = %q, want nil (pins are per-file)", got)
+	}
+	// An empty write pins nothing: there would be no size mismatch to fix, and a
+	// zero-length pin is indistinguishable from "no pin" downstream.
+	p.PinWritten(3, nil)
+	if got := p.writtenBytes(3); got != nil {
+		t.Errorf("read of an empty write = %q, want nil", got)
+	}
+}
+
+// TestAuthoredPins_LatestWriteWins: a second save inside the window supersedes
+// the first, so a verify never reads the previous body back.
+func TestAuthoredPins_LatestWriteWins(t *testing.T) {
+	var p authoredPins
+	p.PinWritten(9, []byte("first save"))
+	p.PinWritten(9, []byte("second save"))
+
+	if got := string(p.writtenBytes(9)); got != "second save" {
+		t.Errorf("pinned bytes = %q, want the most recent write", got)
+	}
+}
+
+// TestAuthoredPins_ExpiredPinIsNotServed guards the staleness bound: a pin no
+// Lookup ever consumed must not be served later, when Linear's stored body may
+// have moved on.
+func TestAuthoredPins_ExpiredPinIsNotServed(t *testing.T) {
+	var p authoredPins
+	p.PinWritten(7, []byte("stale write"))
+
+	// Age the pin past its deadline without sleeping.
+	p.mu.Lock()
+	pin := p.pins[7]
+	pin.deadline = time.Now().Add(-time.Second)
+	p.pins[7] = pin
+	p.mu.Unlock()
+
+	if got := p.writtenBytes(7); got != nil {
+		t.Errorf("read of an expired pin = %q, want nil", got)
+	}
+	p.mu.Lock()
+	_, still := p.pins[7]
+	p.mu.Unlock()
+	if still {
+		t.Error("an expired pin must be dropped when read, not left holding bytes")
+	}
+}
+
+// TestAuthoredPins_PinSweepsExpired keeps the store from growing without bound
+// when writes are never followed by a Lookup.
+func TestAuthoredPins_PinSweepsExpired(t *testing.T) {
+	var p authoredPins
+	p.PinWritten(1, []byte("first"))
+
+	p.mu.Lock()
+	pin := p.pins[1]
+	pin.deadline = time.Now().Add(-time.Second)
+	p.pins[1] = pin
+	p.mu.Unlock()
+
+	p.PinWritten(2, []byte("second"))
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if _, ok := p.pins[1]; ok {
+		t.Error("a later write must sweep pins that expired unread")
+	}
+	if _, ok := p.pins[2]; !ok {
+		t.Error("the fresh pin must survive the sweep")
+	}
+}
+
+// TestAuthoredPins_PinCopiesContent: renameSave hands over the scratch node's
+// live buffer, which the node may reuse or a later writer may overwrite. The pin
+// must own its bytes.
+func TestAuthoredPins_PinCopiesContent(t *testing.T) {
+	var p authoredPins
+	content := []byte("original")
+	p.PinWritten(5, content)
+	copy(content, "MANGLED")
+
+	if got := string(p.writtenBytes(5)); got != "original" {
+		t.Errorf("pinned bytes = %q, want an unaliased copy of the write", got)
+	}
+}
+
+// TestSeedAuthored_PinnedWriteWinsOverRender is the seeding half of the fix: the
+// buffer AND the size the Lookup publishes both come from the pin, and the buffer
+// is marked authored so a background refresh cannot replace the client's bytes
+// before it re-reads them.
+func TestSeedAuthored_PinnedWriteWinsOverRender(t *testing.T) {
+	var p authoredPins
+	written := []byte("body the client wrote  ") // trailing space Linear strips
+	rendered := []byte("body the client wrote")  // what persisted, 2 bytes shorter
+	p.PinWritten(11, written)
+
+	var b editBuffer
+	served := p.seedAuthored(&b, 11, rendered)
+
+	if string(served) != string(written) {
+		t.Errorf("published size bytes = %q, want the pinned write %q", served, written)
+	}
+	if string(b.content) != string(written) {
+		t.Errorf("buffer = %q, want the pinned write %q", b.content, written)
+	}
+	if !b.authored {
+		t.Error("a pin-seeded buffer must be authored, or a refresh can drop the client's bytes mid-verify")
+	}
+}
+
+func TestSeedAuthored_NoPinServesTheRender(t *testing.T) {
+	var p authoredPins
+	rendered := []byte("what Linear stored")
+
+	var b editBuffer
+	served := p.seedAuthored(&b, 12, rendered)
+
+	if string(served) != string(rendered) || string(b.content) != string(rendered) {
+		t.Errorf("served %q / buffer %q, want the render %q", served, b.content, rendered)
+	}
+	if b.authored {
+		t.Error("an ordinary Lookup must not be authored — later reads have to converge to what persisted")
+	}
+}

--- a/internal/fs/editbuffer.go
+++ b/internal/fs/editbuffer.go
@@ -35,6 +35,18 @@ type editBuffer struct {
 	authored bool
 }
 
+// committedWrite reports whether the Flush that just ran through this buffer
+// actually committed a write to Linear. editFlush marks a buffer authored on
+// exactly that outcome — a front half that proceeded plus a clean commit (#365) —
+// so the atomic-save tail reads the flag back off the transient node it flushed
+// through rather than inferring a commit from errno 0, which a flush that changed
+// nothing returns too (see renamesave.go, #379).
+func (b *editBuffer) committedWrite() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.authored
+}
+
 // size is the current buffer length, for a node's Getattr.
 func (b *editBuffer) size() int {
 	b.mu.Lock()

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -116,9 +116,10 @@ func (i *InitiativeNode) manifest() *dirManifest {
 	// initiative.md is editable-only; identity/status/owner live in initiative.meta.
 	m.file("initiative.md", initiativeInfoIno(initiative.ID), func(ctx context.Context) (fs.InodeEmbedder, []byte, syscall.Errno) {
 		node := &InitiativeInfoNode{BaseNode: BaseNode{lfs: lfs}, initiative: initiative, initiativeID: initiative.ID}
-		content := node.generateContent()
-		node.content = content
-		return node, content, 0
+		// An atomic save may have pinned the bytes the client just wrote; they
+		// win over the render for this one Lookup (authoredpin.go, #379).
+		served := lfs.seedAuthored(&node.editBuffer, initiativeInfoIno(initiative.ID), node.generateContent())
+		return node, served, 0
 	})
 
 	// initiative.meta: read-through from the freshest initiative so an edit to

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -179,14 +179,15 @@ func (i *InitiativeNode) Rename(ctx context.Context, name string, newParent fs.I
 		dirIno:     i.EmbeddedInode().StableAttr().Ino,
 		fileIno:    initiativeInfoIno(initiative.ID),
 		scratch:    func(oldName string) ([]byte, func(), bool) { return scratchRenameBytes(i, oldName) },
-		flush: func(ctx context.Context, content []byte) syscall.Errno {
+		flush: func(ctx context.Context, content []byte) (bool, syscall.Errno) {
 			fileNode = &InitiativeInfoNode{
 				BaseNode:     BaseNode{lfs: i.lfs},
 				initiative:   initiative,
 				initiativeID: initiative.ID,
 				editBuffer:   editBuffer{content: content, dirty: true},
 			}
-			return fileNode.Flush(ctx, nil)
+			errno := fileNode.Flush(ctx, nil)
+			return fileNode.committedWrite(), errno
 		},
 		adopt: func() { i.setEntity(fileNode.initiative) },
 	})

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -423,13 +423,14 @@ func (n *IssueDirectoryNode) Rename(ctx context.Context, name string, newParent 
 		dirIno:     n.EmbeddedInode().StableAttr().Ino,
 		fileIno:    issueIno(issue.ID),
 		scratch:    func(oldName string) ([]byte, func(), bool) { return scratchRenameBytes(n, oldName) },
-		flush: func(ctx context.Context, content []byte) syscall.Errno {
+		flush: func(ctx context.Context, content []byte) (bool, syscall.Errno) {
 			fileNode = &IssueFileNode{
 				BaseNode:   BaseNode{lfs: n.lfs},
 				issue:      issue,
 				editBuffer: editBuffer{content: content, dirty: true},
 			}
-			return fileNode.Flush(ctx, nil)
+			errno := fileNode.Flush(ctx, nil)
+			return fileNode.committedWrite(), errno
 		},
 		adopt: func() { n.setEntity(fileNode.issue) },
 	})

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -336,11 +336,11 @@ func (n *IssueDirectoryNode) manifest() *dirManifest {
 		if err != nil {
 			return nil, nil, syscall.EIO
 		}
-		return &IssueFileNode{
-			BaseNode:   BaseNode{lfs: n.lfs},
-			issue:      issue,
-			editBuffer: editBuffer{content: content},
-		}, content, 0
+		node := &IssueFileNode{BaseNode: BaseNode{lfs: n.lfs}, issue: issue}
+		// An atomic save may have pinned the bytes the client just wrote; they
+		// win over the render for this one Lookup (authoredpin.go, #379).
+		served := n.lfs.seedAuthored(&node.editBuffer, issueIno(issue.ID), content)
+		return node, served, 0
 	})
 
 	// issue.meta: read-only server-managed fields, rendered read-through from the

--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -74,6 +74,10 @@ type LinearFS struct {
 	// .error / .last state for every writable surface (see writefeedback.go).
 	// Embedded, so lfs.SetWriteError / lfs.AppendWriteSuccess / … promote.
 	writeFeedback
+
+	// Serve-your-own-writes pins for atomic saves (see authoredpin.go, #379).
+	// Embedded, so lfs.PinWritten / lfs.seedAuthored promote. Zero value ready.
+	authoredPins
 }
 
 // BaseNode provides common functionality for all LinearFS nodes.

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -260,9 +260,10 @@ func (p *ProjectNode) manifest() *dirManifest {
 	// project.md is editable-only; identity/status/dates live in project.meta.
 	m.file("project.md", projectInfoIno(project.ID), func(ctx context.Context) (fs.InodeEmbedder, []byte, syscall.Errno) {
 		node := &ProjectInfoNode{BaseNode: BaseNode{lfs: lfs}, team: team, project: project}
-		content := node.generateContent(ctx)
-		node.content = content
-		return node, content, 0
+		// An atomic save may have pinned the bytes the client just wrote; they
+		// win over the render for this one Lookup (authoredpin.go, #379).
+		served := lfs.seedAuthored(&node.editBuffer, projectInfoIno(project.ID), node.generateContent(ctx))
+		return node, served, 0
 	})
 
 	// project.meta: read-through from the freshest project so an edit to

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -324,14 +324,15 @@ func (p *ProjectNode) Rename(ctx context.Context, name string, newParent fs.Inod
 		dirIno:     p.EmbeddedInode().StableAttr().Ino,
 		fileIno:    projectInfoIno(project.ID),
 		scratch:    func(oldName string) ([]byte, func(), bool) { return scratchRenameBytes(p, oldName) },
-		flush: func(ctx context.Context, content []byte) syscall.Errno {
+		flush: func(ctx context.Context, content []byte) (bool, syscall.Errno) {
 			fileNode = &ProjectInfoNode{
 				BaseNode:   BaseNode{lfs: p.lfs},
 				team:       team,
 				project:    project,
 				editBuffer: editBuffer{content: content, dirty: true},
 			}
-			return fileNode.Flush(ctx, nil)
+			errno := fileNode.Flush(ctx, nil)
+			return fileNode.committedWrite(), errno
 		},
 		adopt: func() { p.setEntity(fileNode.project) },
 	})

--- a/internal/fs/renamesave.go
+++ b/internal/fs/renamesave.go
@@ -28,14 +28,23 @@ import (
 // inode tree — and is unit-tested with a recording sink and stub closures: no
 // FUSE mount, SQLite, or API.
 
-// renameSink is the minimal surface the atomic-save tail needs: .error
-// reporting for the wrong-target guard and the kernel-cache coherence policy
-// for the consumed scratch entry. *LinearFS satisfies it directly (writeFeedback
-// and kernelNotify promotions), so production wiring needs no adapter while
-// tests inject a fake.
+// renameSink is the minimal surface a rename tail needs: .error reporting for
+// the guards and the kernel-cache coherence policy for the renamed entry.
+// *LinearFS satisfies it directly (writeFeedback and kernelNotify promotions),
+// so production wiring needs no adapter while tests inject a fake. Shared with
+// commitRename (renamecommit.go), the title-rename tail.
 type renameSink interface {
 	errorSink
 	InvalidateRenamed(dirIno uint64, oldName, newName string, fileIno uint64)
+}
+
+// renameSaveSink adds the one surface only the atomic-save tail needs: the
+// serve-your-own-writes pin that carries the written bytes across the re-Lookup
+// this tail forces (see authoredpin.go, #379). *LinearFS satisfies it through
+// its embedded authoredPins.
+type renameSaveSink interface {
+	renameSink
+	PinWritten(fileIno uint64, content []byte)
 }
 
 // renameSaveSpec describes the per-entity parts of an atomic save. Everything
@@ -79,7 +88,7 @@ type renameSaveSpec struct {
 // path a direct in-place edit uses. The canonical file is the only writable
 // file in the directory, so renames onto any other target — or of the canonical
 // files themselves — are rejected.
-func renameSave(ctx context.Context, sink renameSink, name string, newParent fs.InodeEmbedder, newName string, spec renameSaveSpec) syscall.Errno {
+func renameSave(ctx context.Context, sink renameSaveSink, name string, newParent fs.InodeEmbedder, newName string, spec renameSaveSpec) syscall.Errno {
 	// The atomic-save pattern keeps the temp file a sibling of the canonical file.
 	if newParent.EmbeddedInode().StableAttr().Ino != spec.dirIno {
 		return syscall.EXDEV
@@ -115,6 +124,20 @@ func renameSave(ctx context.Context, sink renameSink, name string, newParent fs.
 		// ESTALE drives the VFS to re-Lookup the real node.
 		spec.adopt()
 		consume()
+		// Serve-your-own-writes (#379). The re-Lookup the invalidation below
+		// forces builds a node from what PERSISTED, so without a pin the bytes
+		// the client just wrote are never served back and a server-side reformat
+		// that changed the byte count reads to the client as a truncated write.
+		// Pin them for that Lookup to seed (see authoredpin.go), before the
+		// invalidation that triggers it.
+		//
+		// ONLY on a clean commit, exactly as editFlush arms `authored` (#365): on
+		// EIO the write did NOT persist as written — a silent revert or a
+		// truncation — and serving the written bytes there would hide the loss
+		// from the re-read .error tells the agent to make.
+		if errno == 0 {
+			sink.PinWritten(spec.fileIno, content)
+		}
 		sink.InvalidateRenamed(spec.dirIno, name, newName, spec.fileIno)
 	}
 

--- a/internal/fs/renamesave.go
+++ b/internal/fs/renamesave.go
@@ -75,8 +75,11 @@ type renameSaveSpec struct {
 	// construct a transient file node with a dirty editBuffer and Flush it
 	// (frontmatter validation, read-your-writes verification, .error handling,
 	// cache invalidation). The closure captures the transient node so adopt can
-	// read the flushed entity back.
-	flush func(ctx context.Context, content []byte) syscall.Errno
+	// read the flushed entity back — and so it can report committed, whether the
+	// flush actually wrote to Linear (editBuffer.committedWrite). Errno alone
+	// cannot say: a save that resolved to no changes at all also returns 0, and
+	// pinning there would echo a dropped edit back as a byte-for-byte success.
+	flush func(ctx context.Context, content []byte) (committed bool, errno syscall.Errno)
 	// adopt stores the flushed node's fresh entity on the directory node so the
 	// canonical file re-renders the persisted content. Called exactly when the
 	// write reached Linear — flush errno 0 or EIO (see renameSave).
@@ -108,7 +111,7 @@ func renameSave(ctx context.Context, sink renameSaveSink, name string, newParent
 		return syscall.ENOTSUP
 	}
 
-	errno := spec.flush(ctx, content)
+	committed, errno := spec.flush(ctx, content)
 
 	if errno == 0 || errno == syscall.EIO {
 		// Adopt on EIO too: Flush returns EIO only on a fatal read-your-writes
@@ -131,11 +134,15 @@ func renameSave(ctx context.Context, sink renameSaveSink, name string, newParent
 		// Pin them for that Lookup to seed (see authoredpin.go), before the
 		// invalidation that triggers it.
 		//
-		// ONLY on a clean commit, exactly as editFlush arms `authored` (#365): on
-		// EIO the write did NOT persist as written — a silent revert or a
-		// truncation — and serving the written bytes there would hide the loss
-		// from the re-read .error tells the agent to make.
-		if errno == 0 {
+		// ONLY on a committed clean save, exactly as editFlush arms `authored`
+		// (#365). On EIO the write did NOT persist as written — a silent revert
+		// or a truncation — and serving the written bytes there would hide the
+		// loss from the re-read .error tells the agent to make. A save that
+		// committed nothing (an edit that resolved to no changes, e.g. one that
+		// only touched frontmatter keys marshal ignores) returns 0 too, and
+		// pinning there would report a dropped edit back as a byte-for-byte
+		// success — the same false signal in the other direction.
+		if committed && errno == 0 {
 			sink.PinWritten(spec.fileIno, content)
 		}
 		sink.InvalidateRenamed(spec.dirIno, name, newName, spec.fileIno)

--- a/internal/fs/renamesave_test.go
+++ b/internal/fs/renamesave_test.go
@@ -53,7 +53,7 @@ type recordingRenameSpec struct {
 	adoptCalls   int
 }
 
-func newRecordingRenameSpec(scratchOK bool, flushErrno syscall.Errno) *recordingRenameSpec {
+func newRecordingRenameSpec(scratchOK, flushCommitted bool, flushErrno syscall.Errno) *recordingRenameSpec {
 	r := &recordingRenameSpec{}
 	r.spec = renameSaveSpec{
 		targetName: "issue.md",
@@ -64,10 +64,10 @@ func newRecordingRenameSpec(scratchOK bool, flushErrno syscall.Errno) *recording
 			r.scratchCalls++
 			return []byte("scratch bytes"), func() { r.consumeCalls++ }, scratchOK
 		},
-		flush: func(ctx context.Context, content []byte) syscall.Errno {
+		flush: func(ctx context.Context, content []byte) (bool, syscall.Errno) {
 			r.flushCalls++
 			r.flushContent = content
-			return flushErrno
+			return flushCommitted, flushErrno
 		},
 		adopt: func() { r.adoptCalls++ },
 	}
@@ -77,6 +77,7 @@ func newRecordingRenameSpec(scratchOK bool, flushErrno syscall.Errno) *recording
 func TestRenameSave_FlushOutcomes(t *testing.T) {
 	cases := []struct {
 		name            string
+		flushCommitted  bool
 		flushErrno      syscall.Errno
 		wantAdopts      int
 		wantInvalidates int
@@ -84,17 +85,22 @@ func TestRenameSave_FlushOutcomes(t *testing.T) {
 	}{
 		// A clean save adopts the fresh entity, pins the written bytes for the
 		// re-Lookup to serve back (#379), and drops the kernel caches.
-		{"flush success adopts, pins and invalidates", 0, 1, 1, 1},
+		{"flush success adopts, pins and invalidates", true, 0, 1, 1, 1},
+		// A save that resolved to no changes also returns 0. The tail still
+		// adopts/consumes/invalidates, but it must NOT pin: echoing the written
+		// bytes back would report an edit Linear never took as a byte-for-byte
+		// success.
+		{"flush that committed nothing never pins", false, 0, 1, 1, 0},
 		// The policy under test: Flush returns EIO only on a fatal
 		// read-your-writes divergence — the write still reached Linear, so the
 		// fresh entity is adopted (refusing would serve stale content while
 		// .error explains the divergence). It must NOT pin: the write did not
 		// persist as written, and serving the written bytes back would hide that
 		// from the re-read .error asks for (#365's errno == 0 rule).
-		{"flush EIO adopts but never pins", syscall.EIO, 1, 1, 0},
+		{"flush EIO adopts but never pins", true, syscall.EIO, 1, 1, 0},
 		// EINVAL means the write never reached Linear (parse/validation
 		// failure): nothing to adopt, nothing to pin, nothing to invalidate.
-		{"flush EINVAL adopts nothing", syscall.EINVAL, 0, 0, 0},
+		{"flush EINVAL adopts nothing", false, syscall.EINVAL, 0, 0, 0},
 	}
 	// The scratch buffer is consumed exactly when the rename succeeds (the same
 	// {0, EIO} branch that adopts): go-fuse has moved the spent node over the
@@ -104,7 +110,7 @@ func TestRenameSave_FlushOutcomes(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			sink := &renameRecorder{}
-			rec := newRecordingRenameSpec(true, tc.flushErrno)
+			rec := newRecordingRenameSpec(true, tc.flushCommitted, tc.flushErrno)
 
 			errno := renameSave(context.Background(), sink, "issue.md.tmp.1",
 				&renameParent{}, "issue.md", rec.spec)
@@ -158,7 +164,7 @@ func TestRenameSave_FlushOutcomes(t *testing.T) {
 
 func TestRenameSave_WrongTarget(t *testing.T) {
 	sink := &renameRecorder{}
-	rec := newRecordingRenameSpec(true, 0)
+	rec := newRecordingRenameSpec(true, true, 0)
 
 	errno := renameSave(context.Background(), sink, "issue.md.tmp.1",
 		&renameParent{}, "notes.md", rec.spec)
@@ -188,7 +194,7 @@ func TestRenameSave_WrongTarget(t *testing.T) {
 
 func TestRenameSave_CrossDirectory(t *testing.T) {
 	sink := &renameRecorder{}
-	rec := newRecordingRenameSpec(true, 0)
+	rec := newRecordingRenameSpec(true, true, 0)
 	// The zero-value parent inode has ino 0; a nonzero dirIno makes the rename
 	// cross-directory.
 	rec.spec.dirIno = 7
@@ -213,7 +219,7 @@ func TestRenameSave_NotAScratchFile(t *testing.T) {
 	sink := &renameRecorder{}
 	// e.g. an attempt to rename issue.md itself: the canonical files aren't
 	// renamable, and no .error is recorded (there is nothing to persist).
-	rec := newRecordingRenameSpec(false, 0)
+	rec := newRecordingRenameSpec(false, true, 0)
 
 	errno := renameSave(context.Background(), sink, "issue.md",
 		&renameParent{}, "renamed.md", rec.spec)

--- a/internal/fs/renamesave_test.go
+++ b/internal/fs/renamesave_test.go
@@ -17,6 +17,10 @@ type renameRecorder struct {
 	sets           int
 	clears         int
 	invalidates    []string
+	pins           []string
+	// events orders the coherence calls against each other: the pin has to be in
+	// place before the invalidation that triggers the re-Lookup which consumes it.
+	events []string
 }
 
 func (r *renameRecorder) SetWriteError(key, message string) {
@@ -27,6 +31,11 @@ func (r *renameRecorder) ClearWriteError(key string) { r.clears++ }
 func (r *renameRecorder) InvalidateRenamed(dirIno uint64, oldName, newName string, fileIno uint64) {
 	r.invalidates = append(r.invalidates,
 		fmt.Sprintf("renamed(%d,%q,%q,%d)", dirIno, oldName, newName, fileIno))
+	r.events = append(r.events, "invalidate")
+}
+func (r *renameRecorder) PinWritten(fileIno uint64, content []byte) {
+	r.pins = append(r.pins, fmt.Sprintf("pin(%d,%q)", fileIno, content))
+	r.events = append(r.events, "pin")
 }
 
 // renameParent is a bare InodeEmbedder whose zero-value inode has ino 0, so a
@@ -71,17 +80,21 @@ func TestRenameSave_FlushOutcomes(t *testing.T) {
 		flushErrno      syscall.Errno
 		wantAdopts      int
 		wantInvalidates int
+		wantPins        int
 	}{
-		// A clean save adopts the fresh entity and drops the kernel caches.
-		{"flush success adopts and invalidates", 0, 1, 1},
+		// A clean save adopts the fresh entity, pins the written bytes for the
+		// re-Lookup to serve back (#379), and drops the kernel caches.
+		{"flush success adopts, pins and invalidates", 0, 1, 1, 1},
 		// The policy under test: Flush returns EIO only on a fatal
 		// read-your-writes divergence — the write still reached Linear, so the
 		// fresh entity is adopted (refusing would serve stale content while
-		// .error explains the divergence).
-		{"flush EIO still adopts and invalidates", syscall.EIO, 1, 1},
+		// .error explains the divergence). It must NOT pin: the write did not
+		// persist as written, and serving the written bytes back would hide that
+		// from the re-read .error asks for (#365's errno == 0 rule).
+		{"flush EIO adopts but never pins", syscall.EIO, 1, 1, 0},
 		// EINVAL means the write never reached Linear (parse/validation
-		// failure): nothing to adopt, nothing to invalidate.
-		{"flush EINVAL adopts nothing", syscall.EINVAL, 0, 0},
+		// failure): nothing to adopt, nothing to pin, nothing to invalidate.
+		{"flush EINVAL adopts nothing", syscall.EINVAL, 0, 0, 0},
 	}
 	// The scratch buffer is consumed exactly when the rename succeeds (the same
 	// {0, EIO} branch that adopts): go-fuse has moved the spent node over the
@@ -118,6 +131,22 @@ func TestRenameSave_FlushOutcomes(t *testing.T) {
 				want := `renamed(0,"issue.md.tmp.1","issue.md",99)`
 				if sink.invalidates[0] != want {
 					t.Errorf("invalidate = %q, want %q", sink.invalidates[0], want)
+				}
+			}
+			if len(sink.pins) != tc.wantPins {
+				t.Fatalf("pins = %v, want %d call(s)", sink.pins, tc.wantPins)
+			}
+			if tc.wantPins == 1 {
+				// The pin carries the written bytes under the CANONICAL file's
+				// inode — that is the Lookup that will serve them back.
+				want := `pin(99,"scratch bytes")`
+				if sink.pins[0] != want {
+					t.Errorf("pin = %q, want %q", sink.pins[0], want)
+				}
+				// Ordering matters: the invalidation is what forces the
+				// re-Lookup, so the pin has to be waiting before it fires.
+				if len(sink.events) != 2 || sink.events[0] != "pin" {
+					t.Errorf("event order = %v, want the pin before the invalidation", sink.events)
 				}
 			}
 			if sink.sets != 0 {

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -338,6 +338,11 @@ Failure model (every writable surface follows this contract):
 - Whatever the errno, the reason lands in .error; success clears it. Always read
   .error after any failed write (including an atomic-save rename that returns
   EINVAL/EMSGSIZE) — the errno alone cannot carry the reason.
+- NOT a failure: a .error that says "saved, but Linear reformatted the markdown
+  server-side". The write succeeded and no text was lost (the errno was 0);
+  Linear stored its own formatting of your markdown. Re-read the file to see what
+  it stored. A write that truly did not persist says so — "reverted to its
+  previous content" or "substantially shorter" — and returns EIO.
 So an edit that "fails" or appears to no-op is explained at the sibling .error.
 
 Stale-catalog self-healing: a name that resolves nowhere locally (a status,
@@ -384,6 +389,12 @@ EDITING FILES:
 - Use the Edit tool to modify issue.md, project.md, initiative.md frontmatter
 - The Edit tool works correctly because it reads then writes (unlike raw editors on _create)
 - After editing, changes sync to Linear immediately
+- A save reads back byte-for-byte right away, but Linear normalizes markdown when
+  it STORES a body — it collapses blank runs, flips bullet markers, and can move
+  emphasis around inline code spans — so a later read shows the stored formatting,
+  not your bytes. Re-read the file before any follow-up edit that find-and-replaces
+  text from the earlier version; an in-context copy goes stale in reformatted
+  regions, and the failure looks like a bad match rather than a rewritten file.
 
 CREATING ITEMS:
 - Use Bash(echo "text" > path/_create) — never use the Write tool on _create files

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -335,9 +335,10 @@ Failure model (every writable surface follows this contract):
   lingering listing entry. Either way, restart the daemon or wait for the next
   sync to reflect it. (A succeeded mutation is never a silent no-op -- it appears
   locally or says why in .error.)
-- Whatever the errno, the reason lands in .error; success clears it. Always read
-  .error after any failed write (including an atomic-save rename that returns
-  EINVAL/EMSGSIZE) — the errno alone cannot carry the reason.
+- Whatever the errno, the reason lands in .error; success clears it, except for
+  the one informational note below. Always read .error after any failed write
+  (including an atomic-save rename that returns EINVAL/EMSGSIZE) — the errno
+  alone cannot carry the reason.
 - NOT a failure: a .error that says "saved, but Linear reformatted the markdown
   server-side". The write succeeded and no text was lost (the errno was 0);
   Linear stored its own formatting of your markdown. Reading the file right after

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -340,9 +340,11 @@ Failure model (every writable surface follows this contract):
   EINVAL/EMSGSIZE) — the errno alone cannot carry the reason.
 - NOT a failure: a .error that says "saved, but Linear reformatted the markdown
   server-side". The write succeeded and no text was lost (the errno was 0);
-  Linear stored its own formatting of your markdown. Re-read the file to see what
-  it stored. A write that truly did not persist says so — "reverted to its
-  previous content" or "substantially shorter" — and returns EIO.
+  Linear stored its own formatting of your markdown. Reading the file right after
+  the save gives you your own bytes back, so the reformat is not visible yet — a
+  later read shows what Linear stored (see EDITING FILES). A write that truly did
+  not persist says so — "reverted to its previous content" or "substantially
+  shorter" — and returns EIO.
 So an edit that "fails" or appears to no-op is explained at the sibling .error.
 
 Stale-catalog self-healing: a name that resolves nowhere locally (a status,
@@ -392,9 +394,11 @@ EDITING FILES:
 - A save reads back byte-for-byte right away, but Linear normalizes markdown when
   it STORES a body — it collapses blank runs, flips bullet markers, and can move
   emphasis around inline code spans — so a later read shows the stored formatting,
-  not your bytes. Re-read the file before any follow-up edit that find-and-replaces
-  text from the earlier version; an in-context copy goes stale in reformatted
-  regions, and the failure looks like a bad match rather than a rewritten file.
+  not your bytes. The immediate read-back therefore verifies that the write landed,
+  not how Linear stored it. Re-read the file before any follow-up edit that
+  find-and-replaces text from the earlier version; an in-context copy goes stale in
+  reformatted regions, and the failure looks like a bad match rather than a
+  rewritten file.
 
 CREATING ITEMS:
 - Use Bash(echo "text" > path/_create) — never use the Write tool on _create files

--- a/internal/fs/writeback.go
+++ b/internal/fs/writeback.go
@@ -101,7 +101,7 @@ func writeBackDivergence(field, want, got, prev string) writeBackResult {
 	// normalize (e.g. bold spanning a newline). The write succeeded; report a
 	// non-fatal note rather than failing the close.
 	return writeBackResult{
-		message: fmt.Sprintf("Field: %s\nNote: saved, but Linear reformatted the markdown server-side (you wrote %d chars, %d persisted). The text is intact; re-read the file to see the stored formatting.", field, wantLen, gotLen),
+		message: fmt.Sprintf("Field: %s\nNote: saved, but Linear reformatted the markdown server-side (you wrote %d chars, %d persisted). The text is intact; an immediate re-read still shows your own bytes, a later read shows the stored formatting.", field, wantLen, gotLen),
 		fatal:   false,
 	}
 }

--- a/internal/integration/atomicsave_pin_test.go
+++ b/internal/integration/atomicsave_pin_test.go
@@ -1,0 +1,263 @@
+package integration
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jra3/linear-fuse/internal/marshal"
+	"github.com/jra3/linear-fuse/internal/testutil/mockmutation"
+)
+
+// #379 end-to-end, at the syscall level a real editor uses.
+//
+// TestOffline_AtomicSaveServesTheWrittenBytes (edit_persist_test.go) pins the
+// issue.md size after a reformat that normalizeMarkdown forgives — so it fixes
+// the byte count but leaves .error clear. The report's actual shape was the other
+// one: Linear rewrote inline markup it does NOT forgive, so the save landed BOTH
+// an informational "saved, but Linear reformatted the markdown" note AND a
+// changed byte count, and the client read the pair as data loss. These tests
+// cover that shape, and the two atomic-save sites the issue never touched
+// (project.md, initiative.md).
+
+// codeSpanReformat models the transform the #379 report quoted: Linear rewriting
+// inline markup around a code span, here by padding it with spaces. Unlike a
+// blank-line collapse it is NOT one of the reflows normalizeMarkdown forgives
+// (writeback.go), so the write-back check records its non-fatal reformat note —
+// and the stored body is 2 bytes LONGER than what was written, which is exactly
+// the "is N bytes on disk, expected N-2" delta the report carried.
+func codeSpanReformat(body string) string {
+	return strings.ReplaceAll(body, "the`pin`holds", "the `pin` holds")
+}
+
+// atomicSave writes content the way every editor and the Claude Code Write tool
+// do: to a scratch sibling, then rename(2) over the canonical file. It is the
+// path #365's in-place serve-your-own-writes never covered.
+func atomicSave(t *testing.T, path string, content []byte) {
+	t.Helper()
+	tmp := fmt.Sprintf("%s.tmp.%d.5aved", path, len(content))
+	if err := os.WriteFile(tmp, content, 0o644); err != nil {
+		t.Fatalf("write scratch temp %s: %v", filepath.Base(tmp), err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		t.Fatalf("rename %s over %s: %v", filepath.Base(tmp), filepath.Base(path), err)
+	}
+}
+
+// TestOffline_AtomicSaveVerifyAfterReformatNote is the report reproduced whole:
+// save issue.md atomically, then make the two verification syscalls a client
+// makes next (stat, then open+read) while Linear reformats the body it stores.
+// Before the pin, both answered from the re-render of what PERSISTED, so the
+// size was the reformatted length and the client — told by .error only that the
+// markdown was reformatted — reported the successful write as possible silent
+// truncation.
+func TestOffline_AtomicSaveVerifyAfterReformatNote(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode check; needs the mock mutator's reformat-on-store")
+	}
+	enableMockMutations(t, mockmutation.WithBodyReformat(codeSpanReformat))
+
+	// Throwaway issue: the atomic save consumes a scratch node, so the shared
+	// fixtures stay untouched (same reason as the sibling test in edit_persist).
+	identifier := createRefreshTestIssue(t, "Atomic Save Verify Probe")
+	path := issueFilePath(testTeamKey, identifier)
+	orig, err := readFileWithRetry(path, defaultWaitTime)
+	if err != nil {
+		t.Fatalf("read issue.md: %v", err)
+	}
+	doc, err := marshal.Parse(orig)
+	if err != nil {
+		t.Fatalf("parse issue.md: %v", err)
+	}
+	doc.Body = strings.TrimRight(doc.Body, "\n") + "\n\nverified read-back is what the`pin`holds"
+	edited, err := marshal.Render(doc)
+	if err != nil {
+		t.Fatalf("render issue.md: %v", err)
+	}
+
+	t.Logf("$ printf %%s \"<edited>\" > %s.tmp.N && mv %s.tmp.N %s   # the atomic save every editor performs",
+		filepath.Base(path), filepath.Base(path), filepath.Base(path))
+	atomicSave(t, path, edited)
+	t.Logf("  wrote %d bytes to %s/issue.md", len(edited), identifier)
+
+	// No retry loop anywhere below: the point is what the very next syscalls see.
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat issue.md after atomic save: %v", err)
+	}
+	t.Logf("$ stat -c %%s issue.md          -> %d   (client expected %d)", fi.Size(), len(edited))
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("re-read issue.md after atomic save: %v", err)
+	}
+	t.Logf("$ cat issue.md | cmp - written  -> %s", map[bool]string{true: "identical", false: "DIFFERS"}[bytes.Equal(after, edited)])
+	t.Logf("$ cat %s/.error\n%s", identifier, readIssueError(t, identifier))
+
+	if fi.Size() != int64(len(edited)) {
+		t.Errorf("stat size after atomic save = %d, want %d — this is the #379 report: %q",
+			fi.Size(), len(edited),
+			fmt.Sprintf("issue.md is %d bytes on disk, expected %d ... may have silently truncated the write",
+				fi.Size(), len(edited)))
+	}
+	if !bytes.Equal(after, edited) {
+		t.Errorf("read-back after atomic save is not what was written\n--- wrote ---\n%q\n--- got ---\n%q", edited, after)
+	}
+	t.Logf("client verdict: %s", map[bool]string{
+		true:  "write verified byte-for-byte; the .error note is informational",
+		false: "MISMATCH — reads as a possible truncated write (#379)",
+	}[fi.Size() == int64(len(edited)) && bytes.Equal(after, edited)])
+
+	// The .error note is the other half of the report: it must still SAY the
+	// server reformatted (that is true and the agent needs it), while telling the
+	// agent the immediate read-back is its own bytes.
+	gotErr := readIssueError(t, identifier)
+	if !strings.Contains(gotErr, "saved, but Linear reformatted the markdown") {
+		t.Errorf(".error after a server-side reformat = %q, want the informational reformat note", gotErr)
+	}
+	if !strings.Contains(gotErr, "an immediate re-read still shows your own bytes") {
+		t.Errorf(".error note does not describe the pinned read-back (#379): %q", gotErr)
+	}
+}
+
+// TestOffline_AtomicSaveDoesNotPinOverRealDataLoss is the other half of the
+// contract, and the reason the pin is armed only on a clean commit: when the
+// server does NOT store what was written, the loss has to stay visible. Here the
+// fake truncates the body, so the write-back check calls it fatal (EIO) — the
+// rename must fail, .error must say the value was truncated, and the re-read must
+// show the SHORT stored body, not the bytes the client wrote. A pin taken on EIO
+// would echo the full text back and hide the loss behind a byte-for-byte match.
+func TestOffline_AtomicSaveDoesNotPinOverRealDataLoss(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode check; needs the mock mutator's reformat-on-store")
+	}
+	const kept = "refresh-retry probe body"
+	// Keep a prefix rather than reverting to the previous body, so the write-back
+	// check classifies this as truncation and not as the (also fatal) silent
+	// revert — the same EIO outcome by the path #379 is actually about.
+	enableMockMutations(t, mockmutation.WithBodyReformat(func(body string) string {
+		if len(body) > 40 {
+			return body[:40]
+		}
+		return body
+	}))
+
+	identifier := createRefreshTestIssue(t, "Atomic Save Truncation Probe")
+	path := issueFilePath(testTeamKey, identifier)
+	orig, err := readFileWithRetry(path, defaultWaitTime)
+	if err != nil {
+		t.Fatalf("read issue.md: %v", err)
+	}
+	doc, err := marshal.Parse(orig)
+	if err != nil {
+		t.Fatalf("parse issue.md: %v", err)
+	}
+	doc.Body = kept + "\n\na long paragraph of text the server is about to drop on the floor"
+	edited, err := marshal.Render(doc)
+	if err != nil {
+		t.Fatalf("render issue.md: %v", err)
+	}
+
+	tmp := fmt.Sprintf("%s.tmp.%d.5aved", path, len(edited))
+	if err := os.WriteFile(tmp, edited, 0o644); err != nil {
+		t.Fatalf("write scratch temp: %v", err)
+	}
+	renameErr := os.Rename(tmp, path)
+	_ = os.Remove(tmp)
+	t.Logf("$ mv issue.md.tmp.N issue.md   # wrote %d bytes -> %v", len(edited), renameErr)
+	if renameErr == nil {
+		t.Errorf("atomic save over a truncating server returned success; want EIO so the client sees the loss")
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("re-read issue.md after the failed save: %v", err)
+	}
+	t.Logf("$ cat issue.md | cmp - written  -> %s (%d bytes on disk vs %d written)",
+		map[bool]string{true: "identical", false: "DIFFERS"}[bytes.Equal(after, edited)], len(after), len(edited))
+	t.Logf("$ cat %s/.error\n%s", identifier, readIssueError(t, identifier))
+
+	if bytes.Equal(after, edited) {
+		t.Error("the written bytes were served back over a truncated save — a pin on EIO hides real data loss (#365/#379)")
+	}
+	if strings.Contains(string(after), "drop on the floor") {
+		t.Errorf("re-read still shows the dropped paragraph; want the short stored body\n--- got ---\n%q", after)
+	}
+	if e := readIssueError(t, identifier); !strings.Contains(e, "substantially shorter") {
+		t.Errorf(".error after a truncating save = %q, want the fatal truncation report", e)
+	}
+}
+
+// TestOffline_AtomicSaveServesWrittenBytesForProjectAndInitiative covers the two
+// atomic-save sites the #379 report never exercised. renameSave is entity-neutral
+// and all three canonical files route through it, so a pin wired at only the
+// issue path would leave these two reading back Linear's render — the same
+// false-truncation signal, on project.md and initiative.md.
+func TestOffline_AtomicSaveServesWrittenBytesForProjectAndInitiative(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode check; needs the mock mutator's reformat-on-store")
+	}
+	enableMockMutations(t, mockmutation.WithBodyReformat(codeSpanReformat))
+
+	initiativeDir, err := firstInitiativeDir()
+	if err != nil {
+		t.Skipf("no initiative fixture: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"project.md", projectMDPath()},
+		{"initiative.md", filepath.Join(initiativeDir, "initiative.md")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			orig, err := readFileWithRetry(tc.path, defaultWaitTime)
+			if err != nil {
+				t.Fatalf("read %s: %v", tc.name, err)
+			}
+			// Restore through the SAME atomic path, not an in-place write: that
+			// supersedes this test's pin with the original bytes, so a later test
+			// re-looking up the file inside the pin window sees the fixture.
+			t.Cleanup(func() { atomicSave(t, tc.path, orig) })
+
+			doc, err := marshal.Parse(orig)
+			if err != nil {
+				t.Fatalf("parse %s: %v", tc.name, err)
+			}
+			doc.Body = strings.TrimRight(doc.Body, "\n") + "\n\nverified read-back is what the`pin`holds"
+			edited, err := marshal.Render(doc)
+			if err != nil {
+				t.Fatalf("render %s: %v", tc.name, err)
+			}
+
+			atomicSave(t, tc.path, edited)
+			t.Logf("$ mv %s.tmp.N %s   # wrote %d bytes", tc.name, tc.name, len(edited))
+
+			fi, err := os.Stat(tc.path)
+			if err != nil {
+				t.Fatalf("stat %s after atomic save: %v", tc.name, err)
+			}
+			after, err := os.ReadFile(tc.path)
+			if err != nil {
+				t.Fatalf("re-read %s after atomic save: %v", tc.name, err)
+			}
+			t.Logf("$ stat -c %%s %s -> %d (expected %d); read-back %s",
+				tc.name, fi.Size(), len(edited),
+				map[bool]string{true: "identical", false: "DIFFERS"}[bytes.Equal(after, edited)])
+
+			if fi.Size() != int64(len(edited)) {
+				t.Errorf("stat size after atomic save of %s = %d, want %d (the bytes written)",
+					tc.name, fi.Size(), len(edited))
+			}
+			if !bytes.Equal(after, edited) {
+				t.Errorf("read-back of %s is not what was written\n--- wrote ---\n%q\n--- got ---\n%q",
+					tc.name, edited, after)
+			}
+		})
+	}
+}

--- a/internal/integration/edit_persist_test.go
+++ b/internal/integration/edit_persist_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/jra3/linear-fuse/internal/marshal"
+	"github.com/jra3/linear-fuse/internal/testutil/mockmutation"
 )
 
 // These tests exercise the per-entity EDIT (Flush) persistence paths OFFLINE,
@@ -126,6 +128,82 @@ func TestOffline_AtomicRenameEditPersists(t *testing.T) {
 	}
 	if !strings.Contains(string(after), marker) {
 		t.Fatalf("atomic-rename edit did not persist marker %q\n--- got ---\n%s", marker, after)
+	}
+}
+
+// TestOffline_AtomicSaveServesTheWrittenBytes guards the write→verify contract
+// #379 broke: an editor's atomic save must read back byte-for-byte, even when
+// Linear reformatted the body it stored.
+//
+// Every editor and the Claude Code Write/Edit tools save via scratch-file +
+// rename, and renameSave deliberately drops the canonical file's inode so it
+// re-Looks-up from what PERSISTED. Serve-your-own-writes (#365) lives in the
+// editBuffer the bytes were written through, and on this path that buffer belongs
+// to a transient node the rename discards — so the client's own verify re-read
+// saw Linear's normalized render instead of its bytes, and any byte-count
+// difference was reported as "the filesystem may have silently truncated the
+// write" on a save that fully succeeded. The pin (authoredpin.go) carries the
+// written bytes across that re-Lookup.
+//
+// The fake reformats on store (collapsing a blank-line run, one of the transforms
+// real Linear applies), so persisted is a byte shorter than written — without the
+// pin the stat below reports that shorter size.
+func TestOffline_AtomicSaveServesTheWrittenBytes(t *testing.T) {
+	if liveAPIMode {
+		t.Skip("fixture-mode check; needs the mock mutator's reformat-on-store")
+	}
+	enableMockMutations(t, mockmutation.WithBodyReformat(func(body string) string {
+		return strings.ReplaceAll(body, "\n\n\n", "\n\n")
+	}))
+
+	// A throwaway issue: the atomic save consumes a scratch node, so reusing the
+	// shared fixture is unreliable across -count reruns (see the test above).
+	identifier := createRefreshTestIssue(t, "Atomic Save Byte Count Probe")
+	path := issueFilePath(testTeamKey, identifier)
+	orig, err := readFileWithRetry(path, defaultWaitTime)
+	if err != nil {
+		t.Fatalf("read issue.md: %v", err)
+	}
+
+	doc, err := marshal.Parse(orig)
+	if err != nil {
+		t.Fatalf("parse issue.md: %v", err)
+	}
+	// The blank-line run is what the fake will collapse on store.
+	doc.Body = strings.TrimRight(doc.Body, "\n") + "\n\nfirst para\n\n\nsecond para"
+	edited, err := marshal.Render(doc)
+	if err != nil {
+		t.Fatalf("render issue.md: %v", err)
+	}
+	if !strings.Contains(string(edited), "\n\n\n") {
+		t.Fatalf("test setup: the rendered file carries no blank-line run to reformat\n%s", edited)
+	}
+
+	tmp := path + ".tmp.43.f00dcafe"
+	if err := os.WriteFile(tmp, edited, 0o644); err != nil {
+		t.Fatalf("write scratch temp: %v", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		t.Fatalf("atomic rename over issue.md should persist with mock mutator: %v", err)
+	}
+
+	// The verification a client makes immediately after its save — no retry loop:
+	// the point is what the very next stat and read observe.
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat issue.md after atomic save: %v", err)
+	}
+	if fi.Size() != int64(len(edited)) {
+		t.Errorf("size after atomic save = %d, want %d (the bytes written) — a byte-count verify reads this as a truncated write",
+			fi.Size(), len(edited))
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("re-read issue.md after atomic save: %v", err)
+	}
+	if !bytes.Equal(after, edited) {
+		t.Errorf("read-back after atomic save is not what was written\n--- wrote ---\n%q\n--- got ---\n%q", edited, after)
 	}
 }
 

--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -17,16 +17,17 @@ import (
 // failing at the network with the fixture-mode dummy key. The real client is
 // restored on cleanup so loud-failure tests that intend mutations to fail are
 // unaffected. Tests using this must not t.Parallel() (the fake is process-global
-// on the shared mount).
-func enableMockMutations(t *testing.T) {
+// on the shared mount). Extra options (e.g. WithBodyReformat) tailor the fake to
+// one test's scenario; the defaults are what every other test gets.
+func enableMockMutations(t *testing.T, opts ...mockmutation.Option) {
 	t.Helper()
 	if liveAPIMode {
 		return // live mode uses the real API; the fake would mask it
 	}
-	lfs.InjectTestMutationClient(mockmutation.New(
+	lfs.InjectTestMutationClient(mockmutation.New(append([]mockmutation.Option{
 		mockmutation.WithTeamKey(testTeamKey),
 		mockmutation.WithStore(lfs.GetStore()),
-	))
+	}, opts...)...))
 	t.Cleanup(func() { lfs.InjectTestMutationClient(nil) })
 }
 

--- a/internal/integration/readme_test.go
+++ b/internal/integration/readme_test.go
@@ -138,6 +138,20 @@ func TestGeneratedReadmeMatchesBehavior(t *testing.T) {
 		t.Error("README still claims a project/initiative body maps to the ≤255 description field (#5)")
 	}
 
+	// #379: a successful write whose body Linear reformatted leaves an
+	// informational .error note, and a later read shows the stored formatting
+	// rather than the written bytes. Both are contract an agent gets wrong by
+	// default — it reads the note as a failed write, and it find-and-replaces
+	// against a now-stale in-context copy — so the README must state them.
+	for _, want := range []string{
+		"saved, but Linear reformatted the markdown",
+		"Re-read the file before any follow-up edit",
+	} {
+		if !strings.Contains(readme, want) {
+			t.Errorf("README does not document the server-side reformat contract: missing %q", want)
+		}
+	}
+
 	// Project labels (#130): the README must teach the catalog surface and the
 	// assignment rules ("one child" pins group exclusivity; "retired" pins the
 	// lifecycle; the reference-files line must point at the catalog).

--- a/internal/integration/readme_test.go
+++ b/internal/integration/readme_test.go
@@ -146,10 +146,17 @@ func TestGeneratedReadmeMatchesBehavior(t *testing.T) {
 	for _, want := range []string{
 		"saved, but Linear reformatted the markdown",
 		"Re-read the file before any follow-up edit",
+		"a later read shows",
 	} {
 		if !strings.Contains(readme, want) {
 			t.Errorf("README does not document the server-side reformat contract: missing %q", want)
 		}
+	}
+	// The written bytes are pinned across the atomic-save re-Lookup, so an
+	// immediate re-read shows the agent's own bytes, never Linear's formatting.
+	// The two places the README describes the reformat must agree on that timing.
+	if strings.Contains(readme, "Re-read the file to see what it stored") {
+		t.Error("README still tells an agent an immediate re-read shows Linear's stored formatting (#379 pins the written bytes)")
 	}
 
 	// Project labels (#130): the README must teach the catalog surface and the

--- a/internal/testutil/mockmutation/mock.go
+++ b/internal/testutil/mockmutation/mock.go
@@ -83,10 +83,12 @@ func WithStore(store *db.Store) Option {
 
 // WithBodyReformat models the one server behaviour the fake otherwise cannot:
 // Linear normalizes markdown when it STORES a body, so what persists is not
-// byte-identical to what was written (#146). fn is applied to an issue
-// description on update, so the verify getter reads back a body of a different
-// length than the one sent — the condition under which a byte-count re-read of a
-// fully successful save used to look like a truncated write (#379).
+// byte-identical to what was written (#146). fn is applied to the stored body of
+// every entity whose canonical .md is atomically saved — an issue description, a
+// project's content, an initiative's content — so the verify getter reads back a
+// body of a different length than the one sent, the condition under which a
+// byte-count re-read of a fully successful save used to look like a truncated
+// write (#379).
 //
 // Off by default: without it the fake echoes bodies verbatim, which is the
 // conservative choice for every other test.
@@ -412,7 +414,7 @@ func (c *Client) UpdateProject(ctx context.Context, projectID string, input api.
 		proj.Name = *input.Name
 	}
 	if input.Content != nil { // the editable body maps here (#5)
-		proj.Content = *input.Content
+		proj.Content = c.reformat(*input.Content)
 	}
 	if input.Description != nil {
 		proj.Description = *input.Description
@@ -496,7 +498,7 @@ func (c *Client) UpdateInitiative(ctx context.Context, initiativeID string, inpu
 		init.Name = *input.Name
 	}
 	if input.Content != nil { // the editable body maps here (#5)
-		init.Content = *input.Content
+		init.Content = c.reformat(*input.Content)
 	}
 	if input.Description != nil {
 		init.Description = *input.Description

--- a/internal/testutil/mockmutation/mock.go
+++ b/internal/testutil/mockmutation/mock.go
@@ -53,6 +53,10 @@ type Client struct {
 	// via DocumentFields (issue/project/team/initiative); without it the upsert
 	// would clear issue_id and drop the doc from its parent listing.
 	docState map[string]api.Document
+	// bodyReformat, when set, is applied to a stored issue description to model
+	// Linear's server-side markdown normalization (see WithBodyReformat). nil
+	// means the fake stores what it was sent, verbatim.
+	bodyReformat func(string) string
 	// liveLinkOverride, when set for a parent ID (project or initiative), replaces
 	// the store-backed authoritative live link list served by the liveReader seam.
 	// It lets a test present a phantom — a link the store still has but Linear no
@@ -75,6 +79,19 @@ func WithTeamKey(key string) Option {
 // project — matching what the live API returns. Without it those render blank.
 func WithStore(store *db.Store) Option {
 	return func(c *Client) { c.store = store }
+}
+
+// WithBodyReformat models the one server behaviour the fake otherwise cannot:
+// Linear normalizes markdown when it STORES a body, so what persists is not
+// byte-identical to what was written (#146). fn is applied to an issue
+// description on update, so the verify getter reads back a body of a different
+// length than the one sent — the condition under which a byte-count re-read of a
+// fully successful save used to look like a truncated write (#379).
+//
+// Off by default: without it the fake echoes bodies verbatim, which is the
+// conservative choice for every other test.
+func WithBodyReformat(fn func(string) string) Option {
+	return func(c *Client) { c.bodyReformat = fn }
 }
 
 // New returns a fake mutation client. Created issues get identifiers like
@@ -225,6 +242,14 @@ func (c *Client) projectName(ctx context.Context, id string) string {
 	return ""
 }
 
+// reformat applies the configured server-side body normalization, if any.
+func (c *Client) reformat(body string) string {
+	if c.bodyReformat == nil {
+		return body
+	}
+	return c.bodyReformat(body)
+}
+
 func (c *Client) UpdateIssue(ctx context.Context, issueID string, input map[string]any) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -233,7 +258,7 @@ func (c *Client) UpdateIssue(ctx context.Context, issueID string, input map[stri
 		iss.Title = v
 	}
 	if v, ok := input["description"].(string); ok {
-		iss.Description = v
+		iss.Description = c.reformat(v)
 	}
 	// Overlay the editable scalar frontmatter fields the issue Flush can send, so
 	// the verify getter reads them back — mirroring CreateIssue's field handling.


### PR DESCRIPTION
## Intent

Fix GitHub issue #379, which the user called critical: an editor's atomic save of
issue.md reports a successful write as a possible data-loss event ("is N bytes on
disk, expected N-2 ... may have silently truncated the write"), even though
Linear persisted the write and the sibling .error says only that Linear
reformatted the markdown server-side.

The issue's own follow-up comment hypothesized emoji/variation-selector
normalization as the residual trigger (n=2, explicitly caveated). I investigated
and rejected that: the real cause is that serve-your-own-writes (#365, the
previous fix) lives in editBuffer.authored, and editors never write in place —
they write a scratch temp file and rename(2) it over the canonical .md. On that
path renameSave flushes through a TRANSIENT file node built only to run Flush,
so editFlush arms `authored` on a buffer that is discarded immediately, and
renameSave then deliberately drops the canonical file's inode so it re-Looks-up
and re-renders what PERSISTED. The written bytes were therefore never served
back, and ANY byte-count difference from Linear's reformat produced the symptom;
the emoji edits were just the ones where the render happened to differ. Fixing
the emoji hypothesis instead would have fixed nothing.

Decisions made while implementing, which a reviewer reading only the diff would
not know:

- New module internal/fs/authoredpin.go (authoredPins), embedded on LinearFS by
value (zero value ready, no constructor wiring needed), rather than extending
editBuffer: the pin must survive a node boundary that the buffer by definition
cannot cross.
- Pin only on a clean commit (errno == 0), deliberately NOT on EIO. This mirrors
#365's rule: a fatal read-your-writes divergence (silent revert or truncation)
must stay visible to the byte-count re-read that .error tells the agent to
make, so serving the written bytes there would hide real data loss.
- The pin is bounded by TIME (pinTTL, 10s), not consumed by the first Lookup. My
first implementation was consume-once and the mount test caught it as wrong: a
client's verification is several syscalls (stat, then open+read), each able to
drive its own Lookup after the rename invalidation, so a pin consumed by the
first left the second answering from the render again. A TTL is also a tighter
staleness bound than the in-place path's "until the next Open", which has no
time limit at all.
- The Lookup must publish the pinned bytes as the file's SIZE as well as serve
them, because manifest.file() reports len(rendered content) in the EntryOut —
that is where the size delta actually leaked to the client.
- Wired at all three atomic-save sites (issue.md, project.md, initiative.md),
not just the issue path the report came from.
- renameSink was NOT widened; a separate renameSaveSink interface adds
PinWritten, so commitRename (the title-rename tail, which shares renameSink)
keeps the narrower surface.
- Added mockmutation.WithBodyReformat (off by default) so the offline fake can
model Linear normalizing a body on store. Without it persisted always equalled
written, and this entire bug class was untestable offline. Deliberate change to
a test double, not production behavior.
- A deterministic mount-level integration test was written on purpose even
though a previous mount test for #365 was deleted as machine-dependently
flaky: that one needed a ~30s entry-timeout wait, whereas here the rename
itself forces the re-Lookup, so write→rename→stat→read is sub-millisecond. It
passes 8/8 and fails 3/3 with the pin disabled.

Docs updated in the same change, per this repo's CLAUDE.md rules: the
authoredPins seam in docs/ARCHITECTURE.md, and the generated README (root.go)
gained two lines pinned by internal/integration/readme_test.go — that a "saved,
but Linear reformatted the markdown" .error note is informational and not a
failure, and that a later read shows Linear's stored formatting so an agent must
re-read before a follow-up find-and-replace. docs/THREAT-MODEL.md was
deliberately NOT changed: the pin is memory-only, bounded to 10s, and holds
bytes the process already had in the write buffer — no new trust boundary,
on-disk artifact, network caller, or remote-string-to-path conversion.

Scope note: the second defect in #379 — Linear rewriting inline markup around
code spans, which can render visibly broken — is NOT fixed and cannot be fixed
from the client side without reimplementing Linear's normalizer. The README line
about re-reading before a dependent edit is the deliberate mitigation for it.

## What Changed

- New `internal/fs/authoredpin.go` (`authoredPins`, embedded by value on `LinearFS`) carries a client's written bytes across the node boundary the atomic-save path crosses. `renameSave` pins them under the canonical file's inode before the invalidation that forces a re-Lookup, and the Lookup seeds the new node's `editBuffer` with them — marked authored, and published as the file's size in the `EntryOut`, since `manifest.file()` reported the render's length. Pins are bounded by a 10s TTL rather than consumed by the first Lookup (a verify is several syscalls, each able to drive its own Lookup), and expire back to Linear's stored render. Previously an editor's write→rename→stat→read saw the re-rendered persisted body, so any server-side reformat that changed the byte count read as a possible truncation on a write that fully succeeded (#379).
- Pinning is gated on a clean *committed* save: `renameSaveSpec.flush` now returns `(committed, errno)`, read off the transient node via a new `editBuffer.committedWrite()`. EIO is excluded so a real read-your-writes divergence stays visible to the byte-count re-read, and a save that resolved to no changes (errno 0, nothing sent) is excluded so a dropped edit isn't echoed back as a byte-for-byte success. A separate `renameSaveSink` interface adds `PinWritten` so `commitRename` keeps the narrower `renameSink`. Wired at all three atomic-save sites: `issues.go`, `projects.go`, `initiatives.go`.
- Test double and docs: `mockmutation.WithBodyReformat` (off by default) lets the offline fake model Linear normalizing a stored body, which is what made this class testable offline; new `internal/fs/authoredpin_test.go` and a deterministic mount-level `internal/integration/atomicsave_pin_test.go` (green 8/8, fails 3/3 with the pin disabled per the negative control). `docs/ARCHITECTURE.md`, `CONTEXT.md`, and the generated mount README (`root.go`, pinned by `readme_test.go`) record the `authoredPins` seam plus two agent-facing lines: the "saved, but Linear reformatted the markdown" `.error` note is informational, and a later read shows Linear's formatting so re-read before a follow-up find-and-replace. `README.md` notes the same carve-out in its `.error` contract. `docs/THREAT-MODEL.md` is unchanged — the pin is memory-only, bounded, and holds bytes the process already had.

Not fixed: the second defect in #379, Linear rewriting inline markup around code spans. That needs Linear's normalizer; the re-read guidance is the deliberate client-side mitigation.

## Risk Assessment

✅ Low: Every round-1 finding is fixed with a targeted test or doc correction, the commit-signal threading is sound (committed can only be true on editFlush's proceed-and-clean outcome), and the sole remaining item is two stale seam names in comments.

## Testing

`Reproduced the #379 report at the syscall level on a real FUSE mount — scratch file + rename(2) over issue.md while the fake Linear rewrote inline markup around a code span (+2 chars, a reflow normalizeMarkdown does not forgive, so the save lands both the informational .error note and a byte-count change, exactly the pairing the report carried). With the fix, stat and the read-back both return the client's own 141 bytes and .error reads as informational; the same holds for project.md and initiative.md, the two wired sites the report never exercised. A truncating server still surfaces as EIO with a short body on disk, so the pin does not hide real loss. Disabling the pin regresses all three sites to serving Linear's render, confirming the tests bite. Full suite green, and the two new agent-facing README lines were confirmed in the rendered <mount>/README.md rather than only in the template source (this change has no graphical UI, so the mount's generated README text is the reviewer-visible end-user surface).`

<details>
<summary>Evidence: Evidence summary (before/after, all three sites, negative control)</summary>

```text
# Evidence — #379 atomic-save read-your-writes pin

Scenario reproduced at the syscall level on a **real FUSE mount** (fixture mode,
no network): an editor saves `issue.md` by writing a scratch sibling and
`rename(2)`-ing it over the canonical file, while Linear reformats the body it
stores (`the\`pin\`holds` → `the \`pin\` holds`, +2 chars — a code-span rewrite
`normalizeMarkdown` does **not** forgive, so the save lands the informational
`.error` note *and* a byte-count change, exactly the pairing the report carried).

## After the fix (`atomic-save-fixed.txt`)

`` `
$ printf %s "<edited>" > issue.md.tmp.N && mv issue.md.tmp.N issue.md
  wrote 141 bytes to TST-1001/issue.md
$ stat -c %s issue.md          -> 141   (client expected 141)
$ cat issue.md | cmp - written  -> identical
$ cat TST-1001/.error
    Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).
    Field: description (body)
    Note: saved, but Linear reformatted the markdown server-side (you wrote 66 chars, 68 persisted).
          The text is intact; an immediate re-read still shows your own bytes, a later read shows the stored formatting.
client verdict: write verified byte-for-byte; the .error note is informational
`` `

Same result at all three wired atomic-save sites:

| file | wrote | `stat -c %s` | read-back |
|---|---|---|---|
| `issue.md` | 141 | 141 | identical |
| `project.md` | 104 | 104 | identical |
| `initiative.md` | 101 | 101 | identical |

## Real data loss stays visible (same file, `TestOffline_AtomicSaveDoesNotPinOverRealDataLoss`)

With the fake truncating the stored body, the pin correctly stays out of the way:

`` `
$ mv issue.md.tmp.N issue.md   # wrote 170 bytes -> input/output error (EIO)
$ cat issue.md | cmp - written  -> DIFFERS (104 bytes on disk vs 170 written)
$ cat TST-1001/.error
    Read-your-writes violation: your write was accepted by Linear but did not persist as written.
    Field: description (body)
    Error: the persisted value is substantially shorter than what you wrote (you wrote 91 chars,
           40 persisted — 51 lost). The change may have been truncated server-side ...
`` `

## Negative control (`atomic-save-pin-disabled.txt`)

`renamesave.go`'s `sink.PinWritten(...)` was temporarily short-circuited
(`if false && ...`), the same tests re-run, then the file restored to HEAD.
All three sites regress to serving Linear's stored render:

`` `
$ cat issue.md | cmp - written  -> DIFFERS
--- wrote --- "... read-back is what the`pin`holds"
--- got   --- "... read-back is what the `pin` holds"
client verdict: MISMATCH — reads as a possible truncated write (#379)
`` `

Observation: `stat` reported the written size in *both* runs — the client-visible
divergence that reproduces here is the **read content**, not the `EntryOut` size.
The fix is correct either way (a client comparing what it read back to what it
wrote is what produces the "N bytes on disk, expected N-2" report), but the size
assertion alone would not have caught the regression; the byte-equality assertion
did.

## Generated README (`mount-readme-excerpt.txt`)

The agent-facing surface, read straight from `<mount>/README.md` on the live
mount — the two contracts the change added are present in the rendered doc, not
just in the template source.

## Reproduce

`` `bash
go test ./internal/integration/ -run TestOffline_AtomicSave -v -count=1
go test ./internal/fs/ -run 'AuthoredPins|SeedAuthored|RenameSave' -v -count=1
`` `
```
</details>
<details>
<summary>Evidence: Mount transcript with the fix — atomic save reads back byte-for-byte</summary>

<code>$ printf %s &#34;&lt;edited&gt;&#34; &gt; issue.md.tmp.N &amp;&amp; mv issue.md.tmp.N issue.md # the atomic save every editor performs&#10;wrote 141 bytes to TST-1001/issue.md&#10;$ stat -c %s issue.md -&gt; 141 (client expected 141)&#10;$ cat issue.md | cmp - written -&gt; identical&#10;$ cat TST-1001/.error&#10;Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).&#10;Field: description (body)&#10;Note: saved, but Linear reformatted the markdown server-side (you wrote 66 chars, 68 persisted). The text is intact; an immediate re-read still shows your own bytes, a later read shows the stored formatting.&#10;client verdict: write verified byte-for-byte; the .error note is informational&#10;--- PASS: TestOffline_AtomicSaveVerifyAfterReformatNote&#10;&#10;$ mv project.md.tmp.N project.md # wrote 104 bytes&#10;$ stat -c %s project.md -&gt; 104 (expected 104); read-back identical&#10;$ mv initiative.md.tmp.N initiative.md # wrote 101 bytes&#10;$ stat -c %s initiative.md -&gt; 101 (expected 101); read-back identical&#10;--- PASS: TestOffline_AtomicSaveServesWrittenBytesForProjectAndInitiative</code>

```text
=== RUN   TestOffline_AtomicSaveVerifyAfterReformatNote
    atomicsave_pin_test.go:82: $ printf %s "<edited>" > issue.md.tmp.N && mv issue.md.tmp.N issue.md   # the atomic save every editor performs
Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).
Field: description (body)
Note: saved, but Linear reformatted the markdown server-side (you wrote 66 chars, 68 persisted). The text is intact; an immediate re-read still shows your own bytes, a later read shows the stored formatting.
    atomicsave_pin_test.go:85:   wrote 141 bytes to TST-1001/issue.md
    atomicsave_pin_test.go:92: $ stat -c %s issue.md          -> 141   (client expected 141)
    atomicsave_pin_test.go:98: $ cat issue.md | cmp - written  -> identical
    atomicsave_pin_test.go:99: $ cat TST-1001/.error
        Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).
        Field: description (body)
        Note: saved, but Linear reformatted the markdown server-side (you wrote 66 chars, 68 persisted). The text is intact; an immediate re-read still shows your own bytes, a later read shows the stored formatting.
    atomicsave_pin_test.go:110: client verdict: write verified byte-for-byte; the .error note is informational
--- PASS: TestOffline_AtomicSaveVerifyAfterReformatNote (0.00s)
=== RUN   TestOffline_AtomicSaveDoesNotPinOverRealDataLoss
Read-your-writes violation: your write was accepted by Linear but did not persist as written.
Field: description (body)
Error: the persisted value is substantially shorter than what you wrote (you wrote 91 chars, 40 persisted — 51 lost). The change may have been truncated server-side — re-read the file to see the stored value.
    atomicsave_pin_test.go:171: $ mv issue.md.tmp.N issue.md   # wrote 170 bytes -> rename /home/john/tmp/linearfs-test-3457684576/teams/TST/issues/TST-1002/issue.md.tmp.170.5aved /home/john/tmp/linearfs-test-3457684576/teams/TST/issues/TST-1002/issue.md: input/output error
    atomicsave_pin_test.go:180: $ cat issue.md | cmp - written  -> DIFFERS (104 bytes on disk vs 170 written)
    atomicsave_pin_test.go:182: $ cat TST-1002/.error
        Read-your-writes violation: your write was accepted by Linear but did not persist as written.
        Field: description (body)
        Error: the persisted value is substantially shorter than what you wrote (you wrote 91 chars, 40 persisted — 51 lost). The change may have been truncated server-side — re-read the file to see the stored value.
--- PASS: TestOffline_AtomicSaveDoesNotPinOverRealDataLoss (0.00s)
=== RUN   TestOffline_AtomicSaveServesWrittenBytesForProjectAndInitiative
=== RUN   TestOffline_AtomicSaveServesWrittenBytesForProjectAndInitiative/project.md
Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).
Field: content (body)
Note: saved, but Linear reformatted the markdown server-side (you wrote 40 chars, 42 persisted). The text is intact; an immediate re-read still shows your own bytes, a later read shows the stored formatting.
    atomicsave_pin_test.go:239: $ mv project.md.tmp.N project.md   # wrote 104 bytes
    atomicsave_pin_test.go:249: $ stat -c %s project.md -> 104 (expected 104); read-back identical
=== RUN   TestOffline_AtomicSaveServesWrittenBytesForProjectAndInitiative/initiative.md
Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).
Field: content (body)
Note: saved, but Linear reformatted the markdown server-side (you wrote 40 chars, 42 persisted). The text is intact; an immediate re-read still shows your own bytes, a later read shows the stored formatting.
    atomicsave_pin_test.go:239: $ mv initiative.md.tmp.N initiative.md   # wrote 101 bytes
    atomicsave_pin_test.go:249: $ stat -c %s initiative.md -> 101 (expected 101); read-back identical
--- PASS: TestOffline_AtomicSaveServesWrittenBytesForProjectAndInitiative (0.01s)
    --- PASS: TestOffline_AtomicSaveServesWrittenBytesForProjectAndInitiative/project.md (0.00s)
    --- PASS: TestOffline_AtomicSaveServesWrittenBytesForProjectAndInitiative/initiative.md (0.00s)
=== RUN   TestOffline_AtomicSaveServesTheWrittenBytes
--- PASS: TestOffline_AtomicSaveServesTheWrittenBytes (0.00s)
PASS
ok  	github.com/jra3/linear-fuse/internal/integration	0.092s
```
</details>
<details>
<summary>Evidence: Negative control — same mount transcript with the pin disabled (#379 symptom returns)</summary>

<code>$ cat issue.md | cmp - written -&gt; DIFFERS&#10;--- wrote --- &#34;... verified read-back is what the`pin`holds&#34;&#10;--- got --- &#34;... verified read-back is what the `pin` holds&#34;&#10;client verdict: MISMATCH — reads as a possible truncated write (#379)&#10;--- FAIL: TestOffline_AtomicSaveVerifyAfterReformatNote&#10;--- FAIL: TestOffline_AtomicSaveServesWrittenBytesForProjectAndInitiative/project.md&#10;--- FAIL: TestOffline_AtomicSaveServesWrittenBytesForProjectAndInitiative/initiative.md&#10;--- FAIL: TestOffline_AtomicSaveServesTheWrittenBytes</code>

```text
=== RUN   TestOffline_AtomicSaveVerifyAfterReformatNote
    atomicsave_pin_test.go:82: $ printf %s "<edited>" > issue.md.tmp.N && mv issue.md.tmp.N issue.md   # the atomic save every editor performs
Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).
Field: description (body)
Note: saved, but Linear reformatted the markdown server-side (you wrote 66 chars, 68 persisted). The text is intact; an immediate re-read still shows your own bytes, a later read shows the stored formatting.
    atomicsave_pin_test.go:85:   wrote 141 bytes to TST-1001/issue.md
    atomicsave_pin_test.go:92: $ stat -c %s issue.md          -> 141   (client expected 141)
    atomicsave_pin_test.go:98: $ cat issue.md | cmp - written  -> DIFFERS
    atomicsave_pin_test.go:99: $ cat TST-1001/.error
        Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).
        Field: description (body)
        Note: saved, but Linear reformatted the markdown server-side (you wrote 66 chars, 68 persisted). The text is intact; an immediate re-read still shows your own bytes, a later read shows the stored formatting.
    atomicsave_pin_test.go:108: read-back after atomic save is not what was written
        --- wrote ---
        "---\npriority: none\ntitle: Atomic Save Verify Probe 1785386034064798258\n---\nrefresh-retry probe body\n\nverified read-back is what the`pin`holds"
        --- got ---
        "---\npriority: none\ntitle: Atomic Save Verify Probe 1785386034064798258\n---\nrefresh-retry probe body\n\nverified read-back is what the `pin` holds"
    atomicsave_pin_test.go:110: client verdict: MISMATCH — reads as a possible truncated write (#379)
--- FAIL: TestOffline_AtomicSaveVerifyAfterReformatNote (0.01s)
=== RUN   TestOffline_AtomicSaveServesWrittenBytesForProjectAndInitiative
=== RUN   TestOffline_AtomicSaveServesWrittenBytesForProjectAndInitiative/project.md
Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).
Field: content (body)
Note: saved, but Linear reformatted the markdown server-side (you wrote 40 chars, 42 persisted). The text is intact; an immediate re-read still shows your own bytes, a later read shows the stored formatting.
    atomicsave_pin_test.go:171: $ mv project.md.tmp.N project.md   # wrote 104 bytes
    atomicsave_pin_test.go:181: $ stat -c %s project.md -> 104 (expected 104); read-back DIFFERS
    atomicsave_pin_test.go:190: read-back of project.md is not what was written
        --- wrote ---
        "---\nlabels:\n    - Backend\n    - Legacy\nname: Test Project\n---\n\n\nverified read-back is what the`pin`holds"
        --- got ---
        "---\nlabels:\n    - Backend\n    - Legacy\nname: Test Project\n---\nverified read-back is what the `pin` holds"
=== RUN   TestOffline_AtomicSaveServesWrittenBytesForProjectAndInitiative/initiative.md
Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).
Field: content (body)
Note: saved, but Linear reformatted the markdown server-side (you wrote 40 chars, 42 persisted). The text is intact; an immediate re-read still shows your own bytes, a later read shows the stored formatting.
    atomicsave_pin_test.go:171: $ mv initiative.md.tmp.N initiative.md   # wrote 101 bytes
    atomicsave_pin_test.go:181: $ stat -c %s initiative.md -> 101 (expected 101); read-back DIFFERS
    atomicsave_pin_test.go:190: read-back of initiative.md is not what was written
        --- wrote ---
        "---\nname: Test Initiative\nprojects:\n    - test-project\n---\n\n\nverified read-back is what the`pin`holds"
        --- got ---
        "---\nname: Test Initiative\nprojects:\n    - test-project\n---\nverified read-back is what the `pin` holds"
--- FAIL: TestOffline_AtomicSaveServesWrittenBytesForProjectAndInitiative (0.01s)
    --- FAIL: TestOffline_AtomicSaveServesWrittenBytesForProjectAndInitiative/project.md (0.00s)
    --- FAIL: TestOffline_AtomicSaveServesWrittenBytesForProjectAndInitiative/initiative.md (0.00s)
=== RUN   TestOffline_AtomicSaveServesTheWrittenBytes
    edit_persist_test.go:206: read-back after atomic save is not what was written
        --- wrote ---
        "---\npriority: none\ntitle: Atomic Save Byte Count Probe 1785386034076857269\n---\nrefresh-retry probe body\n\nfirst para\n\n\nsecond para"
        --- got ---
        "---\npriority: none\ntitle: Atomic Save Byte Count Probe 1785386034076857269\n---\nrefresh-retry probe body\n\nfirst para\n\nsecond para"
--- FAIL: TestOffline_AtomicSaveServesTheWrittenBytes (0.00s)
FAIL
FAIL	github.com/jra3/linear-fuse/internal/integration	0.091s
FAIL
```
</details>
<details>
<summary>Evidence: Real data loss still visible (truncating server → EIO, short body on disk)</summary>

```text
$ mv issue.md.tmp.N issue.md # wrote 170 bytes -> input/output error
$ cat issue.md | cmp - written -> DIFFERS (104 bytes on disk vs 170 written)
$ cat TST-1001/.error
Read-your-writes violation: your write was accepted by Linear but did not persist as written.
Field: description (body)
Error: the persisted value is substantially shorter than what you wrote (you wrote 91 chars, 40 persisted — 51 lost). The change may have been truncated server-side — re-read the file to see the stored value.
--- PASS: TestOffline_AtomicSaveDoesNotPinOverRealDataLoss
```
</details>
<details>
<summary>Evidence: Agent-facing surface: the two new contracts rendered in &lt;mount&gt;/README.md</summary>

<code>&lt;mount&gt;/README.md line 250:&#10;- NOT a failure: a .error that says &#34;saved, but Linear reformatted the markdown&#10;server-side&#34;. The write succeeded and no text was lost (the errno was 0); ...&#10;Reading the file right after the save gives you your own bytes back, so the&#10;reformat is not visible yet — a later read shows what Linear stored.&#10;&#10;&lt;mount&gt;/README.md line 303:&#10;- A save reads back byte-for-byte right away, but Linear normalizes markdown when&#10;it STORES a body ... Re-read the file before any follow-up edit that&#10;find-and-replaces text from the earlier version.</code>

```text
=== RUN   TestZZDumpReadmeSections
    zz_readme_dump_test.go:22: <mount>/README.md line 250:
        - NOT a failure: a .error that says "saved, but Linear reformatted the markdown
          server-side". The write succeeded and no text was lost (the errno was 0);
          Linear stored its own formatting of your markdown. Reading the file right after
          the save gives you your own bytes back, so the reformat is not visible yet — a
          later read shows what Linear stored (see EDITING FILES). A write that truly did
          not persist says so — "reverted to its previous content" or "substantially
          shorter" — and returns EIO.
        So an edit that "fails" or appears to no-op is explained at the sibling .error.
    zz_readme_dump_test.go:22: <mount>/README.md line 303:
        - A save reads back byte-for-byte right away, but Linear normalizes markdown when
          it STORES a body — it collapses blank runs, flips bullet markers, and can move
          emphasis around inline code spans — so a later read shows the stored formatting,
          not your bytes. The immediate read-back therefore verifies that the write landed,
          not how Linear stored it. Re-read the file before any follow-up edit that
          find-and-replaces text from the earlier version; an in-context copy goes stale in
          reformatted regions, and the failure looks like a bad match rather than a
          rewritten file.
--- PASS: TestZZDumpReadmeSections (0.00s)
PASS
ok  	github.com/jra3/linear-fuse/internal/integration	0.073s
```
</details>
- Outcome: ⚠️ 2 infos across 1 run (12m4s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `internal/fs/authoredpin.go:112` - seedAuthored assigns the stored pin&#39;s slice directly to the node&#39;s buffer (`b.content = pinned`) instead of copying it, unlike PinWritten (line 75) and editBuffer.refresh, which both copy for exactly this reason. Because the pin is deliberately not consumed, every Lookup in the 10s window hands out the same backing array, and editBuffer.Write mutates that array in place whenever the write fits inside the current length (editbuffer.go:111-117). Fix: `b.content = append([]byte(nil), pinned...)`.
- ⚠️ `internal/fs/renamesave.go:138` - The pin is armed on any `errno == 0` from spec.flush, but editFlush returns 0 *without* arming `authored` when the front half reports `!proceed` (editflush.go:96-100), i.e. when nothing was committed at all (issues.go:500, `len(updates) == 0`). So the atomic-save path now serves the client&#39;s bytes back for a save that changed nothing on Linear, whereas the #365 rule the comment says it mirrors only arms after a committed write. Since marshal silently ignores unknown frontmatter keys (internal/marshal/issue.go:329), an agent that writes an unsupported/read-only key gets a byte-for-byte verify pass for 10s on an edit that was dropped — a false success in the exact class of signal this codebase keeps loud. Tightening it would mean having the flush closure report whether a commit actually happened.
- ⚠️ `internal/fs/root.go:343` - The added &#34;NOT a failure&#34; bullet tells the agent &#34;Re-read the file to see what it stored&#34;, but the pin makes an immediate re-read return the agent&#39;s own bytes for 10s on the atomic-save path — the path every editor and the Edit/Write tools use. It also contradicts the other bullet added by this same change (root.go:392-397: &#34;a later read shows the stored formatting, not your bytes&#34;). The .error note the bullet quotes carries the same now-inert advice (writeback.go:104, &#34;re-read the file to see the stored formatting&#34;), so an agent that follows it promptly concludes nothing was reformatted and then sees the file change later.
- ⚠️ `CONTEXT.md:117` - CONTRIBUTING.md:23 and .github/PULL_REQUEST_TEMPLATE.md require CONTEXT.md updated in the same PR when a seam changes, and docs/ARCHITECTURE.md was updated accordingly — but CONTEXT.md was not. Its &#34;Rename save (renameSave)&#34; section now lies twice: line 117 says the tail &#34;depends only on the `renameSink` seam&#34; (it now takes renameSaveSink, renamesave.go:45-48) and line 104 lists the tail as &#34;adopt + consume + InvalidateRenamed, all on {0, EIO}&#34; with no mention of the errno==0 pin. The new authoredPins deep module also has no section, unlike every sibling module (Edit buffer, Rename save, Node refresh), and the &#34;Edit buffer&#34; section (line 664) still describes `authored` as set only by editFlush.
- ℹ️ `internal/fs/authoredpin.go:56` - A pin is only superseded by another PinWritten for the same inode or by its TTL — a successful in-place edit of the same file inside the window does not drop it (editFlush only calls InvalidateUpdated → InodeNotify, so the node usually survives and the pin stays unread). If that inode is re-Looked-up before the 10s expires (dentry eviction, a fresh open from another path), seedAuthored serves the older atomic-save bytes instead of the newer in-place content — read-your-writes going backwards rather than converging. Narrow (needs a forget inside the window), and arguably outside the staleness reasoning recorded for the TTL, so worth a decision rather than a silent fix.

🔧 Fix: pin only committed saves, copy pinned bytes, sync docs
1 info still open:
- ℹ️ `internal/fs/renamesave.go:26` - Two in-file comments still claim the narrower seam that this change replaced — the same false claim CONTEXT.md:117 was corrected for in this very commit. renamesave.go:26 says the tail &#34;depends only on the renameSink seam plus the spec&#39;s closures&#34; when renameSave now takes renameSaveSink (line 94), and authoredpin.go:57 says PinWritten &#34;promotes onto it for the renameSink seam&#34; when PinWritten is precisely the method renameSaveSink adds on top of renameSink. Both should say renameSaveSink.

</details>

<details>
<summary>⚠️ **Test** - 2 infos</summary>

- ℹ️ `internal/fs/authoredpin.go:118` - The change&#39;s rationale states the size delta leaked through manifest.file()&#39;s EntryOut length. In the negative-control run (pin disabled), `stat -c %s` still reported the written length at all three sites — only the read-back content diverged. The fix is correct either way, but the size assertion in TestOffline_AtomicSaveServesTheWrittenBytes would not have caught the regression on its own; the byte-equality assertion is what bites. No action needed unless the author wants the rationale comment adjusted.
- ℹ️ `internal/integration/atomicsave_pin_test.go` - new test file written by agent: internal/integration/atomicsave_pin_test.go
- <code>`go test ./... -count=1` (full suite, green)</code>
- `go test ./internal/integration/ -run TestOffline_AtomicSave -v -count=1`
- <code>`go test ./internal/integration/ -run TestOffline_AtomicSave -count=8` (determinism)</code>
- `go test ./internal/fs/ -run 'Pin|Authored|RenameSave|Rename' -count=1`
- `go test ./internal/integration/ -run TestGeneratedReadmeMatchesBehavior -count=1`
- <code>Negative control: disabled `sink.PinWritten` in internal/fs/renamesave.go, re-ran atomic-save tests (all three sites fail), restored file to HEAD</code>
- <code>Manual: read `&lt;mount&gt;/README.md` from the live fixture mount to confirm the two new agent-facing lines render</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `README.md:292` - README.md&#39;s Validation Errors section still states flatly that &#34;The `.error` file is cleared on successful writes&#34;, which the informational &#34;saved, but Linear reformatted the markdown server-side&#34; note contradicts — a save that returns errno 0 leaves that note in `.error`. This predates the change (#146) and this change did not alter that behavior, so I left it rather than opportunistically editing a second copy of the failure model; the generated mount README owns the agent-facing version and is now correct. Worth a one-clause follow-up here if the user wants the user-facing copy tightened too.

🔧 Fix: note reformat carve-out in README .error contract
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


---

Closes #379 — the false-truncation defect. Its second defect, Linear rewriting
inline markup around code spans, is split out to #382 (not fixable client-side
without reimplementing Linear's normalizer). Follow-up #381 tracks making an
in-place edit supersede a pin.
