### PR TITLE
Stop the live make targets leaking LINEAR_API_KEY, and point the suite at a throwaway workspace

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -66,11 +66,18 @@ jobs:
       # -timeout matches `make integration-tests-rw`: the live suite's setup gate
       # spends up to a third of it waiting for the cold-start full sync, and the
       # job's own timeout-minutes must stay above the total.
+      # LINEARFS_TEST_TEAM names the team the suite mutates. It is a team key, not
+      # a credential, so it is a plain value — but it must agree with whatever
+      # workspace the LINEAR_API_KEY secret belongs to. A team the key's workspace
+      # does not have is a hard setup error listing the teams that were found, not
+      # a silent fallback onto teams[0]; repointing the secret at a different
+      # workspace without updating this line fails the job loudly, by design.
       - name: Run integration tests (with writes)
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           LINEARFS_LIVE_API: "1"
           LINEARFS_WRITE_TESTS: "1"
+          LINEARFS_TEST_TEAM: "FUS"
         run: go test -v -timeout 25m ./internal/integration/...
 
       - name: Cleanup on failure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,12 +49,19 @@ Integration tests:
 go test -v ./internal/integration/...
 
 # Live API mode: Runs against real Linear API (the -timeout is a budget the
-# setup gate shares — see below; go test's 10m default is too tight)
-LINEARFS_LIVE_API=1 LINEAR_API_KEY=xxx go test -v -timeout 15m ./internal/integration/...
+# setup gate shares — see below; go test's 10m default is too tight).
+# LINEARFS_TEST_TEAM picks the team; omit it to get TST.
+LINEARFS_LIVE_API=1 LINEAR_API_KEY=xxx LINEARFS_TEST_TEAM=FUS go test -v -timeout 15m ./internal/integration/...
 
 # Include write tests (creates/modifies issues in Linear)
-LINEARFS_LIVE_API=1 LINEAR_API_KEY=xxx LINEARFS_WRITE_TESTS=1 go test -v -timeout 25m ./internal/integration/...
+LINEARFS_LIVE_API=1 LINEAR_API_KEY=xxx LINEARFS_TEST_TEAM=FUS LINEARFS_WRITE_TESTS=1 go test -v -timeout 25m ./internal/integration/...
 ```
+
+The setup gate waits on the **workspace-wide** full-cycle stamp, not on the test
+team, so live mode wants a workspace whose whole cold start fits the budget. A
+workspace with a multi-thousand-issue team will time the gate out even though the
+test team synced in seconds — that is the real cost behind #394's "use a
+throwaway workspace". #407 proposes gating on the test team instead.
 
 The make targets wrap the two live modes (all three require `LINEAR_API_KEY`; the
 default offline suite is plain `make test` and needs no key):
@@ -472,5 +479,9 @@ After schema changes:
 ## Development Notes
 
 - Breaking changes are acceptable - this is a prototype
-- Integration tests use TST team by preference (falls back to first team)
+- Integration tests run against the team named by `LINEARFS_TEST_TEAM`, defaulting
+  to `TST`. A pinned team that the workspace does not have is a hard setup error —
+  never a silent substitution, because `-rw` mutates whatever team it lands on.
+  With no pin and no `TST`, discovery falls back to the first team and logs a
+  warning. Fixture mode is always `TST`; the variable steers live discovery only.
 - Test cache TTL is 100ms for fast tests; waits removed after filesystem writes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,10 +52,16 @@ budget-hungry. Run live mode through the make targets rather than by hand — th
 the `-timeout` the live suite's cold-start sync gate needs (see the integration-test notes
 in [`CLAUDE.md`](CLAUDE.md)):
 
+Pass the key through the **environment**, not as a `make VAR=value` argument: a make-level
+variable lands in your shell history and in this `make` process's own `argv`, where any
+other local user can read it out of `ps`.
+
 ```bash
-go test ./internal/integration/...             # fixtures (default, no key)
-make integration-tests-ro LINEAR_API_KEY=xxx   # live API, READS ONLY
-make integration-tests-rw LINEAR_API_KEY=xxx   # live API + writes: CREATES AND MODIFIES REAL LINEAR DATA
+go test ./internal/integration/...    # fixtures (default, no key)
+
+export LINEAR_API_KEY=lin_api_xxx     # or: set -a; . ~/.config/linearfs/env; set +a
+make integration-tests-ro             # live API, READS ONLY
+make integration-tests-rw             # live API + writes: CREATES AND MODIFIES REAL LINEAR DATA
 ```
 
 ## The testing philosophy (important)

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,18 @@ LDFLAGS=-ldflags "-X $(PKG).Version=$(VERSION) -X $(PKG).GitCommit=$(COMMIT) -X 
 # argv, readable via `ps` by any local user for the whole 25-minute run. Exporting
 # it keeps it in the environment, which neither of those exposes.
 # (`make integration-tests-rw LINEAR_API_KEY=...` still puts the key in your shell
-# history and this process's own argv — prefer the env or ~/.config/linearfs/env.)
-export LINEAR_API_KEY
+# history and this process's own argv — prefer the env or a .env file.)
+#
+# .env is the developer-local home for live-test credentials: gitignored, and
+# deliberately NOT ~/.config/linearfs/env, which is the systemd unit's
+# EnvironmentFile — a test key there repoints the running mount at the throwaway
+# workspace. Leading `-` so a checkout without one is fine. Plain KEY=value only;
+# make parses this as makefile syntax, so a `#` in a value truncates it and a `$`
+# needs doubling. Note these override same-named variables already in your
+# environment (a makefile assignment beats the environment unless you run -e).
+-include .env
+
+export LINEAR_API_KEY LINEARFS_TEST_TEAM
 
 build:
 	go build -trimpath $(LDFLAGS) -o bin/$(BINARY) ./cmd/linearfs

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,16 @@ DATE=$(shell git show -s --format=%cI HEAD 2>/dev/null || echo "unknown")
 PKG=github.com/jra3/linear-fuse/internal/cmd
 LDFLAGS=-ldflags "-X $(PKG).Version=$(VERSION) -X $(PKG).GitCommit=$(COMMIT) -X $(PKG).BuildDate=$(DATE)"
 
+# The live targets take the API key from the environment and MUST NOT name it in
+# a recipe line. A `LINEAR_API_KEY=$(LINEAR_API_KEY) go test ...` prefix leaks the
+# secret twice over: make echoes recipe lines with variables already expanded, so
+# the key lands in every terminal scrollback and CI log, and it sits in the child's
+# argv, readable via `ps` by any local user for the whole 25-minute run. Exporting
+# it keeps it in the environment, which neither of those exposes.
+# (`make integration-tests-rw LINEAR_API_KEY=...` still puts the key in your shell
+# history and this process's own argv — prefer the env or ~/.config/linearfs/env.)
+export LINEAR_API_KEY
+
 build:
 	go build -trimpath $(LDFLAGS) -o bin/$(BINARY) ./cmd/linearfs
 
@@ -36,14 +46,14 @@ test-cover:
 # readiness gate (waitForInitialSync) spends up to a third of it waiting for the
 # cold-start full sync, so this must leave the tests themselves room.
 integration-tests-ro:
-	@if [ -z "$(LINEAR_API_KEY)" ]; then echo "LINEAR_API_KEY required"; exit 1; fi
-	LINEAR_API_KEY=$(LINEAR_API_KEY) LINEARFS_LIVE_API=1 go test -v -timeout 15m ./internal/integration/...
+	@if [ -z "$$LINEAR_API_KEY" ]; then echo "LINEAR_API_KEY required"; exit 1; fi
+	LINEARFS_LIVE_API=1 go test -v -timeout 15m ./internal/integration/...
 
 # Run the integration suite including the write tests. This CREATES AND MODIFIES
 # REAL LINEAR DATA and may hit API limits on free workspaces.
 integration-tests-rw:
-	@if [ -z "$(LINEAR_API_KEY)" ]; then echo "LINEAR_API_KEY required"; exit 1; fi
-	LINEAR_API_KEY=$(LINEAR_API_KEY) LINEARFS_LIVE_API=1 LINEARFS_WRITE_TESTS=1 go test -v -timeout 25m ./internal/integration/...
+	@if [ -z "$$LINEAR_API_KEY" ]; then echo "LINEAR_API_KEY required"; exit 1; fi
+	LINEARFS_LIVE_API=1 LINEARFS_WRITE_TESTS=1 go test -v -timeout 25m ./internal/integration/...
 
 # Both, in that order. -rw is a SUPERSET of -ro, not a disjoint half: WRITE_TESTS=1
 # only ADDS the 55 write tests, so the read suite runs twice. What this buys is
@@ -91,7 +101,7 @@ coverage-html: coverage
 	go tool cover -html=coverage.out
 
 bench-dirs: build
-	@if [ -z "$(LINEAR_API_KEY)" ]; then echo "LINEAR_API_KEY required"; exit 1; fi
+	@if [ -z "$$LINEAR_API_KEY" ]; then echo "LINEAR_API_KEY required"; exit 1; fi
 	./scripts/bench-dirs.sh
 
 # Default mount point (~ expands in shell context)

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -162,6 +162,22 @@ the `LINEAR_API_KEY` env path is the escape hatch and is unaffected. The
 mountpoint itself stays `0755` — the FUSE mount is owner-only regardless
 (AllowOther is never set), so tightening it is cosmetic.
 
+**A developer checkout holds a second copy of the secret.** `.env` in the repo
+root is the local home for live-test credentials (`LINEAR_API_KEY`,
+`LINEARFS_TEST_TEAM`); the `Makefile` `-include`s it so the live targets pick it
+up. Three properties keep it from becoming a leak. It is gitignored, so it cannot
+be committed — the one control that actually matters, since a key in git history
+outlives any chmod. It is deliberately *not* `~/.config/linearfs/env`, which is
+the systemd unit's `EnvironmentFile`: a throwaway-workspace test key placed there
+would silently repoint the running mount, so the split is a correctness boundary
+as much as a security one. And **nothing chmods it** — `internal/atrest` covers
+artifacts LinearFS *writes*, and this file is created by hand, so a default
+`umask` leaves it `0644` and world-readable to P3 (observed in practice). Unlike
+`config.yaml` there is no load-time mode refusal, because the reader is `make`,
+not `internal/config`. Treat `chmod 600 .env` as the developer's job; the same
+caveat applies to any shell that `export`s the key, whose value is visible in
+`/proc/<pid>/environ` to its owner alone but lands in shell history if typed.
+
 ### TB4 — Build & release (P4)
 
 The path from source to running binary: the release artifacts goreleaser

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -199,7 +199,18 @@ along with the secret is open in #386.
 Locally the same credential reaches the same suite through `make
 integration-tests-ro` (live, reads only), `make integration-tests-rw` (live,
 CREATES AND MODIFIES REAL LINEAR DATA), and `make integration-tests` (both, in
-that order); the default `make test` needs no key and touches no network. The
+that order); the default `make test` needs no key and touches no network. Those
+targets take the key from the **environment** and never name it in a recipe
+line, which closes two P3 reads that the earlier
+`LINEAR_API_KEY=$(LINEAR_API_KEY) go test …` prefix left open: make echoes recipe
+lines with variables already expanded, so the raw key was printed into every
+terminal scrollback and CI log, and it sat in the test process's `argv` for the
+length of a run — up to 25 minutes of `ps` for any other local user. The
+emptiness guards read `$$LINEAR_API_KEY` (the shell's own environment) rather
+than expanding the make variable, so the value never enters a command string at
+all. Passing the key as a make-level argument (`make integration-tests-rw
+LINEAR_API_KEY=…`) re-opens both reads against `make`'s own process and your
+shell history; `CONTRIBUTING.md` documents the `export` form instead. The
 read-only target is read-only by enforcement, not convention: the write-contract
 guards that write through the mount now skip under a live key (`skipIfLiveAPI`),
 so a `-ro` run cannot leak a probe issue into the workspace. #395 widened the set

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -25,6 +25,11 @@ import (
 	"github.com/jra3/linear-fuse/internal/testutil/fixtures"
 )
 
+// defaultTestTeamKey is the team the suite uses when LINEARFS_TEST_TEAM does
+// not name one: the key the offline fixtures are seeded under, and the
+// conventional scratch team in a live workspace.
+const defaultTestTeamKey = "TST"
+
 var (
 	mountPoint string
 	stateDir   string // holds the SQLite db, in its own temp dir OUTSIDE the mount (see setupSQLiteFixtures)
@@ -396,9 +401,11 @@ func setupSQLiteFixtures() error {
 		return fmt.Errorf("wait mount: %w", err)
 	}
 
-	// Use fixture team
+	// Use fixture team. The fixtures are seeded as TST/TST-1 and the offline
+	// tests assert those identifiers, so this is fixed regardless of
+	// LINEARFS_TEST_TEAM — that variable only steers live team discovery.
 	testTeamID = "team-1"
-	testTeamKey = "TST"
+	testTeamKey = defaultTestTeamKey
 
 	return nil
 }
@@ -672,18 +679,41 @@ func discoverTestTeam() error {
 		return fmt.Errorf("no teams found in workspace")
 	}
 
-	// Prefer TST team for tests, fall back to first team
+	// Which team the live suite runs against. LINEARFS_TEST_TEAM names it;
+	// unset means the historical default, TST.
+	want, pinned := os.LookupEnv("LINEARFS_TEST_TEAM")
+	if !pinned {
+		want = defaultTestTeamKey
+	}
+
+	keys := make([]string, 0, len(teams))
 	for _, team := range teams {
-		if team.Key == "TST" {
+		keys = append(keys, team.Key)
+		if team.Key == want {
 			testTeamID = team.ID
 			testTeamKey = team.Key
 			return nil
 		}
 	}
 
-	// Fallback to first team if TST not found
+	// An explicitly named team that isn't there is a setup error, never a
+	// silent substitution: -rw CREATES AND MODIFIES REAL DATA in whatever
+	// team it lands on, and "wrong workspace for this key" looks exactly
+	// like "typo'd key" from here. Fail instead of mutating a stranger.
+	if pinned {
+		return fmt.Errorf("LINEARFS_TEST_TEAM=%q names no team in this workspace (found: %s); "+
+			"the key and the team have to belong to the same workspace",
+			want, strings.Join(keys, ", "))
+	}
+
+	// No pin and no TST: fall back to the first team, but say so. The write
+	// suite mutates this team, so an unnoticed fallback onto a real one is
+	// the failure mode worth being loud about.
 	testTeamID = teams[0].ID
 	testTeamKey = teams[0].Key
+	log.Printf("WARNING: no %s team in this workspace (found: %s); falling back to %s. "+
+		"Set LINEARFS_TEST_TEAM to choose deliberately — the write suite mutates this team.",
+		defaultTestTeamKey, strings.Join(keys, ", "), testTeamKey)
 	return nil
 }
 

--- a/internal/integration/testdata_test.go
+++ b/internal/integration/testdata_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -126,9 +127,72 @@ func mkdirIssueWithRetry(issuePath string) error {
 	return fmt.Errorf("still EAGAIN after %d attempts: %w", mkdirIssueRetries+1, err)
 }
 
+// issueOptionInput folds the caller's options into an IssueUpdateInput. The
+// IssueOption constructors already write Linear's own field names
+// (description, dueDate, stateId, cycleId, …), so the map goes to
+// UpdateIssue untranslated.
+func issueOptionInput(opts []IssueOption) map[string]any {
+	input := make(map[string]any, len(opts))
+	for _, opt := range opts {
+		opt(input)
+	}
+	return input
+}
+
+// configureTestIssue applies the fields mkdir cannot carry, and returns the
+// issue as the server now holds it.
+//
+// Every createTestIssue caller is behind skipIfNoWriteTests, so this only ever
+// runs live and apiClient is the real client — in fixture mode it would reach
+// offlineAPIServer and fail by design.
+func configureTestIssue(id, identifier string, input map[string]any) (*api.Issue, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	keys := make([]string, 0, len(input))
+	for k := range input {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	rateLimitWait()
+	if err := apiClient.UpdateIssue(ctx, id, input); err != nil {
+		return nil, fmt.Errorf("apply test-issue options %v to %s: %w", keys, identifier, err)
+	}
+
+	// The mutation went straight to Linear, so the mount still serves the
+	// pre-update issue out of SQLite. Refetch and upsert, the same thing a
+	// write through the mount would have done in its flush handler.
+	rateLimitWait()
+	fresh, err := apiClient.GetIssue(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("refetch %s after applying %v: %w", identifier, keys, err)
+	}
+	if err := lfs.UpsertIssue(ctx, *fresh); err != nil {
+		return nil, fmt.Errorf("upsert %s after applying %v: %w", identifier, keys, err)
+	}
+
+	// The identifier search above read issue.md, which primes the kernel page
+	// cache with the pre-update body — a later read would otherwise be served
+	// the stale bytes rather than the fields we just set. Stat for the inode
+	// the kernel knows this file by and drop it. Best-effort: a miss here
+	// costs freshness, not correctness, and must not fail setup.
+	if fi, err := os.Stat(issueFilePath(testTeamKey, identifier)); err == nil {
+		if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+			lfs.InvalidateUpdated(st.Ino)
+		}
+	}
+
+	return fresh, nil
+}
+
 // createTestIssue creates an issue via filesystem mkdir for testing.
 // The title is prefixed with [TEST] and a timestamp.
 // Returns the issue and a cleanup function (currently no-op since Linear doesn't have delete).
+//
+// mkdir carries the title and nothing else, so any IssueOption the caller
+// passes is applied afterward by configureTestIssue, and the returned issue is
+// the server's post-update copy rather than a locally-built stub.
 func createTestIssue(title string, opts ...IssueOption) (*TestIssue, func(), error) {
 	rateLimitWait() // Prevent API rate limiting
 
@@ -182,6 +246,19 @@ func createTestIssue(title string, opts ...IssueOption) (*TestIssue, func(), err
 				Identifier: identifier,
 				Title:      fullTitle,
 				Team:       &api.Team{Key: testTeamKey, ID: testTeamID},
+			}
+
+			// mkdir carries only the title, so every option the caller passed
+			// still has to be applied. Skipping this is what made 7 tests set
+			// themselves up wrong in silence — clearing a due date that was
+			// never set, editing an empty description, removing a cycle
+			// membership that never existed (#405).
+			if input := issueOptionInput(opts); len(input) > 0 {
+				fresh, err := configureTestIssue(id, identifier, input)
+				if err != nil {
+					return nil, nil, err
+				}
+				issue = fresh
 			}
 
 			cleanup := func() {


### PR DESCRIPTION
Four commits from wiring the live integration suite to a throwaway workspace.
The first is a secret-handling fix and stands alone; the rest are what it took
to get a live run to happen at all.

## fix(build): stop the live make targets leaking LINEAR_API_KEY

The live and bench targets each named the key in a recipe line
(`LINEAR_API_KEY=$(LINEAR_API_KEY) go test ...`, and `[ -z "$(LINEAR_API_KEY)" ]`
in the guards). Both spellings expand the secret into the command text, which
leaks it twice: make echoes recipe lines with variables already substituted, so
the raw key lands in terminal scrollback and CI logs — **observed**, a local
`make integration-tests-ro` printed it in cleartext on line 1 — and the
`VAR=value cmd` prefix puts it in the child's argv, readable by `ps` for the
whole run (`-rw` budgets 25 minutes).

Now exported once at the top of the file, so it travels in the environment,
which neither `make`'s echo nor `ps` exposes. Guards read `$$LINEAR_API_KEY`
(the shell's own environment) so the value never enters a command string.
Verified: a sentinel key appears **0** times across `make -n` of all three
targets.

## test(integration): pick the live test team with LINEARFS_TEST_TEAM

`discoverTestTeam` preferred `TST` and otherwise took `teams[0]` **in silence**.
The fallback picks a team by position and `-rw` then creates and modifies real
data in it — a key belonging to a different workspace than intended reaches
exactly that path and the run looks normal.

`LINEARFS_TEST_TEAM` names the team; unset keeps `TST`. A pinned team the
workspace does not have is now a setup error listing the teams found, because
"wrong workspace for this key" and "typo'd team" are indistinguishable from
inside discovery and neither should end in a mutation. Fixture mode stays `TST`.

## build: load .env, pin the CI test team

`.env` was the convention for live-test credentials but nothing read it. The
Makefile `-include`s it now. Deliberately **not** `~/.config/linearfs/env`,
which is the systemd unit's `EnvironmentFile` — a test key there silently
repoints a running mount at the throwaway workspace. `integration.yml` pins
`LINEARFS_TEST_TEAM=FUS` beside the secret; disagreement between the two now
fails loudly rather than mutating a stranger's first team.

## test(integration): apply createTestIssue's options instead of dropping them

`createTestIssue` took `opts ...IssueOption` and never referenced them, so seven
tests set themselves up wrong in silence — clearing a due date never set,
removing a cycle membership that never existed, asserting against a description
nobody wrote. Options are now folded into an `IssueUpdateInput` and applied
after the mkdir, with a refetch+upsert so the mount stops serving the pre-update
issue, and a kernel page-cache drop so a later read isn't handed the stale body
(without which the fix would look applied while changing nothing — the same
species of silence as the original bug).

Closes #405

## Verification

- Offline suite green (`ok`, 64s and 66s across two runs).
- Live read-only green against the throwaway workspace: **61 passed, 0 failed**,
  setup gate clearing in 36s.
- Key-leak fix confirmed in a real run: 0 occurrences in the log.

## Not verified

The seven `#405` tests still have never executed live. The first live write
dispatch hit a workspace quota wall (`usage limit exceeded`) that failed 42 of
45 tests before they could assert anything, so that fix is verified by
construction, not observation. #394/#401 stay open.

Also documented while here: `docs/THREAT-MODEL.md` gains `.env` under TB3, and
`CLAUDE.md` records that the setup gate waits on the workspace-wide full-cycle
stamp rather than the test team (#407).

🤖 Generated with [Claude Code](https://claude.com/claude-code)