### PR TITLE
test(integration): count comments, not directory entries

### DIFF
--- a/internal/integration/cache_test.go
+++ b/internal/integration/cache_test.go
@@ -102,11 +102,7 @@ func TestCommentCreateInvalidatesCache(t *testing.T) {
 
 	// Count initial comments
 	commentsDir := commentsPath(testTeamKey, issue.Identifier)
-	entries1, err := os.ReadDir(commentsDir)
-	if err != nil {
-		t.Fatalf("Failed to read comments: %v", err)
-	}
-	initialCount := len(entries1)
+	initialCount := countItemFiles(t, commentsDir)
 
 	// Create comment via _create
 	commentBody := "[TEST] Cache invalidation comment"
@@ -116,15 +112,11 @@ func TestCommentCreateInvalidatesCache(t *testing.T) {
 	}
 
 	// No wait needed - kernel cache invalidated on filesystem write
-	// Re-read comments directory
-	entries2, err := os.ReadDir(commentsDir)
-	if err != nil {
-		t.Fatalf("Failed to re-read comments: %v", err)
-	}
-
-	// Should have one more entry (the new comment)
-	if len(entries2) != initialCount+1 {
-		t.Errorf("Comment cache not invalidated, expected %d entries, got %d", initialCount+1, len(entries2))
+	// Should have one more comment. Count .md files, not directory entries:
+	// each comment also carries a .meta sidecar, so the raw entry count moves
+	// by two (see countItemFiles).
+	if got := countItemFiles(t, commentsDir); got != initialCount+1 {
+		t.Errorf("Comment cache not invalidated, expected %d comments, got %d", initialCount+1, got)
 	}
 }
 
@@ -143,11 +135,7 @@ func TestCommentVisibleImmediatelyAfterCreate(t *testing.T) {
 
 	// First read populates the cache
 	commentsDir := commentsPath(testTeamKey, issue.Identifier)
-	entries1, err := os.ReadDir(commentsDir)
-	if err != nil {
-		t.Fatalf("Failed to read comments: %v", err)
-	}
-	initialCount := len(entries1)
+	initialCount := countItemFiles(t, commentsDir)
 
 	// Create comment via _create
 	commentBody := "[TEST] Immediate visibility comment"
@@ -156,16 +144,11 @@ func TestCommentVisibleImmediatelyAfterCreate(t *testing.T) {
 		t.Fatalf("Failed to create comment: %v", err)
 	}
 
-	// NO wait needed - kernel cache is invalidated on filesystem write
-	// Re-read comments directory - should see new comment immediately
-	entries2, err := os.ReadDir(commentsDir)
-	if err != nil {
-		t.Fatalf("Failed to re-read comments: %v", err)
-	}
-
-	// Should have one more entry without waiting for cache expiry
-	if len(entries2) != initialCount+1 {
-		t.Errorf("Comment not immediately visible after creation, expected %d entries, got %d", initialCount+1, len(entries2))
+	// NO wait needed - kernel cache is invalidated on filesystem write.
+	// Should see one more comment without waiting for cache expiry. Counts
+	// .md files, not entries — each comment carries a .meta sidecar too.
+	if got := countItemFiles(t, commentsDir); got != initialCount+1 {
+		t.Errorf("Comment not immediately visible after creation, expected %d comments, got %d", initialCount+1, got)
 	}
 }
 

--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -49,6 +50,30 @@ func firstRealEntry(entries []os.DirEntry) string {
 		}
 	}
 	return ""
+}
+
+// countItemFiles counts the item .md files in a collection directory, which is
+// almost never the same number as len(os.ReadDir(dir)).
+//
+// A collection listing is three things concatenated (collectionDir.entries):
+// the trio (_create, .error, .last), one .md per item, and one .meta sidecar
+// per .md. So a directory holding N items has N*2+3 entries, and adding one
+// item moves the raw count by two, not one. Asserting on entry counts couples a
+// test to the trio and sidecar layout; asserting on .md files says what the
+// test actually means.
+func countItemFiles(t *testing.T, dir string) int {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	n := 0
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".md") {
+			n++
+		}
+	}
+	return n
 }
 
 // Path builders


### PR DESCRIPTION
Two failures from the first live write run (#401) that the workspace quota wall
did **not** explain:

```
cache_test.go:127: Comment cache not invalidated, expected 4 entries, got 5
cache_test.go:168: Comment not immediately visible after creation, expected 4 entries, got 5
```

Neither is a cache bug. The arithmetic is stale.

## The count

`collectionDir.entries()` concatenates three things:

```go
files := c.listing(items).entries()
out := append(c.trio.entries(), files...)      // _create, .error, .last
out = append(out, metaSidecarEntries(files)...) // one .meta per .md
```

So a collection holding N items has **N*2+3** entries. A fresh issue's
`comments/` holds 3 — exactly the `initialCount` both tests observed — and
creating one comment adds two, taking it to 5. Both tests assert
`initialCount+1`.

The expectation predates the `.meta` sidecar (#148 moved the volatile server
fields out of the editable file). Both tests sit behind `skipIfNoWriteTests`, so
they had never executed live (#394) and nothing caught the drift.

## The fix

Count `.md` files, via a `countItemFiles` helper. That asserts what the tests
mean — one more *comment* — instead of coupling them to the trio and sidecar
layout, so the next control surface added to a collection listing doesn't break
them again.

## Verification

Offline suite green (64s).

**This does not verify the fix.** Both tests are live-only, so the offline suite
cannot reach them; the change is derived from the listing code, not observed.
Confirming it needs a live write run, currently blocked on the test workspace's
`usage limit exceeded` (see #409, #401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)