### PR TITLE
Pin live runs to a named workspace and team, from .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Credentials for LIVE integration runs (`make integration-tests-ro` / `-rw`).
+# Copy to .env, which is gitignored. The live targets read THIS file and override
+# anything already exported: a LINEAR_API_KEY in your shell is normally the key
+# for the workspace you actually work in, and a live run reads that whole
+# workspace and — in write mode — creates issues and projects in it.
+#
+# Neither line affects `make test`, which is offline and needs no key.
+
+# A personal API key for the TEST workspace. Not your day-to-day workspace.
+LINEAR_API_KEY=lin_api_xxxxxxxx
+
+# The team the suite acts on. This is the interlock: if the key's workspace has
+# no team with this key, setup fails and names the teams it did find, instead of
+# falling back to some other team and mutating it. Leave unset only if you are
+# happy with "prefer TST, else whichever team is listed first".
+LINEARFS_TEST_TEAM=FUS

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -66,11 +66,18 @@ jobs:
       # -timeout matches `make integration-tests-rw`: the live suite's setup gate
       # spends up to a third of it waiting for the cold-start full sync, and the
       # job's own timeout-minutes must stay above the total.
+      # LINEARFS_TEST_TEAM names the team this job may write to, and setup FAILS if
+      # the key's workspace has no such team. CI cannot read the developer's .env,
+      # so without it the job would accept whatever workspace the secret happens to
+      # authenticate to and create issues and projects there — which is how a local
+      # run came to mutate a real work workspace whose TST team merely existed.
+      # Change this when the test workspace changes; a mismatch is meant to be loud.
       - name: Run integration tests (with writes)
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           LINEARFS_LIVE_API: "1"
           LINEARFS_WRITE_TESTS: "1"
+          LINEARFS_TEST_TEAM: "FUS"
         run: go test -v -timeout 25m ./internal/integration/...
 
       - name: Cleanup on failure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,14 +56,29 @@ LINEARFS_LIVE_API=1 LINEAR_API_KEY=xxx go test -v -timeout 15m ./internal/integr
 LINEARFS_LIVE_API=1 LINEAR_API_KEY=xxx LINEARFS_WRITE_TESTS=1 go test -v -timeout 25m ./internal/integration/...
 ```
 
-The make targets wrap the two live modes (all three require `LINEAR_API_KEY`; the
-default offline suite is plain `make test` and needs no key):
+The make targets wrap the two live modes (the default offline suite is plain
+`make test` and needs no key):
 
 ```bash
 make integration-tests-ro    # live API, READS ONLY
 make integration-tests-rw    # live API + writes: CREATES AND MODIFIES REAL LINEAR DATA
 make integration-tests       # -ro then -rw (rw is a superset; the value is sequencing)
 ```
+
+**Which workspace a live run touches is a choice, not an accident.** The live
+targets read `.env` (gitignored; see `.env.example`) and OVERRIDE the ambient
+environment, because a `LINEAR_API_KEY` exported in a shell is normally the key
+for the workspace you actually work in — and a live run reads that entire
+workspace, then in write mode creates issues and projects in it. `.env` carries
+two lines: the test workspace's key, and `LINEARFS_TEST_TEAM`.
+
+`LINEARFS_TEST_TEAM` is the interlock. Set it and `pickTestTeam` either finds
+that team or fails setup naming the teams it did find; unset, it falls back to
+"prefer TST, else the first team listed", which is how a run with the wrong key
+in the environment quietly proceeded against a real work workspace that happened
+to have a TST team. The CI write job sets it explicitly for the same reason (it
+cannot read `.env`). Every live run also logs the resolved organization — and,
+in write mode, says so loudly — before it mounts anything.
 
 Live mode gates setup on the sync worker's persisted full-cycle stamp
 (`sync.ScheduleKeyFullCycle`) before any test touches the mount: its SQLite cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,10 +52,18 @@ budget-hungry. Run live mode through the make targets rather than by hand — th
 the `-timeout` the live suite's cold-start sync gate needs (see the integration-test notes
 in [`CLAUDE.md`](CLAUDE.md)):
 
+The live targets take their credentials from `.env` (gitignored; copy `.env.example`),
+not from your shell and not from a `make VAR=value` argument. Both of those are the wrong
+source: an exported `LINEAR_API_KEY` is normally the key for the workspace you actually
+work in, and a make-level variable additionally lands in your shell history and in this
+`make` process's own `argv`, where any other local user can read it out of `ps`.
+
 ```bash
-go test ./internal/integration/...             # fixtures (default, no key)
-make integration-tests-ro LINEAR_API_KEY=xxx   # live API, READS ONLY
-make integration-tests-rw LINEAR_API_KEY=xxx   # live API + writes: CREATES AND MODIFIES REAL LINEAR DATA
+go test ./internal/integration/...    # fixtures (default, no key)
+
+cp .env.example .env                  # then fill in the TEST workspace's key + team
+make integration-tests-ro             # live API, READS ONLY
+make integration-tests-rw             # live API + writes: CREATES AND MODIFIES REAL LINEAR DATA
 ```
 
 ## The testing philosophy (important)

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,20 @@ test:
 test-cover:
 	go test ./... -cover
 
+# Live runs take their credentials from .env (gitignored), never from the ambient
+# environment. LINEAR_API_KEY in a developer's shell is normally the key for the
+# workspace they actually work in, and a live run of this suite reads that whole
+# workspace and — in write mode — creates issues and projects in it. .env is the
+# one file whose contents are chosen for testing, so the live targets read it and
+# refuse to run without it. Pair it with LINEARFS_TEST_TEAM (see .env.example):
+# naming the team makes a key for the wrong workspace fail during setup.
+#
+# It deliberately OVERRIDES anything already exported: an ambient key silently
+# winning over the file is the exact failure this exists to prevent.
+LIVE_ENV = test -f .env || { echo "no .env: copy .env.example and fill in the TEST workspace's key"; exit 1; }; \
+	set -a; . ./.env; set +a; \
+	test -n "$$LINEAR_API_KEY" || { echo "LINEAR_API_KEY missing from .env (see .env.example)"; exit 1; };
+
 # Run the integration suite against the LIVE Linear API, READS ONLY. Consumes real
 # API quota — the offline fixture suite is plain `make test`, which needs no key.
 # LINEARFS_LIVE_API is what liveAPIMode reads; both targets demanded a key and then
@@ -36,14 +50,12 @@ test-cover:
 # readiness gate (waitForInitialSync) spends up to a third of it waiting for the
 # cold-start full sync, so this must leave the tests themselves room.
 integration-tests-ro:
-	@if [ -z "$(LINEAR_API_KEY)" ]; then echo "LINEAR_API_KEY required"; exit 1; fi
-	LINEAR_API_KEY=$(LINEAR_API_KEY) LINEARFS_LIVE_API=1 go test -v -timeout 15m ./internal/integration/...
+	@$(LIVE_ENV) LINEARFS_LIVE_API=1 go test -v -timeout 15m ./internal/integration/...
 
 # Run the integration suite including the write tests. This CREATES AND MODIFIES
 # REAL LINEAR DATA and may hit API limits on free workspaces.
 integration-tests-rw:
-	@if [ -z "$(LINEAR_API_KEY)" ]; then echo "LINEAR_API_KEY required"; exit 1; fi
-	LINEAR_API_KEY=$(LINEAR_API_KEY) LINEARFS_LIVE_API=1 LINEARFS_WRITE_TESTS=1 go test -v -timeout 25m ./internal/integration/...
+	@$(LIVE_ENV) LINEARFS_LIVE_API=1 LINEARFS_WRITE_TESTS=1 go test -v -timeout 25m ./internal/integration/...
 
 # Both, in that order. -rw is a SUPERSET of -ro, not a disjoint half: WRITE_TESTS=1
 # only ADDS the 55 write tests, so the read suite runs twice. What this buys is

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ coverage-html: coverage
 	go tool cover -html=coverage.out
 
 bench-dirs: build
-	@if [ -z "$(LINEAR_API_KEY)" ]; then echo "LINEAR_API_KEY required"; exit 1; fi
+	@if [ -z "$$LINEAR_API_KEY" ]; then echo "LINEAR_API_KEY required"; exit 1; fi
 	./scripts/bench-dirs.sh
 
 # Default mount point (~ expands in shell context)

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -162,6 +162,23 @@ the `LINEAR_API_KEY` env path is the escape hatch and is unaffected. The
 mountpoint itself stays `0755` — the FUSE mount is owner-only regardless
 (AllowOther is never set), so tightening it is cosmetic.
 
+**A developer checkout holds a second copy of the secret.** `.env` in the repo
+root is the local home for live-test credentials (`LINEAR_API_KEY`,
+`LINEARFS_TEST_TEAM`); the live make targets source it into the recipe's own
+shell (`set -a; . ./.env; set +a`) and refuse to run without it. Three properties
+keep it from becoming a leak. It is gitignored, so it cannot be committed — the
+one control that actually matters, since a key in git history outlives any
+chmod. It is deliberately *not* `~/.config/linearfs/env`, which is the systemd
+unit's `EnvironmentFile`: a throwaway-workspace test key placed there would
+silently repoint the running mount, so the split is a correctness boundary as
+much as a security one. And **nothing chmods it** — `internal/atrest` covers
+artifacts LinearFS *writes*, and this file is created by hand, so a default
+`umask` leaves it `0644` and world-readable to P3 (observed in practice). Unlike
+`config.yaml` there is no load-time mode refusal, because the reader is `make`,
+not `internal/config`. Treat `chmod 600 .env` as the developer's job; the same
+caveat applies to any shell that `export`s the key, whose value is visible in
+`/proc/<pid>/environ` to its owner alone but lands in shell history if typed.
+
 ### TB4 — Build & release (P4)
 
 The path from source to running binary: the release artifacts goreleaser
@@ -209,7 +226,20 @@ along with the secret is open in #386.
 Locally the same credential reaches the same suite through `make
 integration-tests-ro` (live, reads only), `make integration-tests-rw` (live,
 CREATES AND MODIFIES REAL LINEAR DATA), and `make integration-tests` (both, in
-that order); the default `make test` needs no key and touches no network. The
+that order); the default `make test` needs no key and touches no network. Those
+targets read the key out of `.env` and never name it in a recipe line, which
+closes two P3 reads that the earlier `LINEAR_API_KEY=$(LINEAR_API_KEY) go test …`
+prefix left open: make echoes recipe lines with variables already expanded, so
+the raw key was printed into every terminal scrollback and CI log, and it sat in
+the test process's `argv` for the length of a run — up to 25 minutes of `ps` for
+any other local user. The emptiness guard reads `$$LINEAR_API_KEY` (the shell's
+own environment, sourced from `.env` a statement earlier) rather than expanding a
+make variable, so the value never enters a command string at all; `bench-dirs`,
+which still takes its key from the ambient environment, guards the same way for
+the same reason. Passing the key as a make-level argument (`make
+integration-tests-rw LINEAR_API_KEY=…`) re-opens both reads against `make`'s own
+process and your shell history, and is now inert besides — `.env` overrides it.
+`CONTRIBUTING.md` documents the `.env` form instead. The
 read-only target is read-only by enforcement, not convention: the write-contract
 guards that write through the mount now skip under a live key (`skipIfLiveAPI`),
 so a `-ro` run cannot leak a probe issue into the workspace. #395 widened the set

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -183,6 +183,16 @@ offline fixture suite; the label promised mutation and the run delivered none.
 Now that it does what it says, the exposure is real and worth stating: whoever can dispatch that
 workflow can write to the Linear workspace the secret belongs to, so the secret
 should scope to a throwaway/test workspace rather than a production one, and the
+job now states which workspace it accepts rather than trusting the secret to be
+the right one: it sets `LINEARFS_TEST_TEAM`, and setup fails if the key's
+workspace has no team by that key (`pickTestTeam`). That check is the enforcement
+point for "throwaway workspace, not a production one" — a rotated-in key for the
+wrong workspace fails before the first mutation instead of writing to whatever
+team it found. Local runs get the same guarantee from `.env`, which the live make
+targets read in place of the ambient environment for the same reason: a developer's
+exported `LINEAR_API_KEY` is normally their real workspace. The exposure this
+closes is not hypothetical — a local write run against a work workspace is how it
+was found, its `TST` team having been enough to satisfy the old fallback. The
 job stays manual-dispatch (never `push`/`pull_request`, never `pull_request_target`,
 where a fork could reach it) behind its `run_write_tests` confirmation input — which
 was itself declared-but-unread until #386 wired it to a job-level `if`, so the

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -781,6 +781,13 @@ func (c *Client) GetViewer(ctx context.Context) (*User, error) {
 	return fetchOne[User](ctx, c, queryViewer, nil, "viewer")
 }
 
+// GetOrganization fetches the workspace this key authenticates to. It answers
+// "whose data am I about to touch?" in one cheap call, ahead of any read that
+// would make the answer obvious only in hindsight.
+func (c *Client) GetOrganization(ctx context.Context) (*Organization, error) {
+	return fetchOne[Organization](ctx, c, queryOrganization, nil, "organization")
+}
+
 // CreateIssue creates a new issue
 func (c *Client) CreateIssue(ctx context.Context, input map[string]any) (*Issue, error) {
 	return execMutation[Issue](ctx, c, mutationCreateIssue, map[string]any{"input": input}, "issueCreate", "issue")

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -719,6 +719,18 @@ query Viewer {
 }
 ` + userFieldsFragment
 
+// queryOrganization identifies the workspace behind the key. Scalars only and no
+// fragment: nothing else selects an Organization, so there is no second field
+// set to drift away from.
+const queryOrganization = `
+query Organization {
+  organization {
+    id
+    name
+    urlKey
+  }
+}`
+
 const mutationUpdateIssue = `
 mutation UpdateIssue($id: String!, $input: IssueUpdateInput!) {
   issueUpdate(id: $id, input: $input) {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -101,6 +101,17 @@ type User struct {
 	Active      bool   `json:"active"`
 }
 
+// Organization identifies the workspace a key authenticates to. Nothing in the
+// filesystem renders it; it exists so a caller about to act on a real workspace
+// can NAME the one it reached — the live test suite prints it before it mounts,
+// because "which workspace is this key on?" was otherwise answerable only by
+// recognising the team list.
+type Organization struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	URLKey string `json:"urlKey"`
+}
+
 type Labels struct {
 	Nodes []Label `json:"nodes"`
 }

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -328,7 +328,9 @@ func (n *IssueDirectoryNode) manifest() *dirManifest {
 	if issue.Team != nil {
 		teamID = issue.Team.ID
 	}
-	m := newDirManifest(&n.BaseNode, issue.ID, issue.CreatedAt, issue.UpdatedAt, 30*time.Second)
+	// The issue dir hands its children the mount's entry timeout, not a literal
+	// of its own: issue.md's staleness bound IS the mount's kernel-cache policy.
+	m := newDirManifest(&n.BaseNode, issue.ID, issue.CreatedAt, issue.UpdatedAt, n.lfs.entryTimeout())
 
 	// issue.md is editable-only; identity/links/relations live in issue.meta.
 	m.file("issue.md", issueIno(issue.ID), func(ctx context.Context) (fs.InodeEmbedder, []byte, syscall.Errno) {

--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -48,6 +48,15 @@ type LinearFS struct {
 	gid        uint32 // Owner GID for files/dirs
 	mountPoint string // Filesystem mount path (for README generation)
 
+	// kernelEntryTimeout is how long the kernel may serve a looked-up entry from
+	// its own cache before re-asking — the mount's staleness bound for a remote
+	// change, since sync never notifies the kernel. MountFS publishes it (before
+	// the serve loop starts, like mountPoint) so nodes that set a per-directory
+	// timeout read the SAME policy the mount was given, rather than a literal of
+	// their own: the issue directory carried a second hardcoded 30s, and a mount
+	// configured otherwise silently did not apply to it.
+	kernelEntryTimeout time.Duration
+
 	// userFeedback (config UserFeedback / env USER_FEEDBACK, default off) makes
 	// the generated README carry the agent self-reporting protocol. Read only
 	// by generateReadme; off means the README is unchanged.
@@ -774,9 +783,53 @@ func (lfs *LinearFS) projectLabelNames(ctx context.Context, ids []string) []stri
 	return names
 }
 
+// Kernel cache timeouts. The kernel serves attrs and directory entries from its
+// own caches for this long before asking us again, so they are the mount's
+// staleness bound for a remote change the sync worker landed WITHOUT notifying
+// the kernel — which is every remote change (sync deliberately never notifies;
+// see docs/ARCHITECTURE.md). Long is right in production: it is what keeps
+// kernel→userspace calls down on a mount whose data changes on human timescales.
+const (
+	DefaultAttrTimeout  = 60 * time.Second
+	DefaultEntryTimeout = 30 * time.Second
+)
+
+// entryTimeout is the kernel-entry cache bound a node should hand its children.
+// It falls back to the default so a LinearFS built without MountFS (unit tests)
+// behaves like production.
+func (lfs *LinearFS) entryTimeout() time.Duration {
+	if lfs.kernelEntryTimeout <= 0 {
+		return DefaultEntryTimeout
+	}
+	return lfs.kernelEntryTimeout
+}
+
+// MountOption tunes a mount. The defaults are production's; the options exist
+// for callers whose constraints differ from a desktop mount's.
+type MountOption func(*mountConfig)
+
+type mountConfig struct {
+	attrTimeout, entryTimeout time.Duration
+}
+
+// WithKernelCacheTimeouts overrides how long the kernel may serve attrs and
+// directory entries from cache.
+//
+// The integration suite is the caller that needs this. Timeout-driven
+// revalidation can only be observed by WAITING — the expiry is the kernel's own,
+// on the kernel's clock, so no injected clock and no amount of test scaffolding
+// can bring it forward. A test of that path against the 30s default is a test
+// that sleeps 31 seconds, and two of them were the whole runtime of the offline
+// suite. Mounting the fixture with a short timeout keeps the mechanism exactly
+// as it is — the kernel expires the entry, the next walk re-Lookups, the
+// nodeRefresher seam runs — and shortens only the interval.
+func WithKernelCacheTimeouts(attr, entry time.Duration) MountOption {
+	return func(c *mountConfig) { c.attrTimeout, c.entryTimeout = attr, entry }
+}
+
 // MountFS mounts an existing LinearFS instance at the given path.
 // This is useful for testing when you need to configure LinearFS before mounting.
-func MountFS(mountpoint string, lfs *LinearFS, debug bool) (*fuse.Server, error) {
+func MountFS(mountpoint string, lfs *LinearFS, debug bool, opts ...MountOption) (*fuse.Server, error) {
 	root := &RootNode{BaseNode: BaseNode{lfs: lfs}}
 
 	// Publish the mount path *before* fs.Mount starts the serve loop. Handlers
@@ -785,11 +838,14 @@ func MountFS(mountpoint string, lfs *LinearFS, debug bool) (*fuse.Server, error)
 	// — a plain data race the first README lookup can hit.
 	lfs.mountPoint = mountpoint
 
-	// Use longer timeouts to reduce kernel→userspace calls
-	attrTimeout := 60 * time.Second
-	entryTimeout := 30 * time.Second
+	mc := mountConfig{attrTimeout: DefaultAttrTimeout, entryTimeout: DefaultEntryTimeout}
+	for _, o := range opts {
+		o(&mc)
+	}
+	attrTimeout, entryTimeout := mc.attrTimeout, mc.entryTimeout
+	lfs.kernelEntryTimeout = entryTimeout // published before the serve loop, as above
 
-	opts := &fs.Options{
+	fsOpts := &fs.Options{
 		AttrTimeout:  &attrTimeout,
 		EntryTimeout: &entryTimeout,
 		MountOptions: fuse.MountOptions{
@@ -799,7 +855,7 @@ func MountFS(mountpoint string, lfs *LinearFS, debug bool) (*fuse.Server, error)
 		},
 	}
 
-	server, err := fs.Mount(mountpoint, root, opts)
+	server, err := fs.Mount(mountpoint, root, fsOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -98,6 +98,15 @@ func TestMain(m *testing.M) {
 // setupLiveAPI configures tests to run against real Linear API
 func setupLiveAPI(apiKey string) error {
 	var err error
+
+	// Name the workspace BEFORE anything is mounted or synced. A live run
+	// authenticates with whatever LINEAR_API_KEY is in the environment, and the
+	// only previous evidence of which workspace that was arrived implicitly —
+	// team names in a later log line, or an unexplained multi-minute sync of a
+	// workspace far bigger than the test one. In write mode the answer arrives
+	// after the mutations. One call, first line of the run.
+	announceLiveWorkspace(apiKey)
+
 	mountPoint, err = os.MkdirTemp("", "linearfs-test-*")
 	if err != nil {
 		return fmt.Errorf("create mount point: %w", err)
@@ -668,23 +677,80 @@ func discoverTestTeam() error {
 	if err != nil {
 		return fmt.Errorf("failed to get teams: %w", err)
 	}
-	if len(teams) == 0 {
-		return fmt.Errorf("no teams found in workspace")
+
+	team, err := pickTestTeam(teams, os.Getenv("LINEARFS_TEST_TEAM"))
+	if err != nil {
+		return err
+	}
+	testTeamID = team.ID
+	testTeamKey = team.Key
+	return nil
+}
+
+// pickTestTeam chooses the team a live run acts on. `want` is LINEARFS_TEST_TEAM:
+// name a team and the run either gets THAT team or fails — it is the one place
+// an invocation can state which workspace it believes it is talking to, and a
+// key pointed somewhere else fails setup rather than finding some other team to
+// mutate. Unset keeps the historical prefer-TST-else-first behaviour.
+//
+// Pure so workspace_test.go can drive it in every mode; discoverTestTeam owns
+// the fetch.
+func pickTestTeam(teams []api.Team, want string) (api.Team, error) {
+	keys := make([]string, 0, len(teams))
+	for _, t := range teams {
+		keys = append(keys, t.Key)
 	}
 
-	// Prefer TST team for tests, fall back to first team
-	for _, team := range teams {
-		if team.Key == "TST" {
-			testTeamID = team.ID
-			testTeamKey = team.Key
-			return nil
+	if want != "" {
+		for _, t := range teams {
+			if t.Key == want {
+				return t, nil
+			}
+		}
+		return api.Team{}, fmt.Errorf("LINEARFS_TEST_TEAM=%s, but this API key's workspace has no team %s "+
+			"(it has: %s). The key is almost certainly for a different workspace than the run intends — "+
+			"which matters most in write mode, where the fallback this replaces would have created issues "+
+			"and projects in whichever workspace the key DID reach",
+			want, want, strings.Join(keys, ", "))
+	}
+
+	if len(teams) == 0 {
+		return api.Team{}, fmt.Errorf("no teams found in workspace")
+	}
+	for _, t := range teams {
+		if t.Key == fixtureTeamKeyPreference {
+			return t, nil
 		}
 	}
+	return teams[0], nil
+}
 
-	// Fallback to first team if TST not found
-	testTeamID = teams[0].ID
-	testTeamKey = teams[0].Key
-	return nil
+// fixtureTeamKeyPreference is the team key a live run falls back to preferring
+// when LINEARFS_TEST_TEAM is unset — the same key the fixture population uses,
+// so an unconfigured live run lands on the workspace's test team if it has one.
+const fixtureTeamKeyPreference = "TST"
+
+// announceLiveWorkspace logs the workspace behind the key, and in write mode
+// says plainly that this run creates and modifies data in it. It is diagnostic,
+// not a gate: a failure to resolve the organization is reported and the run
+// continues, because the interlock that can actually stop a wrong-workspace run
+// is LINEARFS_TEST_TEAM in pickTestTeam.
+func announceLiveWorkspace(apiKey string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	org, err := api.NewClient(apiKey).GetOrganization(ctx)
+	if err != nil {
+		log.Printf("LIVE MODE: could not identify the workspace behind LINEAR_API_KEY: %v", err)
+		return
+	}
+	if os.Getenv("LINEARFS_WRITE_TESTS") == "1" {
+		log.Printf("LIVE WRITE MODE: this run CREATES AND MODIFIES real data in workspace %q (%s). "+
+			"Set LINEARFS_TEST_TEAM to the team you intend to write to and setup will refuse any other workspace.",
+			org.Name, org.URLKey)
+		return
+	}
+	log.Printf("LIVE MODE (reads only): workspace %q (%s)", org.Name, org.URLKey)
 }
 
 func cleanup() {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -68,6 +68,7 @@ func TestMain(m *testing.M) {
 			_ = os.RemoveAll(fields[1])
 		}
 	}
+	sweepAbandonedTestDirs()
 
 	apiKey := os.Getenv("LINEAR_API_KEY")
 	liveAPIMode = os.Getenv("LINEARFS_LIVE_API") == "1" && apiKey != ""
@@ -168,6 +169,111 @@ func setupLiveAPI(apiKey string) error {
 	}
 
 	return nil
+}
+
+// staleTestDirGrace is how recently a leftover temp dir must have been touched
+// to be treated as a CONCURRENT run's rather than an abandoned one. It is above
+// the longest run the Makefile budgets (25m for the live write suite), because
+// the cost of the two mistakes is not symmetric: sweeping a live run's state dir
+// corrupts that run, while leaving an abandoned dir another hour costs 1.5MB.
+const staleTestDirGrace = time.Hour
+
+// sweepAbandonedTestDirs removes the mountpoint and state dirs left by runs that
+// died before cleanup() — a killed run, a panic, a SIGPIPE from piping `go test`
+// into `head`. cleanup() already removes its own, so nothing accumulates from a
+// normal exit; what accumulated (28 dirs, 45MB, found the hard way) all came
+// from runs that never reached it, plus the ones whose lazy-detached mount was
+// still attached when RemoveAll ran.
+//
+// The preflight above only sweeps dirs that are still MOUNTED. This is the other
+// half: dirs with no mount at all, which nothing was looking at.
+func sweepAbandonedTestDirs() {
+	matches, err := filepath.Glob(filepath.Join(os.TempDir(), "linearfs-test-*"))
+	if err != nil || len(matches) == 0 {
+		return
+	}
+	mounted := map[string]bool{}
+	if mounts, err := os.ReadFile("/proc/self/mounts"); err == nil {
+		for _, line := range strings.Split(string(mounts), "\n") {
+			if fields := strings.Fields(line); len(fields) >= 2 {
+				mounted[fields[1]] = true
+			}
+		}
+	}
+
+	swept := 0
+	for _, dir := range matches {
+		if mounted[dir] {
+			continue // a live run owns it; the preflight above has the policy
+		}
+		info, err := os.Stat(dir)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		if time.Since(info.ModTime()) < staleTestDirGrace {
+			continue // too fresh to be certain it is abandoned
+		}
+		if err := os.RemoveAll(dir); err != nil {
+			log.Printf("Warning: could not remove abandoned test dir %s: %v", dir, err)
+			continue
+		}
+		swept++
+	}
+	if swept > 0 {
+		log.Printf("Swept %d abandoned test dir(s) from %s", swept, os.TempDir())
+	}
+}
+
+// Kernel cache timeouts for the FIXTURE mount, named here so the tests that wait
+// out an expiry derive their wait from the mount's actual policy instead of a
+// literal that can drift from it.
+//
+// They are the PRODUCTION defaults, deliberately, and that costs the offline
+// suite ~60s: the two timeout-driven revalidation tests must wait out a real 30s
+// entry timeout, because the expiry belongs to the kernel and runs on the
+// kernel's clock — no injected clock can bring it forward, so shortening the
+// timeout is the only lever (fs.WithKernelCacheTimeouts exists for it).
+//
+// Shortening was tried and REVERTED: at 1s and at 5s,
+// TestRemoteUpdateVisibleAfterKernelRevalidation becomes order-dependent — it
+// passes alone and fails roughly one run in three inside the full suite, with
+// issue.md never refreshing even after 10s of polling. Something earlier in the
+// suite leaves the node unable to refresh, and until that is understood a fast
+// suite here would mean a flaky one. See the ticket; the plumbing is in place
+// for when it is.
+const (
+	fixtureAttrTimeout  = fs.DefaultAttrTimeout
+	fixtureEntryTimeout = fs.DefaultEntryTimeout
+)
+
+// kernelRevalidationWait bounds the poll below. It is a timeout, not a delay:
+// the common case returns in one iteration.
+const kernelRevalidationWait = 10 * time.Second
+
+// waitForKernelEntryExpiry waits for the kernel to drop its cached entry/attrs
+// for path and serve the remote update behind it, then returns.
+//
+// Two parts, and both are load-bearing. The sleep is real time past the mount's
+// entry timeout: the expiry belongs to the kernel and runs on the kernel's
+// clock, so no injected clock can bring it forward — shortening the timeout
+// (fixtureEntryTimeout) is the only lever, and it changes the interval, not the
+// mechanism. The poll is because WHEN the revalidation lands after that is the
+// kernel's business too: content comes back through the page cache, which drops
+// when a revalidated attr shows a changed mtime, and under full-suite load that
+// arrives a beat later than it does for the test run alone. A single sleep of
+// timeout+margin is therefore a race that passes in isolation and fails in the
+// suite — which is exactly how it behaved — and a bigger margin is only a slower
+// race. On timeout this returns anyway, leaving the caller's assertions to
+// report precisely what was still stale.
+func waitForKernelEntryExpiry(path, want string) {
+	time.Sleep(fixtureEntryTimeout + 250*time.Millisecond)
+	deadline := time.Now().Add(kernelRevalidationWait)
+	for time.Now().Before(deadline) {
+		if data, err := os.ReadFile(path); err == nil && strings.Contains(string(data), want) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
 }
 
 // Store-readiness bounds. The cold-start cycle is a FULL workspace sync of a
@@ -390,8 +496,11 @@ func setupSQLiteFixtures() error {
 		return fmt.Errorf("inject store: %w", err)
 	}
 
-	// Mount the filesystem
-	server, err = fs.MountFS(mountPoint, lfs, false)
+	// Mount with the fixture's kernel cache timeouts, stated explicitly rather
+	// than inherited: staleness_test.go waits these out, so the value the mount
+	// gets and the value the tests sleep are one constant (see them above).
+	server, err = fs.MountFS(mountPoint, lfs, false,
+		fs.WithKernelCacheTimeouts(fixtureAttrTimeout, fixtureEntryTimeout))
 	if err != nil {
 		lfs.Close()
 		store.Close()
@@ -792,10 +901,16 @@ func cleanup() {
 	if offlineAPIServer != nil {
 		offlineAPIServer.Close()
 	}
-	if mountPoint != "" {
-		os.RemoveAll(mountPoint)
-	}
-	if stateDir != "" {
-		os.RemoveAll(stateDir)
+	// Say so when removal fails rather than swallowing it: the usual cause is a
+	// lazy-detached mount still attached at this instant, and a silent failure
+	// here is how leftovers accumulated unnoticed. sweepAbandonedTestDirs picks
+	// up whatever survives, on a later run.
+	for _, dir := range []string{mountPoint, stateDir} {
+		if dir == "" {
+			continue
+		}
+		if err := os.RemoveAll(dir); err != nil {
+			log.Printf("Warning: could not remove %s: %v (a later run will sweep it)", dir, err)
+		}
 	}
 }

--- a/internal/integration/staleness_test.go
+++ b/internal/integration/staleness_test.go
@@ -95,16 +95,20 @@ func TestRemoteUpdateVisibleAfterKernelRevalidation(t *testing.T) {
 	}
 
 	// Let the kernel's caches expire for real — the production freshness
-	// mechanism. The sync worker never notifies the kernel; entry timeouts
-	// (30s) make the next path walk re-Lookup every component, and each
-	// re-Lookup runs the nodeRefresher seam. (The ino namespace is total now —
-	// every ancestor dir has a derivable stable ino — but timeout-driven
-	// revalidation remains the production mechanism, so it is what this
-	// exercises.)
+	// mechanism. The sync worker never notifies the kernel; entry timeouts make
+	// the next path walk re-Lookup every component, and each re-Lookup runs the
+	// nodeRefresher seam. (The ino namespace is total now — every ancestor dir
+	// has a derivable stable ino — but timeout-driven revalidation remains the
+	// production mechanism, so it is what this exercises.)
+	//
+	// The wait is real time and cannot be otherwise: the expiry is the kernel's,
+	// on its clock. fixtureEntryTimeout is the only lever, and it is currently
+	// the production 30s — see the comment on it for why shortening it was
+	// reverted. -short is the escape hatch until that is resolved.
 	if testing.Short() {
-		t.Skip("waits out the 30s kernel entry timeout; skipped with -short")
+		t.Skip("waits out the mount's kernel entry timeout (30s); skipped with -short")
 	}
-	time.Sleep(31 * time.Second)
+	waitForKernelEntryExpiry(path, "Renamed By Remote Sync")
 
 	after, err := os.ReadFile(path)
 	if err != nil {
@@ -286,9 +290,9 @@ func TestRemoteTeamUpdateVisibleAfterKernelRevalidation(t *testing.T) {
 	// variant above: expiry forces the next path walk to re-Lookup every
 	// component, and each re-Lookup runs the nodeRefresher seam.
 	if testing.Short() {
-		t.Skip("waits out the 30s kernel entry timeout; skipped with -short")
+		t.Skip("waits out the mount's kernel entry timeout (30s); skipped with -short")
 	}
-	time.Sleep(31 * time.Second)
+	waitForKernelEntryExpiry(teamFile, "Renamed Team By Remote Sync")
 
 	after, err := os.ReadFile(teamFile)
 	if err != nil {

--- a/internal/integration/workspace_test.go
+++ b/internal/integration/workspace_test.go
@@ -1,0 +1,84 @@
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jra3/linear-fuse/internal/api"
+)
+
+// The workspace a live run acts on is chosen by pickTestTeam, and these are its
+// unit tests: they run in every mode because the function is pure — teams in, a
+// team or a legible error out, no network.
+//
+// What they are guarding is the failure the suite could not previously express.
+// A live run authenticates with whatever LINEAR_API_KEY happens to be in the
+// environment; if that is a developer's real workspace key rather than the test
+// workspace's, the old selection ("prefer TST, else teams[0]") found *a* team
+// there and ran — reading the whole workspace and, under LINEARFS_WRITE_TESTS,
+// creating issues and projects in it. Nothing in the run said whose data it was.
+// LINEARFS_TEST_TEAM turns that into a setup error: name the team you mean, and
+// a key pointed at the wrong workspace fails before the mount instead of after
+// the mutations.
+
+func teams(keys ...string) []api.Team {
+	out := make([]api.Team, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, api.Team{ID: "id-" + strings.ToLower(k), Key: k, Name: k + " team"})
+	}
+	return out
+}
+
+func TestPickTestTeamHonorsTheRequestedKey(t *testing.T) {
+	got, err := pickTestTeam(teams("SPY", "TST", "FUS"), "FUS")
+	if err != nil {
+		t.Fatalf("pickTestTeam(want=FUS) returned %v", err)
+	}
+	if got.Key != "FUS" {
+		t.Errorf("picked %q, want FUS — a named team must win over the TST preference", got.Key)
+	}
+}
+
+// The whole point: a requested team the workspace does not have is a wrong-key
+// diagnosis, not an invitation to run somewhere else.
+func TestPickTestTeamRefusesToSubstituteAnotherTeam(t *testing.T) {
+	_, err := pickTestTeam(teams("SPY", "DES", "GTM", "TST", "ENG"), "FUS")
+	if err == nil {
+		t.Fatal("pickTestTeam accepted a workspace with no FUS team; a wrong key must fail setup, not fall back")
+	}
+	// The message has to be enough to recognise the wrong workspace by eye.
+	for _, want := range []string{"FUS", "ENG", "LINEARFS_TEST_TEAM"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error does not mention %q, got: %v", want, err)
+		}
+	}
+}
+
+// Unset keeps the historical behaviour, so an existing live invocation that
+// never set the variable is unchanged.
+func TestPickTestTeamWithoutARequestPrefersTST(t *testing.T) {
+	got, err := pickTestTeam(teams("SPY", "TST", "ENG"), "")
+	if err != nil {
+		t.Fatalf("pickTestTeam(want=\"\") returned %v", err)
+	}
+	if got.Key != "TST" {
+		t.Errorf("picked %q, want the TST preference", got.Key)
+	}
+
+	got, err = pickTestTeam(teams("SPY", "ENG"), "")
+	if err != nil {
+		t.Fatalf("pickTestTeam(want=\"\", no TST) returned %v", err)
+	}
+	if got.Key != "SPY" {
+		t.Errorf("picked %q, want the first team as the fallback", got.Key)
+	}
+}
+
+func TestPickTestTeamOnAnEmptyWorkspace(t *testing.T) {
+	if _, err := pickTestTeam(nil, ""); err == nil {
+		t.Error("pickTestTeam accepted a workspace with no teams")
+	}
+	if _, err := pickTestTeam(nil, "FUS"); err == nil {
+		t.Error("pickTestTeam accepted a requested team on a workspace with no teams")
+	}
+}


### PR DESCRIPTION
Makes "which workspace does a live run touch" a declared choice rather than
whatever key happens to be exported, plus two pieces of suite hygiene found
while getting a live run to happen at all.

**Supersedes #412.** That PR's three interlock commits are replaced here by a
reworked version: `.env` is *required and overriding* rather than `-include`d,
and `pickTestTeam` is an extracted pure function with unit tests
(`workspace_test.go`) instead of inline discovery logic. #412's fourth commit
(`createTestIssue` options, #405) is independent of all of that and went out
separately as #423; its CONTRIBUTING/THREAT-MODEL content is carried in the
third commit here.

## test(integration): pin live runs to a named workspace and team, from .env

A live run authenticated with whatever `LINEAR_API_KEY` was in the environment,
and the team pick was "prefer TST, else `teams[0]`". Both halves failed open,
and together they are how the first live write run authenticated to a real
**work** workspace whose TST team merely existed: setup was satisfied, the suite
synced all 3464 issues of an unrelated ENG team while the gate waited, and the
write tests created issues and projects in it. Nothing in the run said whose
workspace it was.

- The live make targets source `.env` (gitignored, `.env.example` checked in)
  and **refuse to run without it**. It deliberately overrides anything already
  exported — an ambient key silently winning over the file is the exact failure
  this exists to prevent.
- `LINEARFS_TEST_TEAM` is the interlock. `pickTestTeam` either finds that team
  or fails setup naming the teams it did find. Unset, it keeps the old
  "prefer TST, else first" fallback with a warning. It is now a pure function
  over `[]api.Team` with unit tests covering all five cases, so the behaviour
  is asserted offline rather than only by a live dispatch.
- Every live run resolves and logs the organization before it mounts anything,
  loudly in write mode.
- CI's write job pins `LINEARFS_TEST_TEAM=FUS` beside the secret, since it
  cannot read `.env`.

## test(integration): sweep abandoned temp dirs, one kernel-cache policy

`cleanup()` removed its own dirs, but a run that died first (kill, panic,
`go test | head`) left both behind and the preflight only swept dirs still
*mounted* — 28 dirs / 45MB had piled up in TMPDIR. `sweepAbandonedTestDirs`
handles the unmounted half, skipping anything touched within the hour so a
concurrent run's state dir is never yanked. `cleanup()` also stops swallowing
`RemoveAll` errors.

The mount set entry/attr timeouts of 30s/60s and `issues.go` hardcoded 30s of
its own — two copies of one policy, so a mount configured otherwise silently
did not apply to `issue.md`. `MountFS` takes `fs.WithKernelCacheTimeouts` and
the issue manifest reads the published value. Production behaviour unchanged;
the defaults are the old literals.

**This did not deliver the fast offline suite it was for, and that is #414.**
62 of the suite's 65 seconds are two tests sleeping out that timeout, and the
sleep cannot be mocked — it is the kernel's dentry cache on the kernel's clock.
At 1s and 5s, `TestRemoteUpdateVisibleAfterKernelRevalidation` went
order-dependent: green alone, red ~1 run in 3 in the full suite, and in the red
case `issue.md` never refreshed at all (10s of polling did not rescue it). So
the fixture mount stays on production defaults. The sleeps are now polls behind
the sleep (`waitForKernelEntryExpiry`) and both tests keep their `-short` skip:
`go test -short ./...` is 2.6s against 63s.

## docs: state the .env credential exposure

Carried from #412. CONTRIBUTING still documented `make integration-tests-ro
LINEAR_API_KEY=xxx`, now inert (`.env` overrides it) as well as leaky (shell
history + `make`'s own argv). `bench-dirs` still expanded `$(LINEAR_API_KEY)`
into a shell command string. THREAT-MODEL gains the exposure `.env` itself
creates — a second copy of the secret in the checkout, gitignored but chmodded
by nothing, since `internal/atrest` covers files LinearFS *writes*.

## Verification

- `go test ./...` green, all packages (integration 63.3s).
- `staticcheck` and `check-safename` clean.
- Live read-only green against the throwaway workspace on the predecessor of
  this branch: 61 passed, 0 failed, setup gate clearing in 36s.
- The interlock itself is asserted offline by `workspace_test.go`; the org
  logging is verified by construction — a live dispatch is what confirms it.

Refs #391, #394, #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)
