### PR TITLE
ci: resolve FUSE mounts to the setuid helper via a preflight (#384)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,10 +27,12 @@ jobs:
         with:
           go-version: '1.25'
 
-      - name: Install FUSE
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y fuse3
+      # Replaces an `apt-get install -y fuse3` that was a no-op: fuse3 is
+      # preinstalled on GitHub's ubuntu images (the preflight still installs it if
+      # a future image drops it). Installing was never the problem — WHICH
+      # fusermount3 PATH resolves to is (#384).
+      - name: FUSE preflight
+        run: ./scripts/ci-fuse-preflight.sh
 
       - name: Build
         run: make build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,65 @@ jobs:
         run: |
           fusermount3 -u /tmp/linearfs-test-* 2>/dev/null || true
 
+  # Whether a runner image carries the non-setuid /usr/local/bin/fusermount3 that
+  # breaks mounts is outside our control, so the preflight's REPAIR path would
+  # otherwise sit untested until the next image that has it — exactly the gap that
+  # let #384 reach main. Plant the shadow deliberately and assert the repair.
+  fuse-preflight-selftest:
+    name: FUSE Preflight Self-Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25'
+
+      - name: Plant a non-setuid fusermount3 ahead of the working one
+        run: |
+          set -euo pipefail
+          sudo cp /usr/bin/fusermount3 /usr/local/bin/fusermount3
+          sudo chown "$(id -un):$(id -gn)" /usr/local/bin/fusermount3
+          sudo chmod 0777 /usr/local/bin/fusermount3
+          ls -l /usr/local/bin/fusermount3
+          # The bug only exists if the planted copy is what PATH resolves to.
+          resolved="$(command -v fusermount3)"
+          echo "resolves to: $resolved"
+          [ "$resolved" = /usr/local/bin/fusermount3 ] || {
+            echo "setup failed: expected the planted shadow to win PATH resolution"; exit 1; }
+
+      - name: Confirm the shadow actually breaks mounting
+        run: |
+          set -uo pipefail
+          # Reproduce #384: with the shadow in place, the mounted-fixture TestMain
+          # must fail. A pass here means the self-test is no longer testing anything.
+          if go test -count=1 -run TestNothingMatchesThisName ./internal/integration/ >out.txt 2>&1; then
+            echo "::error::the planted shadow did NOT break mounting — this self-test has stopped reproducing #384"
+            cat out.txt; exit 1
+          fi
+          grep -q "Operation not permitted" out.txt || {
+            echo "::error::failed for a different reason than #384:"; cat out.txt; exit 1; }
+          echo "reproduced: mount denied while the shadow wins PATH"
+
+      - name: FUSE preflight repairs it
+        run: ./scripts/ci-fuse-preflight.sh
+
+      - name: Assert the repair
+        run: |
+          set -euo pipefail
+          [ ! -e /usr/local/bin/fusermount3 ] || {
+            echo "shadow survived the preflight"; ls -l /usr/local/bin/fusermount3; exit 1; }
+          resolved="$(command -v fusermount3)"
+          echo "resolves to: $resolved"
+          [ -u "$resolved" ] && [ "$(stat -c %u "$resolved")" = 0 ] || {
+            echo "resolved helper is not setuid root"; ls -l "$resolved"; exit 1; }
+
+      - name: Mounting works after the repair
+        run: go test -count=1 -run TestGeneratedReadmeMatchesBehavior ./internal/integration/
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,14 +23,12 @@ jobs:
         with:
           go-version: '1.25'
 
-      # TEMPORARY (#384): this job mounts FUSE (internal/integration's TestMain
-      # sets up mounted fixtures) and currently PASSES, while the integration job
-      # on the same commit fails at mount with "Operation not permitted". The only
-      # difference between them is that the other one apt-installs fuse3. Print
-      # the FUSE environment in both so the difference can be diffed. Remove once
-      # #384 is diagnosed.
-      - name: FUSE environment (#384 diagnostics)
-        run: ./scripts/fuse-diagnostics.sh
+      # This job mounts FUSE: `./...` includes internal/integration, whose
+      # TestMain sets up mounted fixtures. It used to rely on whatever the runner
+      # image happened to ship, which is how a stray non-setuid fusermount3 in the
+      # image made a job named "Unit Tests" fail at mount (#384).
+      - name: FUSE preflight
+        run: ./scripts/ci-fuse-preflight.sh
 
       - name: Run unit tests
         run: go test -v -race ./...
@@ -90,20 +88,12 @@ jobs:
         with:
           go-version: '1.25'
 
-      # TEMPORARY (#384): capture the FUSE environment BEFORE and AFTER the apt
-      # install. The Unit Tests job mounts fine without this install; this job
-      # fails at mount with EPERM, so the install itself is the prime suspect and
-      # the before/after pair is the experiment.
-      - name: FUSE environment before install (#384 diagnostics)
-        run: ./scripts/fuse-diagnostics.sh
-
-      - name: Install FUSE
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y fuse3
-
-      - name: FUSE environment after install (#384 diagnostics)
-        run: ./scripts/fuse-diagnostics.sh
+      # Replaces an `apt-get install -y fuse3` that was a no-op: fuse3 is
+      # preinstalled on GitHub's ubuntu images (the preflight still installs it if
+      # a future image drops it). Installing was never the problem — WHICH
+      # fusermount3 PATH resolves to is (#384).
+      - name: FUSE preflight
+        run: ./scripts/ci-fuse-preflight.sh
 
       - name: Build
         run: make build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,15 @@ jobs:
         with:
           go-version: '1.25'
 
+      # TEMPORARY (#384): this job mounts FUSE (internal/integration's TestMain
+      # sets up mounted fixtures) and currently PASSES, while the integration job
+      # on the same commit fails at mount with "Operation not permitted". The only
+      # difference between them is that the other one apt-installs fuse3. Print
+      # the FUSE environment in both so the difference can be diffed. Remove once
+      # #384 is diagnosed.
+      - name: FUSE environment (#384 diagnostics)
+        run: ./scripts/fuse-diagnostics.sh
+
       - name: Run unit tests
         run: go test -v -race ./...
 
@@ -81,10 +90,20 @@ jobs:
         with:
           go-version: '1.25'
 
+      # TEMPORARY (#384): capture the FUSE environment BEFORE and AFTER the apt
+      # install. The Unit Tests job mounts fine without this install; this job
+      # fails at mount with EPERM, so the install itself is the prime suspect and
+      # the before/after pair is the experiment.
+      - name: FUSE environment before install (#384 diagnostics)
+        run: ./scripts/fuse-diagnostics.sh
+
       - name: Install FUSE
         run: |
           sudo apt-get update
           sudo apt-get install -y fuse3
+
+      - name: FUSE environment after install (#384 diagnostics)
+        run: ./scripts/fuse-diagnostics.sh
 
       - name: Build
         run: make build

--- a/scripts/ci-fuse-preflight.sh
+++ b/scripts/ci-fuse-preflight.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Make an unprivileged FUSE mount possible, and fail loudly here if it isn't.
+#
+# Every CI job that mounts LinearFS runs this first. Without it the failure
+# surfaces from inside the test harness as
+#
+#   /usr/local/bin/fusermount3: mount failed: Operation not permitted
+#   Failed to setup SQLite fixtures: mount filesystem: fusermount exited with code 256
+#
+# which reads like a test bug rather than an environment one (#384).
+#
+# What goes wrong: go-fuse resolves the helper by PATH ORDER, not by absolute
+# path (fusermountBinary → lookPathFallback("fusermount3", "/bin")). The helper
+# must be setuid root to mount for an unprivileged user. GitHub runner images
+# have carried a fusermount3 at /usr/local/bin that is mode 0777, owned by
+# `runner`, and NOT setuid:
+#
+#   -rwxrwxrwx 1 runner runner 95944 /usr/local/bin/fusermount3   (3.18.2)
+#   -rwsr-xr-x 1 root   root   39296 /usr/bin/fusermount3         (3.14.0, apt)
+#
+# and /usr/local/bin precedes /usr/bin, so the unusable copy wins and every mount
+# fails with EPERM. It is per-image, which is why some runners worked and others
+# did not on the same commit.
+#
+# The fix is to neutralize any non-setuid helper that shadows a working one — NOT
+# to make that binary setuid root: it is writable by the unprivileged user, so
+# setuid-rooting it would hand that user root.
+set -euo pipefail
+
+log() { printf '[fuse-preflight] %s\n' "$1"; }
+
+# fuse3 is preinstalled on GitHub's ubuntu images, so this is normally a no-op —
+# kept so a future image that drops it fails as a slow install, not a mount error.
+if ! command -v fusermount3 >/dev/null 2>&1 && ! command -v fusermount >/dev/null 2>&1; then
+    log "no fusermount helper found; installing fuse3"
+    sudo apt-get update
+    sudo apt-get install -y fuse3
+fi
+
+setuid_root() { [ -u "$1" ] && [ "$(stat -c %u "$1")" = "0" ]; }
+
+# Walk the PATH-resolved candidates in order. Anything ahead of a usable helper
+# that cannot mount is a shadow, and has to go.
+mapfile -t candidates < <(type -aP fusermount3 2>/dev/null || true)
+for c in "${candidates[@]:-}"; do
+    [ -n "$c" ] || continue
+    if setuid_root "$c"; then
+        log "usable helper: $c ($(stat -c '%A %U:%G' "$c"))"
+        break
+    fi
+    log "shadowing non-setuid helper: $c ($(stat -c '%A %U:%G' "$c")) — removing"
+    sudo rm -f "$c"
+done
+
+# Assert the outcome rather than trusting the loop: PATH resolution is the thing
+# that was wrong, so re-resolve from scratch and check what a mount would pick.
+resolved="$(command -v fusermount3 2>/dev/null || command -v fusermount 2>/dev/null || true)"
+if [ -z "$resolved" ]; then
+    log "FATAL: no fusermount helper on PATH after preflight"
+    "$(dirname "$0")/fuse-diagnostics.sh" || true
+    exit 1
+fi
+if ! setuid_root "$resolved"; then
+    log "FATAL: $resolved is not setuid root; an unprivileged mount cannot succeed"
+    "$(dirname "$0")/fuse-diagnostics.sh" || true
+    exit 1
+fi
+if [ ! -w /dev/fuse ] || [ ! -r /dev/fuse ]; then
+    log "FATAL: /dev/fuse is not readable+writable by $(id -un)"
+    "$(dirname "$0")/fuse-diagnostics.sh" || true
+    exit 1
+fi
+
+log "ready: $resolved ($("$resolved" --version 2>&1 | head -1)), /dev/fuse ok"

--- a/scripts/fuse-diagnostics.sh
+++ b/scripts/fuse-diagnostics.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Print everything that decides whether an unprivileged FUSE mount can succeed.
+#
+# TEMPORARY (#384). Since 2026-07-30 GitHub-hosted runners fail LinearFS mounts
+# with "/usr/local/bin/fusermount3: mount failed: Operation not permitted", but
+# not in every job: the Unit Tests job mounts fine while the integration job on
+# the SAME commit does not, and the one difference between them is that the
+# integration job apt-installs fuse3. This script runs in both so the two
+# environments can be diffed instead of guessed at.
+#
+# Why each check matters:
+#   - go-fuse picks the helper by PATH order (fusermountBinary →
+#     lookPathFallback("fusermount3", "/bin")), so WHICH fusermount3 wins is a
+#     property of PATH, not of what is installed.
+#   - the helper must be setuid root to mount for an unprivileged user; a
+#     non-setuid copy earlier in PATH fails with exactly EPERM.
+#   - AppArmor confinement of the helper, and the mode/ownership of /dev/fuse,
+#     produce the same EPERM from a different cause.
+#
+# Never fails the job: this is observation, not a gate.
+set -u
+
+section() { printf '\n=== %s ===\n' "$1"; }
+
+section "identity / PATH"
+id
+echo "PATH=$PATH"
+
+section "fusermount3 resolution (first hit is what go-fuse uses)"
+# type -a, not `command -v -a`: bash's command -v takes no -a, so that spelling
+# silently reports nothing and reads as "not installed".
+type -a fusermount3 2>/dev/null || echo "(fusermount3 not on PATH)"
+type -a fusermount 2>/dev/null || echo "(fusermount not on PATH)"
+
+section "candidate binaries (s bit = setuid root, required)"
+for p in /usr/local/bin/fusermount3 /usr/bin/fusermount3 /bin/fusermount3 \
+         /usr/local/bin/fusermount /usr/bin/fusermount; do
+    [ -e "$p" ] && ls -l "$p"
+done
+echo "--- versions ---"
+for p in /usr/local/bin/fusermount3 /usr/bin/fusermount3; do
+    [ -x "$p" ] && { printf '%s: ' "$p"; "$p" --version 2>&1 | head -1; }
+done
+
+section "/dev/fuse"
+ls -l /dev/fuse 2>&1 || echo "(missing)"
+grep -w fuse /proc/filesystems 2>&1 || echo "(fuse not in /proc/filesystems)"
+
+section "packaging"
+if command -v dpkg >/dev/null 2>&1; then
+    dpkg -l fuse3 libfuse3-3 2>/dev/null | tail -n +6
+else
+    echo "(no dpkg)"
+fi
+
+section "AppArmor"
+if [ -d /sys/kernel/security/apparmor ]; then
+    echo "apparmor present"
+    sudo aa-status --json 2>/dev/null | head -c 2000 || sudo aa-status 2>&1 | head -20
+    ls /etc/apparmor.d/ 2>/dev/null | grep -i -E 'fuse|mount' || echo "(no fuse/mount profiles in /etc/apparmor.d)"
+else
+    echo "(no apparmor)"
+fi
+
+section "unprivileged userns / sysctls"
+for s in kernel.unprivileged_userns_clone kernel.apparmor_restrict_unprivileged_userns; do
+    printf '%s = ' "$s"; sysctl -n "$s" 2>/dev/null || echo "(unset)"
+done
+
+echo
+echo "(diagnostics complete; this step never fails the job)"

--- a/scripts/fuse-diagnostics.sh
+++ b/scripts/fuse-diagnostics.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
 # Print everything that decides whether an unprivileged FUSE mount can succeed.
 #
-# TEMPORARY (#384). Since 2026-07-30 GitHub-hosted runners fail LinearFS mounts
-# with "/usr/local/bin/fusermount3: mount failed: Operation not permitted", but
-# not in every job: the Unit Tests job mounts fine while the integration job on
-# the SAME commit does not, and the one difference between them is that the
-# integration job apt-installs fuse3. This script runs in both so the two
-# environments can be diffed instead of guessed at.
+# The failure-path companion to ci-fuse-preflight.sh: the preflight calls this
+# when its assertions fail, so a CI job that cannot mount reports WHY in the same
+# step instead of dying later inside the test harness with a fixture-setup error
+# (#384). Also runnable by hand when debugging a mount problem on any machine.
 #
 # Why each check matters:
 #   - go-fuse picks the helper by PATH order (fusermountBinary →


### PR DESCRIPTION
Closes #384.

## Diagnosis (from the diagnostic run in this PR's first commit)

GitHub runner images carry a `fusermount3` at `/usr/local/bin` that is mode 0777,
owned by `runner`, and **not setuid root**:

```
-rwxrwxrwx 1 runner runner 95944 Jun 26 23:16 /usr/local/bin/fusermount3   (3.18.2)
-rwsr-xr-x 1 root   root   39296 Apr  8  2024 /usr/bin/fusermount3         (3.14.0, apt)
```

`/usr/local/bin` precedes `/usr/bin` on runners, and go-fuse resolves the helper by
**PATH order**, not absolute path (`fusermountBinary` →
`lookPathFallback("fusermount3", "/bin")`). The helper must be setuid root to mount
for an unprivileged user, so the unusable copy wins and every mount fails with
`EPERM`. Whether a given image carries that stray copy is why the same commit
mounted fine on one runner and failed on another.

Two things I had wrong along the way, both corrected by the data:

- The apt-install correlation was **coincidence**. The diagnostics show `fuse3`
  already `ii` installed in the job that never installs it, so
  `apt-get install -y fuse3` was a no-op wherever it appeared.
- It is not runner flakiness in the "retry and it passes" sense — a rerun failed
  identically. The variation is per-image, not per-attempt.

## The fix

`scripts/ci-fuse-preflight.sh`, run before every job that mounts:

1. Installs `fuse3` only if no helper exists at all (normally a no-op — it is
   preinstalled — kept so a future image that drops it fails as a slow install
   rather than a mount error).
2. Walks the PATH-resolved candidates in order and removes any non-setuid helper
   shadowing a working one.
3. **Asserts the outcome** by re-resolving from scratch: the helper a mount would
   pick is setuid root, and `/dev/fuse` is readable+writable. On failure it prints
   the full FUSE environment and exits 1 — in the preflight step, where the
   message belongs, instead of later inside the harness as
   `Failed to setup SQLite fixtures: mount filesystem: fusermount exited with code 256`.

It deliberately does **not** setuid-root the stray binary. That file is writable by
the unprivileged CI user; making it setuid root would hand that user root.

## Also fixes the second problem #384 raised

The `unit-tests` job runs `go test -race ./...`, which includes
`internal/integration` and therefore mounts — with no FUSE setup at all, relying on
whatever the image shipped. That is why a FUSE environment change reddened a job
named "Unit Tests". It now runs the same preflight as the two integration jobs, so
FUSE readiness is explicit in all three.

`scripts/fuse-diagnostics.sh` (added in the first commit as a temporary always-on
step) stays as the failure-path dump the preflight calls, and is useful by hand for
any mount problem.

## Verification

A **`FUSE Preflight Self-Test`** job proves the repair path in CI rather than by
simulation. The shadow's presence is a property of the runner image and outside our
control, so the repair would otherwise sit untested until the next image that has
it — the same gap that let this reach main. The job plants the shadow deliberately
(copy the real helper to `/usr/local/bin`, chown to the unprivileged user, chmod
0777), then:

1. asserts it wins PATH resolution — `resolves to: /usr/local/bin/fusermount3`
2. asserts mounting is genuinely **broken** while it wins —
   `reproduced: mount denied while the shadow wins PATH`, matched on
   "Operation not permitted". Without this step the job would still pass if the
   preflight became a no-op and the planted shadow stopped mattering, so it fails
   loudly as "this self-test has stopped reproducing #384" instead of guarding
   nothing.
3. runs the preflight —
   `shadowing non-setuid helper: /usr/local/bin/fusermount3 (-rwxrwxrwx runner:runner) — removing`
4. asserts the shadow is gone and what PATH resolves to is now setuid root
5. runs a mounted-fixture test to prove an actual mount succeeds afterwards

Worth being explicit that the first green run on this branch did **not** prove the
fix: both jobs happened to land on runners without the shadow, so the preflight
removed nothing. That run showed the preflight is harmless; this job shows it
repairs.

Both script branches were also exercised locally (pass-through, and shadow removal
via a `sudo` shim against a temp-dir stray).
