### PR TITLE
fix(fs): refuse an emptied editable file, and stop calling an unappliable write retryable

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,9 +56,9 @@ issues the resolve step is itself a deep module — see Name→ID resolution bel
 ### Edit-flush shell (`editFlush`)
 The **deep module** owning the invariant *shell* every editable file node's FUSE
 `Flush` wraps around its front half and the [[writeback-tail]]: take the buffer
-lock, skip a clean/empty buffer, bound the API work with a 30s timeout, run the
-front half, and on success run the commit tail, adopt the fresh value,
-invalidate the node's kernel-cache set, and clear dirty. All seven handlers
+lock, skip a clean buffer, reject an emptied one, bound the API work with a 30s
+timeout, run the front half, and on success run the commit tail, adopt the fresh
+value, invalidate the node's kernel-cache set, and clear dirty. All seven handlers
 (issue/comment/label/document/milestone/project/initiative) hand-copied it, and
 it had drifted: issues invalidated **before** persisting (a stale-repopulation
 window — a racing read could reload the not-yet-written row and re-cache it),
@@ -71,9 +71,24 @@ The **front half is one `mutate` closure** returning `(proceed bool, errno
 syscall.Errno)`: `errno != 0` → return it and **keep dirty** (a corrected
 re-save retries; mutate owns its own `.error` message); `errno == 0 && !proceed`
 → nothing changed, clear dirty, return 0; `proceed` → commit path. The
-`writeBack` (commit tail), `adopt` (`n.entity = *fresh`), and **`coherence
+`writeBack` (commit tail), `adopt` (`n.entity = *fresh`), **`coherence
 []uint64`** (the invalidation set, now declared as data — a forgotten `.meta`
-sidecar is a visible one-line omission) round out the spec. Projects/initiatives
+sidecar is a visible one-line omission), and **`restore`** round out the spec.
+
+`restore` re-renders the entity's current content and exists for one case: the
+**emptied-buffer rejection** (#397). An empty document has no fields, so applying
+it diffs as "remove every removable field" — a measured five-field wipe on
+`issue.md` — and it is what a crashed editor or a botched tool call produces. The
+shell refuses it with `EINVAL` before the front half runs, which also subsumes the
+old `content == nil` skip: nil is not a third state, it is how the atomic-save
+path spells an emptied file, and treating it as "nothing to do" gave the two save
+paths opposite answers to `> issue.md`. The rejection then **restores the buffer
+and clears dirty**, which is where it deliberately *differs* from a parse failure:
+a parse failure keeps the writer's text dirty for a corrected re-save, but an
+empty buffer holds no text worth preserving, and leaving it dirty would strand the
+node serving zero bytes for its lifetime ([[edit-buffer]]'s `refresh` refuses a
+dirty buffer) — defeating the very recovery the `.error` prescribes, "re-read the
+file to get its current contents". Projects/initiatives
 put their whole multi-mutation front half (labels + links-reconcile + scalar) in
 `mutate` and always return `proceed=true` (they re-fetch to catch link changes);
 the front-half result reaches the commit-tail `compare` through a method-local
@@ -769,7 +784,12 @@ dentry forget inside the window that a test cannot force through the kernel (the
 [[edit-buffer]] bound, #388): every editable node type asserts the `editableFile`
 interface at compile time next to its `fs.NodeWriter` assertion, and every
 `editFlushSpec` literal in the package must set `pinIno` (an AST rule over the
-package source, in the spirit of `scripts/check-safename.sh`). Unit-tested directly (window, expiry, sweep,
+package source, in the spirit of `scripts/check-safename.sh`). A second AST rule
+of the same shape requires every spec to set `restore`, for the same reason —
+the empty-write rejection (#397) is a behavior a new surface inherits only by
+declaring the field, and without it a rejected write strands the buffer. Both
+rules want an explicit `pinIno: 0` / `restore: nil` plus a comment for a spec
+that genuinely has neither. Unit-tested directly (window, expiry, sweep,
 unaliased copies, seed-beats-render) and at the flush seam (the supersede rule) plus
 deterministic mount-level tests over all three files, the reformat-note shape, and
 the EIO no-pin rule (`internal/integration/atomicsave_pin_test.go`) — the rename

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -617,7 +617,10 @@ a layer above the commit-tail primitives) and no telemetry (matching
    futile; the one case is a project/initiative body-clear Linear declines to
    apply, which is `EINVAL` (#398). The verdict is derived from what actually
    persisted, not from a hardcoded belief about the backend, so a backend that
-   does apply it simply succeeds.
+   does apply it simply succeeds. A retryable divergence in the same save
+   outranks the override — telling a caller not to retry a write a retry would
+   fix is the worse error — so mixed outcomes still surface `EIO`, with both
+   messages in `.error`.
 5. **Upserts the fresh result into SQLite** via the tail's per-spec persist
    closure (direct single-entity upserts; the `reconcile` tails belong to the
    worker and SWR, not this flow). This upsert **gates success** across every
@@ -800,7 +803,13 @@ and `mockmutation`, the in-memory fake behind the `MutationClient` seam.
   exactly what a crashed editor or a botched tool call produces. The guard sits
   on the shared shell rather than per-handler so the in-place (`O_TRUNC`, empty
   buffer) and atomic-save (renamed zero-byte scratch, nil buffer) paths cannot
-  give `> issue.md` opposite answers (#397).
+  give `> issue.md` opposite answers (#397). The rejection also RESTORES the
+  buffer from the spec's `restore` closure (the entity's current render) and
+  clears `dirty`, which is what separates it from a parse failure: a parse
+  failure holds text the writer meant and keeps the buffer dirty for a corrected
+  re-save, while an emptied buffer on the in-place path belongs to the canonical
+  node and would otherwise serve zero bytes for the node's whole lifetime —
+  `refresh` refuses a dirty buffer, and only a successful flush clears the flag.
 - **Time handling** is the most common footgun — both directions: parse reads
   via `ParseSQLiteTime*`, stamp writes via `db.Now()` (UTC). Inside the worker,
   scheduling goes through the injected clock seam.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -612,7 +612,12 @@ a layer above the commit-tail primitives) and no telemetry (matching
 4. **Read-your-writes** (`editcommit.go`): re-derives what persisted — an
    independent refetch where a single-entity getter exists (issues, projects,
    initiatives), otherwise the mutation's echoed response — normalizes benign
-   markdown reformatting, and flags a silent revert/truncation as `EIO`.
+   markdown reformatting, and flags a silent revert/truncation as `EIO`. A
+   `writeBackResult` may override that errno where retrying is known to be
+   futile; the one case is a project/initiative body-clear Linear declines to
+   apply, which is `EINVAL` (#398). The verdict is derived from what actually
+   persisted, not from a hardcoded belief about the backend, so a backend that
+   does apply it simply succeeds.
 5. **Upserts the fresh result into SQLite** via the tail's per-spec persist
    closure (direct single-entity upserts; the `reconcile` tails belong to the
    worker and SWR, not this flow). This upsert **gates success** across every
@@ -782,10 +787,20 @@ and `mockmutation`, the in-memory fake behind the `MutationClient` seam.
   `EMSGSIZE`, missing reference → `ENOENT`, rate-limited/timeout/interrupted →
   `EAGAIN`, backend failure → `EIO`; the reason always lands in `.error`,
   cleared on success. A stale local catalog self-heals with one refresh-and-retry
-  before any of that surfaces. One refinement the errno alone cannot carry, so
+  before any of that surfaces. Two refinements the errno alone cannot carry, so
   the `.error` text is load-bearing: an `EAGAIN` says whether the request was
   refused before it was sent (safe to retry blindly) or interrupted in flight
-  (outcome unknown — check first, or duplicate) (#399).
+  (outcome unknown — check first, or duplicate), and an `EIO` from the
+  read-your-writes check means retry, so the one divergence that retrying can
+  never fix — a declined body-clear — is `EINVAL` instead (#398/#399).
+- **Empty writes are refused at the shell:** `editFlush` rejects a flush whose
+  buffer is empty or whitespace-only with `EINVAL` before any handler's front
+  half runs. An empty document has no fields, so applying it diffs as "remove
+  every removable field" — a measured five-field wipe on `issue.md` — and it is
+  exactly what a crashed editor or a botched tool call produces. The guard sits
+  on the shared shell rather than per-handler so the in-place (`O_TRUNC`, empty
+  buffer) and atomic-save (renamed zero-byte scratch, nil buffer) paths cannot
+  give `> issue.md` opposite answers (#397).
 - **Time handling** is the most common footgun — both directions: parse reads
   via `ParseSQLiteTime*`, stamp writes via `db.Now()` (UTC). Inside the worker,
   scheduling goes through the injected clock seam.

--- a/internal/fs/comments.go
+++ b/internal/fs/comments.go
@@ -178,6 +178,7 @@ func (n *CommentNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errno 
 			},
 		},
 		adopt:     func(fresh *api.Comment) { n.comment = *fresh },
+		restore:   func() []byte { return marshal.CommentToMarkdown(&n.comment) },
 		coherence: []uint64{commentIno(n.comment.ID), commentMetaIno(n.comment.ID)},
 		pinIno:    commentIno(n.comment.ID),
 	})

--- a/internal/fs/documents.go
+++ b/internal/fs/documents.go
@@ -268,7 +268,14 @@ func (n *DocumentFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.E
 				return results
 			},
 		},
-		adopt:     func(fresh *api.Document) { n.document = *fresh },
+		adopt: func(fresh *api.Document) { n.document = *fresh },
+		restore: func() []byte {
+			content, err := marshal.DocumentToMarkdown(&n.document)
+			if err != nil {
+				return nil
+			}
+			return content
+		},
 		coherence: []uint64{documentIno(n.document.ID), documentMetaIno(n.document.ID)},
 		pinIno:    documentIno(n.document.ID),
 	})

--- a/internal/fs/editablewiring_test.go
+++ b/internal/fs/editablewiring_test.go
@@ -36,6 +36,34 @@ import (
 // visible, which is all this rule asks for.
 func TestEverySpecSetsPinIno(t *testing.T) {
 	t.Parallel()
+	if missing := specsMissingField(t, "pinIno"); len(missing) > 0 {
+		t.Errorf("editFlushSpec literals with no pinIno (their writes would not survive the node — see #387):\n  %s",
+			strings.Join(missing, "\n  "))
+	}
+}
+
+// TestEverySpecSetsRestore is the same rule for the other field a handler can
+// quietly forget. Without restore, the empty-write rejection (#397) leaves the
+// buffer empty AND dirty, and on the in-place path that buffer belongs to the
+// canonical node: refresh refuses a dirty buffer and only a successful flush
+// clears the flag, so the file serves zero bytes for the rest of the node's life
+// — the exact state the .error tells the writer to recover from by re-reading.
+//
+// Like pinIno, a future spec that genuinely cannot render its entity should say
+// `restore: nil` explicitly with a comment saying why.
+func TestEverySpecSetsRestore(t *testing.T) {
+	t.Parallel()
+	if missing := specsMissingField(t, "restore"); len(missing) > 0 {
+		t.Errorf("editFlushSpec literals with no restore (a rejected empty write would strand the buffer — see #397):\n  %s",
+			strings.Join(missing, "\n  "))
+	}
+}
+
+// specsMissingField reads the package's own source and returns the position of
+// every editFlushSpec literal that does not set field. It fails the test if it
+// finds no literals at all, which would mean the rule has stopped checking.
+func specsMissingField(t *testing.T, field string) []string {
+	t.Helper()
 
 	entries, err := os.ReadDir(".")
 	if err != nil {
@@ -75,7 +103,7 @@ func TestEverySpecSetsPinIno(t *testing.T) {
 				if !ok {
 					continue
 				}
-				if key, ok := kv.Key.(*ast.Ident); ok && key.Name == "pinIno" {
+				if key, ok := kv.Key.(*ast.Ident); ok && key.Name == field {
 					return true
 				}
 			}
@@ -87,9 +115,6 @@ func TestEverySpecSetsPinIno(t *testing.T) {
 	if found == 0 {
 		t.Fatal("no editFlushSpec literals found; this rule has stopped checking anything")
 	}
-	if len(missing) > 0 {
-		sort.Strings(missing)
-		t.Errorf("editFlushSpec literals with no pinIno (their writes would not survive the node — see #387):\n  %s",
-			strings.Join(missing, "\n  "))
-	}
+	sort.Strings(missing)
+	return missing
 }

--- a/internal/fs/editcommit.go
+++ b/internal/fs/editcommit.go
@@ -62,8 +62,13 @@ type writeBackSpec[T any] struct {
 // commitWriteBack runs the invariant tail of an edit after the API has accepted
 // the write. It returns the fresh value (nil if it could not be fetched) and the
 // errno the Flush should return: syscall.EIO on a fatal read-your-writes
-// divergence, 0 otherwise (including benign reformats, which leave a note in
-// .error but let the close succeed).
+// divergence — unless a divergence overrode that errno (see below) — and 0
+// otherwise (including benign reformats, which leave a note in .error but let the
+// close succeed).
+//
+// Callers that BRANCH on this errno (renamesave.go does) must therefore not read
+// "not EIO" as "nothing reached Linear": every value below except the front
+// half's own comes from a mutation that already landed.
 //
 // Contract:
 //   - fetch fails        → the write succeeded but its verification re-read did
@@ -75,7 +80,10 @@ type writeBackSpec[T any] struct {
 //     into the live fd — the EIO is a wedge signal, not data loss (#278).
 //   - no divergence      → clear .error, return (fresh, 0).
 //   - benign reformat    → set .error note, return (fresh, 0).
-//   - fatal divergence   → set .error, return (fresh, syscall.EIO).
+//   - fatal divergence   → set .error, return (fresh, syscall.EIO), or the errno
+//     a writeBackResult overrode it with when retrying is known to be futile.
+//     The one such case today is a declined body-clear → EINVAL (#398). A
+//     retryable divergence in the same save outranks the override and keeps EIO.
 func commitWriteBack[T any](ctx context.Context, sink errorSink, spec writeBackSpec[T]) (fresh *T, errno syscall.Errno) {
 	start := time.Now()
 	defer func() { recordFuseOp(ctx, "flush", start, errno) }()

--- a/internal/fs/editcommit.go
+++ b/internal/fs/editcommit.go
@@ -108,7 +108,7 @@ func commitWriteBack[T any](ctx context.Context, sink errorSink, spec writeBackS
 		}
 	}
 
-	divergence, fatal := writeBackError(spec.compare(fresh)...)
+	divergence, fatal, fatalErrno := writeBackError(spec.compare(fresh)...)
 	if divergence == "" {
 		sink.ClearWriteError(spec.errKey)
 		return fresh, 0
@@ -117,6 +117,13 @@ func commitWriteBack[T any](ctx context.Context, sink errorSink, spec writeBackS
 	log.Printf("Read-your-writes %s on %s:\n%s", writeBackKind(fatal), spec.errKey, divergence)
 	sink.SetWriteError(spec.errKey, divergence)
 	if fatal {
+		// EIO unless the result named something else. The one exception so far is
+		// a body-clear Linear declines to apply (#398): the write cannot ever
+		// stick, so EINVAL — "this input is not acceptable" — is the truthful
+		// verdict, where EIO would tell the caller to retry forever.
+		if fatalErrno != 0 {
+			return fresh, fatalErrno
+		}
 		return fresh, syscall.EIO
 	}
 	return fresh, 0

--- a/internal/fs/editflush.go
+++ b/internal/fs/editflush.go
@@ -10,14 +10,20 @@ import (
 
 // emptyWriteMessage is the .error an emptied editable file gets. It follows the
 // Field/Value/Error shape the rest of the write feedback uses, and it says what
-// the writer must do next — the file's current contents are still on the server,
-// so a re-read recovers them.
+// the writer must do next — the shell puts the file's current contents back into
+// the buffer on this rejection, so a re-read recovers them.
+//
+// It deliberately does NOT offer "or empty the body" as a way to clear one
+// field: it is shared by all seven editable surfaces, and on project.md /
+// initiative.md emptying the body is the one write Linear declines to apply
+// (#398). Removing a frontmatter key is the advice that holds everywhere, and it
+// is the wording the generated README already uses.
 func emptyWriteMessage(op string) string {
 	return fmt.Sprintf("Empty write rejected\nOperation: %s\n"+
 		"Error: the file was written with no content. An empty file carries no fields, so applying it "+
 		"would clear every removable field at once rather than change the one you meant. Nothing was written.\n"+
 		"Fix: re-read the file to get its current contents, change the field you mean to change, and write "+
-		"the whole document back. To clear a single field, omit that field's key (or empty the body) and keep the rest.", op)
+		"the whole document back. To clear a single field, omit that field's key and keep the rest.", op)
 }
 
 // The edit-flush shell.
@@ -88,6 +94,20 @@ type editFlushSpec[T any] struct {
 	// forgotten sidecar is a visible one-line omission, not a missing call
 	// buried in a handler. Invalidated only after the commit tail persists.
 	coherence []uint64
+	// restore re-renders the entity's CURRENT content, exactly as the node's
+	// construction seam rendered it. The shell calls it on one path only: the
+	// empty-write rejection below, where it puts those bytes back into the buffer
+	// and clears dirty. Return nil (or an empty render) to decline, and the buffer
+	// is left as-is.
+	//
+	// This is the difference between the two rejections. A parse failure holds a
+	// document the writer meant, so the buffer stays dirty for a corrected
+	// re-save; an emptied file holds nothing worth preserving, and leaving it
+	// would strand the canonical node serving zero bytes for its whole lifetime —
+	// refresh refuses a dirty buffer, and only a successful editFlush clears the
+	// flag — which is exactly the state emptyWriteMessage tells the writer to
+	// recover from by re-reading.
+	restore func() []byte
 	// pinIno is the inode of the canonical file whose Lookup seeds from
 	// authoredPins. A committed clean write pins its bytes there, which is what
 	// makes serve-your-own-writes survive the node — a dentry forget and
@@ -136,10 +156,18 @@ func editFlush[T any](ctx context.Context, sink editFlushSink, eb *editBuffer, s
 	// Linear had lost it.)
 	//
 	// So the shell refuses it here, before any handler's front half: EINVAL plus a
-	// legible .error, buffer left dirty for a corrected re-save, exactly like a
-	// parse failure. Clearing ONE field stays expressible — drop its key, or empty
+	// legible .error. Clearing ONE field stays expressible — drop its key, or empty
 	// the body while keeping the frontmatter. What is no longer expressible is
 	// "clear everything by accident".
+	//
+	// Unlike a parse failure, the buffer is then RESTORED rather than left dirty.
+	// A parse failure holds text the writer meant and a corrected re-save needs
+	// it; an emptied file holds nothing, and on the in-place path (`> issue.md`,
+	// or collectiondir.go's O_TRUNC Create) that buffer belongs to the CANONICAL
+	// node, which would then serve zero bytes for the rest of its life — nothing
+	// clears dirty but a successful flush, and refresh refuses a dirty buffer. The
+	// .error tells the writer to re-read the file to recover its contents, so the
+	// re-read has to actually return them.
 	//
 	// This subsumes the old `eb.content == nil` half of the guard above, and that
 	// is the point: a nil buffer is not a third state, it is how the ATOMIC-SAVE
@@ -149,6 +177,12 @@ func editFlush[T any](ctx context.Context, sink editFlushSink, eb *editBuffer, s
 	// answers to `> issue.md` — silent success on one, a mutation on the other.
 	if len(bytes.TrimSpace(eb.content)) == 0 {
 		sink.SetWriteError(spec.writeBack.errKey, emptyWriteMessage(spec.writeBack.op))
+		if spec.restore != nil {
+			if current := spec.restore(); len(current) > 0 {
+				eb.content = current
+				eb.dirty = false
+			}
+		}
 		return syscall.EINVAL
 	}
 

--- a/internal/fs/editflush.go
+++ b/internal/fs/editflush.go
@@ -1,10 +1,24 @@
 package fs
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"syscall"
 	"time"
 )
+
+// emptyWriteMessage is the .error an emptied editable file gets. It follows the
+// Field/Value/Error shape the rest of the write feedback uses, and it says what
+// the writer must do next — the file's current contents are still on the server,
+// so a re-read recovers them.
+func emptyWriteMessage(op string) string {
+	return fmt.Sprintf("Empty write rejected\nOperation: %s\n"+
+		"Error: the file was written with no content. An empty file carries no fields, so applying it "+
+		"would clear every removable field at once rather than change the one you meant. Nothing was written.\n"+
+		"Fix: re-read the file to get its current contents, change the field you mean to change, and write "+
+		"the whole document back. To clear a single field, omit that field's key (or empty the body) and keep the rest.", op)
+}
 
 // The edit-flush shell.
 //
@@ -105,8 +119,37 @@ func editFlush[T any](ctx context.Context, sink editFlushSink, eb *editBuffer, s
 	eb.mu.Lock()
 	defer eb.mu.Unlock()
 
-	if !eb.dirty || eb.content == nil {
+	if !eb.dirty {
 		return 0
+	}
+
+	// An emptied file is a truncation accident, not an edit (#397). A crashed
+	// editor, a `> file`, or a botched Write tool call leaves zero bytes, and
+	// nothing downstream reads that as "no change": the parse yields a document
+	// with no fields at all, and a diff against an entity that HAS fields
+	// therefore reads as "the writer removed every one of them". On issue.md that
+	// is measured, not hypothetical — a zero-byte write emits
+	// assigneeId=nil, dueDate=nil, estimate=nil, labelIds=[], description=""
+	// in one mutation, wiping five fields the writer never named. (The title
+	// survives; it is not a removable field. The live run that filed #397 read a
+	// cleared title because the emptied buffer was being served back, not because
+	// Linear had lost it.)
+	//
+	// So the shell refuses it here, before any handler's front half: EINVAL plus a
+	// legible .error, buffer left dirty for a corrected re-save, exactly like a
+	// parse failure. Clearing ONE field stays expressible — drop its key, or empty
+	// the body while keeping the frontmatter. What is no longer expressible is
+	// "clear everything by accident".
+	//
+	// This subsumes the old `eb.content == nil` half of the guard above, and that
+	// is the point: a nil buffer is not a third state, it is how the ATOMIC-SAVE
+	// path spells an emptied file (a zero-byte scratch file renamed over the
+	// target hands the flush nil bytes). Treating nil as "nothing to do" while an
+	// O_TRUNC of the same file was a real edit gave the two save paths opposite
+	// answers to `> issue.md` — silent success on one, a mutation on the other.
+	if len(bytes.TrimSpace(eb.content)) == 0 {
+		sink.SetWriteError(spec.writeBack.errKey, emptyWriteMessage(spec.writeBack.op))
+		return syscall.EINVAL
 	}
 
 	// Bound the API work — the front half and the commit tail both call Linear.

--- a/internal/fs/editflush_test.go
+++ b/internal/fs/editflush_test.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"context"
 	"fmt"
+	"strings"
 	"syscall"
 	"testing"
 )
@@ -336,6 +337,97 @@ func TestEditFlushInvalidatesAfterPersist(t *testing.T) {
 	// The stale-repopulation window closes only if persist precedes invalidate.
 	if len(sink.order) < 2 || sink.order[0] != "persist" || sink.order[1] != "invalidate" {
 		t.Errorf("order = %v, want [persist invalidate] (invalidate must follow persist)", sink.order)
+	}
+}
+
+// TestEditFlushEmptiedFileIsRejected pins #397: a file truncated to zero bytes
+// must not reach the front half. Before this, an empty issue.md parsed as "a
+// document with no fields", which diffs against a populated issue as "remove all
+// of them" — one measured write emitted assigneeId=nil, dueDate=nil,
+// estimate=nil, labelIds=[] and description="" together. The write that caused it
+// is the one a crashed editor or a botched Write tool call makes, so it has to
+// fail loudly rather than apply.
+func TestEditFlushEmptiedFileIsRejected(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		content []byte
+	}{
+		{"zero bytes", []byte{}},
+		{"newline only", []byte("\n")},
+		{"whitespace only", []byte("  \n\t\n")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			eb := &editBuffer{content: tc.content, dirty: true}
+			sink := &recordingFlushSink{}
+			called := false
+			errno := editFlush(context.Background(), sink, eb, editFlushSpec[fakeEntity]{
+				mutate:    func(context.Context) (bool, syscall.Errno) { called = true; return true, 0 },
+				writeBack: writeBackSpec[fakeEntity]{errKey: "k", op: "save issue ENG-1"},
+				adopt:     func(*fakeEntity) {},
+				coherence: []uint64{1},
+				pinIno:    1,
+			})
+			if errno != syscall.EINVAL {
+				t.Errorf("errno = %v, want EINVAL", errno)
+			}
+			if called {
+				t.Error("front half ran on an emptied file; the mutation would clear every removable field")
+			}
+			if sink.sets != 1 {
+				t.Errorf("SetWriteError called %d times, want 1 — the rejection must be legible in .error", sink.sets)
+			}
+			if !eb.dirty {
+				t.Error("dirty cleared on a rejected empty write; a corrected re-save cannot retry")
+			}
+			if eb.authored || len(sink.pins) != 0 {
+				t.Errorf("rejected write armed serve-your-own-writes (authored=%v pins=%v); nothing persisted",
+					eb.authored, sink.pins)
+			}
+			if len(sink.invalidated) != 0 {
+				t.Errorf("invalidated %v on a rejected write, want none", sink.invalidated)
+			}
+		})
+	}
+}
+
+// TestEmptyWriteMessageIsActionable: the .error an emptied file leaves must name
+// the operation and tell the agent how to recover, since the file it is looking
+// at is now the empty one it just wrote — the contents it needs are on the server.
+func TestEmptyWriteMessageIsActionable(t *testing.T) {
+	t.Parallel()
+	msg := emptyWriteMessage("save issue ENG-1")
+	for _, want := range []string{"save issue ENG-1", "Nothing was written", "re-read the file", "clear a single field"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("empty-write .error does not mention %q:\n%s", want, msg)
+		}
+	}
+}
+
+// TestEditFlushNonEmptyContentStillFlushes guards the obvious over-reach: only a
+// content-free file is rejected. A one-byte file, or frontmatter with an empty
+// body, is a real edit and must go through.
+func TestEditFlushNonEmptyContentStillFlushes(t *testing.T) {
+	t.Parallel()
+	for _, content := range []string{"x", "---\ntitle: Keep\n---\n", "---\ntitle: Keep\n---\n\n"} {
+		eb := &editBuffer{content: []byte(content), dirty: true}
+		sink := &recordingFlushSink{}
+		called := false
+		errno := editFlush(context.Background(), sink, eb, editFlushSpec[fakeEntity]{
+			mutate: func(context.Context) (bool, syscall.Errno) { called = true; return true, 0 },
+			writeBack: writeBackSpec[fakeEntity]{
+				errKey:  "k",
+				op:      "save issue ENG-1",
+				fetch:   func(context.Context) (*fakeEntity, error) { return &fakeEntity{}, nil },
+				compare: func(*fakeEntity) []writeBackResult { return nil },
+			},
+			adopt:     func(*fakeEntity) {},
+			coherence: []uint64{1},
+		})
+		if errno != 0 || !called {
+			t.Errorf("content %q: errno=%v mutateCalled=%v, want 0/true — this is a real edit", content, errno, called)
+		}
 	}
 }
 

--- a/internal/fs/editflush_test.go
+++ b/internal/fs/editflush_test.go
@@ -39,9 +39,10 @@ func dirtyBuffer() *editBuffer { return &editBuffer{content: []byte("x"), dirty:
 
 func TestEditFlushFailKeepsDirtyNoCommit(t *testing.T) {
 	t.Parallel()
-	eb := dirtyBuffer()
+	eb := &editBuffer{content: []byte("the text the writer meant"), dirty: true}
 	sink := &recordingFlushSink{}
 	fetched := false
+	restored := false
 	errno := editFlush(context.Background(), sink, eb, editFlushSpec[fakeEntity]{
 		mutate: func(context.Context) (bool, syscall.Errno) { return false, syscall.EINVAL },
 		writeBack: writeBackSpec[fakeEntity]{
@@ -49,6 +50,7 @@ func TestEditFlushFailKeepsDirtyNoCommit(t *testing.T) {
 			fetch:  func(context.Context) (*fakeEntity, error) { fetched = true; return &fakeEntity{}, nil },
 		},
 		adopt:     func(*fakeEntity) {},
+		restore:   func() []byte { restored = true; return []byte("the entity's current render") },
 		coherence: []uint64{1, 2},
 	})
 	if errno != syscall.EINVAL {
@@ -56,6 +58,13 @@ func TestEditFlushFailKeepsDirtyNoCommit(t *testing.T) {
 	}
 	if !eb.dirty {
 		t.Error("dirty cleared on a front-half failure; a corrected re-save cannot retry")
+	}
+	// The restore is for the EMPTY-write rejection only. A parse/resolve/mutation
+	// failure holds text the writer meant, and overwriting it with the server's
+	// render would destroy the very document a corrected re-save edits.
+	if restored || string(eb.content) != "the text the writer meant" {
+		t.Errorf("front-half failure restored the buffer (called=%v, content=%q); the writer's text must survive",
+			restored, eb.content)
 	}
 	if fetched {
 		t.Error("commit tail ran despite the front half failing")
@@ -366,6 +375,7 @@ func TestEditFlushEmptiedFileIsRejected(t *testing.T) {
 				mutate:    func(context.Context) (bool, syscall.Errno) { called = true; return true, 0 },
 				writeBack: writeBackSpec[fakeEntity]{errKey: "k", op: "save issue ENG-1"},
 				adopt:     func(*fakeEntity) {},
+				restore:   func() []byte { return []byte("the entity's current render") },
 				coherence: []uint64{1},
 				pinIno:    1,
 			})
@@ -378,8 +388,17 @@ func TestEditFlushEmptiedFileIsRejected(t *testing.T) {
 			if sink.sets != 1 {
 				t.Errorf("SetWriteError called %d times, want 1 — the rejection must be legible in .error", sink.sets)
 			}
-			if !eb.dirty {
-				t.Error("dirty cleared on a rejected empty write; a corrected re-save cannot retry")
+			// The recovery the .error prescribes is "re-read the file to get its
+			// current contents", and on the in-place path this buffer IS the file:
+			// leaving it empty and dirty would strand the canonical node serving
+			// zero bytes, since refresh refuses a dirty buffer and only a
+			// successful flush clears the flag.
+			if string(eb.content) != "the entity's current render" {
+				t.Errorf("buffer = %q after a rejected empty write, want the entity's current render — "+
+					"the .error tells the writer to re-read the file", eb.content)
+			}
+			if eb.dirty {
+				t.Error("dirty left set after restoring the buffer; a background refresh would stay blocked forever")
 			}
 			if eb.authored || len(sink.pins) != 0 {
 				t.Errorf("rejected write armed serve-your-own-writes (authored=%v pins=%v); nothing persisted",
@@ -387,6 +406,43 @@ func TestEditFlushEmptiedFileIsRejected(t *testing.T) {
 			}
 			if len(sink.invalidated) != 0 {
 				t.Errorf("invalidated %v on a rejected write, want none", sink.invalidated)
+			}
+		})
+	}
+}
+
+// TestEditFlushEmptyWriteWithoutRestoreLeavesBufferAlone pins the zero value.
+// All seven shipped specs set restore, but the field is optional, and a spec
+// that declines it (or a render that fails, which returns nil) must not end up
+// with a buffer the shell half-rewrote: the rejection still stands, and the
+// buffer is left exactly as the writer left it.
+func TestEditFlushEmptyWriteWithoutRestoreLeavesBufferAlone(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		restore func() []byte
+	}{
+		{"no restore closure", nil},
+		{"render failed", func() []byte { return nil }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			eb := &editBuffer{content: []byte{}, dirty: true}
+			sink := &recordingFlushSink{}
+			errno := editFlush(context.Background(), sink, eb, editFlushSpec[fakeEntity]{
+				mutate:    func(context.Context) (bool, syscall.Errno) { return true, 0 },
+				writeBack: writeBackSpec[fakeEntity]{errKey: "k", op: "save issue ENG-1"},
+				adopt:     func(*fakeEntity) {},
+				restore:   tc.restore,
+				coherence: []uint64{1},
+				pinIno:    1,
+			})
+			if errno != syscall.EINVAL {
+				t.Errorf("errno = %v, want EINVAL — the rejection does not depend on the restore", errno)
+			}
+			if len(eb.content) != 0 || !eb.dirty {
+				t.Errorf("buffer = %q (dirty=%v), want it untouched when there is nothing to restore from",
+					eb.content, eb.dirty)
 			}
 		})
 	}

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -351,7 +351,8 @@ func (i *InitiativeInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall
 				return edit.divergences("initiative", fresh.Name, fresh.Content)
 			},
 		},
-		adopt: func(fresh *api.Initiative) { i.initiative = *fresh },
+		adopt:   func(fresh *api.Initiative) { i.initiative = *fresh },
+		restore: func() []byte { return i.generateContent() },
 		// initiative.md, its meta, and the projects/ listing.
 		coherence: []uint64{initiativeInfoIno(i.initiativeID), metaIno(i.initiativeID), initiativeProjectsIno(i.initiativeID)},
 		pinIno:    initiativeInfoIno(i.initiativeID), // initiative.md's Lookup seeds from the pin

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -280,6 +280,10 @@ func (i *InitiativeInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall
 				return false, syscall.EINVAL
 			}
 
+			// Scalar diff, computed before the project reconcile below so the
+			// commit-tail compare has it regardless of which branch runs.
+			edit = newScalarEdit(parsed.Name, parsed.Body, i.initiative.Name, i.initiative.Content)
+
 			// Desired projects, already coerced by the parse (absent ⇒ empty ⇒ unlink all)
 			newProjectSlugs := parsed.Projects
 
@@ -315,8 +319,7 @@ func (i *InitiativeInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall
 
 			// Persist editable scalar fields. The body maps to Linear's uncapped
 			// `content`, not the ≤255 `description` (see #5), matching
-			// generateContent().
-			edit = newScalarEdit(parsed.Name, parsed.Body, i.initiative.Name, i.initiative.Content)
+			// generateContent(); edit was diffed above.
 			initiativeInput := api.InitiativeUpdateInput{Name: edit.name, Content: edit.desc}
 			if edit.changed() {
 				if err := i.lfs.mutator().UpdateInitiative(ctx, i.initiativeID, initiativeInput); err != nil {
@@ -345,7 +348,7 @@ func (i *InitiativeInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall
 				return i.lfs.UpsertInitiative(ctx, *fresh)
 			},
 			compare: func(fresh *api.Initiative) []writeBackResult {
-				return edit.divergences(fresh.Name, fresh.Content)
+				return edit.divergences("initiative", fresh.Name, fresh.Content)
 			},
 		},
 		adopt: func(fresh *api.Initiative) { i.initiative = *fresh },

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -544,7 +544,14 @@ func (i *IssueFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errn
 				return results
 			},
 		},
-		adopt:     func(fresh *api.Issue) { i.issue = *fresh },
+		adopt: func(fresh *api.Issue) { i.issue = *fresh },
+		restore: func() []byte {
+			content, err := marshal.IssueToMarkdown(&i.issue)
+			if err != nil {
+				return nil
+			}
+			return content
+		},
 		coherence: []uint64{issueIno(i.issue.ID), metaIno(i.issue.ID)}, // issue.meta reflects the edit
 		pinIno:    issueIno(i.issue.ID),                                // issue.md's Lookup seeds from the pin
 	})

--- a/internal/fs/labels.go
+++ b/internal/fs/labels.go
@@ -210,6 +210,13 @@ func (n *LabelFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errn
 			},
 		},
 		adopt: func(fresh *api.Label) { n.label = *fresh },
+		restore: func() []byte {
+			content, err := marshal.LabelToMarkdown(&n.label)
+			if err != nil {
+				return nil
+			}
+			return content
+		},
 		// The .meta sidecar renders from the label.
 		coherence: []uint64{labelIno(n.label.ID), labelMetaIno(n.label.ID)},
 		pinIno:    labelIno(n.label.ID),

--- a/internal/fs/milestones.go
+++ b/internal/fs/milestones.go
@@ -202,6 +202,13 @@ func (n *MilestoneFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.
 				n.content = newContent
 			}
 		},
+		restore: func() []byte {
+			content, err := marshal.MilestoneToMarkdown(&n.milestone)
+			if err != nil {
+				return nil
+			}
+			return content
+		},
 		coherence: []uint64{milestoneIno(n.milestone.ID), milestoneMetaIno(n.milestone.ID)},
 		pinIno:    milestoneIno(n.milestone.ID),
 	})

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -444,6 +444,10 @@ func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Er
 				return false, syscall.EINVAL
 			}
 
+			// Scalar diff, computed before the initiative reconcile below so the
+			// commit-tail compare has it regardless of which branch runs.
+			edit = newScalarEdit(parsed.Name, parsed.Body, p.project.Name, p.project.Content)
+
 			// Desired initiatives, already coerced by the parse (absent ⇒ empty ⇒ unlink all)
 			newInitiatives := parsed.Initiatives
 
@@ -481,8 +485,7 @@ func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Er
 
 			// Persist editable scalar fields plus the label set in ONE
 			// UpdateProject call. The body maps to Linear's uncapped `content`,
-			// not the ≤255 `description` (see #5).
-			edit = newScalarEdit(parsed.Name, parsed.Body, p.project.Name, p.project.Content)
+			// not the ≤255 `description` (see #5); edit was diffed above.
 			projectInput := api.ProjectUpdateInput{Name: edit.name, Content: edit.desc}
 			labels.applyTo(&projectInput)
 			if edit.changed() || labels.changed() {
@@ -510,7 +513,7 @@ func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Er
 				return p.lfs.UpsertProject(ctx, p.team.ID, *fresh)
 			},
 			compare: func(fresh *api.Project) []writeBackResult {
-				return append(edit.divergences(fresh.Name, fresh.Content), labels.divergences(fresh.LabelIds)...)
+				return append(edit.divergences("project", fresh.Name, fresh.Content), labels.divergences(fresh.LabelIds)...)
 			},
 		},
 		adopt:     func(fresh *api.Project) { p.project = *fresh },

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -517,6 +517,7 @@ func (p *ProjectInfoNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Er
 			},
 		},
 		adopt:     func(fresh *api.Project) { p.project = *fresh },
+		restore:   func() []byte { return p.generateContent(ctx) },
 		coherence: []uint64{projectInfoIno(p.project.ID), metaIno(p.project.ID)}, // project.meta reflects the edit
 		pinIno:    projectInfoIno(p.project.ID),                                  // project.md's Lookup seeds from the pin
 	})

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -323,6 +323,11 @@ cat the .error next to the file (or _create) you wrote to see what went wrong:
 
 Failure model (every writable surface follows this contract):
 - Bad input (invalid field, unknown name, missing required field) -> EINVAL
+- An EMPTIED editable file (0 bytes, or only whitespace) -> EINVAL, and NOTHING is
+  written. An empty document has no fields, so applying it would clear every
+  removable field at once instead of the one you meant. Re-read the file, change
+  what you mean to change, and write the whole document back. To clear one field,
+  omit that field's key and keep the rest.
 - A field longer than its limit (e.g. a too-long name) -> EMSGSIZE
 - Reference to something that doesn't exist (a relation target, rm of an unknown name) -> ENOENT
 - Rate-limited, deferred, or interrupted -> EAGAIN, retry shortly. Read .error to
@@ -350,6 +355,11 @@ Failure model (every writable surface follows this contract):
   later read shows what Linear stored (see EDITING FILES). A write that truly did
   not persist says so — "reverted to its previous content" or "substantially
   shorter" — and returns EIO.
+- One write Linear cannot apply: EMPTYING the body of project.md or initiative.md.
+  Linear accepts an empty content value and keeps the previous text, so this
+  returns EINVAL (not EIO — retrying cannot help) and .error says the previous
+  body was kept. Replace the body with the text you want instead of emptying it.
+  Frontmatter fields still clear the normal way, by deleting the key.
 So an edit that "fails" or appears to no-op is explained at the sibling .error.
 
 Stale-catalog self-healing: a name that resolves nowhere locally (a status,

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -325,9 +325,9 @@ Failure model (every writable surface follows this contract):
 - Bad input (invalid field, unknown name, missing required field) -> EINVAL
 - An EMPTIED editable file (0 bytes, or only whitespace) -> EINVAL, and NOTHING is
   written. An empty document has no fields, so applying it would clear every
-  removable field at once instead of the one you meant. Re-read the file, change
-  what you mean to change, and write the whole document back. To clear one field,
-  omit that field's key and keep the rest.
+  removable field at once instead of the one you meant. The file KEEPS ITS CURRENT
+  CONTENTS -- re-read it, change what you mean to change, and write the whole
+  document back. To clear one field, omit that field's key and keep the rest.
 - A field longer than its limit (e.g. a too-long name) -> EMSGSIZE
 - Reference to something that doesn't exist (a relation target, rm of an unknown name) -> ENOENT
 - Rate-limited, deferred, or interrupted -> EAGAIN, retry shortly. Read .error to

--- a/internal/fs/scalaredit.go
+++ b/internal/fs/scalaredit.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"strings"
+	"syscall"
 )
 
 // scalarEdit is the diff of the two scalar fields both project.md and
@@ -42,17 +43,60 @@ func newScalarEdit(name, body string, curName, curDesc string) scalarEdit {
 // changed reports whether either scalar field needs an API update.
 func (e scalarEdit) changed() bool { return e.name != nil || e.desc != nil }
 
+// clearsBody reports whether this edit empties a body that currently has
+// content. Linear accepts an empty `content` and then ignores it, so this
+// particular edit does not take effect — observed live as "you wrote 0 chars,
+// 34 persisted" (#398).
+//
+// It is deliberately NOT a pre-flight refusal. The mutation still goes out, and
+// this only changes how the write-back classifies the result: if the body really
+// did survive, the caller gets EINVAL and clearBodyMessage instead of the generic
+// silent-revert EIO. EIO means "the write didn't stick, try again", which is the
+// wrong instruction for a write that can never stick; EINVAL plus an explanation
+// is one the caller can act on. And because the verdict comes from what actually
+// persisted rather than from a hardcoded belief about Linear, a backend that DOES
+// apply an empty content — a future Linear, or the mock mutator offline — simply
+// succeeds, and nobody has to remember to delete a stale refusal.
+func (e scalarEdit) clearsBody() bool {
+	return e.desc != nil && *e.desc == "" && strings.TrimSpace(e.origDesc) != ""
+}
+
+// clearBodyMessage is the .error for a clear that the server declined to apply.
+// entity is "project" or "initiative".
+func clearBodyMessage(entity string) string {
+	return "Field: content (body)\n" +
+		"Error: Linear accepted the update and kept the previous body — it ignores an empty content value, " +
+		"so a " + entity + " body cannot be emptied this way. Re-saving the same empty body will do the same thing.\n" +
+		"Fix: replace the body with the text you want rather than emptying it (a single \"-\" if you need it " +
+		"visually empty). Frontmatter fields still clear the normal way, by removing the key."
+}
+
 // divergences classifies the read-your-writes result for each field that was
 // sent, comparing what we sent against what persisted (relative to the pre-write
 // value). Only fields that actually changed are checked — an untouched field
 // can't diverge. name is checked before description, one canonical order.
-func (e scalarEdit) divergences(freshName, freshDesc string) []writeBackResult {
+//
+// entity ("project"/"initiative") only names the surface in the one message that
+// needs it: a body-clear the server declined (#398).
+func (e scalarEdit) divergences(entity, freshName, freshDesc string) []writeBackResult {
 	var results []writeBackResult
 	if e.name != nil {
 		results = append(results, writeBackDivergence("name", *e.name, freshName, e.origName))
 	}
 	if e.desc != nil {
-		results = append(results, writeBackDivergence("content (body)", *e.desc, freshDesc, e.origDesc))
+		// A declined clear is a silent revert by the generic rule, but a
+		// permanently unfixable one, so it gets its own verdict: EINVAL with an
+		// explanation, not a retryable-looking EIO. If the clear DID take, this
+		// falls through and reports success like any other faithful write.
+		if e.clearsBody() && strings.TrimSpace(freshDesc) != "" {
+			results = append(results, writeBackResult{
+				message: clearBodyMessage(entity),
+				fatal:   true,
+				errno:   syscall.EINVAL,
+			})
+		} else {
+			results = append(results, writeBackDivergence("content (body)", *e.desc, freshDesc, e.origDesc))
+		}
 	}
 	return results
 }

--- a/internal/fs/scalaredit_test.go
+++ b/internal/fs/scalaredit_test.go
@@ -1,6 +1,8 @@
 package fs
 
 import (
+	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -50,10 +52,95 @@ func TestScalarEditEmptyNameLeavesItAlone(t *testing.T) {
 }
 
 func TestScalarEditClearsDescription(t *testing.T) {
-	// Emptying the body clears the description (sends an empty string).
+	// Emptying the body diffs as an empty-string send — the diff is honest about
+	// what the writer asked for, and the mutation goes out. Whether it took is
+	// decided afterwards, from what persisted (see the declined-clear test).
 	e := newScalarEdit("Same", "   ", "Same", "had content")
 	if e.desc == nil || *e.desc != "" {
 		t.Errorf("desc = %v, want pointer to empty string (cleared)", e.desc)
+	}
+}
+
+// TestScalarEditClearsBody pins the shape #398 turns on: which edits are a
+// "clear the body" at all. Only those get the special verdict when the server
+// declines them; everything else keeps the generic divergence classification.
+func TestScalarEditClearsBody(t *testing.T) {
+	cases := []struct {
+		name             string
+		body, currentDoc string
+		want             bool
+	}{
+		{"emptying a body with content", "", "had content", true},
+		{"whitespace-only over content", "   \n", "had content", true},
+		{"already empty stays a no-op", "", "", false},
+		{"already whitespace stays a no-op", "", "  \n", false},
+		{"replacing content is fine", "new text", "had content", false},
+		{"unchanged body is fine", "same", "same", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newScalarEdit("Same", tc.body, "Same", tc.currentDoc)
+			if got := e.clearsBody(); got != tc.want {
+				t.Errorf("clearsBody() = %v, want %v (body=%q current=%q, desc=%v)",
+					got, tc.want, tc.body, tc.currentDoc, e.desc)
+			}
+		})
+	}
+}
+
+// TestClearBodyMessageIsActionable: the verdict is only worth having if it tells
+// the caller the thing they cannot discover themselves — that no re-save of the
+// same bytes will ever work, and what to write instead.
+func TestClearBodyMessageIsActionable(t *testing.T) {
+	msg := clearBodyMessage("project")
+	for _, want := range []string{"content (body)", "kept the previous body", "Re-saving the same empty body", "replace the body"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("clear-body .error does not mention %q:\n%s", want, msg)
+		}
+	}
+}
+
+// TestScalarEditDeclinedClearIsEINVALNotEIO is the classification #398 turns on:
+// the SAME edit gets two different verdicts depending on what the server did with
+// it. Declined (the body survived) → EINVAL, because retrying is futile. Applied
+// (the body really is gone) → clean success, no divergence at all. Deciding from
+// the persisted value rather than from a belief about Linear is what makes the
+// second case work without anyone editing this code.
+func TestScalarEditDeclinedClearIsEINVALNotEIO(t *testing.T) {
+	e := newScalarEdit("Same", "", "Same", "the previous body")
+
+	declined := e.divergences("project", "Same", "the previous body")
+	if len(declined) != 1 || !declined[0].fatal {
+		t.Fatalf("declined clear = %+v, want one fatal result", declined)
+	}
+	if declined[0].errno != syscall.EINVAL {
+		t.Errorf("declined clear errno = %v, want EINVAL (EIO would tell the caller to retry a write that can never stick)", declined[0].errno)
+	}
+	if !strings.Contains(declined[0].message, "kept the previous body") {
+		t.Errorf("declined clear message is the generic silent-revert text, not the #398 explanation:\n%s", declined[0].message)
+	}
+
+	applied := e.divergences("project", "Same", "")
+	if len(applied) != 1 || applied[0].message != "" || applied[0].fatal {
+		t.Errorf("applied clear = %+v, want a clean result — the body really was emptied", applied)
+	}
+}
+
+// TestWriteBackErrorCarriesFatalErrno: the errno override has to survive the
+// combine step, and a plain fatal result must still leave it zero so
+// commitWriteBack falls back to EIO.
+func TestWriteBackErrorCarriesFatalErrno(t *testing.T) {
+	_, fatal, errno := writeBackError(writeBackResult{message: "m", fatal: true, errno: syscall.EINVAL})
+	if !fatal || errno != syscall.EINVAL {
+		t.Errorf("fatal=%v errno=%v, want true/EINVAL", fatal, errno)
+	}
+	_, fatal, errno = writeBackError(writeBackResult{message: "m", fatal: true})
+	if !fatal || errno != 0 {
+		t.Errorf("plain fatal: fatal=%v errno=%v, want true/0 (caller falls back to EIO)", fatal, errno)
+	}
+	_, fatal, errno = writeBackError(writeBackResult{message: "note", fatal: false, errno: syscall.EINVAL})
+	if fatal || errno != 0 {
+		t.Errorf("non-fatal note: fatal=%v errno=%v, want false/0 — errno is ignored unless fatal", fatal, errno)
 	}
 }
 
@@ -61,7 +148,7 @@ func TestScalarEditDivergencesOnlyChangedFields(t *testing.T) {
 	// Only the fields that were sent are checked — an untouched field can't
 	// diverge. Here only the name changed.
 	e := newScalarEdit("Sent Name", "Same body", "Old Name", "Same body")
-	results := e.divergences("Sent Name", "Same body")
+	results := e.divergences("project", "Sent Name", "Same body")
 	if len(results) != 1 {
 		t.Fatalf("divergences = %d results, want 1 (only name changed)", len(results))
 	}
@@ -73,7 +160,7 @@ func TestScalarEditDivergencesOnlyChangedFields(t *testing.T) {
 func TestScalarEditDivergencesFlagsSilentRevert(t *testing.T) {
 	// Sent a new name, but the fresh value reverted to the original: fatal.
 	e := newScalarEdit("Sent Name", "b", "Old Name", "b")
-	results := e.divergences("Old Name", "b") // fresh reverted to original
+	results := e.divergences("project", "Old Name", "b") // fresh reverted to original
 	if len(results) != 1 || !results[0].fatal {
 		t.Fatalf("expected 1 fatal divergence for a silent revert, got %+v", results)
 	}

--- a/internal/fs/writeback.go
+++ b/internal/fs/writeback.go
@@ -117,26 +117,45 @@ func writeBackDivergence(field, want, got, prev string) writeBackResult {
 // whether the overall outcome is fatal, plus the errno a fatal outcome should
 // surface (EIO unless a result asked for something else). Returns ("", false, 0)
 // when every field persisted faithfully.
+//
+// A RETRYABLE fatal result outranks an override. One save can carry both kinds:
+// project.md's compare concatenates the scalar divergences with the label ones,
+// so a save that empties the body (declined, EINVAL) and also loses a label
+// (a plain fatal, EIO) produces both. EIO wins there, because the two wrong
+// answers are not symmetric — an EIO the caller retries pointlessly costs one
+// request, while an EINVAL tells them not to retry a write a retry would fix,
+// and the label loss stays lost. Both messages are in the .error either way, so
+// only the errno is at stake.
 func writeBackError(results ...writeBackResult) (string, bool, syscall.Errno) {
 	var msgs []string
 	fatal := false
+	retryable := false
 	errno := syscall.Errno(0)
 	for _, r := range results {
 		if r.message == "" {
 			continue
 		}
 		msgs = append(msgs, r.message)
-		if r.fatal {
-			fatal = true
-			// First explicit errno wins; a plain fatal result leaves it zero and
-			// the caller falls back to EIO.
-			if errno == 0 {
-				errno = r.errno
-			}
+		if !r.fatal {
+			continue
+		}
+		fatal = true
+		if r.errno == 0 {
+			// A plain fatal result is the retryable kind: the caller falls back
+			// to EIO, and that fallback outranks any override.
+			retryable = true
+			continue
+		}
+		// First explicit errno wins among the overrides.
+		if errno == 0 {
+			errno = r.errno
 		}
 	}
 	if len(msgs) == 0 {
 		return "", false, 0
+	}
+	if retryable {
+		errno = 0
 	}
 	header := "Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).\n"
 	if fatal {

--- a/internal/fs/writeback.go
+++ b/internal/fs/writeback.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"syscall"
 )
 
 // Read-your-writes verification.
@@ -63,6 +64,12 @@ func normalizeMarkdown(s string) string {
 type writeBackResult struct {
 	message string
 	fatal   bool
+	// errno overrides the errno a fatal result surfaces. Zero means EIO, the
+	// right answer for the general case: the write didn't stick, so retry. It is
+	// set only where retrying is known to be futile — a body-clear Linear
+	// declines to apply (#398) is EINVAL, because the same bytes will always be
+	// declined and "try again" would be a lie. Ignored when fatal is false.
+	errno syscall.Errno
 }
 
 // writeBackDivergence classifies how a single free-text field persisted. want is
@@ -107,11 +114,13 @@ func writeBackDivergence(field, want, got, prev string) writeBackResult {
 }
 
 // writeBackError combines per-field results into the .error payload and reports
-// whether the overall outcome is fatal. Returns ("", false) when every field
-// persisted faithfully.
-func writeBackError(results ...writeBackResult) (string, bool) {
+// whether the overall outcome is fatal, plus the errno a fatal outcome should
+// surface (EIO unless a result asked for something else). Returns ("", false, 0)
+// when every field persisted faithfully.
+func writeBackError(results ...writeBackResult) (string, bool, syscall.Errno) {
 	var msgs []string
 	fatal := false
+	errno := syscall.Errno(0)
 	for _, r := range results {
 		if r.message == "" {
 			continue
@@ -119,16 +128,21 @@ func writeBackError(results ...writeBackResult) (string, bool) {
 		msgs = append(msgs, r.message)
 		if r.fatal {
 			fatal = true
+			// First explicit errno wins; a plain fatal result leaves it zero and
+			// the caller falls back to EIO.
+			if errno == 0 {
+				errno = r.errno
+			}
 		}
 	}
 	if len(msgs) == 0 {
-		return "", false
+		return "", false, 0
 	}
 	header := "Read-your-writes note: your write was accepted; Linear reformatted the markdown server-side (no content lost).\n"
 	if fatal {
 		header = "Read-your-writes violation: your write was accepted by Linear but did not persist as written.\n"
 	}
-	return header + strings.Join(msgs, "\n"), fatal
+	return header + strings.Join(msgs, "\n"), fatal, errno
 }
 
 // writeBackKind returns a word for log lines describing a divergence outcome.

--- a/internal/fs/writeback_test.go
+++ b/internal/fs/writeback_test.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -131,5 +132,37 @@ func TestWriteBackError_Aggregation(t *testing.T) {
 	}
 	if !strings.Contains(msg, "reformatted") || !strings.Contains(msg, "reverted") {
 		t.Errorf("expected both field messages joined, got: %q", msg)
+	}
+}
+
+// TestWriteBackError_ErrnoPrecedence pins which errno a save carrying more than
+// one fatal divergence surfaces. project.md's compare concatenates the scalar
+// divergences with the label ones, so "empty the body AND lose a label" is a
+// single reachable save, and the two verdicts disagree: the declined body-clear
+// says EINVAL (retrying is futile), the lost label says EIO (retry). EIO must
+// win — an EINVAL there tells the caller not to retry a write a retry would fix,
+// and the label stays lost. Both messages ride along regardless.
+func TestWriteBackError_ErrnoPrecedence(t *testing.T) {
+	t.Parallel()
+	declined := writeBackResult{message: "Field: content (body)\nError: kept the previous body", fatal: true, errno: syscall.EINVAL}
+	retryable := writeBackResult{message: "Field: labels\nError: reverted", fatal: true}
+
+	// An override alone is honoured.
+	if _, fatal, errno := writeBackError(declined); !fatal || errno != syscall.EINVAL {
+		t.Errorf("declined clear alone: fatal=%v errno=%v, want true/EINVAL", fatal, errno)
+	}
+	// A plain fatal alone leaves the errno zero so the caller falls back to EIO.
+	if _, fatal, errno := writeBackError(retryable); !fatal || errno != 0 {
+		t.Errorf("retryable alone: fatal=%v errno=%v, want true/0 (caller falls back to EIO)", fatal, errno)
+	}
+	// Mixed, in either order: the retryable one wins, and both messages survive.
+	for _, order := range [][]writeBackResult{{declined, retryable}, {retryable, declined}} {
+		msg, fatal, errno := writeBackError(order...)
+		if !fatal || errno != 0 {
+			t.Errorf("mixed: fatal=%v errno=%v, want true/0 — a retryable divergence outranks the override", fatal, errno)
+		}
+		if !strings.Contains(msg, "kept the previous body") || !strings.Contains(msg, "Field: labels") {
+			t.Errorf("mixed: .error lost a message, got: %q", msg)
+		}
 	}
 }

--- a/internal/fs/writeback_test.go
+++ b/internal/fs/writeback_test.go
@@ -106,13 +106,13 @@ func TestWriteBackDivergence_BenignReformat(t *testing.T) {
 func TestWriteBackError_Aggregation(t *testing.T) {
 	t.Parallel()
 	// All faithful → empty, non-fatal.
-	if msg, fatal := writeBackError(writeBackResult{}, writeBackResult{}); msg != "" || fatal {
+	if msg, fatal, _ := writeBackError(writeBackResult{}, writeBackResult{}); msg != "" || fatal {
 		t.Errorf("all-faithful should be empty/non-fatal, got msg=%q fatal=%v", msg, fatal)
 	}
 
 	// A note alone → non-fatal, "note" header.
 	note := writeBackResult{message: "Field: x\nNote: reformatted", fatal: false}
-	msg, fatal := writeBackError(note)
+	msg, fatal, _ := writeBackError(note)
 	if fatal {
 		t.Error("a note alone must not be fatal")
 	}
@@ -122,7 +122,7 @@ func TestWriteBackError_Aggregation(t *testing.T) {
 
 	// Any fatal field makes the whole outcome fatal with the violation header.
 	bad := writeBackResult{message: "Field: y\nError: reverted", fatal: true}
-	msg, fatal = writeBackError(note, bad)
+	msg, fatal, _ = writeBackError(note, bad)
 	if !fatal {
 		t.Error("any fatal field must make the outcome fatal")
 	}

--- a/internal/integration/claude_tools_test.go
+++ b/internal/integration/claude_tools_test.go
@@ -9,6 +9,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/jra3/linear-fuse/internal/marshal"
 )
 
 // =============================================================================
@@ -721,6 +723,62 @@ func TestClaudeToolEditPersistsProjectDescription(t *testing.T) {
 	}
 	if !strings.Contains(string(after), marker) {
 		t.Fatalf("project description did not persist marker %q\n--- got ---\n%s", marker, after)
+	}
+}
+
+// TestClearProjectBodyIsRejectedLegibly is the live half of #398. Linear accepts
+// an empty `content` and then ignores it, so emptying a project body does not
+// take effect. The read-your-writes check catches that correctly; what was wrong
+// was the verdict — EIO, which reads as "retry", for a write that can never
+// succeed no matter how many times it is retried. It must be EINVAL, with a
+// .error saying the previous body was kept and what to write instead.
+//
+// Live-only by necessity: the verdict is derived from what the SERVER did with
+// the empty content, and the offline mock applies it (correctly reporting
+// success), so there is nothing to assert in fixture mode.
+func TestClearProjectBodyIsRejectedLegibly(t *testing.T) {
+	skipIfNoWriteTests(t)
+
+	slug, cleanup := createTestProject(t, "Clear Body")
+	defer cleanup()
+
+	path := projectFilePath(testTeamKey, slug)
+	orig, err := readFileWithRetry(path, defaultWaitTime)
+	if err != nil {
+		t.Fatalf("read new project.md: %v", err)
+	}
+
+	// Give it a body first — clearing an already-empty body is a no-op, not the
+	// case under test.
+	doc, err := parseFrontmatter(orig)
+	if err != nil {
+		t.Fatalf("parse project.md: %v", err)
+	}
+	withBody, err := marshal.Render(&marshal.Document{Frontmatter: doc.Frontmatter, Body: "a body that cannot be cleared"})
+	if err != nil {
+		t.Fatalf("render project.md with a body: %v", err)
+	}
+	claudeToolWrite(t, path, withBody)
+	waitForCacheExpiry()
+
+	// Now empty the body, keeping the frontmatter — the shape a "clear the
+	// description" edit takes, and the shape the restore half of an undo takes.
+	cleared, err := marshal.Render(&marshal.Document{Frontmatter: doc.Frontmatter, Body: ""})
+	if err != nil {
+		t.Fatalf("render project.md with an empty body: %v", err)
+	}
+	werr := claudeToolSaveExpectingError(t, path, cleared)
+	if !errors.Is(werr, syscall.EINVAL) {
+		t.Errorf("clearing a project body returned %v, want EINVAL — Linear cannot apply it, "+
+			"so the caller needs a verdict they can act on rather than a retryable-looking EIO", werr)
+	}
+
+	errPath := filepath.Join(projectDirPath(testTeamKey, slug), ".error")
+	data := readFileUntilContains(t, errPath, "kept the previous body", errorVisibilityWait)
+	for _, want := range []string{"kept the previous body", "Re-saving the same empty body"} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("project .error does not mention %q, got:\n%s", want, data)
+		}
 	}
 }
 

--- a/internal/integration/error_test.go
+++ b/internal/integration/error_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+
+	"github.com/jra3/linear-fuse/internal/marshal"
 )
 
 // =============================================================================
@@ -189,8 +191,7 @@ func TestMalformedYAMLDoesNotCrash(t *testing.T) {
 // .error explains it, and the issue's fields are untouched.
 func TestEmptyWriteDoesNotCorrupt(t *testing.T) {
 	skipIfNoWriteTests(t)
-	issue, cleanup, err := createTestIssue("Empty Write Test",
-		WithDescription("a body that an empty write must not clear"))
+	issue, cleanup, err := createTestIssue("Empty Write Test")
 	if err != nil {
 		t.Fatalf("Failed to create test issue: %v", err)
 	}
@@ -208,8 +209,36 @@ func TestEmptyWriteDoesNotCorrupt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse original issue.md: %v", err)
 	}
+
+	// Give the issue a real body FIRST. createTestIssue mkdirs the issue with
+	// nothing but a title, so without this the description is "" and the
+	// body-was-not-cleared assertion below compares "" to "" — it would pass just
+	// as happily if the empty write had wiped the body, which is the whole point
+	// of #397. The write goes through the mount so it needs no option the helper
+	// honours.
+	withBody, err := marshal.Render(&marshal.Document{
+		Frontmatter: doc.Frontmatter,
+		Body:        "a body that an empty write must not clear",
+	})
+	if err != nil {
+		t.Fatalf("render issue.md with a body: %v", err)
+	}
+	claudeToolWrite(t, path, withBody)
+	waitForCacheExpiry()
+
+	original, err = readFileWithRetry(path, defaultWaitTime)
+	if err != nil {
+		t.Fatalf("re-read issue.md after seeding the body: %v", err)
+	}
+	doc, err = parseFrontmatter(original)
+	if err != nil {
+		t.Fatalf("parse seeded issue.md: %v", err)
+	}
 	originalTitle, _ := doc.Frontmatter["title"].(string)
 	originalBody := doc.Body
+	if strings.TrimSpace(originalBody) == "" {
+		t.Fatal("issue.md still has no body after seeding one; the body-wipe assertion below would be vacuous")
+	}
 
 	// Empty the file the way a truncating save does. The rename form is used
 	// deliberately: an O_TRUNC+write can have its verdict masked when the kernel
@@ -231,9 +260,10 @@ func TestEmptyWriteDoesNotCorrupt(t *testing.T) {
 		}
 	}
 
-	// And nothing was applied. Read through the API-backed .meta path rather than
-	// the just-written file: a rejected write leaves the empty bytes in the buffer,
-	// so issue.md itself is expected to read empty until the next refresh.
+	// And nothing was applied. The check reads the stored row rather than the file
+	// so it sees what LINEAR holds: the atomic-save path this test uses lands the
+	// empty bytes on a transient node, so issue.md still serves its own content
+	// either way and would not distinguish "rejected" from "applied".
 	fresh, err := getIssueFromSQLite(issue.ID)
 	if err != nil {
 		t.Fatalf("issue not readable after the rejected write: %v", err)

--- a/internal/integration/error_test.go
+++ b/internal/integration/error_test.go
@@ -1,7 +1,11 @@
 package integration
 
 import (
+	"errors"
 	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -173,9 +177,20 @@ func TestMalformedYAMLDoesNotCrash(t *testing.T) {
 	}
 }
 
+// TestEmptyWriteDoesNotCorrupt is the live half of #397. An emptied issue.md is
+// a truncation accident — a crashed editor, a `> file`, a botched Write tool
+// call — and it must be REJECTED, not applied: an empty document has no fields,
+// so applying it clears every removable field the issue had (measured: assignee,
+// due, estimate, labels, and the body, in one mutation).
+//
+// This test used to observe that and t.Logf about it, so a test named
+// "DoesNotCorrupt" reported PASS while watching the corruption. The assertions
+// below are the ones its name always claimed: the write fails with EINVAL, the
+// .error explains it, and the issue's fields are untouched.
 func TestEmptyWriteDoesNotCorrupt(t *testing.T) {
 	skipIfNoWriteTests(t)
-	issue, cleanup, err := createTestIssue("Empty Write Test")
+	issue, cleanup, err := createTestIssue("Empty Write Test",
+		WithDescription("a body that an empty write must not clear"))
 	if err != nil {
 		t.Fatalf("Failed to create test issue: %v", err)
 	}
@@ -189,22 +204,44 @@ func TestEmptyWriteDoesNotCorrupt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to read issue: %v", err)
 	}
-
-	// Write empty content
-	err = os.WriteFile(path, []byte{}, 0644)
-	// Should either fail or be handled gracefully
-	_ = err
-
-	// Verify via filesystem that issue still exists
-	fsIssue, err := getIssueFromFilesystem(issue.Identifier)
+	doc, err := parseFrontmatter(original)
 	if err != nil {
-		t.Fatalf("Issue became inaccessible after empty write: %v", err)
+		t.Fatalf("parse original issue.md: %v", err)
+	}
+	originalTitle, _ := doc.Frontmatter["title"].(string)
+	originalBody := doc.Body
+
+	// Empty the file the way a truncating save does. The rename form is used
+	// deliberately: an O_TRUNC+write can have its verdict masked when the kernel
+	// serves the write from a primed page cache, whereas a rename runs Flush
+	// inline and hands back the errno (the same reason claudeToolSaveExpectingError
+	// exists).
+	werr := claudeToolSaveExpectingError(t, path, []byte{})
+	if !errors.Is(werr, syscall.EINVAL) {
+		t.Errorf("emptying issue.md returned %v, want EINVAL — an empty document has no fields, "+
+			"so applying it clears every removable field the issue had", werr)
 	}
 
-	// Original title should still be there (empty write shouldn't corrupt)
-	doc, _ := parseFrontmatter(original)
-	originalTitle, _ := doc.Frontmatter["title"].(string)
-	if fsIssue.Title != originalTitle {
-		t.Logf("Note: Empty write may have affected issue (original: %q, current: %q)", originalTitle, fsIssue.Title)
+	// The rejection is legible: .error says what happened and how to recover.
+	errPath := filepath.Join(issueDirPath(testTeamKey, issue.Identifier), ".error")
+	data := readFileUntilContains(t, errPath, "Empty write rejected", errorVisibilityWait)
+	for _, want := range []string{"Empty write rejected", "Nothing was written"} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf(".error does not mention %q after an empty write, got:\n%s", want, data)
+		}
+	}
+
+	// And nothing was applied. Read through the API-backed .meta path rather than
+	// the just-written file: a rejected write leaves the empty bytes in the buffer,
+	// so issue.md itself is expected to read empty until the next refresh.
+	fresh, err := getIssueFromSQLite(issue.ID)
+	if err != nil {
+		t.Fatalf("issue not readable after the rejected write: %v", err)
+	}
+	if fresh.Title != originalTitle {
+		t.Errorf("title = %q after a rejected empty write, want the original %q", fresh.Title, originalTitle)
+	}
+	if strings.TrimSpace(fresh.Description) != strings.TrimSpace(originalBody) {
+		t.Errorf("description = %q after a rejected empty write, want the original %q", fresh.Description, originalBody)
 	}
 }

--- a/internal/integration/readme_test.go
+++ b/internal/integration/readme_test.go
@@ -1,11 +1,13 @@
 package integration
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -131,6 +133,15 @@ func TestGeneratedReadmeMatchesBehavior(t *testing.T) {
 		t.Error("README carves attachments/relations out of .last, but every create surface reports to .last now")
 	}
 
+	// #397/#398: the two empty-write verdicts. Both are things an agent discovers
+	// only by doing the destructive thing, so the README has to say them up front —
+	// and they must not drift back into the old behavior (an emptied issue.md
+	// clearing five fields; an empty project body returning a retryable EIO).
+	for _, want := range []string{"EMPTIED editable file", "Linear cannot apply"} {
+		if !strings.Contains(readme, want) {
+			t.Errorf("README failure model does not document the empty-write contract: missing %q", want)
+		}
+	}
 	// #399: EAGAIN covers two situations with different safe follow-ups, and the
 	// README must not collapse them back into one "the write did not take effect"
 	// promise — that promise is false for a request interrupted after it was sent,
@@ -140,6 +151,28 @@ func TestGeneratedReadmeMatchesBehavior(t *testing.T) {
 			t.Errorf("README does not distinguish the two EAGAIN outcomes: missing %q", want)
 		}
 	}
+	// And the documented behavior is real. The probe targets a doc .md rather
+	// than issue.md for two reasons: the guard lives on the shared edit-flush
+	// shell, so any editable file proves it; and a rejected write leaves .error
+	// populated, which on issue.md would be shared-mount residue another test
+	// reads. A collection's .error is explicitly not assumed empty by this suite
+	// (see TestErrorFileExposedOnWritableSurfaces).
+	//
+	// Emptying goes through O_TRUNC rather than the atomic-rename helper: docs/
+	// does not accept a scratch temp file (#389), and O_TRUNC is deterministic
+	// here anyway — the truncate is a real setattr the kernel cannot serve from
+	// cache, so the close-time Flush always runs and hands back its errno.
+	if docTarget, err := firstWritableFile(docsPath(testTeamKey, readmeIssueID)); err == nil {
+		f, err := os.OpenFile(docTarget, os.O_WRONLY|os.O_TRUNC, 0644)
+		if err != nil {
+			t.Fatalf("open %s to empty it: %v", docTarget, err)
+		}
+		if cerr := f.Close(); !errors.Is(cerr, syscall.EINVAL) {
+			t.Errorf("README says an emptied editable file is EINVAL, but emptying %s returned %v",
+				docTarget, cerr)
+		}
+	}
+
 	// #5: project/initiative bodies map to the long content field, not the ≤255
 	// description; the README must not tell writers the body is the description
 	// (which silently rejected any real write-up), and must place description in

--- a/internal/integration/readme_test.go
+++ b/internal/integration/readme_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"os/exec"
@@ -137,7 +138,7 @@ func TestGeneratedReadmeMatchesBehavior(t *testing.T) {
 	// only by doing the destructive thing, so the README has to say them up front —
 	// and they must not drift back into the old behavior (an emptied issue.md
 	// clearing five fields; an empty project body returning a retryable EIO).
-	for _, want := range []string{"EMPTIED editable file", "Linear cannot apply"} {
+	for _, want := range []string{"EMPTIED editable file", "KEEPS ITS CURRENT", "Linear cannot apply"} {
 		if !strings.Contains(readme, want) {
 			t.Errorf("README failure model does not document the empty-write contract: missing %q", want)
 		}
@@ -162,7 +163,19 @@ func TestGeneratedReadmeMatchesBehavior(t *testing.T) {
 	// does not accept a scratch temp file (#389), and O_TRUNC is deterministic
 	// here anyway — the truncate is a real setattr the kernel cannot serve from
 	// cache, so the close-time Flush always runs and hands back its errno.
+	//
+	// The bytes are read before and after, which does double duty. It pins the
+	// other half of the README's promise — the file KEEPS ITS CURRENT CONTENTS,
+	// so the "re-read it" recovery works — and it proves this probe leaves the
+	// SHARED mount as it found it. Without the restore, the rejected flush left
+	// this node dirty and empty for the rest of the run, and the next test to
+	// read the same doc (t6_conformance's editable-only check) would assert
+	// against zero bytes and pass vacuously.
 	if docTarget, err := firstWritableFile(docsPath(testTeamKey, readmeIssueID)); err == nil {
+		before, err := os.ReadFile(docTarget)
+		if err != nil {
+			t.Fatalf("read %s before emptying it: %v", docTarget, err)
+		}
 		f, err := os.OpenFile(docTarget, os.O_WRONLY|os.O_TRUNC, 0644)
 		if err != nil {
 			t.Fatalf("open %s to empty it: %v", docTarget, err)
@@ -170,6 +183,15 @@ func TestGeneratedReadmeMatchesBehavior(t *testing.T) {
 		if cerr := f.Close(); !errors.Is(cerr, syscall.EINVAL) {
 			t.Errorf("README says an emptied editable file is EINVAL, but emptying %s returned %v",
 				docTarget, cerr)
+		}
+		after, err := os.ReadFile(docTarget)
+		if err != nil {
+			t.Fatalf("read %s after the rejected empty write: %v", docTarget, err)
+		}
+		if !bytes.Equal(before, after) {
+			t.Errorf("%s reads back as %d bytes after a rejected empty write, want its original %d — "+
+				"the README tells the writer to re-read the file to recover its contents",
+				docTarget, len(after), len(before))
 		}
 	}
 


### PR DESCRIPTION
Closes #397
Closes #398

**Stacked on #403 (merged).** Two write-path semantics fixes filed from the first live dispatch of the write suite ([run 30578999501](https://github.com/jra3/linear-fuse/actions/runs/30578999501)) — both cases where the filesystem's answer to a destructive edit was wrong in a way only a live workspace could reveal.

## #397 — an emptied editable file was applied as an edit

Truncating `issue.md` to zero bytes is what a crashed editor, a `> file`, or a botched Write tool call produces. Nothing downstream read it as "no change": the parse yields a document with no fields, and diffing that against an entity that HAS fields reads as *"the writer removed every one of them"*.

Measured, not hypothetical — one zero-byte write emits `assigneeId=nil, dueDate=nil, estimate=nil, labelIds=[], description=""` in a single mutation, wiping five fields the writer never named.

`editFlush` now refuses it with `EINVAL` and a legible `.error`, before any handler's front half runs.

**The guard subsumes the old `eb.content == nil` early return, on purpose.** A nil buffer was never a third state — it is how the atomic-save path spells an emptied file (a zero-byte scratch renamed over the target hands the flush nil bytes). Treating nil as "nothing to do" while an `O_TRUNC` of the same file was a real edit gave the two save paths **opposite answers to `> issue.md`**: silent success on one, a five-field wipe on the other.

**The rejection restores the buffer** (`editFlushSpec.restore`, wired on all seven editable surfaces and enforced by an AST rule). This is where it deliberately *differs* from a parse failure:

| rejection | buffer |
|---|---|
| parse failure | left **dirty**, preserving the writer's text for a corrected re-save |
| empty write | **restored** to the entity's current render, dirty cleared |

An empty buffer holds no text worth preserving, and leaving it dirty stranded the node serving zero bytes for its lifetime — `editBuffer.refresh` refuses a dirty buffer, so nothing ever recovered it. That defeated the very recovery the `.error` prescribes ("re-read the file to get its current contents"). This asymmetry came out of the review gate; the first version of the guard had the bug.

## #398 — a project body cannot be cleared, and we told the caller to retry

Linear accepts an empty `content` and then ignores it. The read-your-writes check caught the divergence correctly — what was wrong was **the verdict**: `EIO`, which means "the write didn't stick, try again", for a write that can never stick.

It is now `EINVAL`, with an `.error` saying the previous body was kept and what to write instead. `writeBackResult` gained an optional errno override; zero still means `EIO`, the right default everywhere else.

**Deliberately not a pre-flight refusal.** The mutation still goes out and the verdict comes from what actually persisted — so a backend that DOES apply an empty content (a future Linear, or the offline mock) simply succeeds, and there is no hardcoded belief about Linear that someone must remember to delete.

**Errno precedence:** a retryable `EIO` now outranks the `EINVAL`. A save that both clears the body (declined → EINVAL) and has a genuinely retryable label divergence would otherwise tell the caller not to retry a write a retry would fix.

## Docs

Generated README, `docs/ARCHITECTURE.md`, and `CONTEXT.md` all updated in-change, per the repo rule that a surface/contract change carries its docs. `readme_test.go` pins the README text.

## Testing

Full offline suite green. Unit coverage for both verdicts plus the restore behavior; the empty-write rejection is pinned end-to-end through the mount in `readme_test`, which asserts the doc's original bytes are readable again after the rejected write.

**Not yet observed live.** `TestClearProjectBodyIsRejectedLegibly` is live-only by necessity — the verdict derives from what the server did with the empty content, and the mock applies it, so there is nothing to assert offline. It and the rewritten `TestEmptyWriteDoesNotCorrupt` are what #401 exists to observe. (`TestEmptyWriteDoesNotCorrupt` previously watched the corruption happen and `t.Logf`'d about it, reporting PASS; it now asserts what its name always claimed.)

## Follow-ups filed, deliberately not fixed here

- **#405** — `createTestIssue` silently ignores its `IssueOption` variadic; seven live write tests are set up wrong as a result. Worked around narrowly in the one test this PR touches.
- **#406** — `renameSave` skips `adopt()` on the new EINVAL verdict, so an atomic save that renames a project *and* empties its body applies the rename remotely but re-renders the stale name. Widening the errno check is wrong (EINVAL also means "nothing reached Linear"); separating them needs a `committed` signal threaded through every `editFlushSpec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)