### PR TITLE
feat(issues): make `team:` an editable issue.md field — editing it moves the issue

### DIFF
--- a/internal/fs/catalogrefresh.go
+++ b/internal/fs/catalogrefresh.go
@@ -32,6 +32,7 @@ const (
 	CatalogCycles      CatalogKind = "cycles"      // scopeID = team ID
 	CatalogUsers       CatalogKind = "users"       // scopeID unused (workspace)
 	CatalogInitiatives CatalogKind = "initiatives" // scopeID unused (workspace)
+	CatalogTeams       CatalogKind = "teams"       // scopeID unused (workspace)
 )
 
 // unknownNameError marks a LOCAL name→ID resolution miss: the name is absent
@@ -93,6 +94,8 @@ func (lfs *LinearFS) refreshCatalogViaSync(ctx context.Context, kind CatalogKind
 	switch kind {
 	case CatalogUsers, CatalogInitiatives:
 		return w.RefreshWorkspaceCatalogs(ctx)
+	case CatalogTeams:
+		return w.RefreshTeamList(ctx)
 	case CatalogMilestones:
 		// Milestones ride the team-metadata drain (nested under projects);
 		// map the owning project to its canonical team first — locally, no

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -36,7 +36,12 @@ func (lfs *LinearFS) createIssueFromSpec(ctx context.Context, team api.Team, spe
 	if ferr := resolveIssueUpdate(ctx, lfs, &synthetic, spec); ferr != nil {
 		return nil, ferr
 	}
-	spec["teamId"] = team.ID
+	// An explicit `team:` in the spec wins over the directory (#429) — it is
+	// the more deliberate signal; resolveIssueUpdate already turned it into an
+	// ID (and resolved status/labels against it). The dir team is the default.
+	if _, ok := spec["teamId"]; !ok {
+		spec["teamId"] = team.ID
+	}
 	if t, ok := spec["title"].(string); !ok || t == "" {
 		spec["title"] = "Untitled issue"
 	}
@@ -543,10 +548,31 @@ func (i *IssueFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errn
 				if want, ok := updates["description"].(string); ok {
 					results = append(results, writeBackDivergence("description (body)", want, fresh.Description, i.issue.Description))
 				}
+				if want, ok := updates["teamId"].(string); ok {
+					var got, prev string
+					if fresh.Team != nil {
+						got = fresh.Team.ID
+					}
+					if i.issue.Team != nil {
+						prev = i.issue.Team.ID
+					}
+					results = append(results, writeBackDivergence("team", want, got, prev))
+				}
 				return results
 			},
 		},
-		adopt: func(fresh *api.Issue) { i.issue = *fresh },
+		adopt: func(fresh *api.Issue) {
+			// A team move (#429) re-homes and re-numbers the issue: evict the
+			// old identifier from the old team's listings and announce the new
+			// one, so neither dir serves a stale entry for a dir-cache TTL.
+			if prev := i.issue.Team; prev != nil && fresh.Team != nil && prev.ID != fresh.Team.ID {
+				i.lfs.InvalidateDeleted(issuesDirIno(prev.ID), i.issue.Identifier)
+				i.lfs.InvalidateDeleted(recentDirIno(prev.ID), i.issue.Identifier)
+				i.lfs.InvalidateCreated(issuesDirIno(fresh.Team.ID), fresh.Identifier)
+				i.lfs.InvalidateCreated(recentDirIno(fresh.Team.ID), fresh.Identifier)
+			}
+			i.issue = *fresh
+		},
 		restore: func() []byte {
 			content, err := marshal.IssueToMarkdown(&i.issue)
 			if err != nil {

--- a/internal/fs/linearfs.go
+++ b/internal/fs/linearfs.go
@@ -619,6 +619,19 @@ func (lfs *LinearFS) ResolveIssueID(ctx context.Context, identifier string) (str
 	return issue.ID, nil
 }
 
+// ResolveTeamID converts a team key to its ID (#429 team moves). A local
+// catalog miss triggers one targeted refresh + retry (see catalogrefresh.go).
+func (lfs *LinearFS) ResolveTeamID(ctx context.Context, teamKey string) (string, error) {
+	return lfs.resolveWithRefresh(ctx, CatalogTeams, "", func() (string, error) {
+		teams, err := lfs.repo.GetTeams(ctx)
+		if err != nil {
+			return "", err
+		}
+		return resolveByName(teams, teamKey, "team",
+			func(t api.Team) string { return t.Key /* safename:ok resolution key */ }, func(t api.Team) string { return t.ID })
+	})
+}
+
 // ResolveStateID converts a state name to its ID for a given team. A local
 // catalog miss triggers one targeted refresh + retry (see catalogrefresh.go).
 func (lfs *LinearFS) ResolveStateID(ctx context.Context, teamID string, stateName string) (string, error) {

--- a/internal/fs/resolve.go
+++ b/internal/fs/resolve.go
@@ -70,6 +70,7 @@ type FieldError = marshal.FieldError
 // issueResolver is the minimal set of name→ID lookups resolveIssueUpdate needs.
 // *LinearFS satisfies it through its existing Resolve* methods.
 type issueResolver interface {
+	ResolveTeamID(ctx context.Context, teamKey string) (string, error)
 	ResolveStateID(ctx context.Context, teamID, stateName string) (string, error)
 	ResolveUserID(ctx context.Context, identifier string) (string, error)
 	ResolveLabelIDs(ctx context.Context, teamID string, labelNames []string) ([]string, []string, error)
@@ -86,6 +87,18 @@ func resolveIssueUpdate(ctx context.Context, r issueResolver, issue *api.Issue, 
 	teamID := ""
 	if issue.Team != nil {
 		teamID = issue.Team.ID
+	}
+
+	// team key -> ID, resolved FIRST: a team change moves the issue (#429), so
+	// status, labels, project, and cycle in the same edit must resolve against
+	// the team the issue is moving to, not the one it is leaving.
+	if teamKey, ok := updates["teamId"].(string); ok {
+		newTeamID, err := r.ResolveTeamID(ctx, teamKey)
+		if err != nil {
+			return &FieldError{Field: "team", Value: teamKey, Message: err.Error() + ". See teams/ for valid team keys."}
+		}
+		updates["teamId"] = newTeamID
+		teamID = newTeamID
 	}
 
 	// status name -> state ID

--- a/internal/fs/resolve_test.go
+++ b/internal/fs/resolve_test.go
@@ -12,6 +12,7 @@ import (
 // fakeResolver resolves names via simple maps and errors on anything unknown. It
 // satisfies issueResolver, so resolveIssueUpdate is tested with no repo or API.
 type fakeResolver struct {
+	teams      map[string]string
 	states     map[string]string
 	users      map[string]string
 	labels     map[string]string // name -> id; absence means "not found"
@@ -19,9 +20,22 @@ type fakeResolver struct {
 	projects   map[string]string
 	milestones map[string]string
 	cycles     map[string]string
+	// gotStateTeamID, when set, records the teamID ResolveStateID was handed —
+	// the team-resolves-first contract (#429) is observable only through it.
+	gotStateTeamID *string
 }
 
-func (f fakeResolver) ResolveStateID(_ context.Context, _, name string) (string, error) {
+func (f fakeResolver) ResolveTeamID(_ context.Context, key string) (string, error) {
+	if id, ok := f.teams[key]; ok {
+		return id, nil
+	}
+	return "", errors.New("unknown team " + key)
+}
+
+func (f fakeResolver) ResolveStateID(_ context.Context, teamID, name string) (string, error) {
+	if f.gotStateTeamID != nil {
+		*f.gotStateTeamID = teamID
+	}
 	if id, ok := f.states[name]; ok {
 		return id, nil
 	}
@@ -75,6 +89,7 @@ func teamedIssue() *api.Issue {
 
 func fullResolver() fakeResolver {
 	return fakeResolver{
+		teams:      map[string]string{"SPY": "team-2"},
 		states:     map[string]string{"In Progress": "state-1"},
 		users:      map[string]string{"a@b.com": "user-1"},
 		labels:     map[string]string{"Bug": "label-1", "Backend": "label-2"},
@@ -129,6 +144,12 @@ func TestResolveIssueUpdate_FieldErrors(t *testing.T) {
 			wantField: "status", wantValue: "Bogus",
 		},
 		{
+			name:      "unknown team",
+			issue:     teamedIssue(),
+			updates:   map[string]any{"teamId": "NOPE"},
+			wantField: "team", wantValue: "NOPE",
+		},
+		{
 			name:      "state with no team",
 			issue:     &api.Issue{}, // no team
 			updates:   map[string]any{"stateId": "In Progress"},
@@ -162,6 +183,25 @@ func TestResolveIssueUpdate_FieldErrors(t *testing.T) {
 
 // TestResolveIssueUpdate_ClearLabels confirms an empty labels list clears via
 // removedLabelIds (Linear rejects an empty labelIds).
+// TestResolveIssueUpdate_TeamResolvesFirst pins the #429 ordering contract: a
+// team change resolves before every other relational field, so a status in the
+// same edit resolves against the team the issue is moving TO.
+func TestResolveIssueUpdate_TeamResolvesFirst(t *testing.T) {
+	r := fullResolver()
+	var stateTeamID string
+	r.gotStateTeamID = &stateTeamID
+	updates := map[string]any{"teamId": "SPY", "stateId": "In Progress"}
+	if ferr := resolveIssueUpdate(context.Background(), r, teamedIssue(), updates); ferr != nil {
+		t.Fatalf("unexpected FieldError: %v", ferr)
+	}
+	if updates["teamId"] != "team-2" {
+		t.Errorf("teamId = %v, want team-2", updates["teamId"])
+	}
+	if stateTeamID != "team-2" {
+		t.Errorf("status resolved against team %q, want the new team \"team-2\"", stateTeamID)
+	}
+}
+
 func TestResolveIssueUpdate_ClearLabels(t *testing.T) {
 	issue := teamedIssue()
 	issue.Labels.Nodes = []api.Label{{ID: "label-1"}, {ID: "label-2"}}

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -220,6 +220,9 @@ branch, created, updated, …). A successful write never rewrites issue.md.
 ---
 title: "Fix bug"                    [editable]
 status: "In Progress"               [must match states.md]
+team: ENG                           [team key; changing it MOVES the issue —
+                                     Linear re-numbers it in the target team,
+                                     so its directory name changes]
 assignee: "user@example.com"        [email or display name]
 priority: high                      [none|low|medium|high|urgent]
 labels: [Bug, Backend]              [must match labels.md]
@@ -367,7 +370,7 @@ label, assignee, project, milestone, cycle, or initiative created in Linear
 moments ago) triggers ONE targeted catalog refresh and one retry before the
 write fails — a value that really exists usually just works on first write.
 
-Validated issue fields: status, assignee, labels, priority, project, milestone, cycle, parent
+Validated issue fields: status, team, assignee, labels, priority, project, milestone, cycle, parent
 Validated project fields: initiatives, labels
 Reference files: states.md (valid statuses), labels.md (valid issue labels),
 project-labels.md (valid project labels), initiatives/ (valid initiatives)

--- a/internal/integration/edit_persist_test.go
+++ b/internal/integration/edit_persist_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,7 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jra3/linear-fuse/internal/db"
 	"github.com/jra3/linear-fuse/internal/marshal"
+	"github.com/jra3/linear-fuse/internal/testutil/fixtures"
 	"github.com/jra3/linear-fuse/internal/testutil/mockmutation"
 )
 
@@ -686,5 +689,98 @@ func TestOffline_InitiativeEditPersistsDescription(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Errorf("initiative edit lost %q\n--- got ---\n%s", want, got)
 		}
+	}
+}
+
+// TestOffline_TeamMoveRehomesIssue drives the team-move surface (#429) end to
+// end: editing `team:` in issue.md moves the issue to the target team. The mock
+// mutator models the API's re-home + re-number, so the issue must reappear
+// under the target team's issues/ with a NEW identifier and leave the source
+// team's listing. A probe issue is created (and archived after) so the shared
+// fixture rows stay untouched.
+func TestOffline_TeamMoveRehomesIssue(t *testing.T) {
+	skipIfLiveAPI(t, "fixture-mode offline edit-persistence check; uses the mock mutator")
+	enableMockMutations(t)
+
+	// The shared fixture seeds a single team, so the move target is seeded
+	// here (same pattern as the staleness isolation tests) and removed after.
+	const targetTeamKey = "MOV"
+	ctx := context.Background()
+	target := fixtures.FixtureAPITeam()
+	target.ID = "team-move-target"
+	target.Key = targetTeamKey
+	target.Name = "Move Target"
+	if err := testStore.Queries().UpsertTeam(ctx, db.APITeamToDBTeam(target)); err != nil {
+		t.Fatalf("seed target team: %v", err)
+	}
+	t.Cleanup(func() { _, _ = testStore.DB().Exec("DELETE FROM teams WHERE id = ?", target.ID) })
+
+	const title = "Offline Team Move Probe"
+	if err := os.Mkdir(filepath.Join(issuesPath(testTeamKey), title), 0o755); err != nil {
+		t.Fatalf("mkdir probe issue: %v", err)
+	}
+	last := lastEntryByTitle(t, issuesLastPath(testTeamKey), title)
+	if last == nil {
+		t.Fatalf("issues/.last has no entry titled %q", title)
+	}
+	oldID := last["identifier"]
+	if oldID == "" {
+		t.Fatalf("issues/.last entry missing identifier: %v", last)
+	}
+
+	path := filepath.Join(issueDirPath(testTeamKey, oldID), "issue.md")
+	orig, err := readFileWithRetry(path, defaultWaitTime)
+	if err != nil {
+		t.Fatalf("read probe issue.md: %v", err)
+	}
+	doc, err := marshal.Parse(orig)
+	if err != nil {
+		t.Fatalf("parse probe issue.md: %v", err)
+	}
+	doc.Frontmatter["team"] = targetTeamKey
+	edited, err := marshal.Render(doc)
+	if err != nil {
+		t.Fatalf("render edited issue.md: %v", err)
+	}
+	claudeToolWrite(t, path, edited)
+
+	// The move re-numbered the issue, so find it under the target team by
+	// title rather than by a predicted identifier.
+	var newID string
+	for _, e := range mustReadDir(t, issuesPath(targetTeamKey)) {
+		if !e.IsDir() {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(issuesPath(targetTeamKey), e.Name(), "issue.md"))
+		if err == nil && strings.Contains(string(content), title) {
+			newID = e.Name()
+			break
+		}
+	}
+	if newID == "" {
+		t.Fatalf("moved issue %q not found under teams/%s/issues/", title, targetTeamKey)
+	}
+	t.Cleanup(func() {
+		// Archive the probe from its post-move home; ignore errors — a failed
+		// assertion above may have left it elsewhere, and cleanup is best-effort.
+		_ = os.Remove(issueDirPath(targetTeamKey, newID))
+	})
+	if newID == oldID {
+		t.Errorf("identifier unchanged after team move: %q (move must re-number)", newID)
+	}
+	if !strings.HasPrefix(newID, targetTeamKey+"-") {
+		t.Errorf("moved identifier = %q, want %s-N", newID, targetTeamKey)
+	}
+
+	// The moved issue serves its new team, and the source listing forgets it.
+	moved, err := readFileWithRetry(filepath.Join(issueDirPath(targetTeamKey, newID), "issue.md"), defaultWaitTime)
+	if err != nil {
+		t.Fatalf("read moved issue.md: %v", err)
+	}
+	if !strings.Contains(string(moved), "team: "+targetTeamKey) {
+		t.Errorf("moved issue.md does not carry team: %s\n--- got ---\n%s", targetTeamKey, moved)
+	}
+	if !dirLacks(issuesPath(testTeamKey), oldID) {
+		t.Errorf("source team still lists %q after the move", oldID)
 	}
 }

--- a/internal/marshal/issue.go
+++ b/internal/marshal/issue.go
@@ -58,6 +58,15 @@ type issueScalarField struct {
 var issueScalarFields = []issueScalarField{
 	{"title", "title", func(i *api.Issue) (string, bool) { return i.Title, true }, false},
 	{"status", "stateId", func(i *api.Issue) (string, bool) { return i.State.Name, i.State.ID != "" }, false},
+	// team is editable (#429): changing it moves the issue. Non-removable — an
+	// issue always has a team. Linear re-numbers the issue in the target team;
+	// the write-back re-fetch adopts the new identifier.
+	{"team", "teamId", func(i *api.Issue) (string, bool) {
+		if i.Team != nil {
+			return i.Team.Key, true
+		}
+		return "", false
+	}, false},
 	{"assignee", "assigneeId", func(i *api.Issue) (string, bool) {
 		if i.Assignee != nil {
 			return i.Assignee.Email, true
@@ -105,10 +114,8 @@ var issueScalarFields = []issueScalarField{
 func IssueToMarkdown(issue *api.Issue) ([]byte, error) {
 	fm := make(map[string]any)
 
-	// Editable scalar fields, table-driven (title, status, assignee, due, parent,
-	// project, milestone, cycle). team is read-only (an issue's team is fixed) — it
-	// lives in issue.meta, not here, so issue.md carries no editable-looking-but-
-	// ignored fields (#148).
+	// Editable scalar fields, table-driven (title, status, team, assignee, due,
+	// parent, project, milestone, cycle). team edits move the issue (#429).
 	for _, f := range issueScalarFields {
 		if v, present := f.current(issue); present {
 			fm[f.yamlKey] = v
@@ -156,9 +163,6 @@ func IssueMetaToMarkdown(issue *api.Issue, attachments ...api.Attachment) ([]byt
 	fm["id"] = issue.ID
 	fm["identifier"] = issue.Identifier
 	fm["url"] = issue.URL
-	if issue.Team != nil {
-		fm["team"] = issue.Team.Key
-	}
 	fm["created"] = issue.CreatedAt.Format(time.RFC3339)
 	fm["updated"] = issue.UpdatedAt.Format(time.RFC3339)
 	if issue.Creator != nil {

--- a/internal/marshal/issue_test.go
+++ b/internal/marshal/issue_test.go
@@ -1,6 +1,7 @@
 package marshal
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -47,6 +48,7 @@ func TestIssueToMarkdown(t *testing.T) {
 			wantContain: []string{
 				"title: Fix authentication bug",
 				"status: In Progress",
+				"team: ENG",
 				"priority: high",
 				"assignee: alice@example.com",
 				"due: \"2025-02-01\"",
@@ -61,7 +63,6 @@ func TestIssueToMarkdown(t *testing.T) {
 				"identifier: ENG-456",
 				"url:",
 				"updated:",
-				"team:", // read-only -> issue.meta
 			},
 		},
 		{
@@ -459,6 +460,42 @@ New description`,
 				} else if gotVal != want {
 					t.Errorf("MarkdownToIssueUpdate() field %q = %v, want %v", k, gotVal, want)
 				}
+			}
+		})
+	}
+}
+
+// TestMarkdownToIssueUpdateTeamMove pins the team-move surface (#429): a
+// changed `team:` emits teamId, an unchanged one emits nothing, and an absent
+// one clears nothing — team has no removal semantics.
+func TestMarkdownToIssueUpdateTeamMove(t *testing.T) {
+	t.Parallel()
+	original := &api.Issue{
+		ID:          "issue-123",
+		Title:       "Original Title",
+		Description: "Body",
+		State:       api.State{ID: "state-1", Name: "Todo", Type: "unstarted"},
+		Team:        &api.Team{ID: "team-1", Key: "ENG", Name: "Engineering"},
+	}
+
+	tests := []struct {
+		name       string
+		team       string // frontmatter line, "" = omit
+		wantUpdate map[string]any
+	}{
+		{name: "team changed", team: "team: SPY\n", wantUpdate: map[string]any{"teamId": "SPY"}},
+		{name: "team unchanged", team: "team: ENG\n", wantUpdate: map[string]any{}},
+		{name: "team absent does not clear", team: "", wantUpdate: map[string]any{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := "---\ntitle: Original Title\nstatus: Todo\npriority: none\n" + tt.team + "---\nBody"
+			update, err := MarkdownToIssueUpdate([]byte(content), original)
+			if err != nil {
+				t.Fatalf("MarkdownToIssueUpdate() error = %v", err)
+			}
+			if !reflect.DeepEqual(update, tt.wantUpdate) {
+				t.Errorf("update = %#v, want %#v", update, tt.wantUpdate)
 			}
 		})
 	}
@@ -1011,6 +1048,7 @@ func TestIssueScalarFieldsWiring(t *testing.T) {
 	wantAPIKey := map[string]string{
 		"title":     "title",
 		"status":    "stateId",
+		"team":      "teamId",
 		"assignee":  "assigneeId",
 		"due":       "dueDate",
 		"parent":    "parentId",
@@ -1033,8 +1071,9 @@ func TestIssueScalarFieldsWiring(t *testing.T) {
 		if f.apiKey != want {
 			t.Errorf("field %q apiKey = %q, want %q", f.yamlKey, f.apiKey, want)
 		}
-		// title and status have no removal semantics; everything else clears on absence.
-		wantRemovable := f.yamlKey != "title" && f.yamlKey != "status"
+		// title, status, and team have no removal semantics; everything else
+		// clears on absence.
+		wantRemovable := f.yamlKey != "title" && f.yamlKey != "status" && f.yamlKey != "team"
 		if f.removable != wantRemovable {
 			t.Errorf("field %q removable = %v, want %v", f.yamlKey, f.removable, wantRemovable)
 		}

--- a/internal/sync/worker.go
+++ b/internal/sync/worker.go
@@ -923,6 +923,22 @@ func (w *Worker) RefreshWorkspaceCatalogs(ctx context.Context) error {
 	return w.syncWorkspace(ctx)
 }
 
+// RefreshTeamList synchronously re-fetches the workspace's team list and
+// upserts it — the teams-catalog sibling of RefreshWorkspaceCatalogs, for
+// resolving a `team:` edit against a team created since the last cycle (#429).
+func (w *Worker) RefreshTeamList(ctx context.Context) error {
+	teams, err := w.client.GetTeams(ctx)
+	if err != nil {
+		return fmt.Errorf("get teams: %w", err)
+	}
+	for _, team := range teams {
+		if err := w.store.Queries().UpsertTeam(ctx, db.APITeamToDBTeam(team)); err != nil {
+			return fmt.Errorf("upsert team %s: %w", team.Key, err)
+		}
+	}
+	return nil
+}
+
 // syncTeamMetadata syncs all metadata for a team: states, labels, cycles,
 // projects (with milestones), and members. GetTeamMetadata drains every
 // unbounded connection, so meta is the complete server-side truth — which

--- a/internal/testutil/mockmutation/mock.go
+++ b/internal/testutil/mockmutation/mock.go
@@ -244,6 +244,20 @@ func (c *Client) stateName(ctx context.Context, id string) string {
 	return ""
 }
 
+func (c *Client) teamKeyByID(ctx context.Context, id string) string {
+	if c.store == nil {
+		return ""
+	}
+	if teams, err := c.store.Queries().ListTeams(ctx); err == nil {
+		for _, t := range teams {
+			if t.ID == id {
+				return t.Key
+			}
+		}
+	}
+	return ""
+}
+
 func (c *Client) labelName(ctx context.Context, id string) string {
 	if c.store == nil {
 		return ""
@@ -308,6 +322,15 @@ func (c *Client) UpdateIssue(ctx context.Context, issueID string, input map[stri
 	}
 	if sid, ok := input["stateId"].(string); ok && sid != "" {
 		iss.State = api.State{ID: sid, Name: c.stateName(ctx, sid)}
+	}
+	if tid, ok := input["teamId"].(string); ok && tid != "" {
+		if iss.Team == nil || iss.Team.ID != tid {
+			// A team move re-homes AND re-numbers the issue, like the real API
+			// (#429): the verify getter must serve the new identifier.
+			key := c.teamKeyByID(ctx, tid)
+			iss.Team = &api.Team{ID: tid, Key: key}
+			iss.Identifier = fmt.Sprintf("%s-%d", key, c.next())
+		}
 	}
 	c.issueEdit[issueID] = iss
 	return nil


### PR DESCRIPTION
Closes #429.

## What

`team:` joins the editable scalar field table (#227's single source of field truth), so render, diff-update, and create all handle it from one row. Editing it moves the issue.

- **Resolution**: new `ResolveTeamID` on the resolver seam; the team resolves **first**, so a status/label/cycle in the same edit resolves against the target team. Unknown key → `.error` "unknown team: X. See teams/ for valid team keys." with the #246 stale-catalog refresh-and-retry (new `CatalogTeams` kind → `Worker.RefreshTeamList`), so a just-created team resolves on first write.
- **Re-numbering**: Linear re-keys a moved issue; the existing write-back re-fetch + UUID-keyed upsert adopts the new identifier with no new sync code. The adopt hook evicts the old identifier from the source team's `issues/` and `recent/` kernel entries and announces the new one.
- **issue.meta**: `team` leaves the meta sidecar — a field lives in exactly one file, and it's editable now.
- **Create**: an explicit `team:` in a `_create` spec wins over the directory (the more deliberate signal); the dir stays the default.
- **Divergence**: write-back compares the persisted team against the requested one, alongside title/description.

## Tests

- Marshal: wiring-table row, render (`team: ENG` in issue.md, gone from meta), diff (changed → `teamId`; unchanged/absent → nothing — no removal semantics).
- Resolver: unknown-team FieldError; `TeamResolvesFirst` pins the ordering by recording the teamID handed to state resolution.
- Integration (offline): `TestOffline_TeamMoveRehomesIssue` — mock mutator now models the re-home + re-number; probe issue moves team, gets a new identifier, appears under the target team, leaves the source listing. Target team seeded per-test (staleness-test pattern), fixture rows untouched.
- `make test` green; the 8 `errcheck` lint hits are pre-existing on main (verified — same 8 on both trees).

## Notes

- Docs: the served mount README documents `team:` and that a move re-numbers (directory name changes).
- Follow-up (out of scope): `mv` between team dirs as a move surface — blocked on the #427 identifier-scoped-lookup redesign; noted in #429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
