### PR TITLE
fix(fs): serve your own writes back for comment/doc/label/milestone .md

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -86,9 +86,13 @@ A committed clean write both marks the buffer authored (the node-local half) and
 pins the written bytes under the spec's **`pinIno`** (the half that survives the
 node — see [[authored-pin]]); both key off one condition in one place, so the
 in-place and atomic-save paths cannot disagree about whether a write is servable,
-and the later of two writes to a file always owns the pin. `pinIno` is set only for
-the three files whose Lookup calls `seedAuthored` (`issue.md`, `project.md`,
-`initiative.md`); zero for the rest, where a pin would be bytes nobody can read.
+and the later of two writes to a file always owns the pin. **All seven editable
+files set `pinIno`** since #387; it was originally only the three whose Lookup
+seeded by hand (`issue.md`, `project.md`, `initiative.md`), which left a
+comment/doc/label/milestone `.md` with neither half of the guarantee. Seeding now
+lives in [[node-attr]]'s `newFileInode`, so a reader exists for every editable
+file; zero remains correct only for a file nothing builds through that path,
+where a pin would be bytes nobody can read.
 
 It depends only on the `editFlushSink` seam (`errorSink` + `InvalidateUpdated` +
 `PinWritten`, satisfied by `*LinearFS`), so the shell's outcome dispatch,
@@ -733,10 +737,11 @@ with an empty buffer, so the flag alone would lose the bytes there too.
 `authoredPins` (`internal/fs/authoredpin.go`) is a mount-wide `ino → {bytes,
 deadline}` store embedded on `LinearFS` by value (zero value ready, no constructor
 wiring). Its invariant: **a Lookup that finds a pin serves the pinned bytes as the
-buffer's content *and* as the size it publishes** — `manifest.file` reports
-`len(content)` in the `EntryOut`, and publishing the render's length while serving
-the pin would clamp the client's own read to the wrong size, which is the mismatch
-the module exists to remove. The pin is armed **only on a committed clean write**,
+buffer's content *and* as the size it publishes** — the builder fills
+`EntryOut`'s size from the render, and publishing that length while serving the
+pin would clamp the client's own read to the wrong size, which is the mismatch
+the module exists to remove. `seedBuilt` therefore returns the size alongside the
+seeded bytes rather than letting its caller compute one from what it rendered. The pin is armed **only on a committed clean write**,
 by [[edit-flush]], on the same condition that arms `authored`: not on `EIO`, where
 the write did not persist as written and hiding that would mask real loss; not on a
 write that committed nothing, where echoing the bytes back would report a dropped
@@ -751,10 +756,18 @@ client's verification is several syscalls (stat, then open+read), each able to d
 its own Lookup after the rename invalidation, so all of them must answer alike; the
 TTL is now the outer bound on a pin outliving its truth for a *remote* reason
 (someone else changed the entity), since a newer local write supersedes it outright.
-Reaches the three files whose Lookup calls `seedAuthored` (`issue.md`,
-`project.md`, `initiative.md`) through their specs' `pinIno`, via the
-`editFlushSink` seam; unit-tested directly (window, expiry, sweep, unaliased
-copies, seed-beats-render) and at the flush seam (the supersede rule) plus
+Reaches **every** editable file through its spec's `pinIno`, via the
+`editFlushSink` seam. The consuming half is single-sited in `newFileInode`
+(#387): it seeds any child exposing `editable() *editBuffer`, so embedding the
+buffer is all a new editable surface needs to inherit the guarantee, instead of
+each build helper remembering — which is exactly what the four collection files
+did not do. Two wiring rules guard the halves, since the behavior itself needs a
+dentry forget inside the window that a test cannot force through the kernel (the
+[[serve-your-own-writes]] bound, #388): every editable node type must satisfy the
+`editable()` assertion, and every `editFlushSpec` literal in the package must set
+`pinIno` (an AST rule over the package source, in the spirit of
+`scripts/check-safename.sh`). Unit-tested directly (window, expiry, sweep,
+unaliased copies, seed-beats-render) and at the flush seam (the supersede rule) plus
 deterministic mount-level tests over all three files, the reformat-note shape, and
 the EIO no-pin rule (`internal/integration/atomicsave_pin_test.go`) — the rename
 itself forces the re-Lookup, so no timeout wait is needed.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -90,7 +90,7 @@ and the later of two writes to a file always owns the pin. **All seven editable
 files set `pinIno`** since #387; it was originally only the three whose Lookup
 seeded by hand (`issue.md`, `project.md`, `initiative.md`), which left a
 comment/doc/label/milestone `.md` with neither half of the guarantee. Seeding now
-lives in [[node-attr]]'s `newFileInode`, so a reader exists for every editable
+lives in [[attr-construction]]'s `newFileInode`, so a reader exists for every editable
 file; zero remains correct only for a file nothing builds through that path,
 where a pin would be bytes nobody can read.
 
@@ -695,7 +695,8 @@ verifying a write by re-reading gets a byte-for-byte match instead of racing the
 async refresh. It is deliberately NOT armed on a fatal read-your-writes divergence
 (a silent revert or truncation, where `commitWriteBack` returns EIO) — serving the
 written bytes there would mask the loss from the very re-read the `.error` asks for.
-A fresh `Open` clears it, so independent later readers converge to what persisted.
+A fresh `Open` clears it on that node, but does not end the window outright: a
+rebuild inside the [[authored-pin]]'s TTL re-arms it from the pin (#388).
 The flag protects the bytes only as long as **this node** lives — a dentry forget
 rebuilds the node with an empty buffer and no flag — so [[edit-flush]] arms the
 [[authored-pin]] on the same condition, and a Lookup re-seeds both from it; that
@@ -763,10 +764,10 @@ buffer is all a new editable surface needs to inherit the guarantee, instead of
 each build helper remembering — which is exactly what the four collection files
 did not do. Two wiring rules guard the halves, since the behavior itself needs a
 dentry forget inside the window that a test cannot force through the kernel (the
-[[serve-your-own-writes]] bound, #388): every editable node type must satisfy the
-`editable()` assertion, and every `editFlushSpec` literal in the package must set
-`pinIno` (an AST rule over the package source, in the spirit of
-`scripts/check-safename.sh`). Unit-tested directly (window, expiry, sweep,
+[[edit-buffer]] bound, #388): every editable node type asserts the `editableFile`
+interface at compile time next to its `fs.NodeWriter` assertion, and every
+`editFlushSpec` literal in the package must set `pinIno` (an AST rule over the
+package source, in the spirit of `scripts/check-safename.sh`). Unit-tested directly (window, expiry, sweep,
 unaliased copies, seed-beats-render) and at the flush seam (the supersede rule) plus
 deterministic mount-level tests over all three files, the reformat-note shape, and
 the EIO no-pin rule (`internal/integration/atomicsave_pin_test.go`) — the rename

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -556,12 +556,11 @@ and never read jointly with it. The seven editBuffer file nodes go through
 edit is never clobbered by background sync), **and a just-authored buffer also
 wins** (serve-your-own-writes, #365: `editFlush` marks the buffer authored after a
 write persists, and while set `refresh` keeps the exact written bytes so a client's
-byte-for-byte read-back cannot race the async refresh; a fresh `Open` ends the
-window and the next refresh converges to the normalized render — see
-[[edit-buffer]]) — with Getattr snapshotting
-size+times under one lock; renderFile swaps its closure under `renderMu`
-(embedders with entity fields shadow `refreshFrom` and reuse that lock);
-`EmbeddedFileNode` swaps its file metadata under its own mu. The old
+byte-for-byte read-back cannot race the async refresh; what ends that window is
+the flag's own rule, not this seam's — see [[edit-buffer]]) — with Getattr
+snapshotting size+times under one lock; renderFile swaps its closure under
+`renderMu` (embedders with entity fields shadow `refreshFrom` and reuse that
+lock); `EmbeddedFileNode` swaps its file metadata under its own mu. The old
 exception paragraph is GONE: `TeamNode`/`UserNode`/cycle dirs used to ride
 auto-assigned inos (fresh node per Lookup) and dodge the bug — that
 inconsistency is erased; they are on stable inos with the seam like everyone
@@ -591,7 +590,10 @@ directory node cannot hand-write a divergent one. The `newDirInode`/`newFileInod
 `BaseNode` constructors stash the `nodeAttr` on the child, fill the Lookup
 `EntryOut` from that same value, take the entry timeout as an explicit param
 (the deliberate 30s/5s/0/1s classes are preserved verbatim, never rationalized
-here), and return `StableAttr{Mode, Ino}`.
+here), and return `StableAttr{Mode, Ino}`. `newFileInode` carries one further
+responsibility, because it is the one builder every editable file passes
+through: it seeds serve-your-own-writes for any child exposing `editable()
+*editBuffer` — see [[authored-pin]].
 
 This replaced 54 hand-fabricated attribute blocks whose per-site copies had
 already drifted: `DocsNode`/`AttachmentsNode.Getattr` reported `time.Now()`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -552,9 +552,16 @@ building blocks:
   **One pin site is load-bearing**: a pin is superseded by the next write to the
   same inode, so arming it in `editFlush` rather than in `renameSave` is what
   keeps a later in-place edit from leaving older atomic-save bytes pinned (#381).
-  `pinIno` is set only for the three files whose Lookup calls `seedAuthored`
-  (`issue.md`, `project.md`, `initiative.md`); zero elsewhere means no pin,
-  because nothing would read it. Bounded by time (`pinTTL`), not by one Lookup: a
+  **Both halves are single-sited**, which is what keeps them wired together:
+  `editFlush` is the only place a pin is armed, and `newFileInode` — the one
+  builder every editable file node passes through — is the only place one is
+  consumed, recognising an editable child by the `editable()` accessor
+  `editBuffer` provides (#387). Before that the consuming half was hand-written
+  per file, so `pinIno` was set only for `issue.md`, `project.md`, and
+  `initiative.md`, and a comment/doc/label/milestone `.md` had neither half: its
+  written bytes survived only as long as the node did. All seven set it now;
+  zero still means no pin, correct only for a file nothing builds through that
+  path. Bounded by time (`pinTTL`), not by one Lookup: a
   client's verification is several syscalls, each able to drive its own Lookup, so
   all of them must answer alike. Without it a server-side reformat that changed the
   byte count reached the client as a size mismatch, which editors report as a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -534,11 +534,14 @@ building blocks:
   can't truncate kernel reads of longer dirty content. A **just-authored** buffer
   wins the same way (serve-your-own-writes, #365): after a write commits cleanly
   (`errno == 0`), `editFlush` marks the buffer authored, and `refresh` keeps the
-  exact written bytes until the next fresh `Open` — so a client that verifies a
+  exact written bytes while the flag stands — so a client that verifies a
   write by re-reading gets a byte-for-byte match instead of racing the async
   refresh, while persistence (SQLite and the entity) already holds Linear's
-  normalized render. It is not armed on a fatal read-your-writes divergence (a
-  revert or truncation, EIO), so a real loss is never masked from a re-read.
+  normalized render. A fresh `Open` clears the flag on that node but does not
+  end the window: a rebuild inside the pin's TTL (below) re-arms it from the
+  pin, which is the real outer bound (#388). It is not armed on a fatal
+  read-your-writes divergence (a revert or truncation, EIO), so a real loss is
+  never masked from a re-read.
 - `authoredPins` — the same guarantee for the written *bytes* rather than the
   buffer, so it survives the node the flag dies with (#379, #381). Two paths need
   that: the **atomic-save** path flushes through a transient node and then drops

--- a/internal/fs/authoredpin.go
+++ b/internal/fs/authoredpin.go
@@ -26,6 +26,15 @@ import (
 // editBuffer with them — marked authored, so a background refresh leaves them
 // alone — instead of the fresh render.
 //
+// Both halves are single-sited, which is what keeps them from drifting apart:
+// editFlush is the only place a pin is armed, and newFileInode — the one builder
+// every editable file node passes through — is the only place one is consumed
+// (#387). Before that, the consuming half was hand-written per file, so the four
+// collection files (a comment/doc/label/milestone .md) simply never got it: an
+// agent that wrote a comment and re-read it after a forget saw Linear's render
+// instead of its own bytes, and reported a byte-count mismatch on a write that
+// fully succeeded.
+//
 // Arming it in editFlush rather than in renameSave is what keeps the two write
 // paths from disagreeing. A pin is superseded by the next PinWritten for the same
 // inode, so whichever path wrote LAST owns the pin; arming it only on the rename
@@ -110,27 +119,30 @@ func (p *authoredPins) writtenBytes(fileIno uint64) []byte {
 	return pin.content
 }
 
-// seedAuthored fills a freshly-built editable node's buffer and reports the bytes
-// its Lookup must publish as the file's size: the rendered content normally, or
-// a pinned write when one is waiting for this inode. The two must be
-// the same bytes — a Lookup that published the render's length while the buffer
-// served the pin would clamp the client's own read to the wrong size, which is
-// the very mismatch this module exists to remove.
+// seedBuilt overrides a freshly-built editable node's buffer with the bytes a
+// client last wrote to this inode, when a pin is still standing, and reports the
+// size the Lookup must publish for them. Callers build the node with the fresh
+// render already in its buffer; this replaces it only when there is a pin, so
+// "no pin" costs one map lookup and leaves the render untouched.
+//
+// The published size must move with the bytes: a Lookup that reported the
+// render's length while the buffer served the pin would clamp the client's own
+// read to the wrong size, which is the very mismatch this module exists to
+// remove. That is why the size comes back from here rather than being computed
+// by the caller from what it rendered.
 //
 // The buffer gets its own copy of the pin: the pin is not consumed, so every
 // Lookup in the window is handed the same bytes, and editBuffer.Write mutates a
 // buffer in place whenever the write fits — one node's edit would otherwise
 // rewrite what the next Lookup serves.
-func (p *authoredPins) seedAuthored(b *editBuffer, fileIno uint64, rendered []byte) []byte {
+func (p *authoredPins) seedBuilt(b *editBuffer, fileIno uint64) (int, bool) {
 	pinned := p.writtenBytes(fileIno)
+	if pinned == nil {
+		return 0, false
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if pinned == nil {
-		b.content = rendered
-		return rendered
-	}
-	owned := append([]byte(nil), pinned...)
-	b.content = owned
+	b.content = append([]byte(nil), pinned...)
 	b.authored = true
-	return owned
+	return len(b.content), true
 }

--- a/internal/fs/authoredpin_test.go
+++ b/internal/fs/authoredpin_test.go
@@ -125,11 +125,15 @@ func TestSeedAuthored_PinnedWriteWinsOverRender(t *testing.T) {
 	rendered := []byte("body the client wrote")  // what persisted, 2 bytes shorter
 	p.PinWritten(11, written)
 
-	var b editBuffer
-	served := p.seedAuthored(&b, 11, rendered)
+	// Nodes are built with the render already in the buffer; seedBuilt overrides.
+	b := editBuffer{content: rendered}
+	size, seeded := p.seedBuilt(&b, 11)
 
-	if string(served) != string(written) {
-		t.Errorf("published size bytes = %q, want the pinned write %q", served, written)
+	if !seeded {
+		t.Fatal("seedBuilt reported no pin, so the Lookup would publish the render's size")
+	}
+	if size != len(written) {
+		t.Errorf("published size = %d, want the pinned write's %d", size, len(written))
 	}
 	if string(b.content) != string(written) {
 		t.Errorf("buffer = %q, want the pinned write %q", b.content, written)
@@ -148,17 +152,17 @@ func TestSeedAuthored_BufferWriteCannotCorruptThePin(t *testing.T) {
 	written := []byte("body the client wrote")
 	p.PinWritten(13, written)
 
-	var first editBuffer
-	p.seedAuthored(&first, 13, []byte("what Linear stored"))
+	first := editBuffer{content: []byte("what Linear stored")}
+	p.seedBuilt(&first, 13)
 	if _, errno := first.Write(context.Background(), nil, []byte("MANGLED"), 0); errno != 0 {
 		t.Fatalf("write through the seeded buffer = %v, want 0", errno)
 	}
 
-	var second editBuffer
-	served := p.seedAuthored(&second, 13, []byte("what Linear stored"))
-	if string(served) != string(written) || string(second.content) != string(written) {
-		t.Errorf("second lookup served %q / buffer %q, want the pinned write %q",
-			served, second.content, written)
+	second := editBuffer{content: []byte("what Linear stored")}
+	size, seeded := p.seedBuilt(&second, 13)
+	if !seeded || string(second.content) != string(written) || size != len(written) {
+		t.Errorf("second lookup: buffer %q size %d (seeded=%v), want the pinned write %q",
+			second.content, size, seeded, written)
 	}
 }
 
@@ -166,11 +170,14 @@ func TestSeedAuthored_NoPinServesTheRender(t *testing.T) {
 	var p authoredPins
 	rendered := []byte("what Linear stored")
 
-	var b editBuffer
-	served := p.seedAuthored(&b, 12, rendered)
+	b := editBuffer{content: rendered}
+	size, seeded := p.seedBuilt(&b, 12)
 
-	if string(served) != string(rendered) || string(b.content) != string(rendered) {
-		t.Errorf("served %q / buffer %q, want the render %q", served, b.content, rendered)
+	if seeded || size != 0 {
+		t.Errorf("seedBuilt reported a pin (size %d) with none standing", size)
+	}
+	if string(b.content) != string(rendered) {
+		t.Errorf("buffer = %q, want the render %q left untouched", b.content, rendered)
 	}
 	if b.authored {
 		t.Error("an ordinary Lookup must not be authored — later reads have to converge to what persisted")

--- a/internal/fs/comments.go
+++ b/internal/fs/comments.go
@@ -178,6 +178,7 @@ func (n *CommentNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno 
 		},
 		adopt:     func(fresh *api.Comment) { n.comment = *fresh },
 		coherence: []uint64{commentIno(n.comment.ID), commentMetaIno(n.comment.ID)},
+		pinIno:    commentIno(n.comment.ID),
 	})
 }
 

--- a/internal/fs/comments.go
+++ b/internal/fs/comments.go
@@ -108,6 +108,7 @@ var _ fs.NodeWriter = (*CommentNode)(nil)
 var _ fs.NodeFlusher = (*CommentNode)(nil)
 var _ fs.NodeFsyncer = (*CommentNode)(nil)
 var _ fs.NodeSetattrer = (*CommentNode)(nil)
+var _ editableFile = (*CommentNode)(nil)
 
 func (n *CommentNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
 	// One lock for size + times: a concurrent refresh (refresh.go) swaps

--- a/internal/fs/documents.go
+++ b/internal/fs/documents.go
@@ -269,6 +269,7 @@ func (n *DocumentFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.E
 		},
 		adopt:     func(fresh *api.Document) { n.document = *fresh },
 		coherence: []uint64{documentIno(n.document.ID), documentMetaIno(n.document.ID)},
+		pinIno:    documentIno(n.document.ID),
 	})
 }
 

--- a/internal/fs/documents.go
+++ b/internal/fs/documents.go
@@ -194,6 +194,7 @@ var _ fs.NodeWriter = (*DocumentFileNode)(nil)
 var _ fs.NodeFlusher = (*DocumentFileNode)(nil)
 var _ fs.NodeFsyncer = (*DocumentFileNode)(nil)
 var _ fs.NodeSetattrer = (*DocumentFileNode)(nil)
+var _ editableFile = (*DocumentFileNode)(nil)
 
 func (n *DocumentFileNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
 	// One lock for size + times: a concurrent refresh (refresh.go) swaps

--- a/internal/fs/editablewiring_test.go
+++ b/internal/fs/editablewiring_test.go
@@ -1,0 +1,129 @@
+package fs
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The two halves of serve-your-own-writes are wired per editable file, and #387
+// is what happens when one half is forgotten: a comment/doc/label/milestone .md
+// armed no pin and consulted none, so a write survived only as long as its node
+// did — an agent that wrote a comment and re-read it after a dentry forget saw
+// Linear's render and reported a byte-count mismatch on a write that succeeded.
+//
+// These tests pin the wiring itself rather than the behavior, because the
+// behavior needs a dentry forget inside a 10s window, which a test cannot force
+// through the kernel reliably (the same constraint that keeps #388 a known
+// bound). What they can guarantee is that neither half can be omitted quietly.
+
+// TestEditableNodesReachTheSeedingSeam is the consuming half: newFileInode seeds
+// a pinned write only into a child it can recognise as editable, via the
+// editable() accessor editBuffer provides. A node that holds its content some
+// other way would still compile, still be writable, and silently never serve its
+// own bytes back — so assert every editable file node is reachable through that
+// assertion, in exactly the form newFileInode uses.
+func TestEditableNodesReachTheSeedingSeam(t *testing.T) {
+	t.Parallel()
+
+	// One per editable file surface in the mount. Adding an editable file means
+	// adding it here; if it does not satisfy the assertion, it does not get
+	// serve-your-own-writes no matter what its Flush pins.
+	nodes := map[string]any{
+		"issue.md":      &IssueFileNode{},
+		"project.md":    &ProjectInfoNode{},
+		"initiative.md": &InitiativeInfoNode{},
+		"comment .md":   &CommentNode{},
+		"doc .md":       &DocumentFileNode{},
+		"label .md":     &LabelFileNode{},
+		"milestone .md": &MilestoneFileNode{},
+	}
+
+	for name, node := range nodes {
+		t.Run(name, func(t *testing.T) {
+			e, ok := node.(interface{ editable() *editBuffer })
+			if !ok {
+				t.Fatalf("%s does not satisfy newFileInode's editable() assertion; "+
+					"a pinned write would never be served back through it", name)
+			}
+			if e.editable() == nil {
+				t.Errorf("%s exposed a nil buffer", name)
+			}
+		})
+	}
+}
+
+// TestEverySpecSetsPinIno is the arming half. A pin is armed only when a spec
+// carries a nonzero pinIno, and the field is easy to leave out — it was left out
+// of all four collection files for exactly that reason (#387). Rather than trust
+// review to catch the fifth, read the package's own source and require every
+// editFlushSpec literal to set it.
+//
+// A future editable file that genuinely must not pin (one not built through
+// newFileInode, whose pin nothing would ever read) should set `pinIno: 0`
+// explicitly with a comment saying why: that keeps the omission deliberate and
+// visible, which is all this rule asks for.
+func TestEverySpecSetsPinIno(t *testing.T) {
+	t.Parallel()
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	var missing []string
+	found := 0
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(".", name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			// editFlushSpec[api.Comment]{...} — a generic type instantiation.
+			idx, ok := lit.Type.(*ast.IndexExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := idx.X.(*ast.Ident)
+			if !ok || ident.Name != "editFlushSpec" {
+				return true
+			}
+			found++
+			for _, elt := range lit.Elts {
+				kv, ok := elt.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				if key, ok := kv.Key.(*ast.Ident); ok && key.Name == "pinIno" {
+					return true
+				}
+			}
+			missing = append(missing, fset.Position(lit.Pos()).String())
+			return true
+		})
+	}
+
+	if found == 0 {
+		t.Fatal("no editFlushSpec literals found; this rule has stopped checking anything")
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf("editFlushSpec literals with no pinIno (their writes would not survive the node — see #387):\n  %s",
+			strings.Join(missing, "\n  "))
+	}
+}

--- a/internal/fs/editablewiring_test.go
+++ b/internal/fs/editablewiring_test.go
@@ -17,46 +17,12 @@ import (
 // did — an agent that wrote a comment and re-read it after a dentry forget saw
 // Linear's render and reported a byte-count mismatch on a write that succeeded.
 //
-// These tests pin the wiring itself rather than the behavior, because the
+// This rule pins the wiring itself rather than the behavior, because the
 // behavior needs a dentry forget inside a 10s window, which a test cannot force
 // through the kernel reliably (the same constraint that keeps #388 a known
-// bound). What they can guarantee is that neither half can be omitted quietly.
-
-// TestEditableNodesReachTheSeedingSeam is the consuming half: newFileInode seeds
-// a pinned write only into a child it can recognise as editable, via the
-// editable() accessor editBuffer provides. A node that holds its content some
-// other way would still compile, still be writable, and silently never serve its
-// own bytes back — so assert every editable file node is reachable through that
-// assertion, in exactly the form newFileInode uses.
-func TestEditableNodesReachTheSeedingSeam(t *testing.T) {
-	t.Parallel()
-
-	// One per editable file surface in the mount. Adding an editable file means
-	// adding it here; if it does not satisfy the assertion, it does not get
-	// serve-your-own-writes no matter what its Flush pins.
-	nodes := map[string]any{
-		"issue.md":      &IssueFileNode{},
-		"project.md":    &ProjectInfoNode{},
-		"initiative.md": &InitiativeInfoNode{},
-		"comment .md":   &CommentNode{},
-		"doc .md":       &DocumentFileNode{},
-		"label .md":     &LabelFileNode{},
-		"milestone .md": &MilestoneFileNode{},
-	}
-
-	for name, node := range nodes {
-		t.Run(name, func(t *testing.T) {
-			e, ok := node.(interface{ editable() *editBuffer })
-			if !ok {
-				t.Fatalf("%s does not satisfy newFileInode's editable() assertion; "+
-					"a pinned write would never be served back through it", name)
-			}
-			if e.editable() == nil {
-				t.Errorf("%s exposed a nil buffer", name)
-			}
-		})
-	}
-}
+// bound). What it can guarantee is that the arming half cannot be omitted
+// quietly; the consuming half is a compile-time `var _ editableFile` assertion
+// carried next to each node type (see nodeattr.go's editableFile).
 
 // TestEverySpecSetsPinIno is the arming half. A pin is armed only when a spec
 // carries a nonzero pinIno, and the field is easy to leave out — it was left out

--- a/internal/fs/editbuffer.go
+++ b/internal/fs/editbuffer.go
@@ -31,7 +31,8 @@ type editBuffer struct {
 	// refresh refuses to replace the buffer with Linear's normalized render, so a
 	// client that verifies a write by re-reading sees its own bytes byte-for-byte
 	// across the write→verify window instead of racing an async refresh. A fresh
-	// Open clears it, so independent later readers converge to what persisted.
+	// Open clears it on THIS node; the window itself outlives that if the pin
+	// below is still standing (see Open).
 	//
 	// It protects the bytes only as long as this node lives — a dentry forget
 	// rebuilds the node with an empty buffer and no flag. editFlush therefore arms
@@ -59,8 +60,8 @@ func (b *editBuffer) size() int {
 // nodeRefresher implementation (see refresh.go) — UNLESS the buffer is already
 // serving the user's own bytes: a dirty buffer is an in-flight edit, and an
 // authored buffer holds a just-persisted write (#365). Both always win over a
-// background sync, so the served bytes stay the user's until a fresh Open ends
-// the window. entitySwap runs under the same lock iff the refresh proceeds, so
+// background sync, so the served bytes stay the user's for the life of the
+// window. entitySwap runs under the same lock iff the refresh proceeds, so
 // the node's entity fields and its content swap atomically.
 func (b *editBuffer) refresh(freshContent []byte, entitySwap func()) {
 	b.mu.Lock()
@@ -85,11 +86,16 @@ func (b *editBuffer) truncateBuffer() {
 	b.dirty = true
 }
 
-// Open ends any serve-your-own-writes window (#365): a fresh open means the
-// write→verify cycle that authored the buffer is over, so clear the flag and let
-// the next background refresh converge to what actually persisted. The write's
-// own Open ran before Flush set the flag, so a write can never clear its own
-// authored bytes — only a genuinely later open does.
+// Open clears this node's serve-your-own-writes flag (#365): a fresh open means
+// the write→verify cycle that authored the buffer is over, so let the next
+// background refresh converge to what actually persisted. The write's own Open
+// ran before Flush set the flag, so a write can never clear its own authored
+// bytes — only a genuinely later open does.
+//
+// It does NOT end the window outright: the flag is the node-local half, and a
+// Lookup that rebuilds (or re-seeds) the node while the authoredPins pin still
+// stands re-arms it from the pin. Until pinTTL expires, that is the bound — a
+// deliberate one, recorded in #388.
 func (b *editBuffer) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
 	b.mu.Lock()
 	b.authored = false

--- a/internal/fs/editbuffer.go
+++ b/internal/fs/editbuffer.go
@@ -40,6 +40,14 @@ type editBuffer struct {
 	authored bool
 }
 
+// editable exposes the embedded buffer to newFileInode, the one builder every
+// editable file node passes through. Having the buffer reachable from the
+// generic builder is what lets serve-your-own-writes seed in a single place
+// (#387): embedding editBuffer is what makes a node editable, so a new editable
+// surface inherits the guarantee by construction instead of by remembering to
+// call it. Nothing else should reach a node's buffer this way.
+func (b *editBuffer) editable() *editBuffer { return b }
+
 // size is the current buffer length, for a node's Getattr.
 func (b *editBuffer) size() int {
 	b.mu.Lock()

--- a/internal/fs/editflush.go
+++ b/internal/fs/editflush.go
@@ -75,17 +75,20 @@ type editFlushSpec[T any] struct {
 	// buried in a handler. Invalidated only after the commit tail persists.
 	coherence []uint64
 	// pinIno is the inode of the canonical file whose Lookup seeds from
-	// authoredPins: issue.md, project.md, and initiative.md, the three that both
-	// accept an atomic save and call seedAuthored when they build a node. A
-	// committed clean write pins its bytes there, which is what makes
-	// serve-your-own-writes survive the node — a dentry forget and re-Lookup
-	// inside the window, and the transient node the atomic-save path flushes
-	// through.
+	// authoredPins. A committed clean write pins its bytes there, which is what
+	// makes serve-your-own-writes survive the node — a dentry forget and
+	// re-Lookup inside the window, and the transient node the atomic-save path
+	// flushes through.
 	//
-	// Zero for the entities whose Lookup does not consult pins (a
-	// comment/doc/label/milestone .md): there is no reader, so a pin would be
-	// bytes held for the TTL and swept unread. Wiring one of those files to
-	// seedAuthored is what would give it a nonzero pinIno.
+	// Set by all seven editable files since #387. It was originally the three
+	// that also accept an atomic save (issue.md, project.md, initiative.md),
+	// because only those consulted pins when building a node; a
+	// comment/doc/label/milestone .md left it zero, so its written bytes survived
+	// only as long as the node did. Seeding now happens in newFileInode, the one
+	// builder they all pass through, so the reader exists for every editable file
+	// and the pin has somewhere to land. Zero remains the correct value for any
+	// future spec whose file is not built through that path — an unread pin is
+	// just bytes held for the TTL and swept.
 	pinIno uint64
 }
 

--- a/internal/fs/editflush_test.go
+++ b/internal/fs/editflush_test.go
@@ -223,10 +223,11 @@ func TestEditFlushInPlaceWriteSupersedesAtomicSavePin(t *testing.T) {
 	// The node is then forgotten and re-Looked-up while the window is still open
 	// (dentry eviction, or a fresh open through another path). Before #381 this
 	// served the older atomic-save bytes — read-your-writes running BACKWARDS.
-	fresh := &editBuffer{}
-	served := sink.seedAuthored(fresh, fileIno, []byte("Linear's normalized render"))
-	if string(served) != "newer in-place bytes" {
-		t.Errorf("re-Lookup served %q, want the newest committed write %q", served, "newer in-place bytes")
+	fresh := &editBuffer{content: []byte("Linear's normalized render")}
+	size, seeded := sink.seedBuilt(fresh, fileIno)
+	if !seeded || size != len("newer in-place bytes") {
+		t.Errorf("re-Lookup published size %d (seeded=%v), want the newest committed write's %d",
+			size, seeded, len("newer in-place bytes"))
 	}
 	if string(fresh.content) != "newer in-place bytes" || !fresh.authored {
 		t.Errorf("re-seeded buffer = %q (authored=%v), want the newest write, marked authored", fresh.content, fresh.authored)

--- a/internal/fs/editflush_test.go
+++ b/internal/fs/editflush_test.go
@@ -158,8 +158,11 @@ func TestEditFlushZeroPinInoNeverPins(t *testing.T) {
 	t.Parallel()
 	eb := dirtyBuffer()
 	sink := &recordingFlushSink{}
-	// pinIno zero is a comment/doc/label/milestone .md: its Lookup does not call
-	// seedAuthored, so a pin would be bytes nobody can ever read, held for the TTL.
+	// No shipped file is in this situation since #387 — all seven set pinIno, and
+	// TestEverySpecSetsPinIno requires it. The shell must still honour zero as "do
+	// not pin" for a future spec whose file is not built through newFileInode:
+	// nothing would ever seed from that pin, so it would be bytes nobody can read,
+	// held for the TTL.
 	errno := editFlush(context.Background(), sink, eb, editFlushSpec[fakeEntity]{
 		mutate: func(context.Context) (bool, syscall.Errno) { return true, 0 },
 		writeBack: writeBackSpec[fakeEntity]{
@@ -182,7 +185,7 @@ func TestEditFlushZeroPinInoNeverPins(t *testing.T) {
 }
 
 // pinningFlushSink is the recording sink over a REAL authoredPins, so a test can
-// read a pin back the way a Lookup does (seedAuthored) instead of asserting on the
+// read a pin back the way a Lookup does (seedBuilt) instead of asserting on the
 // call log. Both embedded types define PinWritten, so the override is required.
 type pinningFlushSink struct {
 	recordingFlushSink

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -115,11 +115,13 @@ func (i *InitiativeNode) manifest() *dirManifest {
 
 	// initiative.md is editable-only; identity/status/owner live in initiative.meta.
 	m.file("initiative.md", initiativeInfoIno(initiative.ID), func(ctx context.Context) (fs.InodeEmbedder, []byte, syscall.Errno) {
+		// Built with the fresh render; newFileInode swaps in the bytes an earlier
+		// save pinned under this inode when one is still standing, for every
+		// editable file in one place (authoredpin.go, #379/#387).
 		node := &InitiativeInfoNode{BaseNode: BaseNode{lfs: lfs}, initiative: initiative, initiativeID: initiative.ID}
-		// An atomic save may have pinned the bytes the client just wrote; they
-		// win over the render for this one Lookup (authoredpin.go, #379).
-		served := lfs.seedAuthored(&node.editBuffer, initiativeInfoIno(initiative.ID), node.generateContent())
-		return node, served, 0
+		content := node.generateContent()
+		node.content = content
+		return node, content, 0
 	})
 
 	// initiative.meta: read-through from the freshest initiative so an edit to

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -220,6 +220,7 @@ var _ fs.NodeWriter = (*InitiativeInfoNode)(nil)
 var _ fs.NodeFlusher = (*InitiativeInfoNode)(nil)
 var _ fs.NodeFsyncer = (*InitiativeInfoNode)(nil)
 var _ fs.NodeSetattrer = (*InitiativeInfoNode)(nil)
+var _ editableFile = (*InitiativeInfoNode)(nil)
 
 // generateContent renders the editable-only initiative.md via
 // marshal.InitiativeToMarkdown; a render failure serves an empty file rather

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -461,6 +461,7 @@ var _ fs.NodeWriter = (*IssueFileNode)(nil)
 var _ fs.NodeFlusher = (*IssueFileNode)(nil)
 var _ fs.NodeFsyncer = (*IssueFileNode)(nil)
 var _ fs.NodeSetattrer = (*IssueFileNode)(nil)
+var _ editableFile = (*IssueFileNode)(nil)
 
 func (i *IssueFileNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
 	// One lock for size + times: a concurrent refresh (refresh.go) swaps

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -336,11 +336,11 @@ func (n *IssueDirectoryNode) manifest() *dirManifest {
 		if err != nil {
 			return nil, nil, syscall.EIO
 		}
-		node := &IssueFileNode{BaseNode: BaseNode{lfs: n.lfs}, issue: issue}
-		// An atomic save may have pinned the bytes the client just wrote; they
-		// win over the render for this one Lookup (authoredpin.go, #379).
-		served := n.lfs.seedAuthored(&node.editBuffer, issueIno(issue.ID), content)
-		return node, served, 0
+		// Built with the fresh render; newFileInode swaps in the bytes an earlier
+		// save pinned under this inode when one is still standing, for every
+		// editable file in one place (authoredpin.go, #379/#387).
+		node := &IssueFileNode{BaseNode: BaseNode{lfs: n.lfs}, issue: issue, editBuffer: editBuffer{content: content}}
+		return node, content, 0
 	})
 
 	// issue.meta: read-only server-managed fields, rendered read-through from the

--- a/internal/fs/labels.go
+++ b/internal/fs/labels.go
@@ -141,6 +141,7 @@ var _ fs.NodeWriter = (*LabelFileNode)(nil)
 var _ fs.NodeFlusher = (*LabelFileNode)(nil)
 var _ fs.NodeFsyncer = (*LabelFileNode)(nil)
 var _ fs.NodeSetattrer = (*LabelFileNode)(nil)
+var _ editableFile = (*LabelFileNode)(nil)
 
 func (n *LabelFileNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
 	// api.Label carries no timestamps, so there is nothing to report but now().

--- a/internal/fs/labels.go
+++ b/internal/fs/labels.go
@@ -211,6 +211,7 @@ func (n *LabelFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errn
 		adopt: func(fresh *api.Label) { n.label = *fresh },
 		// The .meta sidecar renders from the label.
 		coherence: []uint64{labelIno(n.label.ID), labelMetaIno(n.label.ID)},
+		pinIno:    labelIno(n.label.ID),
 	})
 }
 

--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -76,7 +76,7 @@ type LinearFS struct {
 	writeFeedback
 
 	// Serve-your-own-writes pins for atomic saves (see authoredpin.go, #379).
-	// Embedded, so lfs.PinWritten / lfs.seedAuthored promote. Zero value ready.
+	// Embedded, so lfs.PinWritten / lfs.seedBuilt promote. Zero value ready.
 	authoredPins
 }
 

--- a/internal/fs/milestones.go
+++ b/internal/fs/milestones.go
@@ -117,6 +117,7 @@ var _ fs.NodeWriter = (*MilestoneFileNode)(nil)
 var _ fs.NodeFlusher = (*MilestoneFileNode)(nil)
 var _ fs.NodeFsyncer = (*MilestoneFileNode)(nil)
 var _ fs.NodeSetattrer = (*MilestoneFileNode)(nil)
+var _ editableFile = (*MilestoneFileNode)(nil)
 
 func (n *MilestoneFileNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
 	// api.ProjectMilestone carries no timestamps, so there is nothing but now().

--- a/internal/fs/milestones.go
+++ b/internal/fs/milestones.go
@@ -202,6 +202,7 @@ func (n *MilestoneFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.
 			}
 		},
 		coherence: []uint64{milestoneIno(n.milestone.ID), milestoneMetaIno(n.milestone.ID)},
+		pinIno:    milestoneIno(n.milestone.ID),
 	})
 }
 

--- a/internal/fs/nodeattr.go
+++ b/internal/fs/nodeattr.go
@@ -106,6 +106,14 @@ type dirChild interface {
 	fillAttr(*fuse.Attr)
 }
 
+// editableFile is a node that embeds editBuffer — newFileInode's recognition
+// seam for serve-your-own-writes (#387). Every editable file node asserts it
+// next to its fs.NodeWriter assertion, so a node that holds its content some
+// other way fails to compile rather than silently never serving its own bytes.
+type editableFile interface {
+	editable() *editBuffer
+}
+
 // newDirInode builds a static-attr directory child from a parent's Lookup. It
 // fixes the child's reporting identity, fills the Lookup EntryOut by calling the
 // child's own fillAttr — the exact method its Getattr uses — sets the entry
@@ -157,7 +165,7 @@ func (b *BaseNode) newFileInode(ctx context.Context, out *fuse.EntryOut, name st
 	// the existing-node size clamp below, which still has the last word: whichever
 	// node ends up serving, the size published is that node's own.
 	if b.lfs != nil {
-		if e, ok := child.(interface{ editable() *editBuffer }); ok {
+		if e, ok := child.(editableFile); ok {
 			if size, seeded := b.lfs.seedBuilt(e.editable(), ino); seeded {
 				out.Attr.Size = uint64(size)
 			}

--- a/internal/fs/nodeattr.go
+++ b/internal/fs/nodeattr.go
@@ -140,6 +140,29 @@ func (b *BaseNode) newFileInode(ctx context.Context, out *fuse.EntryOut, name st
 	na.fill(&out.Attr, b)
 	out.SetAttrTimeout(timeout)
 	out.SetEntryTimeout(timeout)
+	// Serve-your-own-writes, seeded for every editable file in ONE place (#387).
+	// A committed write pins its bytes under the file's inode (editFlush), and the
+	// next Lookup that BUILDS that file must serve them rather than Linear's
+	// render — the node-local `authored` flag dies with the node, so a dentry
+	// forget inside the window would otherwise fall back to the render.
+	//
+	// Hooked here, not in each collection's build helper, because this is the one
+	// function all seven editable files pass through, and `ino` is already the pin
+	// key their editFlushSpec arms. Embedding editBuffer is therefore all a new
+	// editable surface has to do to inherit the guarantee — the four collection
+	// files (#387) went without it precisely because each remembered separately.
+	//
+	// Runs BEFORE refreshExisting so a kept node adopts the pinned bytes too
+	// (refresh refuses only for a dirty or already-authored buffer), and before
+	// the existing-node size clamp below, which still has the last word: whichever
+	// node ends up serving, the size published is that node's own.
+	if b.lfs != nil {
+		if e, ok := child.(interface{ editable() *editBuffer }); ok {
+			if size, seeded := b.lfs.seedBuilt(e.editable(), ino); seeded {
+				out.Attr.Size = uint64(size)
+			}
+		}
+	}
 	// The bridge dedups AFTER this handler returns: push fresh content/entity
 	// into the node it will keep (a dirty edit buffer wins — see refresh.go).
 	refreshExisting(b, name, child)

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -363,6 +363,7 @@ var _ fs.NodeWriter = (*ProjectInfoNode)(nil)
 var _ fs.NodeFlusher = (*ProjectInfoNode)(nil)
 var _ fs.NodeFsyncer = (*ProjectInfoNode)(nil)
 var _ fs.NodeSetattrer = (*ProjectInfoNode)(nil)
+var _ editableFile = (*ProjectInfoNode)(nil)
 
 // generateContent renders the editable-only project.md via
 // marshal.ProjectToMarkdown; a render failure serves an empty file rather

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -259,11 +259,13 @@ func (p *ProjectNode) manifest() *dirManifest {
 
 	// project.md is editable-only; identity/status/dates live in project.meta.
 	m.file("project.md", projectInfoIno(project.ID), func(ctx context.Context) (fs.InodeEmbedder, []byte, syscall.Errno) {
+		// Built with the fresh render; newFileInode swaps in the bytes an earlier
+		// save pinned under this inode when one is still standing, for every
+		// editable file in one place (authoredpin.go, #379/#387).
 		node := &ProjectInfoNode{BaseNode: BaseNode{lfs: lfs}, team: team, project: project}
-		// An atomic save may have pinned the bytes the client just wrote; they
-		// win over the render for this one Lookup (authoredpin.go, #379).
-		served := lfs.seedAuthored(&node.editBuffer, projectInfoIno(project.ID), node.generateContent(ctx))
-		return node, served, 0
+		content := node.generateContent(ctx)
+		node.content = content
+		return node, content, 0
 	})
 
 	// project.meta: read-through from the freshest project so an edit to


### PR DESCRIPTION
## Intent

Fix GitHub issue #387: serve-your-own-writes stops at the node for comment/doc/label/milestone .md files because their editFlushSpec leaves pinIno zero and their Lookups never consult authoredPins. Consequence: an agent that writes a comment and re-reads it to verify can see Linear's normalized reformat instead of its own bytes, and report a byte-count mismatch on a write that fully succeeded — comments being the surface agents touch most, and Linear's normalizer being demonstrably lossy around inline markup (#382).

The user asked me to review the open issues and then work through them; #387 was picked as the next item after #386 (PR #390, separate branch, still open). This branch is cut from main and is independent of it.

KEY DESIGN DECISION, deliberate and beyond the literal ticket text. #387 asked whether the four Lookups have a single place to hook 'the way the three entity files do, or whether each has its own construction path', and said explicitly that if they are four bespoke sites, 'that itself is the finding — seedAuthored would be a candidate to move into whatever builds an editable file node, so a new editable surface gets the guarantee by construction rather than by remembering.' Investigation found BOTH: four bespoke build helpers (buildComment, newDocumentInode, newLabelInode, buildMilestone), but all four AND the other three funnel through one shared builder, newFileInode (internal/fs/nodeattr.go), which already owns publishing the entry size. So instead of adding four more remembered seedAuthored calls, the consuming half was moved INTO newFileInode and made single-sited: it seeds any child exposing editable() *editBuffer. That is the ticket's own stated preference, taken deliberately. Consequences a reviewer should expect: seedAuthored was replaced by seedBuilt with a different signature (returns (size, seeded) instead of the served bytes, and no longer sets the render — callers now build the node with the render already in its buffer); the three former call sites in issues.go/projects.go/initiatives.go lost their seedAuthored calls and now construct like the four collection files always did, so all seven are identical; a new editable() accessor was added to editBuffer purely as the recognition seam.

ORDERING, deliberate: seeding runs BEFORE refreshExisting so a node the bridge keeps also adopts the pinned bytes (editBuffer.refresh still refuses for a dirty or already-authored buffer), and BEFORE the existing-node size clamp, which deliberately still has the last word so the published size is always that of whichever node actually serves. This preserves the pre-existing behavior of the three entity files exactly — their old order was seed-in-closure, then newFileInode, then refreshExisting, then clamp.

TESTING CONSTRAINT, important and not a gap to be 'fixed' by the pipeline: the actual behavior requires a dentry forget inside the 10s pinTTL window, which a test cannot force through the kernel reliably. That is the same constraint recorded in #388 as a known bound, and it is the stated reason #387 sat unfixed. Do NOT attempt to add a mount-level test that forces a specific forget; it will be flaky. Unlike issue.md/project.md/initiative.md there is also no atomic-save path for these four files (renameSave is wired only for those three dirs), so the rename trick that made #379/#381 testable at mount level is unavailable here. Instead the WIRING is pinned on both halves: TestEditableNodesReachTheSeedingSeam asserts all seven editable node types satisfy newFileInode's editable() assertion, and TestEverySpecSetsPinIno is an AST rule over the package source requiring every editFlushSpec literal to set pinIno — deliberately in the spirit of scripts/check-safename.sh, which this repo already runs in CI as a no-bypass grep rule. That AST rule was mutation-checked by hand: deleting comments.go's pinIno makes it fail and name the site.

DOCS: docs/ARCHITECTURE.md and CONTEXT.md both claimed pinIno is set only for the three files whose Lookup calls seedAuthored. Both were corrected in the same commit, per this repo's CLAUDE.md docs discipline. THREAT-MODEL needed no change — no trust boundary moves; this is entirely internal to how an already-existing buffer is seeded.

Verification already done locally: full go test ./... green including the 62s internal/integration run, go test -race ./internal/fs green, go vet, make staticcheck, make check-safename, gofmt all clean.

## What Changed

- Moved the serve-your-own-writes consuming half out of the three per-file Lookups (`issue.md`, `project.md`, `initiative.md`) and into `newFileInode` — the one builder every editable file node passes through. It recognizes an editable child via a new `editable() *editBuffer` accessor behind an `editableFile` interface, and `seedAuthored` became `seedBuilt`, which returns `(size, seeded)` and overrides the buffer only when a pin is standing; callers now build the node with the fresh render already in its buffer. Seeding deliberately runs before `refreshExisting` (so a node the bridge keeps also adopts pinned bytes) and before the existing-node size clamp, which still has the last word.
- Set `pinIno` on the four collection `editFlushSpec`s (comment, document, label, milestone), so a committed write to those `.md` files pins its bytes under the file's inode and survives a dentry forget inside `pinTTL` — previously an agent that wrote a comment and re-read it could be served Linear's normalized render and report a byte-count mismatch on a write that fully succeeded (#387).
- Pinned the wiring on both halves instead of the behavior, which needs a kernel forget inside a 10s window and cannot be forced reliably: compile-time `var _ editableFile` assertions on all seven editable node types, plus `TestEverySpecSetsPinIno`, an AST rule over the package source requiring every `editFlushSpec` literal to set `pinIno` (mutation-checked by deleting `comments.go`'s field). `CONTEXT.md` and `docs/ARCHITECTURE.md` were corrected in the same branch — both claimed `pinIno` applied only to the three atomic-save files, and both described the window as ending at the next `Open` rather than at the pin's TTL.

## Risk Assessment

✅ Low: The fix round is comment-and-declaration only on top of an already-verified change — the sole executable edit is swapping an anonymous interface literal for the identical named `editableFile` type — and every prior finding was addressed completely with no new issues surfaced.

## Testing

Ran the full suite (green, including the 62s integration run) and a race run of internal/fs, then demonstrated the actual user-visible fix end-to-end: a temporary mount-level probe wrote a comment .md and an issue doc .md through a real FUSE mount, forced and confirmed a genuine kernel dentry forget inside the pin window, and made the agent's stat+read — the base commit reproduces #387's byte-count mismatch (59 vs 57 written; doc 132 vs 130, read-back showing Linear's reformat) while the target returns the written bytes byte-for-byte on both surfaces; I also mutation-checked the shipped AST pinIno rule (fails and names comments.go:138:46 when the field is removed) and verified each surface's pinIno matches the inode its builder seeds from. The probe was deleted afterward per the change's stated no-flaky-mount-test constraint, and the worktree is clean.

<details>
<summary>Evidence: A/B: base (pre-fix) vs target (fixed) — agent-visible write→verify across a dentry forget</summary>

```text
########## BASE e30150b (pre-fix) ##########
$ printf %s "<edited>" > 0001-2024-01-01T00-00.md # the agent writes (57 bytes)
$ # kernel forgot the dentry — the node is gone; the next access rebuilds it from what Linear stored
$ stat -c %s 0001-2024-01-01T00-00.md -> 59 (agent expected 57)
$ cat 0001-2024-01-01T00-00.md | cmp - written -> DIFFERS
agent verdict (comment): MISMATCH — byte-count mismatch reported on a write that fully succeeded (#387)
$ printf %s "<edited>" > issue-doc-issue-1-1.md # the agent writes (130 bytes)
$ stat -c %s issue-doc-issue-1-1.md -> 132 (agent expected 130)
$ cat issue-doc-issue-1-1.md | cmp - written -> DIFFERS
agent verdict (document): MISMATCH — byte-count mismatch reported on a write that fully succeeded (#387)

########## TARGET 35f11a6 (fixed) ##########
$ printf %s "<edited>" > 0001-2024-01-01T00-00.md # the agent writes (57 bytes)
$ # kernel forgot the dentry — the node is gone; the next access rebuilds it from what Linear stored
$ stat -c %s 0001-2024-01-01T00-00.md -> 57 (agent expected 57)
$ cat 0001-2024-01-01T00-00.md | cmp - written -> identical
agent verdict (comment): write verified byte-for-byte across the forget; the .error note is informational
$ printf %s "<edited>" > issue-doc-issue-1-1.md # the agent writes (130 bytes)
$ stat -c %s issue-doc-issue-1-1.md -> 130 (agent expected 130)
$ cat issue-doc-issue-1-1.md | cmp - written -> identical
agent verdict (document): write verified byte-for-byte across the forget; the .error note is informational
```
</details>
<details>
<summary>Evidence: Base commit transcript (pre-fix): full probe output reproducing #387 on comment + issue doc</summary>

```text
=== BASE e30150b (pre-fix): comment + issue-doc write, real dentry forget inside the 10s pin window ===
$ git checkout e30150b -- internal/fs && go test ./internal/fs/ -run TestProbe387 -v

=== RUN   TestProbe387_CommentVerifyAfterDentryForget
    zz_probe387_test.go:86: $ cat comments/0001-2024-01-01T00-00.md
    zz_probe387_test.go:86:     | Test comment 1
    zz_probe387_test.go:86: $ printf %s "<edited>" > 0001-2024-01-01T00-00.md      # the agent writes (57 bytes)
2026/07/30 14:07:19 Read-your-writes note on comments:issue-1:
Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).
Field: comment body
Note: saved, but Linear reformatted the markdown server-side (you wrote 56 chars, 58 persisted). The text is intact; an immediate re-read still shows your own bytes, a later read shows the stored formatting.
    zz_probe387_test.go:86: $ # kernel forgot the dentry — the node is gone; the next access rebuilds it from what Linear stored
    zz_probe387_test.go:86: $ stat -c %s 0001-2024-01-01T00-00.md  -> 59   (agent expected 57)
    zz_probe387_test.go:86: $ cat 0001-2024-01-01T00-00.md | cmp - written -> DIFFERS
    zz_probe387_test.go:86: $ cat .error
            | Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).
            | Field: comment body
            | Note: saved, but Linear reformatted the markdown server-side (you wrote 56 chars, 58 persisted). The text is intact; an immediate re-read still shows your own bytes, a later read shows the stored formatting.
    zz_probe387_test.go:86: read back:
            | Test comment 1
            | 
            | verified read-back is what the `pin` holds
    zz_probe387_test.go:86: agent verdict (comment): MISMATCH — byte-count mismatch reported on a write that fully succeeded (#387)
    zz_probe387_test.go:86: comment: stat size after forget = 59, want 57 — "file is 59 bytes on disk, expected 57 ... may have silently truncated the write"
    zz_probe387_test.go:86: comment: read-back after forget is not what was written
        --- wrote ---
        "Test comment 1\n\nverified read-back is what the`pin`holds\n"
        --- got ---
        "Test comment 1\n\nverified read-back is what the `pin` holds\n"
--- FAIL: TestProbe387_CommentVerifyAfterDentryForget (0.08s)
=== RUN   TestProbe387_DocumentVerifyAfterDentryForget
    zz_probe387_test.go:108: $ cat documents/issue-doc-issue-1-1.md
    zz_probe387_test.go:108:     | ---
            | title: Issue Document 1
            | ---
            | # Issue Document 1
            | 
            | Document attached to issue issue-1.
    zz_probe387_test.go:108: $ printf %s "<edited>" > issue-doc-issue-1-1.md      # the agent writes (130 bytes)
2026/07/30 14:07:19 Read-your-writes note on docs:issue-1:
Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).
Field: content (body)
Note: saved, but Linear reformatted the markdown server-side (you wrote 97 chars, 99 persisted). The text is intact; an immediate re-read still shows your own bytes, a later read shows the stored formatting.
    zz_probe387_test.go:108: $ # kernel forgot the dentry — the node is gone; the next access rebuilds it from what Linear stored
    zz_probe387_test.go:108: $ stat -c %s issue-doc-issue-1-1.md  -> 132   (agent expected 130)
    zz_probe387_test.go:108: $ cat issue-doc-issue-1-1.md | cmp - written -> DIFFERS
    zz_probe387_test.go:108: $ cat .error
            | Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).
            | Field: content (body)
            | Note: saved, but Linear reformatted the markdown server-side (you wrote 97 chars, 99 persisted). The text is intact; an immediate re-read still shows your own bytes, a later read shows the stored formatting.
    zz_probe387_test.go:108: read back:
            | ---
            | title: Issue Document 1
            | ---
            | # Issue Document 1
            | 
            | Document attached to issue issue-1.
            | 
            | verified read-back is what the `pin` holds
    zz_probe387_test.go:108: agent verdict (document): MISMATCH — byte-count mismatch reported on a write that fully succeeded (#387)
    zz_probe387_test.go:108: document: stat size after forget = 132, want 130 — "file is 132 bytes on disk, expected 130 ... may have silently truncated the write"
    zz_probe387_test.go:108: document: read-back after forget is not what was written
        --- wrote ---
        "---\ntitle: Issue Document 1\n---\n# Issue Document 1\n\nDocument attached to issue issue-1.\n\nverified read-back is what the`pin`holds\n"
        --- got ---
        "---\ntitle: Issue Document 1\n---\n# Issue Document 1\n\nDocument attached to issue issue-1.\n\nverified read-back is what the `pin` holds\n"
--- FAIL: TestProbe387_DocumentVerifyAfterDentryForget (0.09s)
FAIL
FAIL	github.com/jra3/linear-fuse/internal/fs	0.168s
FAIL
```
</details>
<details>
<summary>Evidence: Target commit transcript (fixed): same probe, same forced forget, byte-for-byte read-back</summary>

```text
=== TARGET 35f11a6 (fixed): identical probe, identical forced dentry forget ===
$ go test ./internal/fs/ -run TestProbe387 -v

=== RUN   TestProbe387_CommentVerifyAfterDentryForget
    zz_probe387_test.go:86: $ cat comments/0001-2024-01-01T00-00.md
    zz_probe387_test.go:86:     | Test comment 1
    zz_probe387_test.go:86: $ printf %s "<edited>" > 0001-2024-01-01T00-00.md      # the agent writes (57 bytes)
2026/07/30 14:07:20 Read-your-writes note on comments:issue-1:
Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).
Field: comment body
Note: saved, but Linear reformatted the markdown server-side (you wrote 56 chars, 58 persisted). The text is intact; an immediate re-read still shows your own bytes, a later read shows the stored formatting.
    zz_probe387_test.go:86: $ # kernel forgot the dentry — the node is gone; the next access rebuilds it from what Linear stored
    zz_probe387_test.go:86: $ stat -c %s 0001-2024-01-01T00-00.md  -> 57   (agent expected 57)
    zz_probe387_test.go:86: $ cat 0001-2024-01-01T00-00.md | cmp - written -> identical
    zz_probe387_test.go:86: $ cat .error
            | Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).
            | Field: comment body
            | Note: saved, but Linear reformatted the markdown server-side (you wrote 56 chars, 58 persisted). The text is intact; an immediate re-read still shows your own bytes, a later read shows the stored formatting.
    zz_probe387_test.go:86: read back:
            | Test comment 1
            | 
            | verified read-back is what the`pin`holds
    zz_probe387_test.go:86: agent verdict (comment): write verified byte-for-byte across the forget; the .error note is informational
--- PASS: TestProbe387_CommentVerifyAfterDentryForget (0.09s)
=== RUN   TestProbe387_DocumentVerifyAfterDentryForget
    zz_probe387_test.go:108: $ cat documents/issue-doc-issue-1-1.md
    zz_probe387_test.go:108:     | ---
            | title: Issue Document 1
            | ---
            | # Issue Document 1
            | 
            | Document attached to issue issue-1.
    zz_probe387_test.go:108: $ printf %s "<edited>" > issue-doc-issue-1-1.md      # the agent writes (130 bytes)
2026/07/30 14:07:20 Read-your-writes note on docs:issue-1:
Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).
Field: content (body)
Note: saved, but Linear reformatted the markdown server-side (you wrote 97 chars, 99 persisted). The text is intact; an immediate re-read still shows your own bytes, a later read shows the stored formatting.
    zz_probe387_test.go:108: $ # kernel forgot the dentry — the node is gone; the next access rebuilds it from what Linear stored
    zz_probe387_test.go:108: $ stat -c %s issue-doc-issue-1-1.md  -> 130   (agent expected 130)
    zz_probe387_test.go:108: $ cat issue-doc-issue-1-1.md | cmp - written -> identical
    zz_probe387_test.go:108: $ cat .error
            | Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).
            | Field: content (body)
            | Note: saved, but Linear reformatted the markdown server-side (you wrote 97 chars, 99 persisted). The text is intact; an immediate re-read still shows your own bytes, a later read shows the stored formatting.
    zz_probe387_test.go:108: read back:
            | ---
            | title: Issue Document 1
            | ---
            | # Issue Document 1
            | 
            | Document attached to issue issue-1.
            | 
            | verified read-back is what the`pin`holds
    zz_probe387_test.go:108: agent verdict (document): write verified byte-for-byte across the forget; the .error note is informational
--- PASS: TestProbe387_DocumentVerifyAfterDentryForget (0.08s)
PASS
ok  	github.com/jra3/linear-fuse/internal/fs	0.175s
```
</details>
<details>
<summary>Evidence: Mutation check of the shipped AST rule (delete comments.go pinIno → named failure, restore → pass)</summary>

<code>$ sed -i &#39;/pinIno: commentIno/d&#39; internal/fs/comments.go &amp;&amp; go test ./internal/fs/ -run TestEverySpecSetsPinIno -v&#10;editablewiring_test.go:92: editFlushSpec literals with no pinIno (their writes would not survive the node — see #387):&#10;comments.go:138:46&#10;--- FAIL: TestEverySpecSetsPinIno (0.01s)&#10;&#10;$ git checkout HEAD -- internal/fs/comments.go &amp;&amp; go test ./internal/fs/ -run TestEverySpecSetsPinIno -v&#10;--- PASS: TestEverySpecSetsPinIno (0.01s)</code>

```text
=== Mutation check of the shipped AST rule (delete comments.go's pinIno, expect a named failure) ===
$ sed -i '/pinIno:    commentIno/d' internal/fs/comments.go && go test ./internal/fs/ -run TestEverySpecSetsPinIno -v

=== RUN   TestEverySpecSetsPinIno
=== PAUSE TestEverySpecSetsPinIno
=== CONT  TestEverySpecSetsPinIno
    editablewiring_test.go:92: editFlushSpec literals with no pinIno (their writes would not survive the node — see #387):
          comments.go:138:46
--- FAIL: TestEverySpecSetsPinIno (0.01s)
FAIL
FAIL	github.com/jra3/linear-fuse/internal/fs	0.012s
FAIL

$ git checkout HEAD -- internal/fs/comments.go && go test ./internal/fs/ -run TestEverySpecSetsPinIno -v

=== RUN   TestEverySpecSetsPinIno
=== PAUSE TestEverySpecSetsPinIno
=== CONT  TestEverySpecSetsPinIno
--- PASS: TestEverySpecSetsPinIno (0.01s)
PASS
ok  	github.com/jra3/linear-fuse/internal/fs	0.012s
```
</details>
<details>
<summary>Evidence: Probe source (temporary, deleted from the tree after the runs — archived for reproduction)</summary>

```text
package fs

import (
	"bytes"
	"context"
	"fmt"
	"net/http"
	"net/http/httptest"
	"os"
	"path/filepath"
	"strings"
	"testing"
	"time"

	gofuse "github.com/hanwen/go-fuse/v2/fs"
	"github.com/jra3/linear-fuse/internal/api"
	"github.com/jra3/linear-fuse/internal/config"
	"github.com/jra3/linear-fuse/internal/testutil/fixtures"
	"github.com/jra3/linear-fuse/internal/testutil/mockmutation"
)

// TEMPORARY EVIDENCE PROBE for #387 — not part of the shipped suite.
//
// It reproduces the report at the syscall level an agent actually uses: write a
// collection .md, lose the node inside the 10s pin window, then make the two
// verification syscalls (stat, open+read) the agent makes to check its own
// write. The node loss is a REAL kernel dentry forget, forced through go-fuse's
// Inode.NotifyEntry and then CONFIRMED (the bridge drops the child from its
// parent) before the verification syscalls run — so the probe cannot pass by
// accident on a node that merely survived, which is what an EntryNotify-only
// attempt does.
//
// Two of the four collection files #387 names are exercised through their two
// distinct build helpers (buildComment, newDocumentInode); both reach the seam
// via newFileInode.

// probeReformat models Linear's normalizer rewriting inline markup — the #382
// behaviour #387 cites — storing 2 bytes MORE than the agent wrote.
func probeReformat(body string) string {
	return strings.ReplaceAll(body, "the`pin`holds", "the `pin` holds")
}

// probeMutator adds the two behaviours mockmutation's comment/doc paths lack:
// Linear normalizes the body it stores, and an update preserves the identity
// fields a filename derives from (a comment's createdAt, a doc's title/slugId),
// as the real mutation responses do.
type probeMutator struct {
	*mockmutation.Client
	created time.Time
	doc     api.Document
}

func (p probeMutator) UpdateComment(ctx context.Context, commentID string, body string) (*api.Comment, error) {
	return &api.Comment{
		ID:        commentID,
		Body:      probeReformat(body),
		CreatedAt: p.created,
		UpdatedAt: p.created.Add(time.Hour),
	}, nil
}

func (p probeMutator) UpdateDocument(ctx context.Context, documentID string, input map[string]any) (*api.Document, error) {
	doc := p.doc
	doc.ID = documentID
	if v, ok := input["title"].(string); ok {
		doc.Title = v
	}
	if v, ok := input["content"].(string); ok {
		doc.Content = probeReformat(v)
	}
	doc.UpdatedAt = p.created.Add(time.Hour)
	return &doc, nil
}

func TestProbe387_CommentVerifyAfterDentryForget(t *testing.T) {
	mnt, root, lfs := probeMount(t)
	comments, err := lfs.repo.GetIssueComments(context.Background(), "issue-1")
	if err != nil || len(comments) == 0 {
		t.Fatalf("get comments: %v", err)
	}
	lfs.InjectTestMutationClient(probeMutator{
		Client:  mockmutation.New(mockmutation.WithTeamKey("TST"), mockmutation.WithStore(lfs.store)),
		created: comments[0].CreatedAt,
	})

	probeVerifyAcrossForget(t, root, probeCase{
		label:   "comment",
		dir:     filepath.Join(mnt, "teams", "TST", "issues", "TST-1", "comments"),
		relPath: []string{"teams", "TST", "issues", "TST-1", "comments"},
		edit: func(orig []byte) []byte {
			return []byte(strings.TrimRight(string(orig), "\n") + "\n\nverified read-back is what the`pin`holds\n")
		},
	})
}

func TestProbe387_DocumentVerifyAfterDentryForget(t *testing.T) {
	mnt, root, lfs := probeMount(t)
	docs, err := lfs.repo.GetIssueDocuments(context.Background(), "issue-1")
	if err != nil || len(docs) == 0 {
		t.Fatalf("get docs: %v", err)
	}
	lfs.InjectTestMutationClient(probeMutator{
		Client:  mockmutation.New(mockmutation.WithTeamKey("TST"), mockmutation.WithStore(lfs.store)),
		created: docs[0].CreatedAt,
		doc:     docs[0],
	})

	probeVerifyAcrossForget(t, root, probeCase{
		label:   "document",
		dir:     filepath.Join(mnt, "teams", "TST", "issues", "TST-1", "docs"),
		relPath: []string{"teams", "TST", "issues", "TST-1", "docs"},
		edit: func(orig []byte) []byte {
			return []byte(strings.TrimRight(string(orig), "\n") + "\n\nverified read-back is what the`pin`holds\n")
		},
	})
}

type probeCase struct {
	label   string
	dir     string
	relPath []string
	edit    func(orig []byte) []byte
}

// probeVerifyAcrossForget is the agent's write→verify cycle with a real dentry
// forget wedged in the middle.
func probeVerifyAcrossForget(t *testing.T, root *gofuse.Inode, c probeCase) {
	t.Helper()
	entries, err := os.ReadDir(c.dir)
	if err != nil {
		t.Fatalf("read %s dir: %v", c.label, err)
	}
	name := ""
	for _, e := range entries {
		if strings.HasSuffix(e.Name(), ".md") && !strings.HasPrefix(e.Name(), "_") {
			name = e.Name()
			break
		}
	}
	if name == "" {
		t.Fatalf("no %s .md under %s", c.label, c.dir)
	}
	path := filepath.Join(c.dir, name)

	orig, err := os.ReadFile(path)
	if err != nil {
		t.Fatalf("read %s: %v", c.label, err)
	}
	written := c.edit(orig)

	t.Logf("$ cat %s/%s", c.label+"s", name)
	t.Logf("%s", probeIndent(orig))
	t.Logf("$ printf %%s \"<edited>\" > %s      # the agent writes (%d bytes)", name, len(written))
	if err := os.WriteFile(path, written, 0o644); err != nil {
		t.Fatalf("write %s: %v", c.label, err)
	}

	// Force the forget, and confirm the node really died before verifying.
	parent := probeInode(t, root, c.relPath...)
	if errno := parent.NotifyEntry(name); errno != 0 {
		t.Fatalf("NotifyEntry(%s): %v", name, errno)
	}
	deadline := time.Now().Add(5 * time.Second)
	for parent.GetChild(name) != nil && time.Now().Before(deadline) {
		time.Sleep(20 * time.Millisecond)
	}
	if parent.GetChild(name) != nil {
		t.Fatalf("node for %s survived the forget; the probe would prove nothing", name)
	}
	t.Logf("$ # kernel forgot the dentry — the node is gone; the next access rebuilds it from what Linear stored")

	// The two verification syscalls an agent makes next. No retry: the point is
	// what the very next syscalls see.
	st, err := os.Stat(path)
	if err != nil {
		t.Fatalf("stat after forget: %v", err)
	}
	after, err := os.ReadFile(path)
	if err != nil {
		t.Fatalf("re-read after forget: %v", err)
	}

	t.Logf("$ stat -c %%s %s  -> %d   (agent expected %d)", name, st.Size(), len(written))
	t.Logf("$ cat %s | cmp - written -> %s", name,
		map[bool]string{true: "identical", false: "DIFFERS"}[bytes.Equal(after, written)])
	t.Logf("$ cat .error\n%s", probeIndent([]byte(probeErrorFile(c.dir))))
	t.Logf("read back:\n%s", probeIndent(after))

	ok := st.Size() == int64(len(written)) && bytes.Equal(after, written)
	t.Logf("agent verdict (%s): %s", c.label, map[bool]string{
		true:  "write verified byte-for-byte across the forget; the .error note is informational",
		false: "MISMATCH — byte-count mismatch reported on a write that fully succeeded (#387)",
	}[ok])

	if st.Size() != int64(len(written)) {
		t.Errorf("%s: stat size after forget = %d, want %d — %q", c.label, st.Size(), len(written),
			fmt.Sprintf("file is %d bytes on disk, expected %d ... may have silently truncated the write",
				st.Size(), len(written)))
	}
	if !bytes.Equal(after, written) {
		t.Errorf("%s: read-back after forget is not what was written\n--- wrote ---\n%q\n--- got ---\n%q",
			c.label, written, after)
	}
}

// probeMount builds a fixture-backed LinearFS, mounts it, and returns the mount
// path, the root inode (for the live go-fuse tree) and the filesystem.
func probeMount(t *testing.T) (string, *gofuse.Inode, *LinearFS) {
	t.Helper()
	ctx := context.Background()
	store := fixtures.NewTestSQLiteStore(t)
	if err := fixtures.PopulateTestData(ctx, store); err != nil {
		t.Fatalf("populate fixtures: %v", err)
	}
	if err := fixtures.PopulateComments(ctx, store, "issue-1", fixtures.FixtureAPIComments(3)); err != nil {
		t.Fatalf("populate comments: %v", err)
	}
	if err := fixtures.PopulateDocuments(ctx, store, []api.Document{fixtures.FixtureAPIIssueDocument("issue-1", 1)}); err != nil {
		t.Fatalf("populate documents: %v", err)
	}

	cfg := &config.Config{APIKey: "probe-key", Cache: config.CacheConfig{TTL: 100 * time.Millisecond}}
	lfs, err := NewLinearFS(cfg, false)
	if err != nil {
		t.Fatalf("new linearfs: %v", err)
	}
	offline := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
		w.WriteHeader(http.StatusServiceUnavailable)
		_, _ = w.Write([]byte(`{"errors":[{"message":"probe: offline"}]}`))
	}))
	t.Cleanup(offline.Close)
	lfs.SetTestAPIURL(offline.URL)
	if err := lfs.InjectTestStore(store); err != nil {
		t.Fatalf("inject store: %v", err)
	}

	mnt := t.TempDir()
	root := &RootNode{BaseNode: BaseNode{lfs: lfs}}
	lfs.mountPoint = mnt
	attrTimeout, entryTimeout := 60*time.Second, 30*time.Second
	server, err := gofuse.Mount(mnt, root, &gofuse.Options{
		AttrTimeout:  &attrTimeout,
		EntryTimeout: &entryTimeout,
	})
	if err != nil {
		t.Fatalf("mount: %v", err)
	}
	if err := server.WaitMount(); err != nil {
		t.Fatalf("wait mount: %v", err)
	}
	lfs.SetServer(server)
	t.Cleanup(func() {
		_ = server.Unmount()
		lfs.Close()
	})
	return mnt, root.EmbeddedInode(), lfs
}

// probeInode walks the live go-fuse inode tree the kernel is using.
func probeInode(t *testing.T, root *gofuse.Inode, segments ...string) *gofuse.Inode {
	t.Helper()
	in := root
	for _, seg := range segments {
		next := in.GetChild(seg)
		if next == nil {
			t.Fatalf("no live inode for %q while walking %v", seg, segments)
		}
		in = next
	}
	return in
}

func probeErrorFile(dir string) string {
	b, err := os.ReadFile(filepath.Join(dir, ".error"))
	if err != nil {
		return fmt.Sprintf("(no .error: %v)", err)
	}
	if len(bytes.TrimSpace(b)) == 0 {
		return "(empty — no error)"
	}
	return string(b)
}

func probeIndent(b []byte) string {
	lines := strings.Split(strings.TrimRight(string(b), "\n"), "\n")
	for i, l := range lines {
		lines[i] = "    | " + l
	}
	return strings.Join(lines, "\n")
}
```
</details>
- Outcome: ⚠️ 1 info across 1 run (15m31s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed ✅</summary>

- ⚠️ `internal/fs/editflush_test.go:161` - TestEditFlushZeroPinInoNeverPins still carries the pre-fix rationale: &#34;pinIno zero is a comment/doc/label/milestone .md: its Lookup does not call seedAuthored, so a pin would be bytes nobody can ever read&#34;. That is exactly the #387 bug this branch fixed, and seedAuthored no longer exists (also referenced at line 185). The invariant the test asserts is still valid, but its stated justification now directly contradicts the new TestEverySpecSetsPinIno rule and the updated CONTEXT.md/ARCHITECTURE.md — a future reader following this comment would conclude the four collection specs should have zero pinIno and regress the fix. Reword to the surviving rationale (&#34;zero pinIno is for a file nothing builds through newFileInode&#34;) and drop the seedAuthored references.
- ℹ️ `internal/fs/nodeattr.go:160` - The recognition seam is an anonymous interface literal duplicated verbatim in production (nodeattr.go:160) and in the test (editablewiring_test.go:49). Extracting `type editableFile interface{ editable() *editBuffer }` would remove the duplication and, more usefully, let the wiring be pinned at compile time (`var _ editableFile = (*CommentNode)(nil)` next to the existing `var _ fs.NodeWriter = ...` assertions each node already carries) instead of via a runtime map that must be hand-maintained. Related: `e.editable() == nil` at editablewiring_test.go:53 is unreachable — editable() returns the address of an embedded field and can never be nil.
- ℹ️ `CONTEXT.md:93` - Two new wiki-links do not match the file&#39;s existing link vocabulary. `[[node-attr]]` points at the section CONTEXT.md already links as `[[attr-construction]]` (used at line 721 for the same &#34;### Attr construction (`nodeAttr`/`attrNode`)&#34; heading), and `[[serve-your-own-writes]]` at line 766 has no corresponding `###` section at all — the concept lives under `[[edit-buffer]]`/`[[authored-pin]]`. In a doc whose stated purpose is &#34;one language&#34;, two aliases for one section is the drift it exists to prevent. Nothing enforces this automatically.
- ℹ️ `internal/fs/editbuffer.go:88` - Tradeoff note, not a defect: arming pins on four more surfaces widens an existing consequence. A pin is mount-wide and time-bounded, so for up to pinTTL (10s) after a committed comment/doc/label/milestone edit, ANY reader of that .md — including a different process — is served the writer&#39;s bytes while the .meta sidecar and SQLite hold Linear&#39;s normalized value. It also means editBuffer.Open&#39;s doc comment (&#34;Open ends any serve-your-own-writes window&#34;) is now weaker for seven files rather than three: a fresh Open clears the node flag, but the next Lookup inside the window re-seeds `authored` from the still-standing pin. This is the accepted #379 design extended, and integration tests already guard against cross-test pin bleed (atomicsave_pin_test.go:224), so no action is implied — flagging so the widened radius is a conscious call.

🔧 Fix: name editableFile seam, fix stale comments and links
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `internal/fs/invalidate.go:72` - Out of scope for this change, but worth knowing (identical on base and target): LinearFS&#39;s kernel-cache invalidation passes entity-hash inode numbers (StableAttr.Ino, e.g. commentIno) to fuse.Server.EntryNotify/InodeNotify, which expect the FUSE nodeid instead. go-fuse allocates nodeids from a separate sequential counter (fs/bridge.go: initInode(..., b.nextNodeId)), so those notifies almost certainly no-op. Observed directly while building the probe: lfs.InvalidateKernelEntry(&lt;dir st_ino&gt;, name) did not cause any re-Lookup or node rebuild, while go-fuse&#39;s own parentInode.NotifyEntry(name) dropped the node within milliseconds. Not a regression from this change and not something I chased further.
- <code>`go test ./...` — full suite, green (internal/integration 64.7s)</code>
- <code>`go test -race ./internal/fs/ -count=1` — green</code>
- <code>`go test ./internal/fs/ -run &#39;TestEverySpecSetsPinIno|TestEditFlush|TestSeed&#39; -v` — shipped wiring + pin unit tests</code>
- <code>Mutation check of the AST rule: deleted `pinIno: commentIno(...)` from internal/fs/comments.go → `TestEverySpecSetsPinIno` FAILs naming `comments.go:138:46`; restored → PASS</code>
- <code>End-to-end probe (temporary, since removed): mounted a fixture-backed LinearFS, wrote a comment .md and an issue doc .md through the mount with a fake that normalizes the stored body, forced a real kernel dentry forget via go-fuse `Inode.NotifyEntry`, asserted the node was actually dropped (`parent.GetChild(name) == nil`), then ran the agent&#39;s `stat` + read</code>
- <code>Control run of the same probe against base `e30150b` (`git checkout e30150b -- internal/fs`) → reproduces the #387 mismatch on both surfaces; restored to HEAD → both pass</code>
- <code>Verified all 7 editable node types carry `var _ editableFile` and that each surface&#39;s `pinIno` matches the ino passed to its `newFileInode` call (comments/documents/labels/milestones/issues/projects/initiatives)</code>
- <code>Cleanup verified: `git status --porcelain` empty, no stray linearfs test mounts in /proc/self/mounts, no leftover temp mount dirs</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `internal/fs/editbuffer_test.go:40` - golangci-lint (default linters, no repo config) reports 5 pre-existing errcheck violations in editbuffer_test.go (lines 40, 65, 99, 177, 219) for unchecked b.Write/b.Setattr/kept.Open returns. Not introduced by this change, in a file it does not touch; CI runs staticcheck + check-safename, not golangci-lint, so it is not a gate. Left unfixed because the only fix is editing tests, which this pass must not do.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
