### PR TITLE
test(integration): guard the declined-clear verdict to fixture mode, and teach the fake to decline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,12 +97,19 @@ Which mode a test runs in is declared in exactly one place —
 - `skipIfNoWriteTests(t)` — needs `liveAPIMode` **and** `LINEARFS_WRITE_TESTS=1`.
   It guards the tests that mutate a real workspace.
 - `skipIfLiveAPI(t, why)` — skips when `liveAPIMode` is true, printing `why` in
-  place of the test. It is the inverse interlock, and covers both kinds of
+  place of the test. It is the inverse interlock, and covers three kinds of
   fixture dependence: the write-contract tests that write *through the mount* to
   assert a structural invariant (#131, #137, #140, #142) — inert offline, but a
   real mutation live, and `TestMkdirIssueFailureIsLegible` leaks an issue it
-  cannot clean up (`fixtureWriteContract`) — and the read tests that assert
-  against seeded rows like `TST-1` or `test-project` (`fixtureSeededData`).
+  cannot clean up (`fixtureWriteContract`) — the read tests that assert
+  against seeded rows like `TST-1` or `test-project` (`fixtureSeededData`) — and
+  the tests whose assertion needs the mock mutator to model a specific BACKEND
+  behavior the real one need not have (`WithBodyReformat`,
+  `WithEmptyContentIgnored`), which take a `why` naming that dependency. #411 is
+  what the last kind costs when it is guarded the other way:
+  `TestClearProjectBodyIsRejectedLegibly` asserted the verdict for a server that
+  declines an empty body, so live it failed the moment Linear applied one —
+  after creating a real project to find that out.
   Never convert one guard to the other: `skipIfNoWriteTests` on a fixture-mode
   guard deletes it from the default offline suite, the only place it runs.
 - **no guard** — the test runs in every mode, and therefore may not name a

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -192,8 +192,7 @@ module dependency set.
 **CI's use of the live workspace credential (#386).** One workflow authenticates
 to Linear with a real key and mutates a real workspace: the `workflow_dispatch`-only
 "Integration Tests (Write)" job, which sets `LINEARFS_LIVE_API=1` +
-`LINEARFS_WRITE_TESTS=1` and runs the 55 write tests gated behind
-`skipIfNoWriteTests`. Before #386 it set `LINEARFS_WRITE_TESTS` but never
+`LINEARFS_WRITE_TESTS=1` and runs every test gated behind `skipIfNoWriteTests`. Before #386 it set `LINEARFS_WRITE_TESTS` but never
 `LINEARFS_LIVE_API` — and `skipIfNoWriteTests` skips on `!liveAPIMode` first — so
 the injected `LINEAR_API_KEY` secret went unused and the job silently ran the
 offline fixture suite; the label promised mutation and the run delivered none.

--- a/internal/integration/claude_tools_test.go
+++ b/internal/integration/claude_tools_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/jra3/linear-fuse/internal/marshal"
+	"github.com/jra3/linear-fuse/internal/testutil/mockmutation"
 )
 
 // =============================================================================
@@ -90,7 +91,7 @@ func claudeToolWrite(t *testing.T, path string, content []byte) {
 	}
 }
 
-// claudeToolSaveExpectingError emulates the atomic save-via-rename that Claude
+// claudeToolAtomicSave emulates the atomic save-via-rename that Claude
 // Code's Edit/Write tools and editors (vim, VS Code) actually use: write a
 // sibling temp file, then rename it over the target. It returns the error the
 // rename surfaces. Unlike a raw truncate+write+close, the rename routes the bytes
@@ -98,8 +99,10 @@ func claudeToolWrite(t *testing.T, path string, content []byte) {
 // (and its validation) inline and returns the errno directly — so a rejected
 // write fails loudly and deterministically, instead of having the verdict masked
 // when the kernel serves an O_TRUNC+write entirely from a primed page cache.
-// Used to assert that invalid writes fail loudly rather than succeeding silently.
-func claudeToolSaveExpectingError(t *testing.T, path string, content []byte) error {
+// Returning the errno rather than failing the test is what lets a caller assert
+// either verdict: that an invalid write fails loudly, or that a save the test
+// needs to succeed did.
+func claudeToolAtomicSave(t *testing.T, path string, content []byte) error {
 	t.Helper()
 
 	tmp := path + ".tmp.999.deadbeef"
@@ -149,6 +152,39 @@ func firstInitiativeDir() (string, error) {
 		}
 	}
 	return "", fmt.Errorf("no initiative directory found")
+}
+
+// restorableInitiativeDir returns the first initiative whose initiative.md has a
+// non-empty body. It is what a borrow-edit-restore test must use instead of
+// firstInitiativeDir: there is no initiative-create surface, so such a test
+// edits a real initiative and puts it back — and putting an originally-EMPTY
+// body back is a body-clear, which a backend that ignores an empty content
+// declines (#398). The restore would fail with EINVAL and the test's marker
+// would stay in a real initiative permanently (#411). Scanning past an
+// empty-bodied first initiative keeps the coverage that skipping there loses.
+func restorableInitiativeDir() (string, error) {
+	entries, err := os.ReadDir(initiativesPath())
+	if err != nil {
+		return "", err
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dir := initiativePath(e.Name())
+		content, err := os.ReadFile(filepath.Join(dir, "initiative.md"))
+		if err != nil {
+			continue
+		}
+		doc, err := parseFrontmatter(content)
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(doc.Body) != "" {
+			return dir, nil
+		}
+	}
+	return "", fmt.Errorf("no initiative with a non-empty body found")
 }
 
 // TestClaudeToolFsyncSupportedOnWritableFiles is the core #139 regression guard:
@@ -506,7 +542,7 @@ func TestWriteInvalidInputIsLoud(t *testing.T) {
 	const badValue = "__no_such_initiative__"
 	bad := []byte("---\nname: Test Project\ninitiatives: [\"" + badValue + "\"]\n---\n\nbody\n")
 
-	werr := claudeToolSaveExpectingError(t, path, bad)
+	werr := claudeToolAtomicSave(t, path, bad)
 	if !errors.Is(werr, syscall.EINVAL) {
 		t.Fatalf("expected EINVAL writing unknown initiative, got %v", werr)
 	}
@@ -673,9 +709,13 @@ func TestReadYourWritesLargeBody(t *testing.T) {
 // `content` (#398). Editing a borrowed project therefore left a `linearfs-smoke-`
 // marker in a real project's description permanently. A project the test owns is
 // archived at the end, so nothing needs restoring.
+//
+// It works in fixture mode too, given enableMockMutations: the mkdir/rmdir go
+// through the fake, and the fixture project's body is likewise not restorable
+// once a test models the declining backend (#411).
 func createTestProject(t *testing.T, name string) (slug string, cleanup func()) {
 	t.Helper()
-	rateLimitWait()
+	rateLimitWait() // no-op in fixture mode
 
 	title := fmt.Sprintf("[TEST] %s %d", name, time.Now().UnixMilli())
 	if err := os.Mkdir(filepath.Join(projectsPath(testTeamKey), title), 0o755); err != nil {
@@ -726,18 +766,25 @@ func TestClaudeToolEditPersistsProjectDescription(t *testing.T) {
 	}
 }
 
-// TestClearProjectBodyIsRejectedLegibly is the live half of #398. Linear accepts
-// an empty `content` and then ignores it, so emptying a project body does not
-// take effect. The read-your-writes check catches that correctly; what was wrong
-// was the verdict — EIO, which reads as "retry", for a write that can never
-// succeed no matter how many times it is retried. It must be EINVAL, with a
-// .error saying the previous body was kept and what to write instead.
+// TestClearProjectBodyIsRejectedLegibly covers #398. A backend that accepts an
+// empty `content` and then ignores it — which is what Linear did when #398 was
+// filed — leaves the previous body in place. The read-your-writes check catches
+// that correctly; what was wrong was the verdict: EIO, which reads as "retry",
+// for a write that can never succeed no matter how many times it is retried. It
+// must be EINVAL, with a .error saying the previous body was kept and what to
+// write instead.
 //
-// Live-only by necessity: the verdict is derived from what the SERVER did with
-// the empty content, and the offline mock applies it (correctly reporting
-// success), so there is nothing to assert in fixture mode.
+// Fixture-mode by necessity, which is the opposite of what it first said (#411).
+// scalarEdit.clearsBody is deliberately not a pre-flight refusal: the EINVAL is
+// derived from what the SERVER did with the empty content, so a backend that
+// APPLIES it just succeeds. Live, Linear applied it and the test failed on a
+// non-bug — after mutating a real workspace to get there. The declining backend
+// is now something the fake models on request (WithEmptyContentIgnored), which
+// makes the verdict deterministic and costs no real project.
 func TestClearProjectBodyIsRejectedLegibly(t *testing.T) {
-	skipIfNoWriteTests(t)
+	skipIfLiveAPI(t, "the EINVAL verdict requires a backend that DECLINES an empty content — "+
+		"that is the mock mutator (WithEmptyContentIgnored), not Linear, which may simply apply it")
+	enableMockMutations(t, mockmutation.WithEmptyContentIgnored())
 
 	slug, cleanup := createTestProject(t, "Clear Body")
 	defer cleanup()
@@ -758,7 +805,14 @@ func TestClearProjectBodyIsRejectedLegibly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("render project.md with a body: %v", err)
 	}
-	claudeToolWrite(t, path, withBody)
+	// Both saves take the SAME atomic-rename path. The rename's Flush diffs
+	// against the project directory node's cached entity, which it refreshes on
+	// each successful save; a plain truncate+write save does not refresh it, so
+	// seeding that way leaves the clear diffing against the pre-seed body — no
+	// change, no mutation, and nothing for the verdict to be about.
+	if err := claudeToolAtomicSave(t, path, withBody); err != nil {
+		t.Fatalf("seed a body via atomic save: %v", err)
+	}
 	waitForCacheExpiry()
 
 	// Now empty the body, keeping the frontmatter — the shape a "clear the
@@ -767,7 +821,7 @@ func TestClearProjectBodyIsRejectedLegibly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("render project.md with an empty body: %v", err)
 	}
-	werr := claudeToolSaveExpectingError(t, path, cleared)
+	werr := claudeToolAtomicSave(t, path, cleared)
 	if !errors.Is(werr, syscall.EINVAL) {
 		t.Errorf("clearing a project body returned %v, want EINVAL — Linear cannot apply it, "+
 			"so the caller needs a verdict they can act on rather than a retryable-looking EIO", werr)
@@ -784,12 +838,18 @@ func TestClearProjectBodyIsRejectedLegibly(t *testing.T) {
 
 // TestClaudeToolEditPersistsInitiativeDescription is the initiative counterpart
 // to the project persistence test. It skips if the workspace has no initiative.
+//
+// Unlike the project half it borrows a real initiative rather than creating one
+// (there is no initiative-create surface), so it takes one it can put back:
+// restoring an originally-EMPTY body is a body-clear, which a backend that
+// ignores an empty content declines — the restore fails with EINVAL and the
+// marker stays in a real initiative for good (#398, #411).
 func TestClaudeToolEditPersistsInitiativeDescription(t *testing.T) {
 	skipIfNoWriteTests(t)
 
-	dir, err := firstInitiativeDir()
+	dir, err := restorableInitiativeDir()
 	if err != nil {
-		t.Skipf("no initiative in workspace: %v", err)
+		t.Skipf("no restorable initiative in workspace: %v", err)
 	}
 	path := filepath.Join(dir, "initiative.md")
 	orig, err := os.ReadFile(path)

--- a/internal/integration/error_test.go
+++ b/internal/integration/error_test.go
@@ -243,9 +243,9 @@ func TestEmptyWriteDoesNotCorrupt(t *testing.T) {
 	// Empty the file the way a truncating save does. The rename form is used
 	// deliberately: an O_TRUNC+write can have its verdict masked when the kernel
 	// serves the write from a primed page cache, whereas a rename runs Flush
-	// inline and hands back the errno (the same reason claudeToolSaveExpectingError
+	// inline and hands back the errno (the same reason claudeToolAtomicSave
 	// exists).
-	werr := claudeToolSaveExpectingError(t, path, []byte{})
+	werr := claudeToolAtomicSave(t, path, []byte{})
 	if !errors.Is(werr, syscall.EINVAL) {
 		t.Errorf("emptying issue.md returned %v, want EINVAL — an empty document has no fields, "+
 			"so applying it clears every removable field the issue had", werr)

--- a/internal/integration/modes_test.go
+++ b/internal/integration/modes_test.go
@@ -27,8 +27,9 @@ import (
 //   - skipIfNoWriteTests(t)   — live + writes only: the tests that mutate a real
 //     workspace.
 //   - skipIfLiveAPI(t, why)   — fixture only, with `why` naming the kind of
-//     fixture dependence (the constants below). Its condition is the exact
-//     inverse of skipIfNoWriteTests; the two must never agree to run one test.
+//     fixture dependence (the constants below, or the mock-modelled backend
+//     behaviour described under them). Its condition is the exact inverse of
+//     skipIfNoWriteTests; the two must never agree to run one test.
 //   - no guard                — runs in every mode. A test in this group may not
 //     name a seeded row: derive identifiers with someIssueID/someProjectSlug.
 //
@@ -56,6 +57,19 @@ const (
 	// suite, which is the only place it ever runs.
 	fixtureWriteContract = "fixture-mode write-contract guard; the same write would mutate a real workspace under a live key"
 )
+
+// The third kind of fixture dependence has no shared constant, because the
+// useful part of the sentence differs per test: the assertion needs the mock
+// mutator to MODEL A BACKEND BEHAVIOUR that the real one need not have —
+// markdown reformat-on-store (mockmutation.WithBodyReformat), or a backend that
+// ignores an empty content (mockmutation.WithEmptyContentIgnored). These take a
+// `why` naming the option they depend on.
+//
+// Guarded the other way, such a test asserts a belief about Linear that nothing
+// upholds: #411 is TestClearProjectBodyIsRejectedLegibly under
+// skipIfNoWriteTests, asserting the declined-clear verdict against whatever the
+// server happened to do — so it failed the first live write run for a non-bug,
+// having created a real project to get there.
 
 // skipIfNoWriteTests skips the test unless it is running in live + writes mode.
 // It guards the tests that mutate a real workspace. liveAPIMode is checked

--- a/internal/integration/testdata_test.go
+++ b/internal/integration/testdata_test.go
@@ -26,8 +26,13 @@ var (
 // The mode interlocks (skipIfNoWriteTests / skipIfLiveAPI) live in
 // modes_test.go, alongside the workspace-derived identifier pickers.
 
-// rateLimitWait ensures we don't make API calls too quickly
+// rateLimitWait ensures we don't make API calls too quickly. In fixture mode
+// there is no API to pace — the mutation fake answers in-process — so it returns
+// immediately rather than costing every mock-backed create a full second.
 func rateLimitWait() {
+	if !liveAPIMode {
+		return
+	}
 	rateLimitMu.Lock()
 	defer rateLimitMu.Unlock()
 

--- a/internal/testutil/mockmutation/mock.go
+++ b/internal/testutil/mockmutation/mock.go
@@ -57,6 +57,10 @@ type Client struct {
 	// Linear's server-side markdown normalization (see WithBodyReformat). nil
 	// means the fake stores what it was sent, verbatim.
 	bodyReformat func(string) string
+	// emptyContentIgnored makes a project/initiative content update of "" a no-op
+	// on the stored body, modelling the backend behaviour behind #398 (see
+	// WithEmptyContentIgnored). false means an empty content clears the body.
+	emptyContentIgnored bool
 	// liveLinkOverride, when set for a parent ID (project or initiative), replaces
 	// the store-backed authoritative live link list served by the liveReader seam.
 	// It lets a test present a phantom — a link the store still has but Linear no
@@ -94,6 +98,22 @@ func WithStore(store *db.Store) Option {
 // conservative choice for every other test.
 func WithBodyReformat(fn func(string) string) Option {
 	return func(c *Client) { c.bodyReformat = fn }
+}
+
+// WithEmptyContentIgnored models the other server behaviour the fake otherwise
+// cannot: a backend that ACCEPTS an empty `content` on a project/initiative
+// update, reports success, and then keeps the previous body — what Linear did
+// when #398 was filed. With it, a body-clear reads back unchanged, which is the
+// only condition under which the write-back tail can reach its declined-clear
+// verdict (EINVAL + clearBodyMessage) instead of reporting a faithful write.
+//
+// It exists because that verdict is derived from what the server DID, never from
+// a hardcoded belief about Linear (scalarEdit.clearsBody) — so asserting it live
+// asserts a backend behaviour nothing guarantees, and mutates a real workspace to
+// do it (#411). Off by default: the fake otherwise applies an empty content like
+// any other value.
+func WithEmptyContentIgnored() Option {
+	return func(c *Client) { c.emptyContentIgnored = true }
 }
 
 // New returns a fake mutation client. Created issues get identifiers like
@@ -250,6 +270,17 @@ func (c *Client) reformat(body string) string {
 		return body
 	}
 	return c.bodyReformat(body)
+}
+
+// storedContent returns the body the fake should keep for a project/initiative
+// content update: what it was sent (normalized like any stored body), or the
+// current value when the fake is modelling a backend that ignores an empty
+// content (WithEmptyContentIgnored).
+func (c *Client) storedContent(current, sent string) string {
+	if c.emptyContentIgnored && sent == "" {
+		return current
+	}
+	return c.reformat(sent)
 }
 
 func (c *Client) UpdateIssue(ctx context.Context, issueID string, input map[string]any) error {
@@ -414,7 +445,7 @@ func (c *Client) UpdateProject(ctx context.Context, projectID string, input api.
 		proj.Name = *input.Name
 	}
 	if input.Content != nil { // the editable body maps here (#5)
-		proj.Content = c.reformat(*input.Content)
+		proj.Content = c.storedContent(proj.Content, *input.Content)
 	}
 	if input.Description != nil {
 		proj.Description = *input.Description
@@ -498,7 +529,7 @@ func (c *Client) UpdateInitiative(ctx context.Context, initiativeID string, inpu
 		init.Name = *input.Name
 	}
 	if input.Content != nil { // the editable body maps here (#5)
-		init.Content = c.reformat(*input.Content)
+		init.Content = c.storedContent(init.Content, *input.Content)
 	}
 	if input.Description != nil {
 		init.Description = *input.Description


### PR DESCRIPTION
`TestClearProjectBodyIsRejectedLegibly` asserted the #398 verdict — `EINVAL`
plus a "kept the previous body" `.error` — under `skipIfNoWriteTests`, so it ran
live. That verdict is derived from what the **server** did with an empty
content; `scalarEdit.clearsBody` is deliberately not a pre-flight refusal,
precisely so a backend that *applies* an empty content simply succeeds.
Asserting it live is asserting a belief about Linear that nothing upholds — and
the test created a real project to do it. First live write run: ~two failures,
no bug.

Re-guarded to `skipIfLiveAPI` with a `why` that names the dependency. The ticket
assumed the offline fake already declined an empty content; it did not — it
applied one, so a bare re-guard would have failed offline. So the declining
backend is now something the fake models on request:

```go
mockmutation.WithEmptyContentIgnored()
```

Opt-in, like `WithBodyReformat`, and applied to project and initiative content
alike (one backend behaviour, not a per-entity toggle). With it the offline test
reaches the declined-clear verdict deterministically, in 0.16s, costing no real
project.

Both saves in the test now take the atomic-rename path. A truncate+write seed
followed by a rename clear diffs against the project directory node's cached
entity, which the truncate path never refreshes — **the clear sends no mutation
at all and reports success**. That staleness is a product defect in its own
right (#415, and the design question is #417), not this test's to fix; the test
avoids depending on it.

## Neighbour sweep (the ticket asked for one)

- `TestClaudeToolEditPersistsInitiativeDescription` borrows a real initiative and
  restores it. Restoring an originally-empty body is itself a clear, so post-#398
  the restore fails with `EINVAL` and leaves the marker in a real initiative
  permanently. It now takes an initiative it can put back
  (`restorableInitiativeDir`).
- No other live-write test asserts a backend-declined verdict: the remaining
  `EINVAL` assertions are LinearFS-side pre-flight refusals, which hold on any
  backend.

## Also here

- `modes_test.go` records the third kind of fixture dependence (the mock
  modelling a backend behaviour) in the file `CLAUDE.md` names as the single
  authoritative place; `CLAUDE.md`'s taxonomy matches.
- `claudeToolSaveExpectingError` → `claudeToolAtomicSave`: it returns the errno,
  and a caller may need either verdict.
- `rateLimitWait` is a no-op in fixture mode — there is no API to pace, and it
  cost every mock-backed create a full second.
- `THREAT-MODEL.md` drops a write-test tally this change would have staled.

## Verification

`go test ./internal/integration/...` green (64.7s).

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)
