### PR TITLE
test(integration): make live mode a declared property, and fix the two harness bugs behind it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,16 +76,31 @@ the test team is visible with a non-zero issue count, and fails setup rather tha
 letting an empty store become 300 unexplained test failures. A test team that
 genuinely has no issues fails here by design.
 
-Two interlocks decide which tests run, and they are inverses:
+Which mode a test runs in is declared in exactly one place —
+`internal/integration/modes_test.go` — and there are exactly three spellings:
 
-- `skipIfNoWriteTests` — needs `liveAPIMode` **and** `LINEARFS_WRITE_TESTS=1`. It
-  guards the tests that mutate a real workspace.
-- `skipIfLiveAPI` — skips when `liveAPIMode` is true. It guards the write-contract
-  tests that write *through the mount* to assert a structural invariant (#131,
-  #137, #140, #142). Those writes are inert offline but would hit a real workspace
-  live, and one of them (`TestMkdirIssueFailureIsLegible`) leaks an issue it cannot
-  clean up. Never convert one to the other: `skipIfNoWriteTests` on a fixture-mode
-  guard deletes it from the default offline suite, which is the only place it runs.
+- `skipIfNoWriteTests(t)` — needs `liveAPIMode` **and** `LINEARFS_WRITE_TESTS=1`.
+  It guards the tests that mutate a real workspace.
+- `skipIfLiveAPI(t, why)` — skips when `liveAPIMode` is true, printing `why` in
+  place of the test. It is the inverse interlock, and covers both kinds of
+  fixture dependence: the write-contract tests that write *through the mount* to
+  assert a structural invariant (#131, #137, #140, #142) — inert offline, but a
+  real mutation live, and `TestMkdirIssueFailureIsLegible` leaks an issue it
+  cannot clean up (`fixtureWriteContract`) — and the read tests that assert
+  against seeded rows like `TST-1` or `test-project` (`fixtureSeededData`).
+  Never convert one guard to the other: `skipIfNoWriteTests` on a fixture-mode
+  guard deletes it from the default offline suite, the only place it runs.
+- **no guard** — the test runs in every mode, and therefore may not name a
+  seeded row. Take the identifier from the workspace with `someIssueID(t)` /
+  `someProjectSlug(t)` (or their `…Dir` forms), which return the fixture's
+  `TST-1`/`test-project` offline and the first listed issue/project live.
+
+So `grep skipIf` over a test file answers "does this run live?" per test. #395
+is what the alternative costs: four files asserted seeded fixture data with no
+guard at all, and the first live dispatch of the write suite failed ~48 tests on
+`no such file or directory` — every one of them a hardcoded path, none a bug.
+A hardcode inside an `if err == nil` is the quieter form of the same defect: it
+does not fail live, it passes while asserting nothing.
 
 ## Claude Code Integration
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -601,8 +601,14 @@ a layer above the commit-tail primitives) and no telemetry (matching
 3. On valid input, calls the `MutationClient`. `classifyMutationErr`
    (`createcommit.go`) is the single owner of the failure model: bad input →
    `EINVAL`, over-length field → `EMSGSIZE`, missing reference → `ENOENT`,
-   rate-limit/timeout → `EAGAIN`, backend failure → `EIO` — reason always
-   written to `.error`.
+   rate-limit/timeout/interruption → `EAGAIN`, backend failure → `EIO` — reason
+   always written to `.error`. The `EAGAIN` branch splits its *message* on
+   `api.IsOutcomeUnknown`: a request refused before it was sent (budget
+   deferral, cancelled pre-send wait, tripped breaker) provably had no effect,
+   while one whose POST was already on the wire (`api.ErrInFlight`, set in the
+   client's transport-error path) may have been applied with the response lost,
+   so its `.error` tells the caller to CHECK before retrying rather than
+   promising a no-op (#399).
 4. **Read-your-writes** (`editcommit.go`): re-derives what persisted — an
    independent refetch where a single-entity getter exists (issues, projects,
    initiatives), otherwise the mutation's echoed response — normalizes benign
@@ -773,10 +779,13 @@ and `mockmutation`, the in-memory fake behind the `MutationClient` seam.
   link-changes are full-cycle-bounded.
 - **Error surfacing contract:** every writable surface has a `.error` sibling
   (and `.last` where entities are minted). Bad input → `EINVAL`, over-length →
-  `EMSGSIZE`, missing reference → `ENOENT`, rate-limited/timeout → `EAGAIN`,
-  backend failure → `EIO`; the reason always lands in `.error`, cleared on
-  success. A stale local catalog self-heals with one refresh-and-retry before
-  any of that surfaces.
+  `EMSGSIZE`, missing reference → `ENOENT`, rate-limited/timeout/interrupted →
+  `EAGAIN`, backend failure → `EIO`; the reason always lands in `.error`,
+  cleared on success. A stale local catalog self-heals with one refresh-and-retry
+  before any of that surfaces. One refinement the errno alone cannot carry, so
+  the `.error` text is load-bearing: an `EAGAIN` says whether the request was
+  refused before it was sent (safe to retry blindly) or interrupted in flight
+  (outcome unknown — check first, or duplicate) (#399).
 - **Time handling** is the most common footgun — both directions: parse reads
   via `ParseSQLiteTime*`, stamp writes via `db.Now()` (UTC). Inside the worker,
   scheduling goes through the injected clock seam.

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -202,7 +202,14 @@ CREATES AND MODIFIES REAL LINEAR DATA), and `make integration-tests` (both, in
 that order); the default `make test` needs no key and touches no network. The
 read-only target is read-only by enforcement, not convention: the write-contract
 guards that write through the mount now skip under a live key (`skipIfLiveAPI`),
-so a `-ro` run cannot leak a probe issue into the workspace. Live mode also opens
+so a `-ro` run cannot leak a probe issue into the workspace. #395 widened the set
+of tests that a `-ro` run reaches — the fixture-only read tests gained the guard,
+and the mount-level contract tests that had no guard now derive their issue and
+project from the workspace instead of hardcoding `TST-1` — without widening what
+it can do: those tests stat, read, and fsync clean handles (an fsync with no bytes
+written flushes an empty buffer, which every create surface no-ops on), and the
+only writes they attempt are the ones asserted to be *rejected* by a read-only
+`.meta` sidecar, which has no writer to reach the API with. Live mode also opens
 its SQLite cache in a per-run temp dir instead of `db.DefaultDBPath()`, so a
 developer's real `~/.config/linearfs/cache.db` — normally held open by a running
 linearfs service — is never written by a test run.

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -264,6 +265,16 @@ func (c *Client) query(ctx context.Context, query string, variables map[string]a
 			log.Printf("[circuit-breaker] opened after %d consecutive errors, cooling down %s", n, circuitBreakerCooldown)
 		}
 		queryErr = fmt.Errorf("failed to execute request: %w", err)
+		// The POST was already on the wire when its context ended, so whether
+		// Linear processed it is unknown — mark it so a caller's retry hint does
+		// not claim the operation had no effect (#399). Only a context death
+		// qualifies: every other Do() failure (DNS, refused connection) failed
+		// before the server could act. Note go-fuse's per-request context reports
+		// context.Canceled for a kernel FUSE INTERRUPT and never sets a deadline,
+		// so an interrupted syscall arrives here as Canceled, not DeadlineExceeded.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			queryErr = fmt.Errorf("%w (%w)", queryErr, ErrInFlight)
+		}
 		return queryErr
 	}
 	defer resp.Body.Close()

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -22,6 +22,24 @@ func IsDeferred(err error) bool {
 	return errors.Is(err, ErrDeferred) || errors.Is(err, ErrBudget)
 }
 
+// ErrInFlight marks a request whose HTTP POST had already been sent when its
+// context died — a cancelled or timed-out request, where the SERVER's view is
+// unknown: it may have processed the mutation and lost the response, or never
+// received it. Live example (#399): a mkdir interrupted mid-create logged
+// `Post "https://api.linear.app/graphql": context canceled`.
+//
+// It exists so a caller can tell that apart from the failures that provably
+// never reached Linear — a budget deferral, a cancelled pre-send rate-limit
+// wait, a tripped circuit breaker. All of them are retryable, but only the
+// pre-send ones can honestly say "the operation did not take effect", and a
+// retry of an in-flight create can duplicate the entity.
+var ErrInFlight = errors.New("request was in flight when its context ended; outcome unknown")
+
+// IsOutcomeUnknown reports whether err left the request's outcome genuinely
+// undetermined (see ErrInFlight). Callers phrasing a retry hint must not claim
+// the operation had no effect when this is true.
+func IsOutcomeUnknown(err error) bool { return errors.Is(err, ErrInFlight) }
+
 // Error predicates: the package-level classification of Linear API failures.
 //
 // Every layer above the client (fs mutation handlers, the repo's orphan

--- a/internal/fs/createcommit.go
+++ b/internal/fs/createcommit.go
@@ -203,7 +203,16 @@ func classifyMutationErr(op string, err error) (string, syscall.Errno) {
 		return ferr.Detail(), syscall.EINVAL
 	}
 	if retryableCreateErr(err) {
-		return "Operation: " + op + "\nError: the request was rate-limited or timed out before it completed, so the operation did not take effect. Wait a few seconds and retry.", syscall.EAGAIN
+		// Both are EAGAIN — retry is the right move either way — but they cannot
+		// make the same promise. A request that never left (budget deferral,
+		// cancelled pre-send wait, tripped breaker) provably had no effect. One
+		// that died mid-flight may have been processed with the response lost, so
+		// claiming "did not take effect" there is a guess the caller acts on: a
+		// retry of an in-flight create can duplicate the entity (#399).
+		if api.IsOutcomeUnknown(err) {
+			return "Operation: " + op + "\nError: the request was interrupted after it was sent, so whether it took effect is UNKNOWN — it may have been applied and the response lost. Wait a few seconds, then CHECK whether the entity exists (read the directory listing, or .last) before retrying: a blind retry can create a duplicate.", syscall.EAGAIN
+		}
+		return "Operation: " + op + "\nError: the request was rate-limited or deferred before it was sent, so the operation did not take effect. Wait a few seconds and retry.", syscall.EAGAIN
 	}
 	// A structured Linear input rejection (userError: true) is the caller's
 	// bad input, not a backend failure: EINVAL, preferring the server's

--- a/internal/fs/createcommit_test.go
+++ b/internal/fs/createcommit_test.go
@@ -3,9 +3,12 @@ package fs
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"syscall"
 	"testing"
+
+	"github.com/jra3/linear-fuse/internal/api"
 )
 
 // fakeCreateSink records every interaction the create tail can have so a test
@@ -124,6 +127,23 @@ func TestCommitCreate_Classification(t *testing.T) {
 			err:       errors.New("rate limit exceeded"),
 			wantErrno: syscall.EAGAIN,
 			wantIn:    "rate-limited",
+		},
+		{
+			// #399: a request cancelled AFTER the POST went out is still EAGAIN,
+			// but its outcome is genuinely unknown — Linear may have applied it
+			// and lost the response. The .error must say so, because the caller's
+			// next move differs: check before retrying, or risk a duplicate.
+			name:      "in-flight cancellation is EAGAIN but does not claim no-effect",
+			err:       fmt.Errorf("failed to execute request: %w (%w)", context.Canceled, api.ErrInFlight),
+			wantErrno: syscall.EAGAIN,
+			wantIn:    "UNKNOWN",
+		},
+		{
+			// The pre-send twin, for contrast: this one CAN promise no effect.
+			name:      "pre-send deferral says the operation did not take effect",
+			err:       fmt.Errorf("deferred: %w", api.ErrDeferred),
+			wantErrno: syscall.EAGAIN,
+			wantIn:    "did not take effect",
 		},
 		{
 			name:      "anything else is EIO carrying the cause",

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -325,7 +325,11 @@ Failure model (every writable surface follows this contract):
 - Bad input (invalid field, unknown name, missing required field) -> EINVAL
 - A field longer than its limit (e.g. a too-long name) -> EMSGSIZE
 - Reference to something that doesn't exist (a relation target, rm of an unknown name) -> ENOENT
-- Rate-limited or timed out (the write did not take effect; retry shortly) -> EAGAIN
+- Rate-limited, deferred, or interrupted -> EAGAIN, retry shortly. Read .error to
+  see WHICH: a request refused before it was sent "did not take effect" and is
+  safe to retry blindly; one "interrupted after it was sent" has an UNKNOWN
+  outcome — check whether the entity exists (listing, or .last) before retrying,
+  or you may create a duplicate.
 - Backend/API failure -> EIO
 - A mutation Linear accepted but whose local reflection fails after retries ->
   EIO, and the .error names the SAFE RECOVERY. For a create it NAMES the entity

--- a/internal/integration/assignee_shadow_test.go
+++ b/internal/integration/assignee_shadow_test.go
@@ -23,9 +23,7 @@ import (
 // (DisplayName "unassigned"), TST-90 assigned to it, TST-91 genuinely
 // unassigned.
 func TestAssigneeUnassignedNotShadowed(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode: asserts the seeded hostile 'unassigned' member")
-	}
+	skipIfLiveAPI(t, "fixture-mode: asserts the seeded hostile 'unassigned' member")
 
 	const (
 		escapedBucket   = "unassigned-user-shadow" // safeName("unassigned", "user-shadow")

--- a/internal/integration/atomicsave_pin_test.go
+++ b/internal/integration/atomicsave_pin_test.go
@@ -56,9 +56,7 @@ func atomicSave(t *testing.T, path string, content []byte) {
 // markdown was reformatted — reported the successful write as possible silent
 // truncation.
 func TestOffline_AtomicSaveVerifyAfterReformatNote(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode check; needs the mock mutator's reformat-on-store")
-	}
+	skipIfLiveAPI(t, "fixture-mode check; needs the mock mutator's reformat-on-store")
 	enableMockMutations(t, mockmutation.WithBodyReformat(codeSpanReformat))
 
 	// Throwaway issue: the atomic save consumes a scratch node, so the shared
@@ -132,9 +130,7 @@ func TestOffline_AtomicSaveVerifyAfterReformatNote(t *testing.T) {
 // show the SHORT stored body, not the bytes the client wrote. A pin taken on EIO
 // would echo the full text back and hide the loss behind a byte-for-byte match.
 func TestOffline_AtomicSaveDoesNotPinOverRealDataLoss(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode check; needs the mock mutator's reformat-on-store")
-	}
+	skipIfLiveAPI(t, "fixture-mode check; needs the mock mutator's reformat-on-store")
 	const kept = "refresh-retry probe body"
 	// Keep a prefix rather than reverting to the previous body, so the write-back
 	// check classifies this as truncation and not as the (also fatal) silent
@@ -198,9 +194,7 @@ func TestOffline_AtomicSaveDoesNotPinOverRealDataLoss(t *testing.T) {
 // issue path would leave these two reading back Linear's render — the same
 // false-truncation signal, on project.md and initiative.md.
 func TestOffline_AtomicSaveServesWrittenBytesForProjectAndInitiative(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode check; needs the mock mutator's reformat-on-store")
-	}
+	skipIfLiveAPI(t, "fixture-mode check; needs the mock mutator's reformat-on-store")
 	enableMockMutations(t, mockmutation.WithBodyReformat(codeSpanReformat))
 
 	initiativeDir, err := firstInitiativeDir()

--- a/internal/integration/attr_conformance_test.go
+++ b/internal/integration/attr_conformance_test.go
@@ -12,9 +12,12 @@ import (
 // DocsNode/AttachmentsNode.Getattr returned time.Now(), so these stats drifted
 // off the issue and reshuffled on every call. The check is fixture-agnostic: it
 // only asserts each subdir agrees with the issue's own mtime (issue.md, whose
-// mtime is updatedAt), so it holds whatever the fixture's timestamps are.
+// mtime is updatedAt), so it holds whatever the issue's timestamps are — which
+// is why it takes its issue from someIssueID and runs live too. It used to
+// hardcode TST-1 and so failed every live run on a path that did not exist
+// (#395), asserting nothing about attrs on the way.
 func TestIssueSubdirsReportIssueTimes(t *testing.T) {
-	const issueID = "TST-1"
+	issueID := someIssueID(t)
 
 	issueInfo, err := os.Stat(issueFilePath(testTeamKey, issueID))
 	if err != nil {
@@ -53,7 +56,7 @@ func TestIssueSubdirsReportIssueTimes(t *testing.T) {
 // reshuffled `ls -lt`. This is the observable form of "a Lookup answer and a
 // later stat can never disagree".
 func TestIssueSubdirStatIsDeterministic(t *testing.T) {
-	base := issueDirPath(testTeamKey, "TST-1")
+	base := someIssueDir(t)
 	for _, name := range []string{"docs", "attachments", "comments", "relations"} {
 		t.Run(name, func(t *testing.T) {
 			path := filepath.Join(base, name)

--- a/internal/integration/claude_tools_test.go
+++ b/internal/integration/claude_tools_test.go
@@ -149,11 +149,14 @@ func firstInitiativeDir() (string, error) {
 	return "", fmt.Errorf("no initiative directory found")
 }
 
-// TestClaudeToolFsyncSupportedOnWritableFiles is the core #139 regression guard.
-// It runs in the default fixture mode (no API key, no network): for each kind of
-// writable file Claude's Edit tool touches, it verifies fsync does not return
-// ENOTSUP. Opening without writing keeps the node clean (dirty=false), so close
-// is a no-op and no API call is made.
+// TestClaudeToolFsyncSupportedOnWritableFiles is the core #139 regression guard:
+// for each kind of writable file Claude's Edit tool touches, it verifies fsync
+// does not return ENOTSUP. Opening without writing keeps the node clean
+// (dirty=false), so close is a no-op and no API call is made — which is what
+// makes it safe to run under a live key as well as in fixture mode. It takes its
+// issue and project from someIssueID/someProjectSlug for exactly that reason;
+// the old hardcoded TST-1 made a mount-level contract fixture-only by accident
+// (#395). A surface the workspace has no instance of skips, and says so.
 func TestClaudeToolFsyncSupportedOnWritableFiles(t *testing.T) {
 	cases := []struct {
 		name string
@@ -161,12 +164,12 @@ func TestClaudeToolFsyncSupportedOnWritableFiles(t *testing.T) {
 	}{
 		{
 			name: "issue.md",
-			path: func(t *testing.T) string { return issueFilePath(testTeamKey, "TST-1") },
+			path: func(t *testing.T) string { return issueFilePath(testTeamKey, someIssueID(t)) },
 		},
 		{
 			name: "project.md",
 			path: func(t *testing.T) string {
-				return filepath.Join(projectsPath(testTeamKey), "test-project", "project.md")
+				return projectFilePath(testTeamKey, someProjectSlug(t))
 			},
 		},
 		{
@@ -174,7 +177,7 @@ func TestClaudeToolFsyncSupportedOnWritableFiles(t *testing.T) {
 			path: func(t *testing.T) string {
 				dir, err := firstInitiativeDir()
 				if err != nil {
-					t.Skipf("no initiative fixture: %v", err)
+					t.Skipf("no initiative in workspace: %v", err)
 				}
 				return filepath.Join(dir, "initiative.md")
 			},
@@ -182,9 +185,9 @@ func TestClaudeToolFsyncSupportedOnWritableFiles(t *testing.T) {
 		{
 			name: "comment",
 			path: func(t *testing.T) string {
-				p, err := firstWritableFile(commentsPath(testTeamKey, "TST-1"))
+				p, err := firstWritableFile(commentsPath(testTeamKey, someIssueID(t)))
 				if err != nil {
-					t.Skipf("no comment fixture: %v", err)
+					t.Skipf("no comment on the picked issue: %v", err)
 				}
 				return p
 			},
@@ -194,7 +197,7 @@ func TestClaudeToolFsyncSupportedOnWritableFiles(t *testing.T) {
 			path: func(t *testing.T) string {
 				p, err := firstWritableFile(labelsPath(testTeamKey))
 				if err != nil {
-					t.Skipf("no label fixture: %v", err)
+					t.Skipf("no label in workspace: %v", err)
 				}
 				return p
 			},
@@ -202,9 +205,9 @@ func TestClaudeToolFsyncSupportedOnWritableFiles(t *testing.T) {
 		{
 			name: "document",
 			path: func(t *testing.T) string {
-				p, err := firstWritableFile(docsPath(testTeamKey, "TST-1"))
+				p, err := firstWritableFile(docsPath(testTeamKey, someIssueID(t)))
 				if err != nil {
-					t.Skipf("no document fixture: %v", err)
+					t.Skipf("no document on the picked issue: %v", err)
 				}
 				return p
 			},
@@ -228,13 +231,17 @@ func TestClaudeToolFsyncSupportedOnWritableFiles(t *testing.T) {
 // write-only _create trigger files (#142 contract item 1). Editors that
 // write-then-fsync must be able to save through a _create file; fsync must
 // never return ENOTSUP. _create is mode 0200, so it is opened write-only.
+//
+// Live-safe, and run live: the handle is closed without a byte written, and
+// createFileNode.Flush no-ops on an empty buffer, so nothing is created.
 func TestWriteContractFsyncOnCreateFiles(t *testing.T) {
+	issueID := someIssueID(t)
 	cases := []struct {
 		name string
 		path string
 	}{
-		{"comments/_create", newCommentPath(testTeamKey, "TST-1")},
-		{"docs/_create", newDocPath(testTeamKey, "TST-1")},
+		{"comments/_create", newCommentPath(testTeamKey, issueID)},
+		{"docs/_create", newDocPath(testTeamKey, issueID)},
 		{"labels/_create", filepath.Join(labelsPath(testTeamKey), "_create")},
 	}
 	for _, tc := range cases {
@@ -260,7 +267,7 @@ func TestWriteContractFsyncOnCreateFiles(t *testing.T) {
 // failure mode. In fixture mode the rename itself may not succeed (no API), but
 // the target document node must remain readable either way.
 func TestWriteContractAtomicRenameNoCorruption(t *testing.T) {
-	skipIfLiveAPI(t)
+	skipIfLiveAPI(t, fixtureWriteContract)
 
 	target, err := firstWritableFile(docsPath(testTeamKey, "TST-1"))
 	if err != nil {
@@ -306,7 +313,7 @@ func TestWriteContractAtomicRenameNoCorruption(t *testing.T) {
 // itself may fail in fixture mode (no live API), but it must never leave the
 // target unreadable/corrupted.
 func TestWriteContractAtomicRenameCreateNoEROFS(t *testing.T) {
-	skipIfLiveAPI(t)
+	skipIfLiveAPI(t, fixtureWriteContract)
 
 	cases := []struct {
 		name    string
@@ -395,6 +402,10 @@ func TestWriteContractAtomicRenameCreateNoEROFS(t *testing.T) {
 // *populates* it is covered by TestWriteInvalidInputIsLoud and
 // TestMkdirIssueFailureIsLegible. (Emptiness is not asserted: in the shared-mount
 // suite another test may have left a collection .error populated.)
+//
+// Pure reads, so it runs live too, off someIssueID/someProjectSlug — the .error
+// surface is a mount-level contract and has nothing to do with which issue it is
+// read from. Hardcoding TST-1 kept it out of every live run (#395).
 func TestErrorFileExposedOnWritableSurfaces(t *testing.T) {
 	cases := []struct {
 		name string
@@ -402,31 +413,29 @@ func TestErrorFileExposedOnWritableSurfaces(t *testing.T) {
 	}{
 		{
 			name: "issue",
-			dir:  func(t *testing.T) string { return issueDirPath(testTeamKey, "TST-1") },
+			dir:  func(t *testing.T) string { return someIssueDir(t) },
 		},
 		{
 			name: "project",
-			dir: func(t *testing.T) string {
-				return filepath.Join(projectsPath(testTeamKey), "test-project")
-			},
+			dir:  func(t *testing.T) string { return someProjectDir(t) },
 		},
 		{
 			name: "initiative",
 			dir: func(t *testing.T) string {
 				dir, err := firstInitiativeDir()
 				if err != nil {
-					t.Skipf("no initiative fixture: %v", err)
+					t.Skipf("no initiative in workspace: %v", err)
 				}
 				return dir
 			},
 		},
 		{
 			name: "comments",
-			dir:  func(t *testing.T) string { return commentsPath(testTeamKey, "TST-1") },
+			dir:  func(t *testing.T) string { return commentsPath(testTeamKey, someIssueID(t)) },
 		},
 		{
 			name: "docs",
-			dir:  func(t *testing.T) string { return docsPath(testTeamKey, "TST-1") },
+			dir:  func(t *testing.T) string { return docsPath(testTeamKey, someIssueID(t)) },
 		},
 		{
 			name: "labels",
@@ -435,21 +444,21 @@ func TestErrorFileExposedOnWritableSurfaces(t *testing.T) {
 		{
 			name: "milestones",
 			dir: func(t *testing.T) string {
-				dir := filepath.Join(projectsPath(testTeamKey), "test-project", "milestones")
+				dir := filepath.Join(someProjectDir(t), "milestones")
 				if _, err := os.Stat(dir); err != nil {
-					t.Skipf("no milestones fixture: %v", err)
+					t.Skipf("no milestones dir on the picked project: %v", err)
 				}
 				return dir
 			},
 		},
 		{
 			name: "attachments",
-			dir:  func(t *testing.T) string { return attachmentsPath(testTeamKey, "TST-1") },
+			dir:  func(t *testing.T) string { return attachmentsPath(testTeamKey, someIssueID(t)) },
 		},
 		{
 			name: "relations",
 			dir: func(t *testing.T) string {
-				dir := filepath.Join(issueDirPath(testTeamKey, "TST-1"), "relations")
+				dir := filepath.Join(someIssueDir(t), "relations")
 				if _, err := os.Stat(dir); err != nil {
 					t.Skipf("no relations dir: %v", err)
 				}
@@ -474,7 +483,7 @@ func TestErrorFileExposedOnWritableSurfaces(t *testing.T) {
 // silent success. The unknown-initiative check resolves against local SQLite,
 // so this runs in fixture mode with no network.
 func TestWriteInvalidInputIsLoud(t *testing.T) {
-	skipIfLiveAPI(t)
+	skipIfLiveAPI(t, fixtureWriteContract)
 
 	dir := filepath.Join(projectsPath(testTeamKey), "test-project")
 	path := filepath.Join(dir, "project.md")
@@ -518,7 +527,7 @@ func TestMkdirIssueFailureIsLegible(t *testing.T) {
 	// Before the mkdir, not after: under a live key this creates a real issue, and
 	// the cleanup below cannot remove it — IssuesNode.Rmdir resolves by
 	// issue.Identifier, never by the typed directory name, so the probe leaks.
-	skipIfLiveAPI(t)
+	skipIfLiveAPI(t, fixtureWriteContract)
 
 	newIssueDir := filepath.Join(issuesPath(testTeamKey), "Mkdir Legibility Probe")
 
@@ -543,7 +552,7 @@ func TestMkdirIssueFailureIsLegible(t *testing.T) {
 // that returns EACCES on every subsequent read. Runs in fixture mode: the write
 // itself won't persist (no API), but the node must stay a real document node.
 func TestOverwriteDocKeepsNodeReadable(t *testing.T) {
-	skipIfLiveAPI(t)
+	skipIfLiveAPI(t, fixtureWriteContract)
 
 	docPath, err := firstWritableFile(docsPath(testTeamKey, "TST-1"))
 	if err != nil {
@@ -655,36 +664,47 @@ func TestReadYourWritesLargeBody(t *testing.T) {
 	}
 }
 
+// createTestProject creates a throwaway project via mkdir and returns its slug
+// plus an archiving cleanup. Tests that mutate a project body use this instead of
+// editing whatever project the workspace happens to have: the edit-then-restore
+// idiom cannot restore an originally-EMPTY body, because Linear ignores an empty
+// `content` (#398). Editing a borrowed project therefore left a `linearfs-smoke-`
+// marker in a real project's description permanently. A project the test owns is
+// archived at the end, so nothing needs restoring.
+func createTestProject(t *testing.T, name string) (slug string, cleanup func()) {
+	t.Helper()
+	rateLimitWait()
+
+	title := fmt.Sprintf("[TEST] %s %d", name, time.Now().UnixMilli())
+	if err := os.Mkdir(filepath.Join(projectsPath(testTeamKey), title), 0o755); err != nil {
+		t.Fatalf("create test project %q: %v", title, err)
+	}
+	last := lastEntryByTitle(t, filepath.Join(projectsPath(testTeamKey), ".last"), title)
+	if last == nil || last["path"] == "" {
+		t.Fatalf("projects/.last has no addressable entry for %q; cannot address the new project", title)
+	}
+	slug = last["path"]
+	return slug, func() {
+		if err := os.Remove(filepath.Join(projectsPath(testTeamKey), slug)); err != nil {
+			t.Logf("archive test project %s: %v (it will linger in the workspace)", slug, err)
+		}
+	}
+}
+
 // TestClaudeToolEditPersistsProjectDescription covers the second half of #139:
 // a write+fsync to project.md must actually persist the description to Linear.
-// It edits a real project and restores it, so it requires live-API write mode.
+// It writes to a project it creates and archives, so it requires live-API write
+// mode — and so it never has to restore a body Linear cannot clear (#398).
 func TestClaudeToolEditPersistsProjectDescription(t *testing.T) {
 	skipIfNoWriteTests(t)
 
-	projectsDir := projectsPath(testTeamKey)
-	entries, err := os.ReadDir(projectsDir)
-	if err != nil {
-		t.Fatalf("read projects dir: %v", err)
-	}
+	slug, cleanup := createTestProject(t, "Edit Persistence")
+	defer cleanup()
 
-	var path string
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		candidate := filepath.Join(projectsDir, e.Name(), "project.md")
-		if _, err := os.Stat(candidate); err == nil {
-			path = candidate
-			break
-		}
-	}
-	if path == "" {
-		t.Skip("no project with project.md in test team; skipping persistence test")
-	}
-
-	orig, err := os.ReadFile(path)
+	path := projectFilePath(testTeamKey, slug)
+	orig, err := readFileWithRetry(path, defaultWaitTime)
 	if err != nil {
-		t.Fatalf("read original project.md: %v", err)
+		t.Fatalf("read new project.md: %v", err)
 	}
 
 	// Emulate Claude's Edit tool: append a unique marker to the description body
@@ -692,9 +712,6 @@ func TestClaudeToolEditPersistsProjectDescription(t *testing.T) {
 	marker := fmt.Sprintf("linearfs-smoke-%d", time.Now().UnixNano())
 	edited := append([]byte(strings.TrimRight(string(orig), "\n")), []byte("\n\n"+marker+"\n")...)
 	claudeToolWrite(t, path, edited)
-
-	// Restore the original description regardless of the assertion outcome.
-	defer claudeToolWrite(t, path, orig)
 
 	waitForCacheExpiry()
 

--- a/internal/integration/edit_persist_test.go
+++ b/internal/integration/edit_persist_test.go
@@ -30,9 +30,7 @@ import (
 // — and it guards the whole-entity round trip through the edit-commit tail, not
 // just the single edited field.
 func TestOffline_MilestoneEditPreservesOtherFields(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline edit-persistence check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline edit-persistence check; uses the mock mutator")
 	enableMockMutations(t)
 
 	path := filepath.Join(projectsPath(testTeamKey), "test-project", "milestones", "Alpha Release.md")
@@ -82,9 +80,7 @@ func TestOffline_MilestoneEditPreservesOtherFields(t *testing.T) {
 // inline Flush persists and the consumed scratch re-Looks-up to the fresh
 // store-backed node, so the mount serves the edit back.
 func TestOffline_AtomicRenameEditPersists(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline edit-persistence check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline edit-persistence check; uses the mock mutator")
 	enableMockMutations(t)
 
 	// Operate on a throwaway issue (unique per run), never the shared TST-1
@@ -149,9 +145,7 @@ func TestOffline_AtomicRenameEditPersists(t *testing.T) {
 // real Linear applies), so persisted is a byte shorter than written — without the
 // pin the stat below reports that shorter size.
 func TestOffline_AtomicSaveServesTheWrittenBytes(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode check; needs the mock mutator's reformat-on-store")
-	}
+	skipIfLiveAPI(t, "fixture-mode check; needs the mock mutator's reformat-on-store")
 	enableMockMutations(t, mockmutation.WithBodyReformat(func(body string) string {
 		return strings.ReplaceAll(body, "\n\n\n", "\n\n")
 	}))
@@ -213,9 +207,7 @@ func TestOffline_AtomicSaveServesTheWrittenBytes(t *testing.T) {
 // write+fsync to project.md must persist the edited body, so the mount serves it
 // back — and the untouched name survives the round trip.
 func TestOffline_ProjectEditPersistsDescription(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline edit-persistence check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline edit-persistence check; uses the mock mutator")
 	enableMockMutations(t)
 
 	path := projectMDPath()
@@ -287,9 +279,7 @@ func mdFileContaining(t *testing.T, dir, marker string) string {
 // comment Update had zero persistence coverage (only marshal round-trips and
 // live-API create/delete lifecycle tests existed).
 func TestOffline_CommentBodyEditPersists(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline edit-persistence check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline edit-persistence check; uses the mock mutator")
 	enableMockMutations(t)
 
 	dir := commentsPath(testTeamKey, "TST-1")
@@ -348,9 +338,7 @@ func contains(ss []string, want string) bool {
 // list back. The junction bumps no updatedAt (b642867), so this through-the-mount
 // round trip is the only offline guard that link/unlink actually persist.
 func TestOffline_InitiativeProjectLinkPersists(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline edit-persistence check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline edit-persistence check; uses the mock mutator")
 	enableMockMutations(t)
 
 	dir, err := firstInitiativeDir()
@@ -402,9 +390,7 @@ func TestOffline_InitiativeProjectLinkPersists(t *testing.T) {
 // initiative<->project junction that TestOffline_InitiativeProjectLinkPersists
 // drives from the initiative side.
 func TestOffline_ProjectInitiativesLinkPersists(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline edit-persistence check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline edit-persistence check; uses the mock mutator")
 	enableMockMutations(t)
 
 	path := projectMDPath()
@@ -467,9 +453,7 @@ func TestOffline_ProjectInitiativesLinkPersists(t *testing.T) {
 // name field (TestOffline_ProjectEditPersistsDescription covers the body). The
 // edited name must land and read back.
 func TestOffline_ProjectNameEditPersists(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline edit-persistence check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline edit-persistence check; uses the mock mutator")
 	enableMockMutations(t)
 
 	path := projectMDPath()
@@ -508,9 +492,7 @@ func TestOffline_ProjectNameEditPersists(t *testing.T) {
 // editable name field (the body is covered by
 // TestOffline_InitiativeEditPersistsDescription).
 func TestOffline_InitiativeNameEditPersists(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline edit-persistence check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline edit-persistence check; uses the mock mutator")
 	enableMockMutations(t)
 
 	dir, err := firstInitiativeDir()
@@ -556,9 +538,7 @@ func TestOffline_InitiativeNameEditPersists(t *testing.T) {
 // page-cache echo, not that the edit reached the store — this is the fixture-mode
 // persistence twin (mutate → upsert → read-your-writes adopt).
 func TestOffline_DocumentBodyAndTitleEditPersist(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline edit-persistence check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline edit-persistence check; uses the mock mutator")
 	enableMockMutations(t)
 
 	dir := docsPath(testTeamKey, "TST-1")
@@ -612,9 +592,7 @@ func TestOffline_DocumentBodyAndTitleEditPersist(t *testing.T) {
 // mount and asserts both land while the untouched title survives — the whole-entity
 // round trip through the edit-commit tail (mutate → verify GetIssue → upsert → adopt).
 func TestOffline_IssueFieldEditsPersist(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline edit-persistence check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline edit-persistence check; uses the mock mutator")
 	enableMockMutations(t)
 
 	path := issueFilePath(testTeamKey, "TST-1")
@@ -673,9 +651,7 @@ func TestOffline_IssueFieldEditsPersist(t *testing.T) {
 // initiative.md persists the edited body through the mock mutator, and the
 // untouched name survives the round trip.
 func TestOffline_InitiativeEditPersistsDescription(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline edit-persistence check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline edit-persistence check; uses the mock mutator")
 	enableMockMutations(t)
 
 	dir, err := firstInitiativeDir()

--- a/internal/integration/fixture_extended_test.go
+++ b/internal/integration/fixture_extended_test.go
@@ -1,5 +1,10 @@
 package integration
 
+// The second half of the fixture read surface — cycles, initiatives, labels, the
+// by/ filters, users, children, attachments. Same contract as
+// fixture_read_test.go: every test asserts against seeded rows, so every test
+// carries skipIfLiveAPI(t, fixtureSeededData) (#395).
+
 import (
 	"os"
 	"path/filepath"
@@ -12,6 +17,7 @@ import (
 // =============================================================================
 
 func TestFixtureCyclesDirectoryExists(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	cyclesPath := filepath.Join(teamPath(testTeamKey), "cycles")
 	info, err := os.Stat(cyclesPath)
 	if err != nil {
@@ -23,6 +29,7 @@ func TestFixtureCyclesDirectoryExists(t *testing.T) {
 }
 
 func TestFixtureCyclesDirectoryListing(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	cyclesPath := filepath.Join(teamPath(testTeamKey), "cycles")
 	entries, err := os.ReadDir(cyclesPath)
 	if err != nil {
@@ -36,6 +43,7 @@ func TestFixtureCyclesDirectoryListing(t *testing.T) {
 }
 
 func TestFixtureCycleDirectoryContents(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	cyclesPath := filepath.Join(teamPath(testTeamKey), "cycles")
 	entries, err := os.ReadDir(cyclesPath)
 	if err != nil {
@@ -71,6 +79,7 @@ func TestFixtureCycleDirectoryContents(t *testing.T) {
 // =============================================================================
 
 func TestFixtureInitiativesDirectoryExists(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	info, err := os.Stat(initiativesPath())
 	if err != nil {
 		t.Fatalf("Failed to stat initiatives directory: %v", err)
@@ -81,6 +90,7 @@ func TestFixtureInitiativesDirectoryExists(t *testing.T) {
 }
 
 func TestFixtureInitiativesDirectoryListing(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(initiativesPath())
 	if err != nil {
 		t.Fatalf("Failed to read initiatives directory: %v", err)
@@ -93,6 +103,7 @@ func TestFixtureInitiativesDirectoryListing(t *testing.T) {
 }
 
 func TestFixtureInitiativeDirectoryContents(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(initiativesPath())
 	if err != nil {
 		t.Fatalf("Failed to read initiatives directory: %v", err)
@@ -129,6 +140,7 @@ func TestFixtureInitiativeDirectoryContents(t *testing.T) {
 }
 
 func TestFixtureInitiativeInfoFile(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(initiativesPath())
 	if err != nil {
 		t.Fatalf("Failed to read initiatives directory: %v", err)
@@ -162,6 +174,7 @@ func TestFixtureInitiativeInfoFile(t *testing.T) {
 // =============================================================================
 
 func TestFixtureLabelsDirectoryExists(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	info, err := os.Stat(labelsPath(testTeamKey))
 	if err != nil {
 		t.Fatalf("Failed to stat labels directory: %v", err)
@@ -172,6 +185,7 @@ func TestFixtureLabelsDirectoryExists(t *testing.T) {
 }
 
 func TestFixtureLabelsDirectoryListing(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(labelsPath(testTeamKey))
 	if err != nil {
 		t.Fatalf("Failed to read labels directory: %v", err)
@@ -184,6 +198,7 @@ func TestFixtureLabelsDirectoryListing(t *testing.T) {
 }
 
 func TestFixtureLabelFileContents(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(labelsPath(testTeamKey))
 	if err != nil {
 		t.Fatalf("Failed to read labels directory: %v", err)
@@ -235,6 +250,7 @@ func TestFixtureLabelFileContents(t *testing.T) {
 // =============================================================================
 
 func TestFixtureByAssigneeDirectoryExists(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	info, err := os.Stat(byAssigneePath(testTeamKey))
 	if err != nil {
 		t.Fatalf("Failed to stat by/assignee directory: %v", err)
@@ -245,6 +261,7 @@ func TestFixtureByAssigneeDirectoryExists(t *testing.T) {
 }
 
 func TestFixtureByAssigneeListing(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(byAssigneePath(testTeamKey))
 	if err != nil {
 		t.Fatalf("Failed to read by/assignee directory: %v", err)
@@ -257,6 +274,7 @@ func TestFixtureByAssigneeListing(t *testing.T) {
 }
 
 func TestFixtureByLabelDirectoryExists(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	info, err := os.Stat(byLabelPath(testTeamKey))
 	if err != nil {
 		t.Fatalf("Failed to stat by/label directory: %v", err)
@@ -267,6 +285,7 @@ func TestFixtureByLabelDirectoryExists(t *testing.T) {
 }
 
 func TestFixtureByLabelListing(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(byLabelPath(testTeamKey))
 	if err != nil {
 		t.Fatalf("Failed to read by/label directory: %v", err)
@@ -279,6 +298,7 @@ func TestFixtureByLabelListing(t *testing.T) {
 }
 
 func TestFixtureByLabelContainsIssues(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	// TST-4 has Bug label
 	bugPath := filepath.Join(byLabelPath(testTeamKey), "Bug")
 	entries, err := os.ReadDir(bugPath)
@@ -299,6 +319,7 @@ func TestFixtureByLabelContainsIssues(t *testing.T) {
 }
 
 func TestFixtureUnassignedDirectoryExists(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	unassignedPath := filepath.Join(byAssigneePath(testTeamKey), "unassigned")
 	info, err := os.Stat(unassignedPath)
 	if err != nil {
@@ -310,6 +331,7 @@ func TestFixtureUnassignedDirectoryExists(t *testing.T) {
 }
 
 func TestFixtureUnassignedContainsIssues(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	// TST-7 is unassigned
 	unassignedPath := filepath.Join(byAssigneePath(testTeamKey), "unassigned")
 	entries, err := os.ReadDir(unassignedPath)
@@ -334,6 +356,7 @@ func TestFixtureUnassignedContainsIssues(t *testing.T) {
 // =============================================================================
 
 func TestFixtureIssueChildrenDirectoryExists(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	// TST-1 is parent of TST-2
 	childrenPath := filepath.Join(issueDirPath(testTeamKey, "TST-1"), "children")
 	info, err := os.Stat(childrenPath)
@@ -346,6 +369,7 @@ func TestFixtureIssueChildrenDirectoryExists(t *testing.T) {
 }
 
 func TestFixtureIssueChildrenContainsChild(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	// TST-1 is parent of TST-2
 	childrenPath := filepath.Join(issueDirPath(testTeamKey, "TST-1"), "children")
 	entries, err := os.ReadDir(childrenPath)
@@ -370,6 +394,7 @@ func TestFixtureIssueChildrenContainsChild(t *testing.T) {
 }
 
 func TestFixtureChildSymlinkTarget(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	// TST-1 is parent of TST-2
 	childLink := filepath.Join(issueDirPath(testTeamKey, "TST-1"), "children", "TST-2")
 
@@ -400,6 +425,7 @@ func TestFixtureChildSymlinkTarget(t *testing.T) {
 // =============================================================================
 
 func TestFixtureByStatusBacklogContainsIssues(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	backlogPath := byStatusPath(testTeamKey, "Backlog")
 	entries, err := os.ReadDir(backlogPath)
 	if err != nil {
@@ -420,6 +446,7 @@ func TestFixtureByStatusBacklogContainsIssues(t *testing.T) {
 }
 
 func TestFixtureFilterSymlinksResolve(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	// Pick a symlink from by/status and verify it resolves
 	inProgressPath := byStatusPath(testTeamKey, "In Progress")
 	entries, err := os.ReadDir(inProgressPath)
@@ -463,6 +490,7 @@ func TestFixtureFilterSymlinksResolve(t *testing.T) {
 // =============================================================================
 
 func TestFixtureMyDirectoryExists(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	info, err := os.Stat(myPath())
 	if err != nil {
 		t.Fatalf("Failed to stat my directory: %v", err)
@@ -473,6 +501,7 @@ func TestFixtureMyDirectoryExists(t *testing.T) {
 }
 
 func TestFixtureMyDirectoryContents(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(myPath())
 	if err != nil {
 		t.Fatalf("Failed to read my directory: %v", err)
@@ -498,6 +527,7 @@ func TestFixtureMyDirectoryContents(t *testing.T) {
 }
 
 func TestFixtureMyCreatedDirectoryExists(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	info, err := os.Stat(myCreatedPath())
 	if err != nil {
 		t.Fatalf("Failed to stat my/created directory: %v", err)
@@ -508,6 +538,7 @@ func TestFixtureMyCreatedDirectoryExists(t *testing.T) {
 }
 
 func TestFixtureMyActiveDirectoryExists(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	info, err := os.Stat(myActivePath())
 	if err != nil {
 		t.Fatalf("Failed to stat my/active directory: %v", err)
@@ -522,6 +553,7 @@ func TestFixtureMyActiveDirectoryExists(t *testing.T) {
 // =============================================================================
 
 func TestFixtureUsersDirectoryExists(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	info, err := os.Stat(usersPath())
 	if err != nil {
 		t.Fatalf("Failed to stat users directory: %v", err)
@@ -532,6 +564,7 @@ func TestFixtureUsersDirectoryExists(t *testing.T) {
 }
 
 func TestFixtureUsersDirectoryListing(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(usersPath())
 	if err != nil {
 		t.Fatalf("Failed to read users directory: %v", err)
@@ -544,6 +577,7 @@ func TestFixtureUsersDirectoryListing(t *testing.T) {
 }
 
 func TestFixtureUserDirectoryContents(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(usersPath())
 	if err != nil {
 		t.Fatalf("Failed to read users directory: %v", err)
@@ -574,6 +608,7 @@ func TestFixtureUserDirectoryContents(t *testing.T) {
 }
 
 func TestFixtureUserInfoFile(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(usersPath())
 	if err != nil {
 		t.Fatalf("Failed to read users directory: %v", err)
@@ -609,6 +644,7 @@ func TestFixtureUserInfoFile(t *testing.T) {
 // =============================================================================
 
 func TestFixtureCycleInfoFile(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	cyclesPath := filepath.Join(teamPath(testTeamKey), "cycles")
 	entries, err := os.ReadDir(cyclesPath)
 	if err != nil {
@@ -659,6 +695,7 @@ func TestFixtureCycleInfoFile(t *testing.T) {
 // =============================================================================
 
 func TestFixtureProjectUpdatesDirectoryExists(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	projectPath := filepath.Join(projectsPath(testTeamKey), "test-project")
 	updatesPath := filepath.Join(projectPath, "updates")
 	info, err := os.Stat(updatesPath)
@@ -671,6 +708,7 @@ func TestFixtureProjectUpdatesDirectoryExists(t *testing.T) {
 }
 
 func TestFixtureProjectUpdatesHasNewMd(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	projectPath := filepath.Join(projectsPath(testTeamKey), "test-project")
 	newMdPath := filepath.Join(projectPath, "updates", "_create")
 	_, err := os.Stat(newMdPath)
@@ -684,6 +722,7 @@ func TestFixtureProjectUpdatesHasNewMd(t *testing.T) {
 // =============================================================================
 
 func TestFixtureInitiativeUpdatesDirectoryExists(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(initiativesPath())
 	if err != nil {
 		t.Fatalf("Failed to read initiatives directory: %v", err)
@@ -704,6 +743,7 @@ func TestFixtureInitiativeUpdatesDirectoryExists(t *testing.T) {
 }
 
 func TestFixtureInitiativeUpdatesHasNewMd(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(initiativesPath())
 	if err != nil {
 		t.Fatalf("Failed to read initiatives directory: %v", err)
@@ -725,6 +765,7 @@ func TestFixtureInitiativeUpdatesHasNewMd(t *testing.T) {
 // =============================================================================
 
 func TestFixtureAttachmentsDirectoryExists(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	// TST-1 has embedded files in the fixtures
 	attachPath := attachmentsPath(testTeamKey, "TST-1")
 	info, err := os.Stat(attachPath)
@@ -737,6 +778,7 @@ func TestFixtureAttachmentsDirectoryExists(t *testing.T) {
 }
 
 func TestFixtureAttachmentsDirectoryListing(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	// TST-1 has 2 embedded files (screenshot.png, design.pdf) and 1 external
 	// URL attachment (Design Spec.link), plus the _create/.error/.last
 	// control files
@@ -789,6 +831,7 @@ func TestFixtureAttachmentsDirectoryListing(t *testing.T) {
 }
 
 func TestFixtureAttachmentsAreFiles(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	attachPath := attachmentsPath(testTeamKey, "TST-1")
 	entries, err := os.ReadDir(attachPath)
 	if err != nil {
@@ -803,6 +846,7 @@ func TestFixtureAttachmentsAreFiles(t *testing.T) {
 }
 
 func TestFixtureAttachmentFileInfo(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	// Check file info for screenshot.png
 	filePath := attachmentFilePath(testTeamKey, "TST-1", "screenshot.png")
 	info, err := os.Stat(filePath)
@@ -821,6 +865,7 @@ func TestFixtureAttachmentFileInfo(t *testing.T) {
 }
 
 func TestFixtureIssueDirectoryContainsAttachments(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	// Verify attachments shows up in issue directory listing
 	issuePath := issueDirPath(testTeamKey, "TST-1")
 	entries, err := os.ReadDir(issuePath)
@@ -845,6 +890,7 @@ func TestFixtureIssueDirectoryContainsAttachments(t *testing.T) {
 }
 
 func TestFixtureEmptyAttachmentsDirectory(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	// TST-2 has no embedded files, only the _create and .error control files
 	attachPath := attachmentsPath(testTeamKey, "TST-2")
 	entries, err := os.ReadDir(attachPath)

--- a/internal/integration/fixture_parity_test.go
+++ b/internal/integration/fixture_parity_test.go
@@ -33,9 +33,7 @@ var fixtureExcludedTables = map[string]string{
 // list: every table in the live fixture store (sqlite_master, i.e. schema.sql
 // as applied) is either populated with at least one row or explicitly excluded.
 func TestSchemaFixtureCoverage(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode conformance: audits the seeded fixture store")
-	}
+	skipIfLiveAPI(t, "fixture-mode conformance: audits the seeded fixture store")
 
 	ctx := context.Background()
 	rows, err := testStore.DB().QueryContext(ctx,
@@ -96,9 +94,7 @@ func TestSchemaFixtureCoverage(t *testing.T) {
 // TestFixtureRelationFiles: the seeded relation (TST-1 blocks TST-3) surfaces
 // as a .rel file on both endpoints, and its content names the other end.
 func TestFixtureRelationFiles(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode: asserts the seeded synthetic relation")
-	}
+	skipIfLiveAPI(t, "fixture-mode: asserts the seeded synthetic relation")
 
 	// Outgoing side: TST-1 blocks TST-3
 	outPath := filepath.Join(issueDirPath(testTeamKey, "TST-1"), "relations", "blocks-TST-3.rel")
@@ -130,9 +126,7 @@ func TestFixtureRelationFiles(t *testing.T) {
 // TestFixtureIssueMetaRelations: issue.meta renders the relations block for
 // both directions (outgoing "blocks", inverse rendered as "blocked-by").
 func TestFixtureIssueMetaRelations(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode: asserts the seeded synthetic relation")
-	}
+	skipIfLiveAPI(t, "fixture-mode: asserts the seeded synthetic relation")
 
 	data, err := os.ReadFile(issueMetaPath(testTeamKey, "TST-1"))
 	if err != nil {
@@ -156,9 +150,7 @@ func TestFixtureIssueMetaRelations(t *testing.T) {
 // TestFixtureMilestoneFile: the seeded milestone lists and reads under
 // projects/<slug>/milestones/.
 func TestFixtureMilestoneFile(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode: asserts the seeded synthetic milestone")
-	}
+	skipIfLiveAPI(t, "fixture-mode: asserts the seeded synthetic milestone")
 
 	path := filepath.Join(projectsPath(testTeamKey), "test-project", "milestones", "Alpha Release.md")
 	data, err := os.ReadFile(path)
@@ -176,17 +168,13 @@ func TestFixtureMilestoneFile(t *testing.T) {
 // TestFixtureProjectUpdateFile: the seeded project status update lists under
 // projects/<slug>/updates/ and renders the health frontmatter.
 func TestFixtureProjectUpdateFile(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode: asserts the seeded synthetic update")
-	}
+	skipIfLiveAPI(t, "fixture-mode: asserts the seeded synthetic update")
 	assertUpdateDirHasHealthyUpdate(t, filepath.Join(projectsPath(testTeamKey), "test-project", "updates"))
 }
 
 // TestFixtureInitiativeUpdateFile: same for initiatives/<slug>/updates/.
 func TestFixtureInitiativeUpdateFile(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode: asserts the seeded synthetic update")
-	}
+	skipIfLiveAPI(t, "fixture-mode: asserts the seeded synthetic update")
 	assertUpdateDirHasHealthyUpdate(t, filepath.Join(initiativesPath(), "test-initiative", "updates"))
 }
 
@@ -218,9 +206,7 @@ func assertUpdateDirHasHealthyUpdate(t *testing.T, updatesDir string) {
 // TestFixtureAttachmentLinkFile: the seeded external URL attachment surfaces
 // as a .link file alongside the embedded files.
 func TestFixtureAttachmentLinkFile(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode: asserts the seeded synthetic attachment")
-	}
+	skipIfLiveAPI(t, "fixture-mode: asserts the seeded synthetic attachment")
 
 	path := filepath.Join(attachmentsPath(testTeamKey, "TST-1"), "Design Spec.link")
 	data, err := os.ReadFile(path)
@@ -238,9 +224,7 @@ func TestFixtureAttachmentLinkFile(t *testing.T) {
 // TestFixtureProjectLinkFile: the seeded project/initiative external links (#249)
 // surface as *.link files under links/, carrying label + url.
 func TestFixtureProjectLinkFile(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode: asserts the seeded synthetic external link")
-	}
+	skipIfLiveAPI(t, "fixture-mode: asserts the seeded synthetic external link")
 
 	for _, dir := range []string{
 		filepath.Join(projectsPath(testTeamKey), "test-project", "links"),
@@ -264,9 +248,7 @@ func TestFixtureProjectLinkFile(t *testing.T) {
 // TestFixtureIssueHistoryRendered: the seeded history cache renders a real
 // change in history.md (not the empty-history placeholder).
 func TestFixtureIssueHistoryRendered(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode: asserts the seeded synthetic history")
-	}
+	skipIfLiveAPI(t, "fixture-mode: asserts the seeded synthetic history")
 
 	path := filepath.Join(issueDirPath(testTeamKey, "TST-1"), "history.md")
 	data, err := os.ReadFile(path)
@@ -284,9 +266,7 @@ func TestFixtureIssueHistoryRendered(t *testing.T) {
 // TestFixtureByAssigneeMembers: with team_members populated, by/assignee lists
 // the members' handles alongside "unassigned".
 func TestFixtureByAssigneeMembers(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode: asserts the seeded synthetic membership")
-	}
+	skipIfLiveAPI(t, "fixture-mode: asserts the seeded synthetic membership")
 
 	names := dirNames(t, byAssigneePath(testTeamKey))
 	// assigneeHandle prefers DisplayName; see FixtureAPIUsers.
@@ -301,9 +281,7 @@ func TestFixtureByAssigneeMembers(t *testing.T) {
 // the default fixture assignee), the my/ views resolve offline and are
 // non-empty.
 func TestFixtureMyViewsPopulated(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode: asserts the seeded synthetic viewer")
-	}
+	skipIfLiveAPI(t, "fixture-mode: asserts the seeded synthetic viewer")
 
 	entries, err := os.ReadDir(myAssignedPath())
 	if err != nil {

--- a/internal/integration/fixture_read_test.go
+++ b/internal/integration/fixture_read_test.go
@@ -1,7 +1,12 @@
 package integration
 
-// Fixture-based read tests that run without live API
-// These tests use pre-populated SQLite fixtures
+// Fixture-based read tests: they run against the pre-populated SQLite fixture
+// store, with no live API. Every test here names a seeded row — TST-1 and its
+// comments/docs/attachments, TST-7's missing assignee, the test-project slug —
+// so every test here carries skipIfLiveAPI(t, fixtureSeededData). A live
+// workspace has no such rows, and running these against one produced ~48
+// "no such file or directory" failures that looked like product bugs (#395).
+// The live twin of this coverage is read_test.go, which creates what it reads.
 
 import (
 	"os"
@@ -15,6 +20,7 @@ import (
 // =============================================================================
 
 func TestFixtureIssueDirectoryContents(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	issuePath := issueDirPath(testTeamKey, "TST-1")
 	entries, err := os.ReadDir(issuePath)
 	if err != nil {
@@ -48,6 +54,7 @@ func TestFixtureIssueDirectoryContents(t *testing.T) {
 }
 
 func TestFixtureIssueFileReadable(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	content, err := os.ReadFile(issueFilePath(testTeamKey, "TST-1"))
 	if err != nil {
 		t.Fatalf("Failed to read issue file: %v", err)
@@ -64,6 +71,7 @@ func TestFixtureIssueFileReadable(t *testing.T) {
 }
 
 func TestFixtureIssueFileContainsRequiredFields(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	// Editable fields live in issue.md; server-managed fields moved to issue.meta (#150).
 	content, err := os.ReadFile(issueFilePath(testTeamKey, "TST-1"))
 	if err != nil {
@@ -95,6 +103,7 @@ func TestFixtureIssueFileContainsRequiredFields(t *testing.T) {
 }
 
 func TestFixtureIssueFileDescription(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	content, err := os.ReadFile(issueFilePath(testTeamKey, "TST-1"))
 	if err != nil {
 		t.Fatalf("Failed to read issue file: %v", err)
@@ -112,6 +121,7 @@ func TestFixtureIssueFileDescription(t *testing.T) {
 }
 
 func TestFixtureIssueWithNoAssignee(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	// TST-7 is the unassigned issue
 	content, err := os.ReadFile(issueFilePath(testTeamKey, "TST-7"))
 	if err != nil {
@@ -134,6 +144,7 @@ func TestFixtureIssueWithNoAssignee(t *testing.T) {
 // =============================================================================
 
 func TestFixtureCommentsDirectoryListing(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(commentsPath(testTeamKey, "TST-1"))
 	if err != nil {
 		t.Fatalf("Failed to read comments directory: %v", err)
@@ -159,6 +170,7 @@ func TestFixtureCommentsDirectoryListing(t *testing.T) {
 }
 
 func TestFixtureCommentFilenameFormat(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(commentsPath(testTeamKey, "TST-1"))
 	if err != nil {
 		t.Fatalf("Failed to read comments directory: %v", err)
@@ -180,6 +192,7 @@ func TestFixtureCommentFilenameFormat(t *testing.T) {
 }
 
 func TestFixtureCommentFileContents(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(commentsPath(testTeamKey, "TST-1"))
 	if err != nil {
 		t.Fatalf("Failed to read comments directory: %v", err)
@@ -220,6 +233,7 @@ func TestFixtureCommentFileContents(t *testing.T) {
 }
 
 func TestFixtureNewMdAlwaysExists(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	// _create should always be present in comments directory
 	_, err := os.Stat(newCommentPath(testTeamKey, "TST-1"))
 	if err != nil {
@@ -228,6 +242,7 @@ func TestFixtureNewMdAlwaysExists(t *testing.T) {
 }
 
 func TestFixtureNewMdWriteOnly(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	// _create should be write-only (0200), so reading should fail
 	_, err := os.ReadFile(newCommentPath(testTeamKey, "TST-1"))
 	if err == nil {
@@ -240,6 +255,7 @@ func TestFixtureNewMdWriteOnly(t *testing.T) {
 // =============================================================================
 
 func TestFixtureDocsDirectoryListing(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(docsPath(testTeamKey, "TST-1"))
 	if err != nil {
 		t.Fatalf("Failed to read docs directory: %v", err)
@@ -265,6 +281,7 @@ func TestFixtureDocsDirectoryListing(t *testing.T) {
 }
 
 func TestFixtureDocumentFilenameFormat(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(docsPath(testTeamKey, "TST-1"))
 	if err != nil {
 		t.Fatalf("Failed to read docs directory: %v", err)
@@ -282,6 +299,7 @@ func TestFixtureDocumentFilenameFormat(t *testing.T) {
 }
 
 func TestFixtureDocumentFileContents(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(docsPath(testTeamKey, "TST-1"))
 	if err != nil {
 		t.Fatalf("Failed to read docs directory: %v", err)
@@ -331,6 +349,7 @@ func TestFixtureDocumentFileContents(t *testing.T) {
 }
 
 func TestFixtureDocsNewMdAlwaysExists(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	_, err := os.Stat(newDocPath(testTeamKey, "TST-1"))
 	if err != nil {
 		t.Errorf("docs/_create should always exist: %v", err)
@@ -338,6 +357,7 @@ func TestFixtureDocsNewMdAlwaysExists(t *testing.T) {
 }
 
 func TestFixtureDocsNewMdWriteOnly(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	_, err := os.ReadFile(newDocPath(testTeamKey, "TST-1"))
 	if err == nil {
 		t.Error("docs/_create should be write-only and not readable")
@@ -348,6 +368,7 @@ func TestFixtureDocsNewMdWriteOnly(t *testing.T) {
 // served from the Repository (SQLite) like every other read, not via a blocking
 // live API call (#261). The fixture seeds one team-level document.
 func TestFixtureTeamDocsServedFromSQLite(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	teamDocsDir := filepath.Join(teamPath(testTeamKey), "docs")
 	entries, err := os.ReadDir(teamDocsDir)
 	if err != nil {
@@ -387,6 +408,7 @@ func TestFixtureTeamDocsServedFromSQLite(t *testing.T) {
 // =============================================================================
 
 func TestFixtureProjectDirectoryContainsInfoFile(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	projectPath := filepath.Join(projectsPath(testTeamKey), "test-project")
 	entries, err := os.ReadDir(projectPath)
 	if err != nil {
@@ -407,6 +429,7 @@ func TestFixtureProjectDirectoryContainsInfoFile(t *testing.T) {
 }
 
 func TestFixtureProjectInfoFile(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	projectInfoPath := filepath.Join(projectsPath(testTeamKey), "test-project", "project.md")
 	content, err := os.ReadFile(projectInfoPath)
 	if err != nil {
@@ -426,6 +449,7 @@ func TestFixtureProjectInfoFile(t *testing.T) {
 }
 
 func TestFixtureProjectIssueSymlinks(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	// TST-6 is assigned to test-project
 	projectPath := filepath.Join(projectsPath(testTeamKey), "test-project")
 	entries, err := os.ReadDir(projectPath)
@@ -455,6 +479,7 @@ func TestFixtureProjectIssueSymlinks(t *testing.T) {
 // =============================================================================
 
 func TestFixtureMyAssignedSymlinkTarget(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(myAssignedPath())
 	if err != nil {
 		t.Fatalf("Failed to read my/assigned: %v", err)
@@ -491,6 +516,7 @@ func TestFixtureMyAssignedSymlinkTarget(t *testing.T) {
 }
 
 func TestFixtureMyAssignedSymlinkResolvable(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	entries, err := os.ReadDir(myAssignedPath())
 	if err != nil {
 		t.Fatalf("Failed to read my/assigned: %v", err)
@@ -527,6 +553,7 @@ func TestFixtureMyAssignedSymlinkResolvable(t *testing.T) {
 }
 
 func TestFixtureUserIssueSymlinkResolvable(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	// Get first user
 	userEntries, err := os.ReadDir(usersPath())
 	if err != nil {
@@ -577,6 +604,7 @@ func TestFixtureUserIssueSymlinkResolvable(t *testing.T) {
 // =============================================================================
 
 func TestFixtureByStatusListing(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	byStatusBasePath := filepath.Join(byPath(testTeamKey), "status")
 	entries, err := os.ReadDir(byStatusBasePath)
 	if err != nil {
@@ -606,6 +634,7 @@ func TestFixtureByStatusListing(t *testing.T) {
 }
 
 func TestFixtureByStatusContainsIssues(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
 	// "In Progress" should contain TST-1, TST-4, TST-6
 	found := dirNames(t, byStatusPath(testTeamKey, "In Progress"))
 

--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -141,6 +141,14 @@ func projectsPath(teamKey string) string {
 	return filepath.Join(mountPoint, "teams", teamKey, "projects")
 }
 
+func projectDirPath(teamKey, slug string) string {
+	return filepath.Join(mountPoint, "teams", teamKey, "projects", slug)
+}
+
+func projectFilePath(teamKey, slug string) string {
+	return filepath.Join(mountPoint, "teams", teamKey, "projects", slug, "project.md")
+}
+
 func projectMetaPath(teamKey, slug string) string {
 	return filepath.Join(mountPoint, "teams", teamKey, "projects", slug, "project.meta")
 }

--- a/internal/integration/interlocks_test.go
+++ b/internal/integration/interlocks_test.go
@@ -46,11 +46,16 @@ func (r *skipRecorder) verdict() string {
 // it skips, and it skips for "requires live API", not for the write flag. That
 // ordering is the whole defect, so assert the reason and not just the boolean.
 //
-// The same table covers skipIfLiveAPI, the inverse guard the fixture-mode
-// write-contract tests use: the two must never agree to run the same test, and
-// the fixture guards must survive in the default offline suite (live=false,
-// no flag) — the column that would vanish if they were ever converted to
-// skipIfNoWriteTests.
+// The same table covers skipIfLiveAPI, the inverse guard every fixture-only
+// test uses: the two must never agree to run the same test, and the fixture
+// guards must survive in the default offline suite (live=false, no flag) — the
+// column that would vanish if they were ever converted to skipIfNoWriteTests.
+//
+// What the table cannot see is a test that carries NO guard while depending on
+// the fixture seed; that is #395, and the defense against it is that
+// skipIfLiveAPI is the only spelling of "fixture-only" in the suite (see
+// modes_test.go), so a missing guard is a missing line rather than a bespoke
+// `if liveAPIMode` that looks like every other one.
 func TestWriteInterlocksAreLiveAPIGated(t *testing.T) {
 	origLive := liveAPIMode
 	origFlag, hadFlag := os.LookupEnv("LINEARFS_WRITE_TESTS")
@@ -122,7 +127,7 @@ func TestWriteInterlocksAreLiveAPIGated(t *testing.T) {
 			write := &skipRecorder{}
 			skipIfNoWriteTests(write)
 			fixture := &skipRecorder{}
-			skipIfLiveAPI(fixture)
+			skipIfLiveAPI(fixture, fixtureSeededData)
 
 			t.Logf("%-46s %-12v %-14q %-12s %s", tc.name, tc.live, tc.writeFlag, write.verdict(), fixture.verdict())
 
@@ -134,6 +139,12 @@ func TestWriteInterlocksAreLiveAPIGated(t *testing.T) {
 			}
 			if fixture.skipped != tc.wantFixtureSkip {
 				t.Errorf("skipIfLiveAPI: skipped = %v (%s), want %v", fixture.skipped, fixture.reason, tc.wantFixtureSkip)
+			}
+			// The reason is the caller's, not a fixed sentence: a live run prints
+			// it in place of the test, and "which kind of fixture dependence"
+			// is what makes the skip triageable (#395).
+			if fixture.skipped && !strings.Contains(fixture.reason, fixtureSeededData) {
+				t.Errorf("skipIfLiveAPI reason = %q, want it to carry the caller's %q", fixture.reason, fixtureSeededData)
 			}
 			if !write.skipped && !fixture.skipped {
 				t.Errorf("both interlocks let the test run under %s; they are inverses and must never overlap", tc.name)
@@ -205,7 +216,7 @@ func TestInitialSyncTimeoutStaysInsideTestBudget(t *testing.T) {
 // testTeamKey at a team the store does not hold reproduces the cycle that
 // stamped after log-and-continuing past a failed fetch.
 func TestLiveSetupGateReleaseCondition(t *testing.T) {
-	skipIfLiveAPI(t)
+	skipIfLiveAPI(t, "fixture-mode: drives the live setup gate against the seeded store")
 
 	store := lfs.GetStore()
 	if store == nil {

--- a/internal/integration/issue148_test.go
+++ b/internal/integration/issue148_test.go
@@ -42,13 +42,14 @@ func hasEntry(t *testing.T, dir, name string) bool {
 // appends the new entity's identity to `.last`, so the agent recovers it in one
 // deterministic read instead of scavenging.
 func TestIssue148_CreateHandsBackNoIdentifier(t *testing.T) {
+	issueID := someIssueID(t)
 	surfaces := []struct {
 		name string
 		dir  string
 	}{
 		{"issues", issuesPath(testTeamKey)},
-		{"comments", commentsPath(testTeamKey, "TST-1")},
-		{"docs", docsPath(testTeamKey, "TST-1")},
+		{"comments", commentsPath(testTeamKey, issueID)},
+		{"docs", docsPath(testTeamKey, issueID)},
 		{"labels", labelsPath(testTeamKey)},
 	}
 
@@ -71,9 +72,7 @@ func TestIssue148_CreateHandsBackNoIdentifier(t *testing.T) {
 // with the mock mutator, creating an issue appends its identifier/url/path to
 // issues/.last as a YAML list, so a batch create is recoverable in one read.
 func TestIssue148_LastReportsCreatedIssueIdentity(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode behavioral check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode behavioral check; uses the mock mutator")
 	enableMockMutations(t)
 
 	title := "Last Sidecar Identity Probe"
@@ -121,13 +120,14 @@ func TestIssue148_LastReportsCreatedIssueIdentity(t *testing.T) {
 // cache. Those live in a sibling read-only issue.meta. So a successful write no
 // longer rewrites the bytes the writer wrote.
 func TestIssue148_EditableFileColocatesVolatileServerFields(t *testing.T) {
-	dir := issueDirPath(testTeamKey, "TST-1")
+	issueID := someIssueID(t)
+	dir := issueDirPath(testTeamKey, issueID)
 
 	if !hasEntry(t, dir, "issue.meta") {
 		t.Fatal("expected issue.meta sidecar (T2/#150 meta split)")
 	}
 
-	content, err := os.ReadFile(issueFilePath(testTeamKey, "TST-1"))
+	content, err := os.ReadFile(issueFilePath(testTeamKey, issueID))
 	if err != nil {
 		t.Fatalf("read issue.md: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestIssue148_EditableFileColocatesVolatileServerFields(t *testing.T) {
 	}
 
 	// issue.meta carries the server-managed fields, read-only.
-	metaContent, err := os.ReadFile(issueMetaPath(testTeamKey, "TST-1"))
+	metaContent, err := os.ReadFile(issueMetaPath(testTeamKey, issueID))
 	if err != nil {
 		t.Fatalf("read issue.meta: %v", err)
 	}
@@ -164,7 +164,7 @@ func TestIssue148_EditableFileColocatesVolatileServerFields(t *testing.T) {
 		}
 	}
 	// issue.meta must be read-only.
-	if err := os.WriteFile(issueMetaPath(testTeamKey, "TST-1"), []byte("x"), 0644); err == nil {
+	if err := os.WriteFile(issueMetaPath(testTeamKey, issueID), []byte("x"), 0644); err == nil {
 		t.Error("issue.meta should be read-only, but a write succeeded")
 	}
 }
@@ -174,8 +174,8 @@ func TestIssue148_EditableFileColocatesVolatileServerFields(t *testing.T) {
 // editable-only, with server fields in read-only project.meta/initiative.meta.
 func TestIssue148_ProjectInitiativeMetaSplit(t *testing.T) {
 	// --- project ---
-	projMD := filepath.Join(projectsPath(testTeamKey), "test-project", "project.md")
-	content, err := os.ReadFile(projMD)
+	slug := someProjectSlug(t)
+	content, err := os.ReadFile(projectFilePath(testTeamKey, slug))
 	if err != nil {
 		t.Fatalf("read project.md: %v", err)
 	}
@@ -191,8 +191,8 @@ func TestIssue148_ProjectInitiativeMetaSplit(t *testing.T) {
 			t.Errorf("project.md still contains server field %q — should live in project.meta", f)
 		}
 	}
-	assertMetaHasFields(t, projectMetaPath(testTeamKey, "test-project"), "id", "slug", "url", "status", "updated")
-	if err := os.WriteFile(projectMetaPath(testTeamKey, "test-project"), []byte("x"), 0644); err == nil {
+	assertMetaHasFields(t, projectMetaPath(testTeamKey, slug), "id", "slug", "url", "status", "updated")
+	if err := os.WriteFile(projectMetaPath(testTeamKey, slug), []byte("x"), 0644); err == nil {
 		t.Error("project.meta should be read-only, but a write succeeded")
 	}
 
@@ -201,8 +201,8 @@ func TestIssue148_ProjectInitiativeMetaSplit(t *testing.T) {
 	if err != nil || firstRealEntry(inits) == "" {
 		return
 	}
-	slug := firstRealEntry(inits)
-	initContent, err := os.ReadFile(filepath.Join(initiativesPath(), slug, "initiative.md"))
+	initSlug := firstRealEntry(inits)
+	initContent, err := os.ReadFile(filepath.Join(initiativesPath(), initSlug, "initiative.md"))
 	if err != nil {
 		t.Fatalf("read initiative.md: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestIssue148_ProjectInitiativeMetaSplit(t *testing.T) {
 			t.Errorf("initiative.md still contains server field %q — should live in initiative.meta", f)
 		}
 	}
-	assertMetaHasFields(t, initiativeMetaPath(slug), "id", "slug", "url", "status", "updated")
+	assertMetaHasFields(t, initiativeMetaPath(initSlug), "id", "slug", "url", "status", "updated")
 }
 
 // TestIssue148_TypedNameNeqResultingPath is a lightweight corroboration of the

--- a/internal/integration/issue333_collision_test.go
+++ b/internal/integration/issue333_collision_test.go
@@ -95,9 +95,7 @@ func assertRecordedNamesRoundTrip(t *testing.T, dir string, urls []string) {
 // OTHER entity — visible in readdir, unopenable by identity. Both surfaces that
 // deduplicate (issue attachments, project/initiative links) are covered.
 func TestIssue333_CreateTailRecordsNameLookupServes(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline write-path check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline write-path check; uses the mock mutator")
 	enableMockMutations(t)
 
 	t.Run("attachments", func(t *testing.T) {

--- a/internal/integration/modes_test.go
+++ b/internal/integration/modes_test.go
@@ -1,0 +1,221 @@
+package integration
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// =============================================================================
+// Which mode does this test run in?
+//
+// The suite runs in three modes:
+//
+//	mode                          LINEARFS_LIVE_API   LINEARFS_WRITE_TESTS
+//	fixture (make test)           unset               —
+//	live read-only (…-ro)         1                   unset
+//	live + writes  (…-rw)         1                   1
+//
+// Every test belongs to some subset of them, and this file is the single place
+// that membership is expressed. There are exactly three ways to say it:
+//
+//   - skipIfNoWriteTests(t)   — live + writes only: the tests that mutate a real
+//     workspace.
+//   - skipIfLiveAPI(t, why)   — fixture only, with `why` naming the kind of
+//     fixture dependence (the constants below). Its condition is the exact
+//     inverse of skipIfNoWriteTests; the two must never agree to run one test.
+//   - no guard                — runs in every mode. A test in this group may not
+//     name a seeded row: derive identifiers with someIssueID/someProjectSlug.
+//
+// So `grep skipIf` over a file answers "does this run live?" per test. #395 was
+// filed because it did not: four files asserted seeded fixture data with no
+// guard at all, and the first live dispatch of the write suite failed ~48 tests
+// by construction — every one of them a hardcoded TST-1 path, not a product bug.
+// =============================================================================
+
+// Reasons a test is fixture-mode-only. skipIfLiveAPI takes one; they are shared
+// constants because the same claim recurs across dozens of tests and the
+// difference between them is what you need when triaging a live run.
+const (
+	// fixtureSeededData: the assertions name rows only the fixture population
+	// creates — TST-1's comments/docs/attachments/child/relation, the
+	// test-project slug and its milestones/updates, the synthetic label
+	// catalog. A live workspace has none of them, so the test fails by
+	// construction instead of finding anything.
+	fixtureSeededData = "fixture-mode: asserts seeded fixture data (TST-1, test-project, …)"
+
+	// fixtureWriteContract: the test proves a structural write contract by
+	// writing through the mount. The write is inert offline (no API, no auth)
+	// but would mutate a real workspace under a live key — and gating it with
+	// skipIfNoWriteTests instead would delete it from the default offline
+	// suite, which is the only place it ever runs.
+	fixtureWriteContract = "fixture-mode write-contract guard; the same write would mutate a real workspace under a live key"
+)
+
+// skipIfNoWriteTests skips the test unless it is running in live + writes mode.
+// It guards the tests that mutate a real workspace. liveAPIMode is checked
+// FIRST and reported first: LINEARFS_WRITE_TESTS=1 alone means the offline
+// fixture suite, not a write run (#386).
+func skipIfNoWriteTests(t interface{ Skip(...any) }) {
+	if !liveAPIMode {
+		t.Skip("Skipped: requires live API (set LINEARFS_LIVE_API=1 and LINEAR_API_KEY)")
+	}
+	if os.Getenv("LINEARFS_WRITE_TESTS") != "1" {
+		t.Skip("Skipped: write tests disabled (set LINEARFS_WRITE_TESTS=1 to enable)")
+	}
+}
+
+// skipIfLiveAPI skips the test under a live API key. It is the inverse interlock
+// to skipIfNoWriteTests and the ONE way this suite marks a test fixture-only;
+// `why` is one of the constants above, or a sentence specific to the test, and
+// is what a live run prints in place of the test.
+func skipIfLiveAPI(t interface{ Skip(...any) }, why string) {
+	if liveAPIMode {
+		t.Skip("Skipped: " + why)
+	}
+}
+
+// The seeded entities the fixture population guarantees. Tests that assert
+// against their *contents* are fixture-only (skipIfLiveAPI + fixtureSeededData);
+// tests that merely need *an* issue or project reach them through someIssueID /
+// someProjectSlug, which fall back to the live workspace.
+const (
+	fixtureIssueID     = "TST-1"
+	fixtureProjectSlug = "test-project"
+)
+
+// someIssueID returns an issue identifier that exists in the mounted workspace:
+// the fixture's fully-populated TST-1 offline, the first issue the live
+// workspace lists otherwise. Tests asserting a contract that must hold in BOTH
+// modes — stat determinism, the .meta split, fsync support — use this instead of
+// hardcoding "TST-1", which is what made them fixture-only by accident (#395).
+//
+// The live pick is an arbitrary issue, so it may have no comments or docs; a
+// caller that needs a populated collection must skip on the empty case rather
+// than fail, and say the workspace lacks it.
+//
+// The live pick is made once per run and memoized. A live run creates issues as
+// it goes, and identifiers sort lexically ("LIG-100" < "LIG-99"), so re-listing
+// per call would let the answer move mid-run: two tests would reason about
+// different issues, and one of them about an issue another test is mutating.
+func someIssueID(t *testing.T) string {
+	t.Helper()
+	if !liveAPIMode {
+		return fixtureIssueID
+	}
+	pickedIssueOnce.Do(func() {
+		pickedIssue = firstRealEntry(mustReadDir(t, issuesPath(testTeamKey)))
+	})
+	if pickedIssue == "" {
+		t.Skipf("workspace team %s lists no issues", testTeamKey)
+	}
+	return pickedIssue
+}
+
+// someProjectSlug is someIssueID's twin for projects: the fixture's
+// test-project offline, the first project the live workspace lists otherwise,
+// memoized the same way and for the same reason.
+func someProjectSlug(t *testing.T) string {
+	t.Helper()
+	if !liveAPIMode {
+		return fixtureProjectSlug
+	}
+	pickedProjectOnce.Do(func() {
+		entries, err := os.ReadDir(projectsPath(testTeamKey))
+		if err != nil {
+			return
+		}
+		pickedProject = firstRealEntry(entries)
+	})
+	if pickedProject == "" {
+		t.Skipf("workspace team %s lists no projects", testTeamKey)
+	}
+	return pickedProject
+}
+
+var (
+	pickedIssueOnce   sync.Once
+	pickedIssue       string
+	pickedProjectOnce sync.Once
+	pickedProject     string
+)
+
+// someProjectDir / someIssueDir are the path forms of the two pickers, for the
+// many callers that want the directory rather than the bare identifier.
+func someIssueDir(t *testing.T) string {
+	t.Helper()
+	return issueDirPath(testTeamKey, someIssueID(t))
+}
+
+func someProjectDir(t *testing.T) string {
+	t.Helper()
+	return projectDirPath(testTeamKey, someProjectSlug(t))
+}
+
+// fixtureLiterals are the seeded names that only exist in the fixture store.
+// A test that spells one is asserting against the fixture seed by definition.
+var fixtureLiterals = []string{`"TST-`, `"test-project"`}
+
+// TestFixtureLiteralsCarryTheGuard is the standing check for #395: a test that
+// names a seeded row must say so with skipIfLiveAPI, because a live workspace
+// has no such row and the test can only fail there — 48 of them did, on the
+// first live dispatch of the write suite, every one a stat of a path that does
+// not exist. The fix is one of two lines, and the failure message says which:
+// add the guard, or take the identifier from someIssueID/someProjectSlug.
+//
+// It reads the suite's own source rather than its behavior, because the thing
+// being guarded is unobservable from inside a fixture-mode run: that is exactly
+// why it went unnoticed until someone spent a live workspace to find out.
+func TestFixtureLiteralsCarryTheGuard(t *testing.T) {
+	files, err := filepath.Glob("*_test.go")
+	if err != nil {
+		t.Fatalf("glob test sources: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no test sources found; the check would pass vacuously")
+	}
+
+	fset := token.NewFileSet()
+	checked := 0
+	for _, file := range files {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		parsed, err := parser.ParseFile(fset, file, src, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		for _, decl := range parsed.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv != nil || !strings.HasPrefix(fn.Name.Name, "Test") || fn.Body == nil {
+				continue
+			}
+			checked++
+			// Positions are FileSet-global; convert to this file's byte offsets.
+			body := string(src[fset.Position(fn.Body.Pos()).Offset:fset.Position(fn.Body.End()).Offset])
+			// This file spells the literals to define them; skip its own bodies.
+			if file == "modes_test.go" {
+				continue
+			}
+			for _, lit := range fixtureLiterals {
+				if !strings.Contains(body, lit) {
+					continue
+				}
+				if strings.Contains(body, "skipIfLiveAPI") || strings.Contains(body, "skipIfNoWriteTests") {
+					continue
+				}
+				t.Errorf("%s: %s names the fixture-seeded %s but carries no mode guard.\n"+
+					"  Either add skipIfLiveAPI(t, fixtureSeededData) — a live workspace has no such row —\n"+
+					"  or take the identifier from someIssueID(t)/someProjectSlug(t) if the contract holds live too.",
+					file, fn.Name.Name, strings.Trim(lit, `"`))
+			}
+		}
+	}
+	t.Logf("checked %d test functions across %d files", checked, len(files))
+}

--- a/internal/integration/projectlabels_test.go
+++ b/internal/integration/projectlabels_test.go
@@ -45,9 +45,7 @@ func projectErrorPath() string {
 // mid-test is visible on the very next read, with NO kernel invalidation
 // surface needed (tested, not asserted).
 func TestProjectLabelsCatalogFile(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode: asserts the seeded synthetic catalog")
-	}
+	skipIfLiveAPI(t, "fixture-mode: asserts the seeded synthetic catalog")
 	path := filepath.Join(mountPoint, "project-labels.md")
 
 	info, err := os.Stat(path)
@@ -120,9 +118,7 @@ func TestProjectLabelsTeamSymlink(t *testing.T) {
 // UpdateProject through the mock, and survives a re-read. The retired label
 // already on the project carries through (full-set write re-sends it).
 func TestProjectLabelsRenderAndAssign(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode: drives the mock mutation client")
-	}
+	skipIfLiveAPI(t, "fixture-mode: drives the mock mutation client")
 	enableMockMutations(t)
 
 	orig, err := os.ReadFile(projectMDPath())
@@ -161,9 +157,7 @@ func TestProjectLabelsRenderAndAssign(t *testing.T) {
 // any mutation fires (no mock injected: a mutation attempt would fail loudly
 // with a different message).
 func TestProjectLabelsValidationErrors(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode legibility check")
-	}
+	skipIfLiveAPI(t, "fixture-mode legibility check")
 	orig, err := os.ReadFile(projectMDPath())
 	if err != nil {
 		t.Fatalf("read project.md: %v", err)
@@ -212,9 +206,7 @@ func TestProjectLabelsValidationErrors(t *testing.T) {
 // (policy-rejected — deliberately stricter than the API, which live-verified
 // accepts it).
 func TestProjectLabelsRetiredNewlyApplied(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode: drives the mock mutation client")
-	}
+	skipIfLiveAPI(t, "fixture-mode: drives the mock mutation client")
 	enableMockMutations(t)
 
 	orig, err := os.ReadFile(projectMDPath())
@@ -289,9 +281,7 @@ func TestProjectLabelsRetiredNewlyApplied(t *testing.T) {
 // renders VERBATIM, and re-saving the untouched file is a no-op success — the
 // round-trip invariant that keeps a cold/stale catalog from stripping labels.
 func TestProjectLabelsStaleIDRoundTrip(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode: seeds a ghost labelId straight into the store")
-	}
+	skipIfLiveAPI(t, "fixture-mode: seeds a ghost labelId straight into the store")
 	enableMockMutations(t)
 	ctx := context.Background()
 

--- a/internal/integration/readme_test.go
+++ b/internal/integration/readme_test.go
@@ -79,14 +79,18 @@ func TestGeneratedReadmeMatchesBehavior(t *testing.T) {
 			t.Errorf("README does not mention %q (collection meta split)", want)
 		}
 	}
-	// And the documented surfaces must really behave that way: a fixture doc's
-	// .meta exists, reads, and rejects writes; the comment .md has no frontmatter.
-	if entries, err := os.ReadDir(docsPath(testTeamKey, "TST-1")); err == nil {
+	// And the documented surfaces must really behave that way: a doc's .meta
+	// exists, reads, and rejects writes; the comment .md has no frontmatter. The
+	// issue comes from the workspace (someIssueID), not a hardcoded TST-1 — under
+	// a live key that path does not exist, and these ReadDir-guarded checks then
+	// pass by doing nothing (#395).
+	readmeIssueID := someIssueID(t)
+	if entries, err := os.ReadDir(docsPath(testTeamKey, readmeIssueID)); err == nil {
 		for _, e := range entries {
 			if isControlFile(e.Name()) || !strings.HasSuffix(e.Name(), ".md") {
 				continue
 			}
-			metaPath := docFilePath(testTeamKey, "TST-1", strings.TrimSuffix(e.Name(), ".md")+".meta")
+			metaPath := docFilePath(testTeamKey, readmeIssueID, strings.TrimSuffix(e.Name(), ".md")+".meta")
 			if _, err := os.ReadFile(metaPath); err != nil {
 				t.Errorf("README documents doc .meta sidecars but %s is unreadable: %v", metaPath, err)
 			}
@@ -96,12 +100,12 @@ func TestGeneratedReadmeMatchesBehavior(t *testing.T) {
 			break
 		}
 	}
-	if entries, err := os.ReadDir(commentsPath(testTeamKey, "TST-1")); err == nil {
+	if entries, err := os.ReadDir(commentsPath(testTeamKey, readmeIssueID)); err == nil {
 		for _, e := range entries {
 			if isControlFile(e.Name()) || !strings.HasSuffix(e.Name(), ".md") {
 				continue
 			}
-			content, err := os.ReadFile(commentFilePath(testTeamKey, "TST-1", e.Name()))
+			content, err := os.ReadFile(commentFilePath(testTeamKey, readmeIssueID, e.Name()))
 			if err == nil && strings.HasPrefix(string(content), "---") {
 				t.Errorf("README documents comment .md as frontmatter-free, but %s carries frontmatter", e.Name())
 			}
@@ -127,6 +131,15 @@ func TestGeneratedReadmeMatchesBehavior(t *testing.T) {
 		t.Error("README carves attachments/relations out of .last, but every create surface reports to .last now")
 	}
 
+	// #399: EAGAIN covers two situations with different safe follow-ups, and the
+	// README must not collapse them back into one "the write did not take effect"
+	// promise — that promise is false for a request interrupted after it was sent,
+	// and acting on it duplicates the entity.
+	for _, want := range []string{"interrupted", "UNKNOWN"} {
+		if !strings.Contains(readme, want) {
+			t.Errorf("README does not distinguish the two EAGAIN outcomes: missing %q", want)
+		}
+	}
 	// #5: project/initiative bodies map to the long content field, not the ≤255
 	// description; the README must not tell writers the body is the description
 	// (which silently rejected any real write-up), and must place description in

--- a/internal/integration/render_files_test.go
+++ b/internal/integration/render_files_test.go
@@ -44,10 +44,12 @@ func TestHistoryFileReadable(t *testing.T) {
 }
 
 // TestProjectUpdateFileReadable exercises the renderFile read path for a project
-// update file. If the fixture carries any update .md, it must read without error
-// and carry the shared update frontmatter (health:).
+// update file. If the workspace carries any update .md, it must read without
+// error and carry the shared update frontmatter (health:). The project comes
+// from someProjectSlug: hardcoding test-project made the "no updates dir" skip
+// unconditional under a live key, so the test passed by doing nothing (#395).
 func TestProjectUpdateFileReadable(t *testing.T) {
-	updatesDir := filepath.Join(projectsPath(testTeamKey), "test-project", "updates")
+	updatesDir := filepath.Join(someProjectDir(t), "updates")
 	entries, err := os.ReadDir(updatesDir)
 	if err != nil {
 		t.Skipf("no project updates dir: %v", err)
@@ -60,7 +62,7 @@ func TestProjectUpdateFileReadable(t *testing.T) {
 		}
 	}
 	if updateFile == "" {
-		t.Skip("no fixture project update files")
+		t.Skip("no project update files in workspace")
 	}
 
 	content, err := os.ReadFile(filepath.Join(updatesDir, updateFile))

--- a/internal/integration/staleness_test.go
+++ b/internal/integration/staleness_test.go
@@ -28,8 +28,9 @@ import (
 // stale content is the latent bug, confirmed end-to-end.
 func TestRemoteUpdateVisibleAfterKernelRevalidation(t *testing.T) {
 	ctx := context.Background()
+	skipIfLiveAPI(t, "fixture-mode: seeds rows straight into the fixture store to stand in for the sync worker")
 	if testStore == nil {
-		t.Skip("store-backed staleness simulation requires fixture mode")
+		t.Fatal("fixture mode left no test store; the sync-side write has nothing to seed into")
 	}
 
 	// Drive the remote-update dance on a THROWAWAY issue (unique per run), never
@@ -150,8 +151,9 @@ func TestRemoteUpdateVisibleAfterKernelRevalidation(t *testing.T) {
 // on project.md) — a latent mismatch the view-dir normalization surfaced once
 // the whole directory chain became stably reusable.
 func TestRejectedSaveKeepsDirtyContentReadable(t *testing.T) {
+	skipIfLiveAPI(t, "fixture-mode: seeds rows straight into the fixture store to stand in for the sync worker")
 	if testStore == nil {
-		t.Skip("store-backed simulation requires fixture mode")
+		t.Fatal("fixture mode left no test store; the sync-side write has nothing to seed into")
 	}
 	enableMockMutations(t)
 	ctx := context.Background()
@@ -228,8 +230,9 @@ func TestRejectedSaveKeepsDirtyContentReadable(t *testing.T) {
 // took on when it moved these nodes off auto-assigned inos.
 func TestRemoteTeamUpdateVisibleAfterKernelRevalidation(t *testing.T) {
 	ctx := context.Background()
+	skipIfLiveAPI(t, "fixture-mode: seeds rows straight into the fixture store to stand in for the sync worker")
 	if testStore == nil {
-		t.Skip("store-backed staleness simulation requires fixture mode")
+		t.Fatal("fixture mode left no test store; the sync-side write has nothing to seed into")
 	}
 
 	// Drive the remote-update dance on a THROWAWAY team (unique key per run),

--- a/internal/integration/t0_mock_test.go
+++ b/internal/integration/t0_mock_test.go
@@ -13,9 +13,7 @@ import (
 // with the real dummy-key client. It is the seam that makes the *success* half of
 // the write contract provable in `make test`.
 func TestT0_MockMutationClientEnablesOfflineCreate(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("T0 fake is for fixture mode; live mode creates real issues")
-	}
+	skipIfLiveAPI(t, "T0 fake is for fixture mode; live mode creates real issues")
 	enableMockMutations(t)
 
 	title := "T0 Mock Create Probe"
@@ -58,9 +56,7 @@ func TestT0_MockMutationClientEnablesOfflineCreate(t *testing.T) {
 // fake, mutations still fail loudly (the real client + dummy key), so the
 // #131/#140 loud-failure contract is unaffected by T0.
 func TestT0_LoudFailureStillWorksWithoutFake(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("only meaningful in fixture mode")
-	}
+	skipIfLiveAPI(t, "only meaningful in fixture mode")
 	err := os.Mkdir(issueDirPath(testTeamKey, "T0 No-Fake Failure Probe"), 0755)
 	if err == nil {
 		_ = os.Remove(issueDirPath(testTeamKey, "T0 No-Fake Failure Probe"))

--- a/internal/integration/t4_create_test.go
+++ b/internal/integration/t4_create_test.go
@@ -42,9 +42,7 @@ func TestT4_CreateSurfaceIsWriteOnly(t *testing.T) {
 // TestT4_InvalidFrontmatterIsLegible: bad priority and unresolvable status both
 // fail with EINVAL and a Field/Error-shaped issues/.error — the same shape.
 func TestT4_InvalidFrontmatterIsLegible(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode legibility check")
-	}
+	skipIfLiveAPI(t, "fixture-mode legibility check")
 	cases := []struct {
 		name      string
 		spec      string
@@ -70,9 +68,7 @@ func TestT4_InvalidFrontmatterIsLegible(t *testing.T) {
 // TestT4_ValidSpecFailsAtAPILoudly: without the mock mutator, a valid spec fails
 // loudly at the API (mirrors TestMkdirIssueFailureIsLegible) rather than silently.
 func TestT4_ValidSpecFailsAtAPILoudly(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode only (no fake => real client + dummy key fails)")
-	}
+	skipIfLiveAPI(t, "fixture-mode only (no fake => real client + dummy key fails)")
 	err := writeCreateSpec(t, "---\ntitle: Loud API Failure Probe\n---\nbody\n")
 	if err == nil {
 		t.Fatal("expected the create to fail loudly without the mock mutator")
@@ -86,9 +82,7 @@ func TestT4_ValidSpecFailsAtAPILoudly(t *testing.T) {
 // TestT4_ValidSpecSucceedsWithAssociations: with the mock mutator, a full spec
 // creates one issue with its fields set and reports identity to issues/.last.
 func TestT4_ValidSpecSucceedsWithAssociations(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode behavioral check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode behavioral check; uses the mock mutator")
 	enableMockMutations(t)
 
 	spec := "---\n" +

--- a/internal/integration/t5_recent_test.go
+++ b/internal/integration/t5_recent_test.go
@@ -19,9 +19,7 @@ import (
 // to `ls -t`). It seeds three issues with distinct, non-insertion-order
 // timestamps so a missing fs-layer sort would fail the ordering assertion.
 func TestT5_RecentViewOrdered(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode ordering check; seeds issues directly into the store")
-	}
+	skipIfLiveAPI(t, "fixture-mode ordering check; seeds issues directly into the store")
 	ctx := context.Background()
 	base := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
 
@@ -94,9 +92,7 @@ func TestT5_RecentViewOrdered(t *testing.T) {
 // immediately — the create tail re-cohers the view rather than leaving it stale
 // until the dir cache TTL (the #148 design's known staleness bound, now closed).
 func TestT5_FreshCreateAppearsInRecent(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode behavioral check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode behavioral check; uses the mock mutator")
 	enableMockMutations(t)
 
 	// Prime the kernel's view of recent/ so a stale cached listing would be caught.
@@ -141,9 +137,7 @@ func TestT5_FreshCreateAppearsInRecent(t *testing.T) {
 
 // TestT5_RecentIsReadOnly: the recent/ view rejects mutation.
 func TestT5_RecentIsReadOnly(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode only")
-	}
+	skipIfLiveAPI(t, "fixture-mode only")
 	if err := os.Mkdir(filepath.Join(recentPath(testTeamKey), "Nope"), 0755); err == nil {
 		t.Error("recent/ should be read-only, but mkdir succeeded")
 	}

--- a/internal/integration/t6_conformance_test.go
+++ b/internal/integration/t6_conformance_test.go
@@ -51,18 +51,21 @@ func assertEditableOnly(t *testing.T, path string, forbidden ...string) {
 
 // TestWriteContractMetaSplitGeneralizes: the editable-in/server-out rule holds
 // for issue.md, project.md, AND initiative.md — each editable file is free of
-// volatile server fields and has a sibling .meta carrying them.
+// volatile server fields and has a sibling .meta carrying them. Pure reads, and
+// the rule is about the render rather than the entity, so it takes its issue and
+// project from the workspace and runs live too (#395).
 func TestWriteContractMetaSplitGeneralizes(t *testing.T) {
 	forbidden := []string{"id", "slug", "url", "updated"}
 
 	// issue
-	assertEditableOnly(t, issueFilePath(testTeamKey, "TST-1"), append(forbidden, "identifier")...)
-	assertMetaHasFields(t, issueMetaPath(testTeamKey, "TST-1"), "id", "identifier", "url", "updated")
+	issueID := someIssueID(t)
+	assertEditableOnly(t, issueFilePath(testTeamKey, issueID), append(forbidden, "identifier")...)
+	assertMetaHasFields(t, issueMetaPath(testTeamKey, issueID), "id", "identifier", "url", "updated")
 
 	// project
-	projMD := filepath.Join(projectsPath(testTeamKey), "test-project", "project.md")
-	assertEditableOnly(t, projMD, forbidden...)
-	assertMetaHasFields(t, projectMetaPath(testTeamKey, "test-project"), "id", "slug", "url", "updated")
+	slug := someProjectSlug(t)
+	assertEditableOnly(t, projectFilePath(testTeamKey, slug), forbidden...)
+	assertMetaHasFields(t, projectMetaPath(testTeamKey, slug), "id", "slug", "url", "updated")
 
 	// initiative (skip if none)
 	inits, err := os.ReadDir(initiativesPath())
@@ -95,28 +98,32 @@ func firstItemFile(t *testing.T, dir string) string {
 // (its edits used to be silently discarded — a no-op with no .error), every
 // item has an openable read-only "{base}.meta" carrying them, and the sidecar
 // can be neither written nor rm'd on its own.
+//
+// Each surface resolves its directory lazily, from the workspace: a live run has
+// no test-project and no TST-1, and a hardcoded path there is a failure that
+// says nothing about the meta split (#395).
 func TestWriteContractMetaSplitCollections(t *testing.T) {
 	surfaces := []struct {
 		name      string
-		dir       string
+		dir       func(t *testing.T) string
 		forbidden []string
 		metaHas   []string
 	}{
 		{
 			name:      "docs",
-			dir:       docsPath(testTeamKey, "TST-1"),
+			dir:       func(t *testing.T) string { return docsPath(testTeamKey, someIssueID(t)) },
 			forbidden: []string{"id", "url", "created", "updated", "creator", "slug"},
 			metaHas:   []string{"id", "url", "created", "updated"},
 		},
 		{
 			name:      "labels",
-			dir:       labelsPath(testTeamKey),
+			dir:       func(t *testing.T) string { return labelsPath(testTeamKey) },
 			forbidden: []string{"id"},
 			metaHas:   []string{"id"},
 		},
 		{
 			name:      "milestones",
-			dir:       filepath.Join(projectsPath(testTeamKey), "test-project", "milestones"),
+			dir:       func(t *testing.T) string { return filepath.Join(someProjectDir(t), "milestones") },
 			forbidden: []string{"id"},
 			metaHas:   []string{"id"},
 		},
@@ -124,29 +131,30 @@ func TestWriteContractMetaSplitCollections(t *testing.T) {
 
 	for _, tc := range surfaces {
 		t.Run(tc.name, func(t *testing.T) {
-			mdName := firstItemFile(t, tc.dir)
+			dir := tc.dir(t)
+			mdName := firstItemFile(t, dir)
 			if mdName == "" && tc.name == "milestones" && !liveAPIMode {
 				// The fixture ships no milestone: seed one via the mock so the
 				// sidecar contract isn't vacuously green here.
 				enableMockMutations(t)
-				if err := os.WriteFile(filepath.Join(tc.dir, "_create"), []byte("MetaSplit Probe\nprobe milestone"), 0200); err != nil {
+				if err := os.WriteFile(filepath.Join(dir, "_create"), []byte("MetaSplit Probe\nprobe milestone"), 0200); err != nil {
 					t.Fatalf("seed milestone: %v", err)
 				}
-				mdName = firstItemFile(t, tc.dir)
+				mdName = firstItemFile(t, dir)
 			}
 			if mdName == "" {
-				t.Skipf("no %s item in fixture", tc.name)
+				t.Skipf("workspace has no %s item to check", tc.name)
 			}
-			assertEditableOnly(t, filepath.Join(tc.dir, mdName), tc.forbidden...)
+			assertEditableOnly(t, filepath.Join(dir, mdName), tc.forbidden...)
 
 			metaName := strings.TrimSuffix(mdName, ".md") + ".meta"
-			metaPath := filepath.Join(tc.dir, metaName)
+			metaPath := filepath.Join(dir, metaName)
 			assertMetaHasFields(t, metaPath, tc.metaHas...)
 
 			// The sidecar is listed alongside its .md (listed⇔openable).
-			entries, err := os.ReadDir(tc.dir)
+			entries, err := os.ReadDir(dir)
 			if err != nil {
-				t.Fatalf("read %s: %v", tc.dir, err)
+				t.Fatalf("read %s: %v", dir, err)
 			}
 			listed := false
 			for _, e := range entries {
@@ -175,10 +183,10 @@ func TestWriteContractMetaSplitCollections(t *testing.T) {
 	// Comments: the .md is the PURE body (no frontmatter at all); id/author/
 	// timestamps live in the sidecar.
 	t.Run("comments", func(t *testing.T) {
-		dir := commentsPath(testTeamKey, "TST-1")
+		dir := commentsPath(testTeamKey, someIssueID(t))
 		mdName := firstItemFile(t, dir)
 		if mdName == "" {
-			t.Skip("no comment in fixture")
+			t.Skip("the picked issue has no comment to check")
 		}
 		content, err := os.ReadFile(filepath.Join(dir, mdName))
 		if err != nil {
@@ -241,9 +249,7 @@ func TestWriteContractLastSidecarShape(t *testing.T) {
 // directory listing, and the two surfaces the #148 design deferred (attachments,
 // relations) now report their creates to .last like every other surface.
 func TestWriteContractCreateTrioUniform(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode; uses the mock mutator")
 	enableMockMutations(t)
 
 	issueDir := issueDirPath(testTeamKey, "TST-1")
@@ -400,9 +406,7 @@ func TestWriteContractCreateTrioUniform(t *testing.T) {
 // sync worker reconciled. Also asserts a successful delete clears .error and
 // an unknown name fails with ENOENT.
 func TestWriteContractDeleteTail(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode; uses the mock mutator")
 	enableMockMutations(t)
 
 	// Create a label to delete.
@@ -457,9 +461,7 @@ func TestWriteContractDeleteTail(t *testing.T) {
 // batch create via _create (recover ids from .last), no-op rewrites that stay
 // byte-stable, and a failure that leaves the success log intact.
 func TestWriteContractAgentLoop(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode agent-loop; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode agent-loop; uses the mock mutator")
 	enableMockMutations(t)
 
 	// (a) Batch create via N sequential _create writes; recover every id from .last.
@@ -572,9 +574,7 @@ func countFailedOutcomes(entries []map[string]string) int {
 // commitWriteBack took its "unverified" early return, persist was skipped, and
 // the edit was lost offline — so the marker's survival is a genuine discriminator.
 func TestWriteContractEditVerifiesOffline(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode; exercises the mock verify seam")
-	}
+	skipIfLiveAPI(t, "fixture-mode; exercises the mock verify seam")
 	enableMockMutations(t)
 
 	projDir := filepath.Join(projectsPath(testTeamKey), "test-project")

--- a/internal/integration/testdata_test.go
+++ b/internal/integration/testdata_test.go
@@ -2,10 +2,14 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/jra3/linear-fuse/internal/api"
@@ -18,28 +22,8 @@ var (
 	apiCallDelay = 1 * time.Second // Minimum delay between API write operations
 )
 
-// skipIfNoWriteTests skips the test if write tests are not enabled
-// Write tests require live API mode with LINEARFS_WRITE_TESTS=1
-func skipIfNoWriteTests(t interface{ Skip(...any) }) {
-	if !liveAPIMode {
-		t.Skip("Skipped: requires live API (set LINEARFS_LIVE_API=1 and LINEAR_API_KEY)")
-	}
-	if os.Getenv("LINEARFS_WRITE_TESTS") != "1" {
-		t.Skip("Skipped: write tests disabled (set LINEARFS_WRITE_TESTS=1 to enable)")
-	}
-}
-
-// skipIfLiveAPI is the inverse interlock to skipIfNoWriteTests, for the
-// write-contract guards that exercise a structural invariant by writing through
-// the mount. Those writes are inert offline (no API, no auth) but hit a real
-// workspace under a live key, so they are fixture-mode-only by design: gating
-// them with skipIfNoWriteTests would instead delete them from the DEFAULT
-// offline suite, which is the only place they ever run.
-func skipIfLiveAPI(t interface{ Skip(...any) }) {
-	if liveAPIMode {
-		t.Skip("Skipped: fixture-mode write-contract guard; the same write would mutate a real workspace under a live key")
-	}
-}
+// The mode interlocks (skipIfNoWriteTests / skipIfLiveAPI) live in
+// modes_test.go, alongside the workspace-derived identifier pickers.
 
 // rateLimitWait ensures we don't make API calls too quickly
 func rateLimitWait() {
@@ -97,6 +81,51 @@ func WithStateID(stateID string) IssueOption {
 	}
 }
 
+// mkdirIssueRetries bounds the EAGAIN retry loop in createTestIssue, and
+// mkdirIssueBackoff is the wait before the first retry (doubled each time).
+// Sized against what the create path actually asks for: a rate-limited create
+// returns EAGAIN with "wait a few seconds and retry", and the live write suite
+// creates ~35 issues in four minutes, so it generates that backpressure itself.
+const (
+	mkdirIssueRetries = 4
+	mkdirIssueBackoff = 2 * time.Second
+)
+
+// mkdirIssueWithRetry creates the issue directory, honoring the retry contract
+// the mount documents: EAGAIN means "the create did not take effect, wait and
+// retry" (#131/#257), so treating it as fatal — which is what this helper used
+// to do — makes every live run flaky in proportion to the rate-limit pressure
+// the run itself generates (#399). Every other errno is a real failure and is
+// returned immediately.
+//
+// Caveat worth knowing when a retry does fire: EAGAIN is also what a create
+// whose POST was cancelled in flight returns, and in that case whether Linear
+// processed it is genuinely unknown — a retry can leave a duplicate behind. The
+// suite accepts that over a guaranteed flake; the underlying ambiguity is the
+// open question in #399, and it lives in the create path, not here.
+func mkdirIssueWithRetry(issuePath string) error {
+	backoff := mkdirIssueBackoff
+	var err error
+	for attempt := 0; attempt <= mkdirIssueRetries; attempt++ {
+		if attempt > 0 {
+			time.Sleep(backoff)
+			backoff *= 2
+			rateLimitWait()
+		}
+		err = os.Mkdir(issuePath, 0755)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, syscall.EAGAIN) {
+			return err
+		}
+		log.Printf("createTestIssue: mkdir %q returned EAGAIN (attempt %d/%d), retrying — "+
+			"this is the mount's documented transient-create signal, not a failure",
+			filepath.Base(issuePath), attempt+1, mkdirIssueRetries+1)
+	}
+	return fmt.Errorf("still EAGAIN after %d attempts: %w", mkdirIssueRetries+1, err)
+}
+
 // createTestIssue creates an issue via filesystem mkdir for testing.
 // The title is prefixed with [TEST] and a timestamp.
 // Returns the issue and a cleanup function (currently no-op since Linear doesn't have delete).
@@ -107,7 +136,7 @@ func createTestIssue(title string, opts ...IssueOption) (*TestIssue, func(), err
 	issuePath := fmt.Sprintf("%s/teams/%s/issues/%s", mountPoint, testTeamKey, fullTitle)
 
 	// Create issue via filesystem mkdir - this goes through FUSE and syncs to SQLite
-	if err := os.Mkdir(issuePath, 0755); err != nil {
+	if err := mkdirIssueWithRetry(issuePath); err != nil {
 		return nil, nil, fmt.Errorf("failed to create test issue via mkdir: %w", err)
 	}
 
@@ -125,14 +154,28 @@ func createTestIssue(title string, opts ...IssueOption) (*TestIssue, func(), err
 			continue
 		}
 		if strings.Contains(string(content), fullTitle) {
-			// Parse frontmatter to get the ID
-			doc, err := parseFrontmatter(content)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to parse issue.md frontmatter: %w", err)
-			}
-
 			identifier := entry.Name()
-			id, _ := doc.Frontmatter["id"].(string)
+
+			// The id lives in issue.meta, not issue.md: #148 moved the volatile
+			// server fields out of the editable file. Reading it from issue.md
+			// and swallowing the miss with `_` is what handed every live test an
+			// api.Issue{ID: ""}, which then failed 14 tests as "not found in
+			// SQLite" and "Argument Validation Error" (#396). Hence: read the
+			// sidecar, and fail loudly on a miss.
+			metaContent, err := os.ReadFile(issueMetaPath(testTeamKey, identifier))
+			if err != nil {
+				return nil, nil, fmt.Errorf("read issue.meta for %s: %w", identifier, err)
+			}
+			meta, err := parseFrontmatter(metaContent)
+			if err != nil {
+				return nil, nil, fmt.Errorf("parse issue.meta frontmatter for %s: %w", identifier, err)
+			}
+			id, ok := meta.Frontmatter["id"].(string)
+			if !ok || id == "" {
+				return nil, nil, fmt.Errorf("issue.meta for %s carries no id; every id-keyed "+
+					"assertion downstream would fail as 'not found'. Frontmatter: %v",
+					identifier, meta.Frontmatter)
+			}
 
 			issue := &api.Issue{
 				ID:         id,

--- a/internal/integration/validation_refresh_test.go
+++ b/internal/integration/validation_refresh_test.go
@@ -90,9 +90,7 @@ func readIssueError(t *testing.T, identifier string) string {
 // + retry — the refresh stub plays "Linear has it", upserting the label the
 // way the real refresh's team-metadata drain would.
 func TestStaleCatalogWriteSelfHeals(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-only: exercises the injected catalog-refresh seam")
-	}
+	skipIfLiveAPI(t, "fixture-only: exercises the injected catalog-refresh seam")
 	enableMockMutations(t)
 	identifier := createRefreshTestIssue(t, "Stale Catalog Self-Heal Probe")
 
@@ -150,9 +148,7 @@ func TestStaleCatalogWriteSelfHeals(t *testing.T) {
 // fails with the same .error message as before — after exactly one refresh
 // attempt, never more.
 func TestNonexistentNameFailsAfterOneRefresh(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-only: exercises the injected catalog-refresh seam")
-	}
+	skipIfLiveAPI(t, "fixture-only: exercises the injected catalog-refresh seam")
 	enableMockMutations(t)
 	identifier := createRefreshTestIssue(t, "Nonexistent Name Probe")
 
@@ -198,9 +194,7 @@ func (r rejectingMutator) UpdateIssue(ctx context.Context, issueID string, input
 // classifier path untouched — resolution succeeded locally, so the catalog
 // refresh never fires.
 func TestAPIRejectionDoesNotRefresh(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-only: exercises the injected catalog-refresh seam")
-	}
+	skipIfLiveAPI(t, "fixture-only: exercises the injected catalog-refresh seam")
 	enableMockMutations(t)
 	identifier := createRefreshTestIssue(t, "API Rejection Probe")
 

--- a/internal/integration/write_offline_test.go
+++ b/internal/integration/write_offline_test.go
@@ -62,9 +62,7 @@ func lastEntryByTitle(t *testing.T, lastPath, title string) map[string]string {
 // forget-from-SQLite that stops an archived project resurrecting on the next
 // readdir (#149) is what this asserts.
 func TestOffline_ProjectCreateAndArchive(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline write-path check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline write-path check; uses the mock mutator")
 	enableMockMutations(t)
 
 	const title = "Offline Mock Project Probe"
@@ -104,9 +102,7 @@ func TestOffline_ProjectCreateAndArchive(t *testing.T) {
 // and Unlink. Labels are a collectionDir, so this also exercises its create and
 // unlink heads.
 func TestOffline_LabelCreateRenameDelete(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline write-path check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline write-path check; uses the mock mutator")
 	enableMockMutations(t)
 
 	// Create. The label filename is the name with spaces→dashes (labelFilename).
@@ -147,9 +143,7 @@ func TestOffline_LabelCreateRenameDelete(t *testing.T) {
 // IssuesNode.Rmdir (archive). This reaches the sub-issue create handler and the
 // issue-archive forget that no offline test touched before.
 func TestOffline_IssueLifecycle(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline write-path check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline write-path check; uses the mock mutator")
 	enableMockMutations(t)
 
 	// Top-level issue via mkdir (title-only quick create).
@@ -206,9 +200,7 @@ func TestOffline_IssueLifecycle(t *testing.T) {
 // This reaches LabelsNode.Create and CommentsNode.Create, which the _create
 // path bypasses.
 func TestOffline_NamedFileCreate(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline write-path check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline write-path check; uses the mock mutator")
 	enableMockMutations(t)
 
 	// Label via a named file. Use a name whose labelFilename is the file we
@@ -261,9 +253,7 @@ func TestOffline_NamedFileCreate(t *testing.T) {
 // nothing (the row/file resurrected on the next readdir). Each probe targets a
 // distinct previously-unguarded node.
 func TestOffline_DeadHandlerUnlinkRejected(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline write-path check")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline write-path check")
 	enableMockMutations(t)
 
 	initDir, err := firstInitiativeDir()
@@ -300,9 +290,7 @@ func TestOffline_DeadHandlerUnlinkRejected(t *testing.T) {
 // (EPERM) rather than silently succeed (go-fuse's no-NodeRmdirer hole). Each probe
 // targets a distinct previously-unguarded node.
 func TestOffline_DeadHandlerRmdirRejected(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline write-path check")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline write-path check")
 	enableMockMutations(t)
 
 	initDir, err := firstInitiativeDir()
@@ -337,9 +325,7 @@ func TestOffline_DeadHandlerRmdirRejected(t *testing.T) {
 // the listing without resurrecting. Milestone deletion had zero coverage of any
 // kind before this (create/edit were covered, delete was not).
 func TestOffline_MilestoneDelete(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline write-path check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline write-path check; uses the mock mutator")
 	enableMockMutations(t)
 
 	msDir := filepath.Join(projectsPath(testTeamKey), "test-project", "milestones")
@@ -364,9 +350,7 @@ func TestOffline_MilestoneDelete(t *testing.T) {
 // must appear and read its body back. Before this only a stat of _create and a
 // pre-seeded read existed — the create-through-the-mount path was uncovered.
 func TestOffline_InitiativeUpdateCreatePersists(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline write-path check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline write-path check; uses the mock mutator")
 	enableMockMutations(t)
 
 	dir, err := firstInitiativeDir()
@@ -394,9 +378,7 @@ func TestOffline_InitiativeUpdateCreatePersists(t *testing.T) {
 // filename must appear in the issue's docs listing (proof the create upserted it
 // with its issue association, not just echoed a .last line).
 func TestOffline_DocumentCreate(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline write-path check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline write-path check; uses the mock mutator")
 	enableMockMutations(t)
 
 	dir := docsPath(testTeamKey, "TST-1")
@@ -415,9 +397,7 @@ func TestOffline_DocumentCreate(t *testing.T) {
 // TestOffline_DocumentDelete drives DocsNode.Unlink: a created doc rm'd must reach
 // DeleteDocument and leave the listing without resurrecting.
 func TestOffline_DocumentDelete(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline write-path check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline write-path check; uses the mock mutator")
 	enableMockMutations(t)
 
 	dir := docsPath(testTeamKey, "TST-1")
@@ -439,9 +419,7 @@ func TestOffline_DocumentDelete(t *testing.T) {
 // TestOffline_MilestoneCreatePersists drives MilestonesNode create: a milestone
 // created via _create must appear with its name and description readable back.
 func TestOffline_MilestoneCreatePersists(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline write-path check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline write-path check; uses the mock mutator")
 	enableMockMutations(t)
 
 	msDir := filepath.Join(projectsPath(testTeamKey), "test-project", "milestones")
@@ -469,9 +447,7 @@ func TestOffline_MilestoneCreatePersists(t *testing.T) {
 // update written to updates/_create must appear as {seq}-{date}-{health}.md and
 // read its body back.
 func TestOffline_ProjectUpdateCreatePersists(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline write-path check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline write-path check; uses the mock mutator")
 	enableMockMutations(t)
 
 	updatesDir := filepath.Join(projectsPath(testTeamKey), "test-project", "updates")
@@ -489,9 +465,7 @@ func TestOffline_ProjectUpdateCreatePersists(t *testing.T) {
 // sub-issue must persist a real child that resolves to its own issue directory
 // (a symlink pointing nowhere would mean the create never reflected).
 func TestOffline_ChildIssuePersistsParent(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline write-path check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline write-path check; uses the mock mutator")
 	enableMockMutations(t)
 
 	childrenDir := filepath.Join(issueDirPath(testTeamKey, "TST-1"), "children")
@@ -509,9 +483,7 @@ func TestOffline_ChildIssuePersistsParent(t *testing.T) {
 }
 
 func TestOffline_RelationCreateAndDelete(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline write-path check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline write-path check; uses the mock mutator")
 	enableMockMutations(t)
 
 	mkIssue := func(title string) string {
@@ -570,9 +542,7 @@ func TestOffline_RelationCreateAndDelete(t *testing.T) {
 // (LinksNode.Unlink): create a project external link via _create, then rm the
 // .link file — it must leave the listing and not resurrect.
 func TestOffline_ProjectLinkCreateAndDelete(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline write-path check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline write-path check; uses the mock mutator")
 	enableMockMutations(t)
 
 	linksDir := filepath.Join(projectsPath(testTeamKey), "test-project", "links")
@@ -601,9 +571,7 @@ func TestOffline_ProjectLinkCreateAndDelete(t *testing.T) {
 // that diverges from the store, is the phantom fall-through covered by
 // TestCreateLinkPhantomProceedsToRealCreate in the fs package.)
 func TestOffline_ProjectLinkCreateIdempotent(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline write-path check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline write-path check; uses the mock mutator")
 	enableMockMutations(t)
 
 	linksDir := filepath.Join(projectsPath(testTeamKey), "test-project", "links")
@@ -631,9 +599,7 @@ func TestOffline_ProjectLinkCreateIdempotent(t *testing.T) {
 // path (AttachmentsNode.Unlink): link an external attachment via _create, then
 // rm the .link file — it must leave the listing and not resurrect.
 func TestOffline_AttachmentCreateAndDelete(t *testing.T) {
-	if liveAPIMode {
-		t.Skip("fixture-mode offline write-path check; uses the mock mutator")
-	}
+	skipIfLiveAPI(t, "fixture-mode offline write-path check; uses the mock mutator")
 	enableMockMutations(t)
 
 	attDir := attachmentsPath(testTeamKey, "TST-1")

--- a/internal/integration/write_test.go
+++ b/internal/integration/write_test.go
@@ -498,9 +498,17 @@ func TestCreatedIssueReadable(t *testing.T) {
 		t.Fatalf("Failed to parse: %v", err)
 	}
 
-	if _, ok := doc.Frontmatter["id"]; !ok {
-		t.Error("Created issue missing id field")
+	// #148 split the created issue's identity out of the editable file: issue.md
+	// carries only editable fields, and the server-managed ones live in the
+	// read-only issue.meta sidecar. Assert BOTH halves — that the id is absent
+	// here is the invariant #148 established, and asserting only "issue.meta has
+	// an id" would still pass if it leaked back into issue.md.
+	for _, f := range []string{"id", "identifier", "url", "updated"} {
+		if _, ok := doc.Frontmatter[f]; ok {
+			t.Errorf("issue.md carries server field %q; #148 moved it to issue.meta", f)
+		}
 	}
+	assertMetaHasFields(t, issueMetaPath(testTeamKey, issue.Identifier), "id", "identifier", "url", "created", "updated")
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes #395
Closes #396
Closes #399

First of a two-PR stack splitting the fixes filed from the first live dispatch of the write suite ([run 30578999501](https://github.com/jra3/linear-fuse/actions/runs/30578999501), 118 pass / 81 fail / 105 skip). **This PR is the test harness; the write-path semantics are in the follow-up so they get reviewed on their own.**

Almost none of the 81 failures were product failure. Three harness defects account for ~62 of them.

## #395 — which mode a test runs in is now declared, not inferred

Four files asserted seeded fixture rows (`TST-1`, `test-project`) with no `liveAPIMode` guard, so they ran live and failed by construction: ~48 `no such file or directory` failures, every one a hardcoded path, none a bug.

The fix is not "add guards" but "give the property one place to live". `internal/integration/modes_test.go` now owns the three spellings, and there are only three:

| spelling | meaning |
|---|---|
| `skipIfNoWriteTests(t)` | mutates a real workspace (live + `LINEARFS_WRITE_TESTS`) |
| `skipIfLiveAPI(t, why)` | fixture-dependent — writes through the mount to assert a structural invariant (`fixtureWriteContract`), or names a seeded row (`fixtureSeededData`) |
| no guard | runs everywhere, and therefore may not name a seeded row — takes identifiers from `someIssueID(t)` / `someProjectSlug(t)` |

So `grep skipIf` over a file answers "does this run live?" per test.

The mount-level contract tests (fsync support, the meta split, the README's documented surfaces) were the accidental casualty of the old scheme: they assert a property of the *render*, not of a particular entity, and hardcoding TST-1 kept them out of every live run. They now derive their target and run.

**Worth flagging for review:** the guards do not catch the quieter form of the same defect — a hardcoded path inside an `if err == nil` does not fail live, it passes while asserting nothing. Where those were found they now resolve from the workspace, but that class is found by reading, not by a rule. #402 tracks the related gap (a sparse live workspace degrades these to skips).

## #396 — `createTestIssue` read `id` from `issue.md`

#148 moved it to the `issue.meta` sidecar. The helper silently bound the empty string and every id-keyed assertion downstream failed as "not found": ~14 failures from one stale line. It reads `issue.meta` now, and fails loudly if the id is missing rather than handing back an issue with no identity.

## #399 — `createTestIssue` treated EAGAIN as fatal

Which is precisely the errno the mount documents as "wait and retry". A live run generates its own EAGAIN under rate-limiting, so the suite was flaky by construction. It now honors the contract with a bounded backoff.

That exposed a **product gap, fixed here too**: EAGAIN covered two situations with different safe follow-ups, and `classifyMutationErr` promised the stronger one for both.

- A request refused *before* it was sent (budget deferral, cancelled pre-send wait, tripped breaker) provably had no effect.
- One whose POST was already on the wire when its context died may have been applied with the response lost — and a blind retry of an in-flight create **duplicates the entity**.

The client marks the latter (`api.ErrInFlight`, set only on a context death in the transport path), `api.IsOutcomeUnknown` exposes it, and the two get different `.error` text. Same errno — the distinction cannot be carried by an errno, which is why the `.error` text is load-bearing. Generated README and `docs/ARCHITECTURE.md` updated to match.

## Testing

Full offline suite green (`go test ./internal/...`). Lint has two pre-existing failures on `main` (`internal/cmd/status_test.go`, `internal/fs/editbuffer_test.go`); neither file is in this stack.

The live behavior is what #401 exists to observe — none of this can be confirmed by the offline suite, by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)