### PR TITLE
fix(fs): a committed in-place write supersedes an atomic-save pin (#381)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -79,11 +79,22 @@ put their whole multi-mutation front half (labels + links-reconcile + scalar) in
 the front-half result reaches the commit-tail `compare` through a method-local
 var the two closures share (mutate runs first). **Invalidate-after-persist is
 uniform by construction** — the shell invalidates only after the tail upserts,
-closing the window issues had (a recorded behavior change). It depends only on
-the `editFlushSink` seam (`errorSink` + `InvalidateUpdated`, satisfied by
-`*LinearFS`), so the shell's outcome dispatch, coherence-set exactness, and
-persist-before-invalidate ordering are unit-tested with a recording sink
-(`editflush_test.go`) — no FUSE mount, SQLite, or API.
+closing the window issues had (a recorded behavior change).
+
+The shell is also **the one place serve-your-own-writes arms** (#365, #379, #381).
+A committed clean write both marks the buffer authored (the node-local half) and
+pins the written bytes under the spec's **`pinIno`** (the half that survives the
+node — see [[authored-pin]]); both key off one condition in one place, so the
+in-place and atomic-save paths cannot disagree about whether a write is servable,
+and the later of two writes to a file always owns the pin. `pinIno` is set only for
+the three files whose Lookup calls `seedAuthored` (`issue.md`, `project.md`,
+`initiative.md`); zero for the rest, where a pin would be bytes nobody can read.
+
+It depends only on the `editFlushSink` seam (`errorSink` + `InvalidateUpdated` +
+`PinWritten`, satisfied by `*LinearFS`), so the shell's outcome dispatch,
+coherence-set exactness, persist-before-invalidate ordering, and the pin/authored
+arming rules are unit-tested with a recording sink (`editflush_test.go`) — no FUSE
+mount, SQLite, or API.
 
 ### Rename save (`renameSave`)
 The **deep module** owning the atomic-save Rename tail — the rename-shaped
@@ -101,8 +112,7 @@ canonical files aren't renamable) → target-name guard (`.error` names the one
 writable target, `ENOTSUP`) → flush the bytes through the file's normal edit
 path (a transient file node with a dirty edit buffer, so frontmatter
 validation, read-your-writes verification, and `.error` handling all apply) →
-**adopt + consume + `InvalidateRenamed`, all on {0, EIO}, plus the
-[[authored-pin]] of the written bytes on a committed clean save**. The adopt-on-EIO
+**adopt + consume + `InvalidateRenamed`, all on {0, EIO}**. The adopt-on-EIO
 line is the policy, now written once: `Flush` returns `EIO` only on a fatal
 read-your-writes divergence, by which point the write has already reached
 Linear — refusing to adopt would keep serving stale content while `.error`
@@ -113,15 +123,17 @@ that dead buffer — whose ops used to `return 0`, silently swallowing a write
 that can no longer persist. A consumed scratch node now returns `ESTALE` from
 `Open`/`Write`/`Flush`/`Fsync`/`Setattr`, so the write fails loud and the
 `ESTALE` on `Open` drives the VFS to re-Lookup the real node (`LOOKUP_REVAL`).
+The [[authored-pin]] this path needs is **not** armed here: it rides the flush,
+because `editFlush` is the one place that knows a write committed (#381). The tail
+used to arm it off a `committed` flag the flush closure reported back, since errno
+alone cannot tell a real write from a save that resolved to no changes — inside
+`editFlush` that distinction is just the `proceed` it already has.
 Lives in `internal/fs/renamesave.go`; each directory hands it a small spec
 (target name, error key, dir/file inos, scratch/flush/adopt closures — the
-scratch closure also returns the per-node consume, and the flush closure reports
-whether it actually **committed** alongside its errno, since a save that resolved
-to no changes returns 0 too and must not pin). It depends only on the
-`renameSaveSink` seam (the `renameSink` surface — ErrorSink +
-`InvalidateRenamed` — plus `PinWritten`, all satisfied by `*LinearFS` through the
-writeFeedback, kernelNotify, and authoredPins promotions; `commitRename` keeps
-the narrower `renameSink`), and the scratch lookup is a spec closure, so it is
+scratch closure also returns the per-node consume). It depends only on the
+`renameSink` seam (ErrorSink + `InvalidateRenamed`, satisfied by `*LinearFS`
+through the writeFeedback and kernelNotify promotions, and shared with
+`commitRename`), and the scratch lookup is a spec closure, so it is
 unit-tested with a recording sink — no FUSE mount, inode tree, SQLite, or API.
 
 ### Create tail (`commitCreate`)
@@ -680,10 +692,10 @@ async refresh. It is deliberately NOT armed on a fatal read-your-writes divergen
 (a silent revert or truncation, where `commitWriteBack` returns EIO) — serving the
 written bytes there would mask the loss from the very re-read the `.error` asks for.
 A fresh `Open` clears it, so independent later readers converge to what persisted.
-The flag is also the atomic-save path's **commit signal**: `editBuffer.committedWrite`
-reads it back off the transient node [[rename-save]] flushes through, so the
-[[authored-pin]] arms on exactly the outcome that arms `authored` here rather than
-on a bare errno 0. See [[node-refresh]]. Each of the seven editable file
+The flag protects the bytes only as long as **this node** lives — a dentry forget
+rebuilds the node with an empty buffer and no flag — so [[edit-flush]] arms the
+[[authored-pin]] on the same condition, and a Lookup re-seeds both from it; that
+pin, not this flag, is what survives the node. See [[node-refresh]]. Each of the seven editable file
 nodes (`IssueFileNode`, `ProjectInfoNode`, `InitiativeInfoNode`, `CommentNode`,
 `LabelFileNode`, `MilestoneFileNode`, `DocumentFileNode`) embeds it and keeps
 only its **`Getattr`** (a one-liner: `fileAttr(n.size(), created, updated).fill`
@@ -707,37 +719,45 @@ truncate-grow/shrink, read-clamps-at-EOF), no FUSE mount.
 
 ### Authored-write pin (`authoredPins`)
 The **deep module** that carries serve-your-own-writes across a node boundary the
-[[edit-buffer]] cannot cross (#379). `authored` pins the written bytes *in the
-buffer they were written through*, which covers in-place edits only — and editors
-never write in place: they rename a scratch temp file onto the canonical `.md`, so
+[[edit-buffer]] cannot cross (#379, #381). `authored` pins the written bytes *in the
+buffer they were written through*, which dies with the node — and editors never
+write in place anyway: they rename a scratch temp file onto the canonical `.md`, so
 [[rename-save]] flushes through a **transient** node (its buffer, and its
 `authored` flag, are discarded a line later) and then deliberately drops the
 canonical file's inode so it re-Looks-up and re-renders what *persisted*. The
 written bytes were therefore never served back, and any server-side reformat that
 moved the byte count reached the client as a size mismatch on a fully successful
-write — which editors report as a possibly truncated write.
+write — which editors report as a possibly truncated write. The same boundary
+exists on the in-place path: a dentry forget inside the window rebuilds the node
+with an empty buffer, so the flag alone would lose the bytes there too.
 `authoredPins` (`internal/fs/authoredpin.go`) is a mount-wide `ino → {bytes,
 deadline}` store embedded on `LinearFS` by value (zero value ready, no constructor
 wiring). Its invariant: **a Lookup that finds a pin serves the pinned bytes as the
 buffer's content *and* as the size it publishes** — `manifest.file` reports
 `len(content)` in the `EntryOut`, and publishing the render's length while serving
 the pin would clamp the client's own read to the wrong size, which is the mismatch
-the module exists to remove. The pin is armed **only on a committed clean save**
-(`committed && errno == 0`, the same rule that arms `authored`): not on `EIO`,
-where the write did not persist as written and hiding that would mask real loss;
-not on a save that committed nothing, where echoing the bytes back would report a
-dropped edit as a byte-for-byte success. It is bounded by **time** (`pinTTL`),
-**not consumed by the first Lookup** — a client's verification is several syscalls
-(stat, then open+read), each able to drive its own Lookup after the rename
-invalidation, so all of them must answer alike; the TTL is also a tighter staleness
-bound than the in-place path's "until the next `Open`", and it is what bounds the
-one gap left open (a later *in-place* edit inside the window does not supersede an
-existing pin). Wired at all three atomic-save sites (`issue.md`, `project.md`,
-`initiative.md`) via the `renameSaveSink` seam; unit-tested directly (window,
-expiry, sweep, unaliased copies, seed-beats-render) plus deterministic
-mount-level tests over all three files, the reformat-note shape, and the EIO
-no-pin rule (`internal/integration/atomicsave_pin_test.go`) — the rename itself
-forces the re-Lookup, so no timeout wait is needed.
+the module exists to remove. The pin is armed **only on a committed clean write**,
+by [[edit-flush]], on the same condition that arms `authored`: not on `EIO`, where
+the write did not persist as written and hiding that would mask real loss; not on a
+write that committed nothing, where echoing the bytes back would report a dropped
+edit as a byte-for-byte success. **Arming it in the flush rather than in
+[[rename-save]] is load-bearing**, not tidiness: a pin is superseded by the next
+`PinWritten` for the same inode, so whichever path wrote LAST owns it. Arming only
+on the rename tail meant a later in-place edit left the older atomic-save bytes
+pinned, and a forget-and-re-Lookup inside the window served them — read-your-writes
+running *backwards* (#381).
+It is bounded by **time** (`pinTTL`), **not consumed by the first Lookup** — a
+client's verification is several syscalls (stat, then open+read), each able to drive
+its own Lookup after the rename invalidation, so all of them must answer alike; the
+TTL is now the outer bound on a pin outliving its truth for a *remote* reason
+(someone else changed the entity), since a newer local write supersedes it outright.
+Reaches the three files whose Lookup calls `seedAuthored` (`issue.md`,
+`project.md`, `initiative.md`) through their specs' `pinIno`, via the
+`editFlushSink` seam; unit-tested directly (window, expiry, sweep, unaliased
+copies, seed-beats-render) and at the flush seam (the supersede rule) plus
+deterministic mount-level tests over all three files, the reformat-note shape, and
+the EIO no-pin rule (`internal/integration/atomicsave_pin_test.go`) — the rename
+itself forces the re-Lookup, so no timeout wait is needed.
 
 ### Render file (`renderFile`)
 The **deep module** owning every read-only *generated* file — the render-through

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -539,19 +539,26 @@ building blocks:
   refresh, while persistence (SQLite and the entity) already holds Linear's
   normalized render. It is not armed on a fatal read-your-writes divergence (a
   revert or truncation, EIO), so a real loss is never masked from a re-read.
-- `authoredPins` — the same guarantee across the **atomic-save** path, where the
-  buffer that was written cannot carry it (#379): `renameSave` flushes through a
-  transient node and then drops the canonical file's inode, so the re-Lookup
-  renders what persisted and the written bytes would be lost. It pins them under
-  the file's inode (only when the flush actually committed a write and returned
-  `errno == 0` — the same rule that arms `authored`, so neither a fatal divergence
-  nor a save that changed nothing is echoed back as a byte-for-byte success) and
-  the Lookup seeds the new buffer — content *and* the size it publishes — from the pin
-  instead of the render. Bounded by time (`pinTTL`), not by one Lookup: a client's
-  verification is several syscalls, each able to drive its own Lookup, so all of
-  them must answer alike. Without it a server-side reformat that changed the byte
-  count reached the client as a size mismatch, which editors report as a possibly
-  truncated write on a save that fully succeeded.
+- `authoredPins` — the same guarantee for the written *bytes* rather than the
+  buffer, so it survives the node the flag dies with (#379, #381). Two paths need
+  that: the **atomic-save** path flushes through a transient node and then drops
+  the canonical file's inode on purpose, so the re-Lookup would render what
+  persisted; and on either path a dentry forget rebuilds the node with an empty
+  buffer and no flag. `editFlush` pins the bytes under the file's `pinIno` on
+  exactly the condition that arms `authored` — a committed write with
+  `errno == 0`, so neither a fatal divergence nor a save that changed nothing is
+  echoed back as a byte-for-byte success — and a Lookup seeds the new buffer,
+  content *and* the size it publishes, from the pin instead of the render.
+  **One pin site is load-bearing**: a pin is superseded by the next write to the
+  same inode, so arming it in `editFlush` rather than in `renameSave` is what
+  keeps a later in-place edit from leaving older atomic-save bytes pinned (#381).
+  `pinIno` is set only for the three files whose Lookup calls `seedAuthored`
+  (`issue.md`, `project.md`, `initiative.md`); zero elsewhere means no pin,
+  because nothing would read it. Bounded by time (`pinTTL`), not by one Lookup: a
+  client's verification is several syscalls, each able to drive its own Lookup, so
+  all of them must answer alike. Without it a server-side reformat that changed the
+  byte count reached the client as a size mismatch, which editors report as a
+  possibly truncated write on a save that fully succeeded.
 - `resolveByName` — collapses the five regular single-name→ID resolvers
   (state, project, milestone, cycle, initiative); user, issue-identifier,
   label, and project-slug resolution remain bespoke.
@@ -570,8 +577,8 @@ a layer above the commit-tail primitives) and no telemetry (matching
 1. `Write` buffers bytes in the `editBuffer`; `Flush` parses the markdown via
    `marshal`. Editor save-via-rename (temp file + `rename`) is caught by a
    scratch node and routed through the same path (`atomicwrite.go`,
-   `renamesave.go`), pinning the written bytes for the re-Lookup that path forces
-   (`authoredPins`).
+   `renamesave.go`); the flush itself pins the written bytes for the re-Lookup
+   that path forces (`authoredPins`, armed in `editFlush`).
 2. The fs layer **resolves names to IDs** (status→stateId, assignee
    email→userId, labels→labelIds, project/milestone/cycle/parent→IDs). A local
    catalog miss self-heals: a typed unknown-name error triggers exactly **one**

--- a/internal/fs/authoredpin.go
+++ b/internal/fs/authoredpin.go
@@ -21,9 +21,19 @@ import (
 // report that as "the filesystem may have silently truncated the write" (#379).
 //
 // authoredPins carries the pin across the node boundary the rename path crosses.
-// renameSave records the written bytes under the canonical file's inode, and a
-// Lookup that builds that file seeds its editBuffer with them — marked authored,
-// so a background refresh leaves them alone — instead of the fresh render.
+// editFlush records the written bytes under the canonical file's inode on every
+// committed clean write (#381), and a Lookup that builds that file seeds its
+// editBuffer with them — marked authored, so a background refresh leaves them
+// alone — instead of the fresh render.
+//
+// Arming it in editFlush rather than in renameSave is what keeps the two write
+// paths from disagreeing. A pin is superseded by the next PinWritten for the same
+// inode, so whichever path wrote LAST owns the pin; arming it only on the rename
+// tail meant a later in-place edit left the older atomic-save bytes pinned, and a
+// forget-and-re-Lookup inside the window served them — read-your-writes going
+// backwards. It also generalises the guarantee: the in-place path's `authored`
+// flag lives on the node (#365), so a forget loses it there too, and the pin is
+// what both paths now survive one through.
 //
 // The pin is bounded by TIME, not by one Lookup: a client's verification is
 // several syscalls (stat, then open+read), each of which can drive its own
@@ -34,19 +44,13 @@ import (
 // nobody ever looked up from becoming a stale read minutes later; it is a
 // tighter bound than the in-place path's "until the next Open" (#365).
 //
-// The TTL is also what bounds the one case where a pin outlives its truth: a
-// successful IN-PLACE edit of the same file inside the window does not drop the
-// pin (editFlush invalidates the inode, which usually leaves the node — and the
-// unread pin — alive), so if that inode is forgotten and re-Looked-up before the
-// window closes, the Lookup serves the older atomic-save bytes rather than the
-// newer in-place ones. It needs a dentry forget inside the window to happen at
-// all, and it converges on expiry; making an in-place write supersede a pin would
-// mean plumbing the file's inode through editFlush, which is deliberately out of
-// scope here.
+// The TTL remains the outer bound on how long a pin can outlive its truth — a
+// write that lands in Linear and is then changed by someone else, say — but it is
+// no longer what covers a newer local write: that supersedes the pin outright.
 const pinTTL = 10 * time.Second
 
-// authoredPin is one pinned write: the exact bytes a client wrote through the
-// atomic-save path, and the deadline past which they must not be served.
+// authoredPin is one pinned write: the exact bytes a client last wrote to the
+// file, and the deadline past which they must not be served.
 type authoredPin struct {
 	content  []byte
 	deadline time.Time
@@ -54,15 +58,16 @@ type authoredPin struct {
 
 // authoredPins is the mount-wide store of pinned writes, keyed by the canonical
 // file's inode. Embedded in LinearFS (zero value ready to use), so PinWritten
-// promotes onto it for the renameSaveSink seam.
+// promotes onto it for the editFlushSink seam.
 type authoredPins struct {
 	mu   sync.Mutex
 	pins map[uint64]authoredPin
 }
 
 // PinWritten records content as the bytes a client just wrote to the file at
-// fileIno through an atomic save, for the next Lookup of that file to serve.
-// Called only on a clean commit — see renameSave.
+// fileIno, for the next Lookup of that file to serve. It replaces any pin already
+// standing for that inode, so the newest write wins. Called only on a committed
+// clean write — see editFlush.
 func (p *authoredPins) PinWritten(fileIno uint64, content []byte) {
 	if len(content) == 0 {
 		return
@@ -107,7 +112,7 @@ func (p *authoredPins) writtenBytes(fileIno uint64) []byte {
 
 // seedAuthored fills a freshly-built editable node's buffer and reports the bytes
 // its Lookup must publish as the file's size: the rendered content normally, or
-// a pinned atomic-save write when one is waiting for this inode. The two must be
+// a pinned write when one is waiting for this inode. The two must be
 // the same bytes — a Lookup that published the render's length while the buffer
 // served the pin would clamp the client's own read to the wrong size, which is
 // the very mismatch this module exists to remove.

--- a/internal/fs/editbuffer.go
+++ b/internal/fs/editbuffer.go
@@ -32,19 +32,12 @@ type editBuffer struct {
 	// client that verifies a write by re-reading sees its own bytes byte-for-byte
 	// across the write→verify window instead of racing an async refresh. A fresh
 	// Open clears it, so independent later readers converge to what persisted.
+	//
+	// It protects the bytes only as long as this node lives — a dentry forget
+	// rebuilds the node with an empty buffer and no flag. editFlush therefore arms
+	// the authoredPins pin on the same condition, and a Lookup re-seeds both from
+	// it (#379, #381); that pin, not this flag, is what survives the node.
 	authored bool
-}
-
-// committedWrite reports whether the Flush that just ran through this buffer
-// actually committed a write to Linear. editFlush marks a buffer authored on
-// exactly that outcome — a front half that proceeded plus a clean commit (#365) —
-// so the atomic-save tail reads the flag back off the transient node it flushed
-// through rather than inferring a commit from errno 0, which a flush that changed
-// nothing returns too (see renamesave.go, #379).
-func (b *editBuffer) committedWrite() bool {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.authored
 }
 
 // size is the current buffer length, for a node's Getattr.

--- a/internal/fs/editflush.go
+++ b/internal/fs/editflush.go
@@ -30,15 +30,24 @@ import (
 // Invalidate-after-persist is uniform here by construction: the shell
 // invalidates only after commitWriteBack has upserted the fresh value, so a
 // racing read can never repopulate the kernel cache from a not-yet-written row.
+//
+// The shell is also the single place serve-your-own-writes arms (#365, #379,
+// #381). A committed clean write both marks the buffer authored — the node-local
+// half — and pins the written bytes under the file's inode, the half that
+// survives the node. Both halves therefore key off one condition in one place, so
+// the in-place and atomic-save paths cannot disagree about whether a write is
+// servable, and the later of two writes to a file always wins the pin.
 
 // editFlushSink is the minimal surface the shell needs: the errorSink the commit
-// tail already requires, plus the kernel-cache invalidation the shell owns.
-// *LinearFS satisfies it directly (SetWriteError/ClearWriteError via
-// writeFeedback, InvalidateUpdated via kernelNotify), so production wiring needs
-// no adapter while tests inject a recording fake.
+// tail already requires, the kernel-cache invalidation the shell owns, and the
+// serve-your-own-writes pin it arms. *LinearFS satisfies it directly
+// (SetWriteError/ClearWriteError via writeFeedback, InvalidateUpdated via
+// kernelNotify, PinWritten via authoredPins), so production wiring needs no
+// adapter while tests inject a recording fake.
 type editFlushSink interface {
 	errorSink
 	InvalidateUpdated(fileIno uint64)
+	PinWritten(fileIno uint64, content []byte)
 }
 
 // editFlushSpec describes the per-entity parts of an edit's flush. T is the
@@ -65,6 +74,19 @@ type editFlushSpec[T any] struct {
 	// forgotten sidecar is a visible one-line omission, not a missing call
 	// buried in a handler. Invalidated only after the commit tail persists.
 	coherence []uint64
+	// pinIno is the inode of the canonical file whose Lookup seeds from
+	// authoredPins: issue.md, project.md, and initiative.md, the three that both
+	// accept an atomic save and call seedAuthored when they build a node. A
+	// committed clean write pins its bytes there, which is what makes
+	// serve-your-own-writes survive the node — a dentry forget and re-Lookup
+	// inside the window, and the transient node the atomic-save path flushes
+	// through.
+	//
+	// Zero for the entities whose Lookup does not consult pins (a
+	// comment/doc/label/milestone .md): there is no reader, so a pin would be
+	// bytes held for the TTL and swept unread. Wiring one of those files to
+	// seedAuthored is what would give it a nonzero pinIno.
+	pinIno uint64
 }
 
 // editFlush runs the invariant shell of a file node's Flush. eb is the node's
@@ -122,8 +144,21 @@ func editFlush[T any](ctx context.Context, sink editFlushSink, eb *editBuffer, s
 	// would hide the loss from the very byte-count re-read the .error tells the
 	// agent to make ("re-read to see the stored value"). The benign reformat this
 	// flag exists to smooth over is errno == 0, so the fix still lands.
+	//
+	// The pin (#379) is that same guarantee for the bytes rather than for the
+	// buffer, armed on the same condition, and it is what carries a write across a
+	// node boundary the flag cannot: the atomic-save path flushes through a
+	// transient node and then drops the canonical inode on purpose, and on either
+	// path a dentry forget inside the window rebuilds the node with an empty
+	// buffer. Pinning HERE rather than in renameSave is also what makes a later
+	// in-place edit supersede an earlier atomic save (#381) — one pin site, so the
+	// pinned bytes are always the newest committed ones instead of whichever path
+	// recorded last.
 	if errno == 0 {
 		eb.authored = true
+		if spec.pinIno != 0 {
+			sink.PinWritten(spec.pinIno, eb.content)
+		}
 	}
 	return errno
 }

--- a/internal/fs/editflush_test.go
+++ b/internal/fs/editflush_test.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"context"
+	"fmt"
 	"syscall"
 	"testing"
 )
@@ -19,6 +20,7 @@ type recordingFlushSink struct {
 	sets        int
 	clears      int
 	invalidated []uint64
+	pins        []string
 	order       []string
 }
 
@@ -27,6 +29,9 @@ func (r *recordingFlushSink) ClearWriteError(key string)        { r.clears++ }
 func (r *recordingFlushSink) InvalidateUpdated(ino uint64) {
 	r.invalidated = append(r.invalidated, ino)
 	r.order = append(r.order, "invalidate")
+}
+func (r *recordingFlushSink) PinWritten(fileIno uint64, content []byte) {
+	r.pins = append(r.pins, fmt.Sprintf("pin(%d,%q)", fileIno, content))
 }
 
 func dirtyBuffer() *editBuffer { return &editBuffer{content: []byte("x"), dirty: true} }
@@ -130,6 +135,7 @@ func TestEditFlushProceedMarksAuthored(t *testing.T) {
 		},
 		adopt:     func(*fakeEntity) {},
 		coherence: []uint64{10},
+		pinIno:    10,
 	})
 	if errno != 0 {
 		t.Fatalf("errno = %v, want 0", errno)
@@ -139,6 +145,91 @@ func TestEditFlushProceedMarksAuthored(t *testing.T) {
 	// until the next fresh Open.
 	if !eb.authored {
 		t.Error("a completed write did not mark the buffer authored; the read-back window is unprotected")
+	}
+	// The same window, for the bytes rather than the buffer (#379, #381): the flag
+	// dies with the node, so the written bytes are also pinned under pinIno for the
+	// next Lookup of the file to seed from.
+	if len(sink.pins) != 1 || sink.pins[0] != `pin(10,"x")` {
+		t.Errorf("pins = %v, want [pin(10,\"x\")] — the written bytes under pinIno", sink.pins)
+	}
+}
+
+func TestEditFlushZeroPinInoNeverPins(t *testing.T) {
+	t.Parallel()
+	eb := dirtyBuffer()
+	sink := &recordingFlushSink{}
+	// pinIno zero is a comment/doc/label/milestone .md: its Lookup does not call
+	// seedAuthored, so a pin would be bytes nobody can ever read, held for the TTL.
+	errno := editFlush(context.Background(), sink, eb, editFlushSpec[fakeEntity]{
+		mutate: func(context.Context) (bool, syscall.Errno) { return true, 0 },
+		writeBack: writeBackSpec[fakeEntity]{
+			errKey:  "k",
+			fetch:   func(context.Context) (*fakeEntity, error) { return &fakeEntity{v: 7}, nil },
+			compare: func(*fakeEntity) []writeBackResult { return nil },
+		},
+		adopt:     func(*fakeEntity) {},
+		coherence: []uint64{10},
+	})
+	if errno != 0 {
+		t.Fatalf("errno = %v, want 0", errno)
+	}
+	if !eb.authored {
+		t.Error("a completed write did not mark the buffer authored; pinIno is about the pin, not the flag")
+	}
+	if len(sink.pins) != 0 {
+		t.Errorf("pins = %v, want none for an entity with no pin-seeded Lookup", sink.pins)
+	}
+}
+
+// pinningFlushSink is the recording sink over a REAL authoredPins, so a test can
+// read a pin back the way a Lookup does (seedAuthored) instead of asserting on the
+// call log. Both embedded types define PinWritten, so the override is required.
+type pinningFlushSink struct {
+	recordingFlushSink
+	authoredPins
+}
+
+func (s *pinningFlushSink) PinWritten(fileIno uint64, content []byte) {
+	s.recordingFlushSink.PinWritten(fileIno, content)
+	s.authoredPins.PinWritten(fileIno, content)
+}
+
+func TestEditFlushInPlaceWriteSupersedesAtomicSavePin(t *testing.T) {
+	t.Parallel()
+	const fileIno = 77
+	sink := &pinningFlushSink{}
+	// An atomic save committed a moment ago and pinned its bytes for the re-Lookup
+	// it forces (#379).
+	sink.authoredPins.PinWritten(fileIno, []byte("atomic save bytes"))
+
+	// Now the client edits the same file IN PLACE, inside the pin's window, and
+	// that write commits cleanly.
+	eb := &editBuffer{content: []byte("newer in-place bytes"), dirty: true}
+	errno := editFlush(context.Background(), sink, eb, editFlushSpec[fakeEntity]{
+		mutate: func(context.Context) (bool, syscall.Errno) { return true, 0 },
+		writeBack: writeBackSpec[fakeEntity]{
+			errKey:  "k",
+			fetch:   func(context.Context) (*fakeEntity, error) { return &fakeEntity{v: 7}, nil },
+			compare: func(*fakeEntity) []writeBackResult { return nil },
+		},
+		adopt:     func(*fakeEntity) {},
+		coherence: []uint64{fileIno},
+		pinIno:    fileIno,
+	})
+	if errno != 0 {
+		t.Fatalf("errno = %v, want 0", errno)
+	}
+
+	// The node is then forgotten and re-Looked-up while the window is still open
+	// (dentry eviction, or a fresh open through another path). Before #381 this
+	// served the older atomic-save bytes — read-your-writes running BACKWARDS.
+	fresh := &editBuffer{}
+	served := sink.seedAuthored(fresh, fileIno, []byte("Linear's normalized render"))
+	if string(served) != "newer in-place bytes" {
+		t.Errorf("re-Lookup served %q, want the newest committed write %q", served, "newer in-place bytes")
+	}
+	if string(fresh.content) != "newer in-place bytes" || !fresh.authored {
+		t.Errorf("re-seeded buffer = %q (authored=%v), want the newest write, marked authored", fresh.content, fresh.authored)
 	}
 }
 
@@ -151,12 +242,18 @@ func TestEditFlushNoChangeDoesNotMarkAuthored(t *testing.T) {
 		writeBack: writeBackSpec[fakeEntity]{errKey: "k"},
 		adopt:     func(*fakeEntity) {},
 		coherence: []uint64{1},
+		pinIno:    1,
 	})
 	if errno != 0 {
 		t.Fatalf("errno = %v, want 0", errno)
 	}
 	if eb.authored {
 		t.Error("a no-op flush marked the buffer authored; only a persisted write should")
+	}
+	// Nor pinned: echoing bytes back for an edit Linear never took would report a
+	// dropped write as a byte-for-byte success.
+	if len(sink.pins) != 0 {
+		t.Errorf("pins = %v on a no-op flush, want none", sink.pins)
 	}
 }
 
@@ -169,12 +266,16 @@ func TestEditFlushFailDoesNotMarkAuthored(t *testing.T) {
 		writeBack: writeBackSpec[fakeEntity]{errKey: "k"},
 		adopt:     func(*fakeEntity) {},
 		coherence: []uint64{1},
+		pinIno:    1,
 	})
 	if errno != syscall.EINVAL {
 		t.Fatalf("errno = %v, want EINVAL", errno)
 	}
 	if eb.authored {
 		t.Error("a failed flush marked the buffer authored; nothing persisted")
+	}
+	if len(sink.pins) != 0 {
+		t.Errorf("pins = %v on a failed flush, want none", sink.pins)
 	}
 }
 
@@ -197,12 +298,16 @@ func TestEditFlushFatalDivergenceDoesNotMarkAuthored(t *testing.T) {
 		},
 		adopt:     func(*fakeEntity) {},
 		coherence: []uint64{1},
+		pinIno:    1,
 	})
 	if errno != syscall.EIO {
 		t.Fatalf("errno = %v, want EIO (fatal divergence)", errno)
 	}
 	if eb.authored {
 		t.Error("a fatal read-your-writes divergence armed authored — SYOW would mask the loss from a byte-count re-read")
+	}
+	if len(sink.pins) != 0 {
+		t.Errorf("pins = %v on a fatal divergence, want none — the pin would hide the loss from the re-read", sink.pins)
 	}
 }
 

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -179,15 +179,14 @@ func (i *InitiativeNode) Rename(ctx context.Context, name string, newParent fs.I
 		dirIno:     i.EmbeddedInode().StableAttr().Ino,
 		fileIno:    initiativeInfoIno(initiative.ID),
 		scratch:    func(oldName string) ([]byte, func(), bool) { return scratchRenameBytes(i, oldName) },
-		flush: func(ctx context.Context, content []byte) (bool, syscall.Errno) {
+		flush: func(ctx context.Context, content []byte) syscall.Errno {
 			fileNode = &InitiativeInfoNode{
 				BaseNode:     BaseNode{lfs: i.lfs},
 				initiative:   initiative,
 				initiativeID: initiative.ID,
 				editBuffer:   editBuffer{content: content, dirty: true},
 			}
-			errno := fileNode.Flush(ctx, nil)
-			return fileNode.committedWrite(), errno
+			return fileNode.Flush(ctx, nil)
 		},
 		adopt: func() { i.setEntity(fileNode.initiative) },
 	})
@@ -349,6 +348,7 @@ func (i *InitiativeInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall
 		adopt: func(fresh *api.Initiative) { i.initiative = *fresh },
 		// initiative.md, its meta, and the projects/ listing.
 		coherence: []uint64{initiativeInfoIno(i.initiativeID), metaIno(i.initiativeID), initiativeProjectsIno(i.initiativeID)},
+		pinIno:    initiativeInfoIno(i.initiativeID), // initiative.md's Lookup seeds from the pin
 	})
 }
 

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -423,14 +423,13 @@ func (n *IssueDirectoryNode) Rename(ctx context.Context, name string, newParent 
 		dirIno:     n.EmbeddedInode().StableAttr().Ino,
 		fileIno:    issueIno(issue.ID),
 		scratch:    func(oldName string) ([]byte, func(), bool) { return scratchRenameBytes(n, oldName) },
-		flush: func(ctx context.Context, content []byte) (bool, syscall.Errno) {
+		flush: func(ctx context.Context, content []byte) syscall.Errno {
 			fileNode = &IssueFileNode{
 				BaseNode:   BaseNode{lfs: n.lfs},
 				issue:      issue,
 				editBuffer: editBuffer{content: content, dirty: true},
 			}
-			errno := fileNode.Flush(ctx, nil)
-			return fileNode.committedWrite(), errno
+			return fileNode.Flush(ctx, nil)
 		},
 		adopt: func() { n.setEntity(fileNode.issue) },
 	})
@@ -546,6 +545,7 @@ func (i *IssueFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errn
 		},
 		adopt:     func(fresh *api.Issue) { i.issue = *fresh },
 		coherence: []uint64{issueIno(i.issue.ID), metaIno(i.issue.ID)}, // issue.meta reflects the edit
+		pinIno:    issueIno(i.issue.ID),                                // issue.md's Lookup seeds from the pin
 	})
 }
 

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -324,15 +324,14 @@ func (p *ProjectNode) Rename(ctx context.Context, name string, newParent fs.Inod
 		dirIno:     p.EmbeddedInode().StableAttr().Ino,
 		fileIno:    projectInfoIno(project.ID),
 		scratch:    func(oldName string) ([]byte, func(), bool) { return scratchRenameBytes(p, oldName) },
-		flush: func(ctx context.Context, content []byte) (bool, syscall.Errno) {
+		flush: func(ctx context.Context, content []byte) syscall.Errno {
 			fileNode = &ProjectInfoNode{
 				BaseNode:   BaseNode{lfs: p.lfs},
 				team:       team,
 				project:    project,
 				editBuffer: editBuffer{content: content, dirty: true},
 			}
-			errno := fileNode.Flush(ctx, nil)
-			return fileNode.committedWrite(), errno
+			return fileNode.Flush(ctx, nil)
 		},
 		adopt: func() { p.setEntity(fileNode.project) },
 	})
@@ -513,6 +512,7 @@ func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Er
 		},
 		adopt:     func(fresh *api.Project) { p.project = *fresh },
 		coherence: []uint64{projectInfoIno(p.project.ID), metaIno(p.project.ID)}, // project.meta reflects the edit
+		pinIno:    projectInfoIno(p.project.ID),                                  // project.md's Lookup seeds from the pin
 	})
 }
 

--- a/internal/fs/renamesave.go
+++ b/internal/fs/renamesave.go
@@ -28,6 +28,10 @@ import (
 // inode tree — and is unit-tested with a recording sink and stub closures: no
 // FUSE mount, SQLite, or API.
 
+// The serve-your-own-writes pin this path needs (authoredpin.go, #379) is NOT
+// armed here: it rides the flush, because editFlush is the one place that knows a
+// write actually committed (#381).
+//
 // renameSink is the minimal surface a rename tail needs: .error reporting for
 // the guards and the kernel-cache coherence policy for the renamed entry.
 // *LinearFS satisfies it directly (writeFeedback and kernelNotify promotions),
@@ -36,15 +40,6 @@ import (
 type renameSink interface {
 	errorSink
 	InvalidateRenamed(dirIno uint64, oldName, newName string, fileIno uint64)
-}
-
-// renameSaveSink adds the one surface only the atomic-save tail needs: the
-// serve-your-own-writes pin that carries the written bytes across the re-Lookup
-// this tail forces (see authoredpin.go, #379). *LinearFS satisfies it through
-// its embedded authoredPins.
-type renameSaveSink interface {
-	renameSink
-	PinWritten(fileIno uint64, content []byte)
 }
 
 // renameSaveSpec describes the per-entity parts of an atomic save. Everything
@@ -74,12 +69,10 @@ type renameSaveSpec struct {
 	// flush routes the scratch bytes through the entity file's normal edit path:
 	// construct a transient file node with a dirty editBuffer and Flush it
 	// (frontmatter validation, read-your-writes verification, .error handling,
-	// cache invalidation). The closure captures the transient node so adopt can
-	// read the flushed entity back — and so it can report committed, whether the
-	// flush actually wrote to Linear (editBuffer.committedWrite). Errno alone
-	// cannot say: a save that resolved to no changes at all also returns 0, and
-	// pinning there would echo a dropped edit back as a byte-for-byte success.
-	flush func(ctx context.Context, content []byte) (committed bool, errno syscall.Errno)
+	// cache invalidation, and the serve-your-own-writes pin — see editFlush). The
+	// closure captures the transient node so adopt can read the flushed entity
+	// back.
+	flush func(ctx context.Context, content []byte) syscall.Errno
 	// adopt stores the flushed node's fresh entity on the directory node so the
 	// canonical file re-renders the persisted content. Called exactly when the
 	// write reached Linear — flush errno 0 or EIO (see renameSave).
@@ -91,7 +84,7 @@ type renameSaveSpec struct {
 // path a direct in-place edit uses. The canonical file is the only writable
 // file in the directory, so renames onto any other target — or of the canonical
 // files themselves — are rejected.
-func renameSave(ctx context.Context, sink renameSaveSink, name string, newParent fs.InodeEmbedder, newName string, spec renameSaveSpec) syscall.Errno {
+func renameSave(ctx context.Context, sink renameSink, name string, newParent fs.InodeEmbedder, newName string, spec renameSaveSpec) syscall.Errno {
 	// The atomic-save pattern keeps the temp file a sibling of the canonical file.
 	if newParent.EmbeddedInode().StableAttr().Ino != spec.dirIno {
 		return syscall.EXDEV
@@ -111,7 +104,7 @@ func renameSave(ctx context.Context, sink renameSaveSink, name string, newParent
 		return syscall.ENOTSUP
 	}
 
-	committed, errno := spec.flush(ctx, content)
+	errno := spec.flush(ctx, content)
 
 	if errno == 0 || errno == syscall.EIO {
 		// Adopt on EIO too: Flush returns EIO only on a fatal read-your-writes
@@ -127,24 +120,14 @@ func renameSave(ctx context.Context, sink renameSaveSink, name string, newParent
 		// ESTALE drives the VFS to re-Lookup the real node.
 		spec.adopt()
 		consume()
-		// Serve-your-own-writes (#379). The re-Lookup the invalidation below
-		// forces builds a node from what PERSISTED, so without a pin the bytes
-		// the client just wrote are never served back and a server-side reformat
-		// that changed the byte count reads to the client as a truncated write.
-		// Pin them for that Lookup to seed (see authoredpin.go), before the
-		// invalidation that triggers it.
-		//
-		// ONLY on a committed clean save, exactly as editFlush arms `authored`
-		// (#365). On EIO the write did NOT persist as written — a silent revert
-		// or a truncation — and serving the written bytes there would hide the
-		// loss from the re-read .error tells the agent to make. A save that
-		// committed nothing (an edit that resolved to no changes, e.g. one that
-		// only touched frontmatter keys marshal ignores) returns 0 too, and
-		// pinning there would report a dropped edit back as a byte-for-byte
-		// success — the same false signal in the other direction.
-		if committed && errno == 0 {
-			sink.PinWritten(spec.fileIno, content)
-		}
+		// Serve-your-own-writes (#379) needs no work here: the flush above armed
+		// the pin under spec.fileIno if — and only if — it committed a clean write
+		// (editFlush, #381), which is already before the invalidation that forces
+		// the re-Lookup seeding from it. This tail used to arm the pin itself, off
+		// a `committed` flag the flush closure reported back, because errno alone
+		// cannot tell a real write from a save that resolved to no changes. Inside
+		// editFlush that distinction is just the `proceed` it already has, and one
+		// pin site is what lets a later in-place edit supersede this save's pin.
 		sink.InvalidateRenamed(spec.dirIno, name, newName, spec.fileIno)
 	}
 

--- a/internal/fs/renamesave_test.go
+++ b/internal/fs/renamesave_test.go
@@ -17,10 +17,6 @@ type renameRecorder struct {
 	sets           int
 	clears         int
 	invalidates    []string
-	pins           []string
-	// events orders the coherence calls against each other: the pin has to be in
-	// place before the invalidation that triggers the re-Lookup which consumes it.
-	events []string
 }
 
 func (r *renameRecorder) SetWriteError(key, message string) {
@@ -31,11 +27,6 @@ func (r *renameRecorder) ClearWriteError(key string) { r.clears++ }
 func (r *renameRecorder) InvalidateRenamed(dirIno uint64, oldName, newName string, fileIno uint64) {
 	r.invalidates = append(r.invalidates,
 		fmt.Sprintf("renamed(%d,%q,%q,%d)", dirIno, oldName, newName, fileIno))
-	r.events = append(r.events, "invalidate")
-}
-func (r *renameRecorder) PinWritten(fileIno uint64, content []byte) {
-	r.pins = append(r.pins, fmt.Sprintf("pin(%d,%q)", fileIno, content))
-	r.events = append(r.events, "pin")
 }
 
 // renameParent is a bare InodeEmbedder whose zero-value inode has ino 0, so a
@@ -53,7 +44,7 @@ type recordingRenameSpec struct {
 	adoptCalls   int
 }
 
-func newRecordingRenameSpec(scratchOK, flushCommitted bool, flushErrno syscall.Errno) *recordingRenameSpec {
+func newRecordingRenameSpec(scratchOK bool, flushErrno syscall.Errno) *recordingRenameSpec {
 	r := &recordingRenameSpec{}
 	r.spec = renameSaveSpec{
 		targetName: "issue.md",
@@ -64,10 +55,10 @@ func newRecordingRenameSpec(scratchOK, flushCommitted bool, flushErrno syscall.E
 			r.scratchCalls++
 			return []byte("scratch bytes"), func() { r.consumeCalls++ }, scratchOK
 		},
-		flush: func(ctx context.Context, content []byte) (bool, syscall.Errno) {
+		flush: func(ctx context.Context, content []byte) syscall.Errno {
 			r.flushCalls++
 			r.flushContent = content
-			return flushCommitted, flushErrno
+			return flushErrno
 		},
 		adopt: func() { r.adoptCalls++ },
 	}
@@ -75,32 +66,25 @@ func newRecordingRenameSpec(scratchOK, flushCommitted bool, flushErrno syscall.E
 }
 
 func TestRenameSave_FlushOutcomes(t *testing.T) {
+	// The serve-your-own-writes pin is not this tail's business — editFlush arms it
+	// inside spec.flush, on the one outcome that knows a write committed (#381), and
+	// editflush_test.go pins that policy.
 	cases := []struct {
 		name            string
-		flushCommitted  bool
 		flushErrno      syscall.Errno
 		wantAdopts      int
 		wantInvalidates int
-		wantPins        int
 	}{
-		// A clean save adopts the fresh entity, pins the written bytes for the
-		// re-Lookup to serve back (#379), and drops the kernel caches.
-		{"flush success adopts, pins and invalidates", true, 0, 1, 1, 1},
-		// A save that resolved to no changes also returns 0. The tail still
-		// adopts/consumes/invalidates, but it must NOT pin: echoing the written
-		// bytes back would report an edit Linear never took as a byte-for-byte
-		// success.
-		{"flush that committed nothing never pins", false, 0, 1, 1, 0},
+		// A clean save adopts the fresh entity and drops the kernel caches.
+		{"flush success adopts and invalidates", 0, 1, 1},
 		// The policy under test: Flush returns EIO only on a fatal
 		// read-your-writes divergence — the write still reached Linear, so the
 		// fresh entity is adopted (refusing would serve stale content while
-		// .error explains the divergence). It must NOT pin: the write did not
-		// persist as written, and serving the written bytes back would hide that
-		// from the re-read .error asks for (#365's errno == 0 rule).
-		{"flush EIO adopts but never pins", true, syscall.EIO, 1, 1, 0},
+		// .error explains the divergence).
+		{"flush EIO still adopts", syscall.EIO, 1, 1},
 		// EINVAL means the write never reached Linear (parse/validation
-		// failure): nothing to adopt, nothing to pin, nothing to invalidate.
-		{"flush EINVAL adopts nothing", false, syscall.EINVAL, 0, 0, 0},
+		// failure): nothing to adopt, nothing to invalidate.
+		{"flush EINVAL adopts nothing", syscall.EINVAL, 0, 0},
 	}
 	// The scratch buffer is consumed exactly when the rename succeeds (the same
 	// {0, EIO} branch that adopts): go-fuse has moved the spent node over the
@@ -110,7 +94,7 @@ func TestRenameSave_FlushOutcomes(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			sink := &renameRecorder{}
-			rec := newRecordingRenameSpec(true, tc.flushCommitted, tc.flushErrno)
+			rec := newRecordingRenameSpec(true, tc.flushErrno)
 
 			errno := renameSave(context.Background(), sink, "issue.md.tmp.1",
 				&renameParent{}, "issue.md", rec.spec)
@@ -139,22 +123,6 @@ func TestRenameSave_FlushOutcomes(t *testing.T) {
 					t.Errorf("invalidate = %q, want %q", sink.invalidates[0], want)
 				}
 			}
-			if len(sink.pins) != tc.wantPins {
-				t.Fatalf("pins = %v, want %d call(s)", sink.pins, tc.wantPins)
-			}
-			if tc.wantPins == 1 {
-				// The pin carries the written bytes under the CANONICAL file's
-				// inode — that is the Lookup that will serve them back.
-				want := `pin(99,"scratch bytes")`
-				if sink.pins[0] != want {
-					t.Errorf("pin = %q, want %q", sink.pins[0], want)
-				}
-				// Ordering matters: the invalidation is what forces the
-				// re-Lookup, so the pin has to be waiting before it fires.
-				if len(sink.events) != 2 || sink.events[0] != "pin" {
-					t.Errorf("event order = %v, want the pin before the invalidation", sink.events)
-				}
-			}
 			if sink.sets != 0 {
 				t.Errorf("SetWriteError calls = %d, want 0", sink.sets)
 			}
@@ -164,7 +132,7 @@ func TestRenameSave_FlushOutcomes(t *testing.T) {
 
 func TestRenameSave_WrongTarget(t *testing.T) {
 	sink := &renameRecorder{}
-	rec := newRecordingRenameSpec(true, true, 0)
+	rec := newRecordingRenameSpec(true, 0)
 
 	errno := renameSave(context.Background(), sink, "issue.md.tmp.1",
 		&renameParent{}, "notes.md", rec.spec)
@@ -194,7 +162,7 @@ func TestRenameSave_WrongTarget(t *testing.T) {
 
 func TestRenameSave_CrossDirectory(t *testing.T) {
 	sink := &renameRecorder{}
-	rec := newRecordingRenameSpec(true, true, 0)
+	rec := newRecordingRenameSpec(true, 0)
 	// The zero-value parent inode has ino 0; a nonzero dirIno makes the rename
 	// cross-directory.
 	rec.spec.dirIno = 7
@@ -219,7 +187,7 @@ func TestRenameSave_NotAScratchFile(t *testing.T) {
 	sink := &renameRecorder{}
 	// e.g. an attempt to rename issue.md itself: the canonical files aren't
 	// renamable, and no .error is recorded (there is nothing to persist).
-	rec := newRecordingRenameSpec(false, true, 0)
+	rec := newRecordingRenameSpec(false, 0)
 
 	errno := renameSave(context.Background(), sink, "issue.md",
 		&renameParent{}, "renamed.md", rec.spec)


### PR DESCRIPTION
Closes #381.

## The bug

`authoredPins` pins the bytes an atomic save wrote so a client's write→verify
re-read gets them back byte-for-byte (#379). A pin was armed **only** by
`renameSave`, and superseded only by another `PinWritten` for the same inode or by
its TTL — so a successful **in-place** edit inside the window left the older
atomic-save bytes pinned. If that inode was then forgotten and re-Looked-up before
the window closed (dentry eviction, a fresh open through another path),
`seedAuthored` served the *older* bytes: read-your-writes running backwards rather
than converging.

## The fix

Move the pin to `editFlush` — the one place that knows a write actually committed —
and give `editFlushSpec` a `pinIno`. One pin site means the newest committed bytes
are always the pinned ones, whichever path wrote them, so a later in-place edit
supersedes an earlier atomic save *by construction* rather than by a drop-the-pin
special case.

It also closes the same hole on the in-place path itself, which #381 called out:
#365's `authored` flag lives on the node, so a forget-and-re-Lookup lost it there
too. Both halves of serve-your-own-writes now arm together, on one condition, in
one place.

`pinIno` is set for the three files whose Lookup calls `seedAuthored` (`issue.md`,
`project.md`, `initiative.md`) and left zero for a comment/doc/label/milestone
`.md`, where a pin would be bytes no Lookup can read.

## What this deletes

`renameSave` gives up its pin as a consequence, and with it:

- the `committed` flag its `flush` closure reported back — `editFlush`
  distinguishes a real write from a no-change save with the `proceed` it already
  has, which is why that flag existed
- `editBuffer.committedWrite`, which existed only to carry it
- the `renameSaveSink` seam, which collapses back to `renameSink`

Arming conditions are **unchanged**: a committed write with `errno == 0`, never on
a fatal read-your-writes divergence (EIO) and never on a save that changed nothing.

## Testing

- `TestEditFlushInPlaceWriteSupersedesAtomicSavePin` reproduces the issue at the
  flush seam, against a real `authoredPins` read back through `seedAuthored` the
  way a Lookup does. Verified it fails without the fix (serves
  `"atomic save bytes"`).
- The arming rules moved with the pin: clean-commit pins, no-op / EINVAL / fatal
  EIO do not, and `pinIno == 0` never pins.
- `renamesave_test.go` sheds its pin assertions; the mount-level pin tests
  (`internal/integration/atomicsave_pin_test.go`) pass unchanged.
- Full suite green (`make test`, integration included). Lint unchanged from
  baseline.

Docs updated in the same change per CLAUDE.md: `docs/ARCHITECTURE.md` (the
`authoredPins` bullet and the write-flow step) and `CONTEXT.md` (edit-flush shell,
rename save, edit buffer, authored-write pin). No threat-model change — no new
trust boundary, on-disk artifact, or network caller. No generated-README change —
no filesystem surface moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)