### PR TITLE
feat(fs): expose team parent/sub-team hierarchy as frontmatter and symlinks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,8 @@ Linear API → api.Client → Sync Worker → SQLite → Repository → LinearFS
 ~/linear/
 ├── teams/<KEY>/
 │   ├── team.md, states.md, labels.md    # Team metadata (read-only)
+│   ├── parent                            # Symlink to the parent team (sub-teams only)
+│   ├── subteams/<KEY>                    # Sub-team symlinks; teams/ itself stays flat
 │   ├── issues/
 │   │   └── <ID>/
 │   │       ├── issue.md                  # Issue content (read/write)

--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ Timestamps are preserved across all views:
 │       ├── team.md              # Team metadata (read-only)
 │       ├── states.md            # Workflow states (read-only)
 │       ├── labels.md            # Labels reference (read-only)
+│       ├── parent               # Symlink to parent team (sub-teams only)
+│       ├── subteams/            # Sub-team symlinks (teams/ itself stays flat)
 │       ├── by/                  # Filter issues by attribute
 │       │   ├── status/<name>/   # Issues filtered by status (symlinks)
 │       │   ├── label/<name>/    # Issues filtered by label (symlinks)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -346,7 +346,11 @@ Design conventions:
   inverse direction — a parent's children — is a query over that column, never
   a second stored copy, so the two directions cannot drift apart. New columns
   land last in `schema.sql` and get a bootstrap `ALTER` in `migrateSchema`, so
-  a fresh and a migrated database agree.
+  a fresh and a migrated database agree — and an **index over such a column is
+  created in `migrateSchema` too, never in `schema.sql`**, which runs first and
+  would fail "no such column" on an upgraded database, tripping the
+  drop-and-recreate fallback below and discarding the user's cache instead of
+  migrating it (#432 tracks the missing guard).
 - **Hydrate-then-overlay:** for entities with extracted columns (states,
   labels, users, cycles, milestones, …), reverse converters unmarshal the
   `data` blob first, then overlay the columns — so no field is silently

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -341,6 +341,12 @@ Design conventions:
   schema stable as Linear's API grows.
 - **`synced_at` everywhere** for staleness detection; issues additionally carry
   `detail_synced_at`, stamped only when a detail batch persisted cleanly.
+- **Hierarchy edges are stored once,** as a `parent_id` column on the child
+  (`issues.parent_id`, `teams.parent_id`, `project_labels.parent_id`). The
+  inverse direction — a parent's children — is a query over that column, never
+  a second stored copy, so the two directions cannot drift apart. New columns
+  land last in `schema.sql` and get a bootstrap `ALTER` in `migrateSchema`, so
+  a fresh and a migrated database agree.
 - **Hydrate-then-overlay:** for entities with extracted columns (states,
   labels, users, cycles, milestones, …), reverse converters unmarshal the
   `data` blob first, then overlay the columns — so no field is silently
@@ -497,7 +503,8 @@ building blocks:
   cache.
 - `symlinkNode` — the one module behind every symlink view: `by/status|label|
   assignee`, `cycles/` (+ the `current` alias), `recent/`, `users/`, `my/`,
-  `children/`, project issue symlinks, and initiative→project links. Target and
+  `children/`, the team hierarchy (`teams/{KEY}/parent` and `subteams/`),
+  project issue symlinks, and initiative→project links. Target and
   times are fixed at construction (a Lookup answer and a later Getattr can never
   disagree); an unresolvable target is `ENOENT` at Lookup, never a dangling
   placeholder.

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -61,7 +61,7 @@ filesystem**:
 
 - **Filenames / directory names** — every name/target builder in `internal/fs`
   routes its output through the single `safeName(raw, id)` chokepoint
-  (`internal/fs/safename.go`, #345): `cycleDirName`, `userDirName`,
+  (`internal/fs/safename.go`, #345): `teamDirName`, `cycleDirName`, `userDirName`,
   `sanitizeFilename` (attachment/link `.link` + embedded-file names),
   `labelFilename`, `documentFilename`, `milestoneFilename`, `projectDirName`,
   `initiativeDirName`, `initiativeProjectDirName`, and the `by/` status/label/

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -74,10 +74,15 @@ filesystem**:
   (`scripts/check-safename.sh`, `make check-safename`) flags any builder
   returning a raw remote name field without it.
 - **Symlink targets** — `symlinkNode` backs every symlink view (`by/`, `cycles/`,
-  `recent/`, `users/`, `my/`, `children/`, project issue links, initiative→project
-  links). A target is remote-derived; every interpolated component (issue
-  identifier, team key, project dir name) passes through `safeName` so a hostile
-  value cannot traverse out of its directory.
+  `recent/`, `users/`, `my/`, `children/`, the team hierarchy —
+  `teams/{KEY}/parent` and `subteams/` — project issue links,
+  initiative→project links). A target is remote-derived; every interpolated
+  component (issue identifier, team key, project dir name) passes through
+  `safeName` so a hostile value cannot traverse out of its directory. The team
+  hierarchy is the case where a remote key crosses *into another entity's*
+  target: `parent` interpolates the PARENT team's key, so the render and the
+  listing both take it from `parentLinkTarget`, and a parent the local
+  workspace copy cannot name yields no entry at all rather than a guessed one.
 - **Disk-write paths** — the embedded-file cache writes bytes to a path derived
   from remote data (see also TB2).
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -101,6 +101,59 @@ func TestGetTeamsDrainsPages(t *testing.T) {
 	}
 }
 
+// TestGetTeamsDecodesParentEdge covers the wire end of the sub-team edge: the
+// Teams query must SELECT parent (a selection the rest of the suite cannot see,
+// because every other layer is seeded from the store, not from a response), and
+// the response must decode into Team.Parent. Without this, dropping the
+// selection or the json tag leaves every team parentless and the whole
+// hierarchy surface silently empty — with no offline test failing, since a live
+// workspace on a plan without team nesting cannot cover it either (#435).
+func TestGetTeamsDecodesParentEdge(t *testing.T) {
+	t.Parallel()
+	mock := testutil.NewMockLinearServer()
+	defer mock.Close()
+
+	top := testutil.FixtureTeam()
+	sub := testutil.FixtureTeam()
+	sub["id"] = "team-sub"
+	sub["key"] = "SUB"
+	sub["name"] = "Sub Team"
+	sub["parent"] = map[string]any{"id": "team-123", "key": "TST", "name": "Test Team"}
+	mock.SetResponse("Teams", testutil.TeamsResponse(top, sub))
+
+	client := NewClient("test-api-key")
+	client.SetAPIURL(mock.URL())
+
+	teams, err := client.GetTeams(context.Background())
+	if err != nil {
+		t.Fatalf("GetTeams failed: %v", err)
+	}
+	if len(teams) != 2 {
+		t.Fatalf("expected 2 teams, got %d", len(teams))
+	}
+
+	// The selection itself: a Team.parent the query never asks for decodes as
+	// nil no matter how correct the Go side is.
+	if call := mock.LastCall(); call == nil || !strings.Contains(call.Query, "parent {") {
+		t.Errorf("Teams query does not select parent:\n%s", mock.LastCall().Query)
+	}
+
+	if teams[0].Parent != nil {
+		t.Errorf("top-level team decoded a parent: %+v", teams[0].Parent)
+	}
+	parent := teams[1].Parent
+	if parent == nil {
+		t.Fatal("sub-team decoded no parent — the edge never reaches the store")
+	}
+	if parent.ID != "team-123" || parent.Key != "TST" || parent.Name != "Test Team" {
+		t.Errorf("parent = %+v, want {ID:team-123 Key:TST Name:Test Team}", parent)
+	}
+	// One level only: the wire carries no grandparent and nothing invents one.
+	if parent.Parent != nil {
+		t.Errorf("parent carries its own parent: %+v", parent.Parent)
+	}
+}
+
 // TestGetProjectUpdatesDrainsPages proves the updates read drains past the
 // old implicit 50-cap: updates accumulate over a project's lifetime and the
 // SWR refresh is upsert-only, so a capped read silently froze completeness.

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -16,6 +16,7 @@ query Teams($after: String) {
       icon
       createdAt
       updatedAt
+      parent { id key name }
     }
   }
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -12,6 +12,18 @@ type Team struct {
 	Icon      string    `json:"icon"`
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`
+	// Parent is the sub-team edge (Linear's Team.parent). Only the ID survives
+	// the DB round-trip; the repo read stitches Key/Name from the teams it
+	// already loaded, and never fills the parent's own Parent — one level, so
+	// a Team value cannot recurse.
+	//
+	// There is deliberately no Children field: sub-teams are derived from the
+	// other teams' parent_id, so the edge is stored in exactly one place and
+	// has no second copy to drift. Read them with repo.GetTeamChildren.
+	// Linear's Team.children is also `[Team!]!` — a bare list, not a
+	// connection (verified against the live API) — so selecting it would take
+	// whatever the server chose to return with no pageInfo to check.
+	Parent *Team `json:"parent,omitempty"`
 }
 
 type Issue struct {

--- a/internal/db/convert.go
+++ b/internal/db/convert.go
@@ -112,8 +112,14 @@ func DBIssuesToAPIIssues(issues []Issue) ([]api.Issue, error) {
 	return result, nil
 }
 
-// APITeamToDBTeam converts an api.Team to db.UpsertTeamParams
+// APITeamToDBTeam converts an api.Team to db.UpsertTeamParams. parent_id comes
+// from the team's own Parent edge (Linear's Team.parent); a top-level team
+// stores NULL.
 func APITeamToDBTeam(team api.Team) UpsertTeamParams {
+	var parentID sql.NullString
+	if team.Parent != nil {
+		parentID = sql.NullString{String: team.Parent.ID, Valid: team.Parent.ID != ""}
+	}
 	return UpsertTeamParams{
 		ID:   team.ID,
 		Key:  team.Key,
@@ -128,12 +134,15 @@ func APITeamToDBTeam(team api.Team) UpsertTeamParams {
 			Valid: !team.UpdatedAt.IsZero(),
 		},
 		SyncedAt: Now(),
+		ParentID: parentID,
 	}
 }
 
-// DBTeamToAPITeam converts a db.Team to api.Team
+// DBTeamToAPITeam converts a db.Team to api.Team. Parent comes strictly from
+// the parent_id column, so only the ID is populated here — the repo read
+// stitches Key/Name over it from the teams it already loaded.
 func DBTeamToAPITeam(team Team) api.Team {
-	return api.Team{
+	t := api.Team{
 		ID:        team.ID,
 		Key:       team.Key,
 		Name:      team.Name,
@@ -141,6 +150,10 @@ func DBTeamToAPITeam(team Team) api.Team {
 		CreatedAt: team.CreatedAt.Time,
 		UpdatedAt: team.UpdatedAt.Time,
 	}
+	if team.ParentID.Valid && team.ParentID.String != "" {
+		t.Parent = &api.Team{ID: team.ParentID.String}
+	}
+	return t
 }
 
 // DBTeamsToAPITeams converts a slice of db.Team to api.Team

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -317,6 +317,7 @@ type Team struct {
 	CreatedAt sql.NullTime   `json:"created_at"`
 	UpdatedAt sql.NullTime   `json:"updated_at"`
 	SyncedAt  time.Time      `json:"synced_at"`
+	ParentID  sql.NullString `json:"parent_id"`
 }
 
 type TeamMember struct {

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -126,16 +126,23 @@ ON CONFLICT(key) DO UPDATE SET last_run = excluded.last_run;
 -- name: ListTeams :many
 SELECT * FROM teams ORDER BY name;
 
+-- ListSubteams reads the sub-team edge in the inverse direction: the children
+-- of a team are the teams naming it as parent. Ordered by key because key is
+-- the directory name the caller renders.
+-- name: ListSubteams :many
+SELECT * FROM teams WHERE parent_id = ? ORDER BY key;
+
 -- name: UpsertTeam :exec
-INSERT INTO teams (id, key, name, icon, created_at, updated_at, synced_at)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+INSERT INTO teams (id, key, name, icon, created_at, updated_at, synced_at, parent_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
     key = excluded.key,
     name = excluded.name,
     icon = excluded.icon,
     created_at = excluded.created_at,
     updated_at = excluded.updated_at,
-    synced_at = excluded.synced_at;
+    synced_at = excluded.synced_at,
+    parent_id = excluded.parent_id;
 
 -- Full-text search queries are handled with raw SQL (FTS5 not supported by sqlc)
 -- See internal/db/search.go for FTS implementation

--- a/internal/db/queries.sql.go
+++ b/internal/db/queries.sql.go
@@ -1654,6 +1654,45 @@ func (q *Queries) ListProjects(ctx context.Context) ([]Project, error) {
 	return items, nil
 }
 
+const listSubteams = `-- name: ListSubteams :many
+SELECT id, "key", name, icon, created_at, updated_at, synced_at, parent_id FROM teams WHERE parent_id = ? ORDER BY key
+`
+
+// ListSubteams reads the sub-team edge in the inverse direction: the children
+// of a team are the teams naming it as parent. Ordered by key because key is
+// the directory name the caller renders.
+func (q *Queries) ListSubteams(ctx context.Context, parentID sql.NullString) ([]Team, error) {
+	rows, err := q.db.QueryContext(ctx, listSubteams, parentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Team{}
+	for rows.Next() {
+		var i Team
+		if err := rows.Scan(
+			&i.ID,
+			&i.Key,
+			&i.Name,
+			&i.Icon,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.SyncedAt,
+			&i.ParentID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listTeamCycles = `-- name: ListTeamCycles :many
 
 SELECT id, team_id, number, name, description, starts_at, ends_at, completed_at, progress, created_at, updated_at, synced_at, data FROM cycles WHERE team_id = ? ORDER BY number DESC
@@ -2252,7 +2291,7 @@ func (q *Queries) ListTeamUnassignedIssues(ctx context.Context, teamID string) (
 
 const listTeams = `-- name: ListTeams :many
 
-SELECT id, "key", name, icon, created_at, updated_at, synced_at FROM teams ORDER BY name
+SELECT id, "key", name, icon, created_at, updated_at, synced_at, parent_id FROM teams ORDER BY name
 `
 
 // Teams queries
@@ -2273,6 +2312,7 @@ func (q *Queries) ListTeams(ctx context.Context) ([]Team, error) {
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.SyncedAt,
+			&i.ParentID,
 		); err != nil {
 			return nil, err
 		}
@@ -3741,15 +3781,16 @@ func (q *Queries) UpsertSyncSchedule(ctx context.Context, arg UpsertSyncSchedule
 }
 
 const upsertTeam = `-- name: UpsertTeam :exec
-INSERT INTO teams (id, key, name, icon, created_at, updated_at, synced_at)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+INSERT INTO teams (id, key, name, icon, created_at, updated_at, synced_at, parent_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
     key = excluded.key,
     name = excluded.name,
     icon = excluded.icon,
     created_at = excluded.created_at,
     updated_at = excluded.updated_at,
-    synced_at = excluded.synced_at
+    synced_at = excluded.synced_at,
+    parent_id = excluded.parent_id
 `
 
 type UpsertTeamParams struct {
@@ -3760,6 +3801,7 @@ type UpsertTeamParams struct {
 	CreatedAt sql.NullTime   `json:"created_at"`
 	UpdatedAt sql.NullTime   `json:"updated_at"`
 	SyncedAt  time.Time      `json:"synced_at"`
+	ParentID  sql.NullString `json:"parent_id"`
 }
 
 func (q *Queries) UpsertTeam(ctx context.Context, arg UpsertTeamParams) error {
@@ -3771,6 +3813,7 @@ func (q *Queries) UpsertTeam(ctx context.Context, arg UpsertTeamParams) error {
 		arg.CreatedAt,
 		arg.UpdatedAt,
 		arg.SyncedAt,
+		arg.ParentID,
 	)
 	return err
 }

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -75,8 +75,20 @@ CREATE TABLE IF NOT EXISTS teams (
     icon TEXT,
     created_at DATETIME,
     updated_at DATETIME,
-    synced_at DATETIME NOT NULL
+    synced_at DATETIME NOT NULL,
+    -- Sub-team edge (Linear's Team.parent). NULL for a top-level team. The
+    -- inverse (children) is a query over this column, never a stored second
+    -- copy. Declared last to match where migrateSchema's ALTER appends it.
+    parent_id TEXT
 );
+
+-- NOTE: idx_teams_parent is created by migrateSchema, not here. An index over
+-- an ALTER-added column CANNOT live in this file: on a database created before
+-- the column existed, CREATE TABLE IF NOT EXISTS leaves the old table alone and
+-- the index statement then fails with "no such column" — which Open reads as
+-- "incompatible schema" and answers by DELETING the cache, so the migration
+-- never runs and every user resyncs from scratch on upgrade. Same for
+-- idx_documents_team.
 
 -- =============================================================================
 -- Workflow States (per team)
@@ -300,8 +312,8 @@ CREATE INDEX IF NOT EXISTS idx_documents_slug ON documents(slug_id);
 CREATE INDEX IF NOT EXISTS idx_documents_issue ON documents(issue_id);
 CREATE INDEX IF NOT EXISTS idx_documents_project ON documents(project_id);
 CREATE INDEX IF NOT EXISTS idx_documents_initiative ON documents(initiative_id);
-CREATE INDEX IF NOT EXISTS idx_documents_team ON documents(team_id);
 CREATE INDEX IF NOT EXISTS idx_documents_creator ON documents(creator_id);
+-- idx_documents_team lives in migrateSchema; see the note on teams.parent_id.
 
 -- =============================================================================
 -- Initiatives

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -150,8 +150,33 @@ func migrateSchema(db *sql.DB) error {
 		if _, err := db.Exec("ALTER TABLE documents ADD COLUMN team_id TEXT"); err != nil {
 			return fmt.Errorf("add documents.team_id: %w", err)
 		}
-		if _, err := db.Exec("CREATE INDEX IF NOT EXISTS idx_documents_team ON documents(team_id)"); err != nil {
-			return fmt.Errorf("index documents.team_id: %w", err)
+	}
+
+	// parent_id carries the sub-team edge. Same sqlc guarantee as above; the
+	// index backs ListSubteams, the only reader of the inverse direction.
+	hasTeamParent, err := tableHasColumn(db, "teams", "parent_id")
+	if err != nil {
+		return err
+	}
+	if !hasTeamParent {
+		if _, err := db.Exec("ALTER TABLE teams ADD COLUMN parent_id TEXT"); err != nil {
+			return fmt.Errorf("add teams.parent_id: %w", err)
+		}
+	}
+
+	// Indexes over ALTER-added columns are created HERE, not in schema.sql,
+	// and unconditionally (IF NOT EXISTS covers both the fresh database, whose
+	// column came from schema.sql, and the just-migrated one). schema.sql runs
+	// BEFORE this function, so on an old database the column does not exist yet
+	// and an index over it fails the whole schema exec — an error Open reads as
+	// "incompatible schema" and answers by deleting the cache, skipping this
+	// migration entirely and forcing a full resync.
+	for _, idx := range []string{
+		"CREATE INDEX IF NOT EXISTS idx_documents_team ON documents(team_id)",
+		"CREATE INDEX IF NOT EXISTS idx_teams_parent ON teams(parent_id)",
+	} {
+		if _, err := db.Exec(idx); err != nil {
+			return fmt.Errorf("create migrated-column index: %w", err)
 		}
 	}
 	return nil

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -812,6 +812,119 @@ func TestMigrateAddsDetailSyncedAt(t *testing.T) {
 	again.Close()
 }
 
+// TestMigrateAddsTeamParentID: the same bootstrap-ALTER contract for the
+// sub-team edge, plus the rule that makes it work — an index over an
+// ALTER-added column belongs in migrateSchema, never in schema.sql. A cache
+// database created before teams.parent_id existed must gain the column on Open
+// (without it every ListTeams fails "no such column" and the mount goes dark,
+// since sqlc expands SELECT * to schema.sql's column list) and must SURVIVE:
+// an index statement that references the not-yet-added column fails the schema
+// exec, which Open answers by deleting the cache. The pre-team_id documents
+// table rides along because a real upgraded cache lacks both columns at once.
+func TestMigrateAddsTeamParentID(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "old-teams.db")
+
+	raw, err := sql.Open("sqlite", "file:"+dbPath+"?_time_format=sqlite")
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	if _, err := raw.Exec(`CREATE TABLE teams (
+		id TEXT PRIMARY KEY,
+		key TEXT UNIQUE NOT NULL,
+		name TEXT NOT NULL,
+		icon TEXT,
+		created_at DATETIME,
+		updated_at DATETIME,
+		synced_at DATETIME NOT NULL
+	)`); err != nil {
+		t.Fatalf("create old teams table: %v", err)
+	}
+	if _, err := raw.Exec(`INSERT INTO teams (id, key, name, synced_at) VALUES ('team-old', 'OLD', 'Old Team', ?)`,
+		Now()); err != nil {
+		t.Fatalf("insert old row: %v", err)
+	}
+	// A real upgraded cache is missing every ALTER-added column at once, so the
+	// pre-team_id documents table rides along: it is the other index that had
+	// to move out of schema.sql, and if either one is left there the schema
+	// exec fails and Open deletes this database instead of migrating it.
+	if _, err := raw.Exec(`CREATE TABLE documents (
+		id TEXT PRIMARY KEY,
+		title TEXT NOT NULL,
+		slug_id TEXT,
+		issue_id TEXT,
+		project_id TEXT,
+		initiative_id TEXT,
+		creator_id TEXT,
+		url TEXT,
+		created_at DATETIME,
+		updated_at DATETIME,
+		synced_at DATETIME NOT NULL,
+		data JSON NOT NULL
+	)`); err != nil {
+		t.Fatalf("create old documents table: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close raw db: %v", err)
+	}
+
+	store, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open on pre-migration db failed: %v", err)
+	}
+	defer store.Close()
+
+	for _, col := range []struct{ table, column string }{
+		{"teams", "parent_id"},
+		{"documents", "team_id"},
+	} {
+		has, err := tableHasColumn(store.DB(), col.table, col.column)
+		if err != nil {
+			t.Fatalf("tableHasColumn %s.%s: %v", col.table, col.column, err)
+		}
+		if !has {
+			t.Fatalf("%s.%s missing after Open — migration did not run", col.table, col.column)
+		}
+	}
+
+	ctx := context.Background()
+	teams, err := store.Queries().ListTeams(ctx)
+	if err != nil {
+		t.Fatalf("ListTeams on migrated db: %v", err)
+	}
+	if len(teams) != 1 || teams[0].Key != "OLD" {
+		t.Fatalf("ListTeams = %v, want the one pre-migration team — column scan misaligned", teams)
+	}
+	if teams[0].ParentID.Valid {
+		t.Errorf("pre-migration team parent_id = %v, want NULL", teams[0].ParentID.String)
+	}
+
+	// The edge is writable on the migrated table, and readable back through
+	// the inverse query.
+	if err := store.Queries().UpsertTeam(ctx, APITeamToDBTeam(api.Team{
+		ID: "team-child", Key: "CHILD", Name: "Child Team",
+		Parent: &api.Team{ID: "team-old"},
+	})); err != nil {
+		t.Fatalf("UpsertTeam with parent on migrated db: %v", err)
+	}
+	kids, err := store.Queries().ListSubteams(ctx, sql.NullString{String: "team-old", Valid: true})
+	if err != nil {
+		t.Fatalf("ListSubteams on migrated db: %v", err)
+	}
+	if len(kids) != 1 || kids[0].Key != "CHILD" {
+		t.Fatalf("ListSubteams = %v, want [CHILD]", kids)
+	}
+
+	store.Close()
+
+	// Idempotent: reopening the already-migrated database succeeds.
+	again, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("reopen migrated db failed: %v", err)
+	}
+	again.Close()
+}
+
 // TestUpsertIssuePreservesDetailSyncedAt: UpsertIssue deliberately omits
 // detail_synced_at from its INSERT list and conflict SET clause — the stamp is
 // owned by the detail-sync paths, so an entity sync upsert must neither set it

--- a/internal/fs/ino.go
+++ b/internal/fs/ino.go
@@ -105,9 +105,10 @@ func myDirIno(name string) uint64   { return ino("mydir", name) }
 
 // Team tree -----------------------------------------------------------------
 
-func teamDirIno(teamID string) uint64   { return ino("teamdir", teamID) }
-func cyclesDirIno(teamID string) uint64 { return ino("cyclesdir", teamID) }
-func cycleDirIno(cycleID string) uint64 { return ino("cycledir", cycleID) }
+func teamDirIno(teamID string) uint64     { return ino("teamdir", teamID) }
+func subteamsDirIno(teamID string) uint64 { return ino("subteams", teamID) }
+func cyclesDirIno(teamID string) uint64   { return ino("cyclesdir", teamID) }
+func cycleDirIno(cycleID string) uint64   { return ino("cycledir", cycleID) }
 
 // Filter views (by/) ----------------------------------------------------------
 // Composite keys: a category dir is per team+category, a value dir per

--- a/internal/fs/ino_test.go
+++ b/internal/fs/ino_test.go
@@ -74,15 +74,16 @@ func TestInodeNamespaceDistinct(t *testing.T) {
 		"successIno":              successIno(id),
 		// View/entity directory kinds (composite keys get the shared id for
 		// every part — distinctness must hold regardless).
-		"viewDirIno":    viewDirIno(id),
-		"myDirIno":      myDirIno(id),
-		"teamDirIno":    teamDirIno(id),
-		"cyclesDirIno":  cyclesDirIno(id),
-		"cycleDirIno":   cycleDirIno(id),
-		"byDirIno":      byDirIno(id),
-		"byCategoryIno": byCategoryIno(id, id),
-		"byValueIno":    byValueIno(id, id, id),
-		"userDirIno":    userDirIno(id),
+		"viewDirIno":     viewDirIno(id),
+		"myDirIno":       myDirIno(id),
+		"teamDirIno":     teamDirIno(id),
+		"subteamsDirIno": subteamsDirIno(id),
+		"cyclesDirIno":   cyclesDirIno(id),
+		"cycleDirIno":    cycleDirIno(id),
+		"byDirIno":       byDirIno(id),
+		"byCategoryIno":  byCategoryIno(id, id),
+		"byValueIno":     byValueIno(id, id, id),
+		"userDirIno":     userDirIno(id),
 	}
 
 	seen := make(map[uint64]string, len(namespace))

--- a/internal/fs/removalguard.go
+++ b/internal/fs/removalguard.go
@@ -56,9 +56,18 @@ var (
 	_ fs.NodeRmdirer = (*ProjectNode)(nil)
 	_ fs.NodeRmdirer = (*InitiativeNode)(nil)
 	_ fs.NodeRmdirer = (*InitiativesNode)(nil)
+	// TeamNode owns every structural sub-directory of a team — subteams/,
+	// issues/, cycles/, projects/, by/, recent/, docs/, labels/ — and Unlink
+	// alone does not cover them: the kernel dispatches rmdir to Rmdir, so
+	// without this handler `rmdir teams/TST/subteams` reports success and
+	// no-ops.
+	_ fs.NodeRmdirer = (*TeamNode)(nil)
+	_ fs.NodeRmdirer = (*SubteamsNode)(nil)
 )
 
 func (*IssueDirectoryNode) Rmdir(context.Context, string) syscall.Errno { return removalRejected() }
 func (*ProjectNode) Rmdir(context.Context, string) syscall.Errno        { return removalRejected() }
 func (*InitiativeNode) Rmdir(context.Context, string) syscall.Errno     { return removalRejected() }
 func (*InitiativesNode) Rmdir(context.Context, string) syscall.Errno    { return removalRejected() }
+func (*TeamNode) Rmdir(context.Context, string) syscall.Errno           { return removalRejected() }
+func (*SubteamsNode) Rmdir(context.Context, string) syscall.Errno       { return removalRejected() }

--- a/internal/fs/removalguard.go
+++ b/internal/fs/removalguard.go
@@ -33,6 +33,7 @@ var (
 	_ fs.NodeUnlinker = (*InitiativeProjectsNode)(nil)
 	_ fs.NodeUnlinker = (*ProjectsNode)(nil)
 	_ fs.NodeUnlinker = (*TeamNode)(nil)
+	_ fs.NodeUnlinker = (*SubteamsNode)(nil)
 	_ fs.NodeUnlinker = (*RootNode)(nil)
 )
 
@@ -45,6 +46,7 @@ func (*InitiativeProjectsNode) Unlink(context.Context, string) syscall.Errno {
 }
 func (*ProjectsNode) Unlink(context.Context, string) syscall.Errno { return removalRejected() }
 func (*TeamNode) Unlink(context.Context, string) syscall.Errno     { return removalRejected() }
+func (*SubteamsNode) Unlink(context.Context, string) syscall.Errno { return removalRejected() }
 func (*RootNode) Unlink(context.Context, string) syscall.Errno     { return removalRejected() }
 
 // Rmdir guards — rmdir of an entity's structural sub-directory, or of an

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -98,8 +98,11 @@ Mount point: %s (all paths below are relative to this mount point)
 
 <directory_structure>
 teams/{KEY}/
-  team.md, states.md, labels.md     [read-only metadata]
+  team.md, states.md, labels.md     [read-only metadata; team.md names parent/subteams]
   project-labels.md                 [symlink to ../../project-labels.md]
+  parent                            [symlink to ../{PARENT_KEY}; listed only for a sub-team]
+  subteams/{KEY}                    [symlinks to sub-team dirs; teams/ itself stays flat,
+                                     so every team is also reachable at teams/{KEY}]
   docs/                             [team-level documents; same surface as issues/docs]
   issues/                           [mkdir "Title" for quick create]
     _create                         [write full frontmatter+body to create one issue with all fields]

--- a/internal/fs/safename_test.go
+++ b/internal/fs/safename_test.go
@@ -146,6 +146,10 @@ func TestBuilders_HostileCorpus(t *testing.T) {
 		// projectDirName
 		assertSafe(t, "projectDirName", raw, projectDirName(api.Project{ID: "prj-1", Slug: "prj-slug", Name: raw}))
 
+		// teamDirName: the single owner of a team's directory name, and the
+		// component every team-rooted symlink target interpolates.
+		assertSafe(t, "teamDirName", raw, teamDirName(api.Team{ID: "team-1", Key: raw}))
+
 		// initiativeDirName
 		assertSafe(t, "initiativeDirName", raw, initiativeDirName(api.Initiative{ID: "ini-1", Name: raw}))
 
@@ -167,6 +171,27 @@ func TestBuilders_HostileCorpus(t *testing.T) {
 			if !strings.HasSuffix(gotTarget, wantSuffix) {
 				t.Errorf("teamIssueTarget(%q) = %q: components must be safeName'd (want suffix %q)", raw, gotTarget, wantSuffix)
 			}
+		}
+
+		// parentLinkTarget (symlink target): the ANOTHER-entity case — the
+		// parent's remote key crosses into this team's target, so a hostile key
+		// must stay one component and never climb past teams/. An absent key
+		// legitimately yields "" (Readdir lists no parent); assert only when a
+		// target is produced.
+		if gotTarget := parentLinkTarget(api.Team{ID: "team-1", Key: "OK", Parent: &api.Team{ID: "team-p", Key: raw}}); gotTarget != "" {
+			assertSafe(t, "parentLinkTarget", raw, strings.TrimPrefix(gotTarget, "../"))
+			if want := "../" + safeName(raw, "team-p"); gotTarget != want {
+				t.Errorf("parentLinkTarget(%q) = %q, want %q (exactly one level up, one component)", raw, gotTarget, want)
+			}
+		}
+
+		// subteamLinkTarget (symlink target) and the entry name SubteamsNode
+		// lists it under: both derive from teamDirName, and the target must be
+		// exactly two levels up plus that one component.
+		child := api.Team{ID: "team-c", Key: raw}
+		assertSafe(t, "subteamLinkTarget", raw, strings.TrimPrefix(subteamLinkTarget(child), "../../"))
+		if got, want := subteamLinkTarget(child), "../../"+teamDirName(child); got != want {
+			t.Errorf("subteamLinkTarget(%q) = %q, want %q (target must equal the listed entry name)", raw, got, want)
 		}
 	}
 }

--- a/internal/fs/symlink.go
+++ b/internal/fs/symlink.go
@@ -91,5 +91,5 @@ func teamIssueTarget(issue api.Issue) (string, syscall.Errno) {
 	// target; safeName keeps each a single path-safe component so a hostile
 	// value can never traverse out of teams/.
 	return fmt.Sprintf("../../teams/%s/issues/%s",
-		safeName(issue.Team.Key, issue.Team.ID), safeName(issue.Identifier, issue.ID)), 0
+		teamDirName(*issue.Team), safeName(issue.Identifier, issue.ID)), 0
 }

--- a/internal/fs/teams.go
+++ b/internal/fs/teams.go
@@ -31,12 +31,21 @@ func (t *TeamsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 	entries := make([]fuse.DirEntry, len(teams))
 	for i, team := range teams {
 		entries[i] = fuse.DirEntry{
-			Name: safeName(team.Key, team.ID),
+			Name: teamDirName(team),
 			Mode: syscall.S_IFDIR,
 		}
 	}
 
 	return fs.NewListDirStream(entries), 0
+}
+
+// teamDirName is the single owner of "what a team's directory under teams/ is
+// called". Readdir, Lookup, the parent/subteam symlink targets and the
+// frontmatter cross-references all derive from here, so a key safeName rewrites
+// stays listable, resolvable and traversable rather than agreeing in one place
+// and diverging in another.
+func teamDirName(team api.Team) string {
+	return safeName(team.Key, team.ID)
 }
 
 func (t *TeamsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
@@ -46,7 +55,7 @@ func (t *TeamsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut)
 	}
 
 	for _, team := range teams {
-		if team.Key == name {
+		if teamDirName(team) == name {
 			node := &TeamNode{attrNode: attrNode{BaseNode: BaseNode{lfs: t.lfs}}, entityCell: entityCell[api.Team]{val: team}}
 			return t.newDirInode(ctx, out, name, node, dirAttr(team.CreatedAt, team.UpdatedAt), teamDirIno(team.ID), inheritTimeout), 0
 		}
@@ -111,7 +120,14 @@ func parentLinkTarget(team api.Team) string {
 	}
 	// From teams/{KEY}/parent, ".." is teams/ — the sibling team dir is one
 	// level up, named exactly as TeamsNode lists it.
-	return "../" + safeName(team.Parent.Key, team.Parent.ID)
+	return "../" + teamDirName(*team.Parent)
+}
+
+// subteamLinkTarget is the target of teams/{KEY}/subteams/{CKEY}: the sibling
+// team dir, two levels up. Readdir names the entry and Lookup builds the
+// target, so both go through teamDirName here and cannot disagree.
+func subteamLinkTarget(child api.Team) string {
+	return "../../" + teamDirName(child)
 }
 
 func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
@@ -125,10 +141,7 @@ func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 		lfs := t.lfs
 		return t.lookupRenderFile(ctx, out, "team.md", func(ctx context.Context) ([]byte, time.Time, time.Time) {
 			children, err := lfs.repo.GetTeamChildren(ctx, team.ID)
-			if err != nil {
-				children = nil
-			}
-			return teamMarkdown(team, children), team.UpdatedAt, team.CreatedAt
+			return teamMarkdown(team, children, err), team.UpdatedAt, team.CreatedAt
 		}, 0, inheritTimeout), 0
 
 	case "parent":
@@ -246,7 +259,7 @@ func (n *SubteamsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno
 	entries := make([]fuse.DirEntry, len(children))
 	for i, child := range children {
 		entries[i] = fuse.DirEntry{
-			Name: safeName(child.Key, child.ID),
+			Name: teamDirName(child),
 			Mode: syscall.S_IFLNK,
 		}
 	}
@@ -259,13 +272,10 @@ func (n *SubteamsNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 		return nil, syscall.EIO
 	}
 	for _, child := range children {
-		childName := safeName(child.Key, child.ID)
-		if childName != name {
+		if teamDirName(child) != name {
 			continue
 		}
-		// The link lives at teams/{KEY}/subteams/{CKEY}; the sibling team dir
-		// is two levels up.
-		return n.newSymlinkInode(ctx, out, "../../"+childName, child.CreatedAt, child.UpdatedAt), 0
+		return n.newSymlinkInode(ctx, out, subteamLinkTarget(child), child.CreatedAt, child.UpdatedAt), 0
 	}
 	return nil, syscall.ENOENT
 }
@@ -277,7 +287,14 @@ func (n *SubteamsNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 // the directory names the symlinks point at (safeName'd, so frontmatter and
 // listing agree), and `parent_id` carries the raw edge — which is all that is
 // left when the parent team itself is not in the local workspace copy.
-func teamMarkdown(team api.Team, children []api.Team) []byte {
+//
+// childrenErr is the verdict of the sub-team load, and it is NOT the same as an
+// empty list: a failed load omits the `subteams` key entirely (absence means
+// unknown) and says so in the body, because rendering "no sub-teams" would
+// contradict subteams/ Readdir, which returns EIO for the same failure. This
+// follows states.md/labels.md, which emit "# Error loading …" rather than an
+// empty catalog.
+func teamMarkdown(team api.Team, children []api.Team, childrenErr error) []byte {
 	fm := map[string]any{
 		"id":      team.ID,
 		"key":     team.Key,
@@ -291,16 +308,19 @@ func teamMarkdown(team api.Team, children []api.Team) []byte {
 	if team.Parent != nil {
 		fm["parent_id"] = team.Parent.ID
 		if team.Parent.Key != "" {
-			fm["parent"] = safeName(team.Parent.Key, team.Parent.ID)
+			fm["parent"] = teamDirName(*team.Parent)
 			hierarchy += fmt.Sprintf("- **Parent team:** %s (`parent` symlink)\n", team.Parent.Key)
 		} else {
 			hierarchy += fmt.Sprintf("- **Parent team:** %s (not in this workspace copy)\n", team.Parent.ID)
 		}
 	}
-	if len(children) > 0 {
+	switch {
+	case childrenErr != nil:
+		hierarchy += "- **Sub-teams:** error loading sub-teams — unknown, not none (`subteams/` reports the same failure)\n"
+	case len(children) > 0:
 		keys := make([]string, 0, len(children))
 		for _, c := range children {
-			keys = append(keys, safeName(c.Key, c.ID))
+			keys = append(keys, teamDirName(c))
 		}
 		fm["subteams"] = keys
 		hierarchy += fmt.Sprintf("- **Sub-teams:** %s (`subteams/`)\n", strings.Join(keys, ", "))

--- a/internal/fs/teams.go
+++ b/internal/fs/teams.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"context"
 	"fmt"
+	"strings"
 	"syscall"
 	"time"
 
@@ -86,18 +87,66 @@ func (t *TeamNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 		{Name: "recent", Mode: syscall.S_IFDIR},
 		{Name: "docs", Mode: syscall.S_IFDIR},
 		{Name: "labels", Mode: syscall.S_IFDIR},
+		{Name: "subteams", Mode: syscall.S_IFDIR},
+	}
+
+	// The parent symlink is listed only when the team HAS a resolvable parent:
+	// a top-level team is the common case, and an unconditional entry would
+	// dangle for every one of them. subteams/ stays unconditional (an empty
+	// directory is honest and needs no query), matching issues' children/.
+	if parentLinkTarget(t.entity()) != "" {
+		entries = append(entries, fuse.DirEntry{Name: "parent", Mode: syscall.S_IFLNK})
 	}
 
 	return fs.NewListDirStream(entries), 0
+}
+
+// parentLinkTarget returns the symlink target for a team's parent, or "" when
+// the team has no parent — or has one the local workspace copy cannot name (an
+// edge to a team this API key never listed). Readdir and Lookup must agree on
+// that verdict, so both ask here.
+func parentLinkTarget(team api.Team) string {
+	if team.Parent == nil || team.Parent.Key == "" {
+		return ""
+	}
+	// From teams/{KEY}/parent, ".." is teams/ — the sibling team dir is one
+	// level up, named exactly as TeamsNode lists it.
+	return "../" + safeName(team.Parent.Key, team.Parent.ID)
 }
 
 func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
 	team := t.entity() // snapshot captured by the arms and their closures
 	switch name {
 	case "team.md":
-		return t.lookupRenderFile(ctx, out, "team.md", func(context.Context) ([]byte, time.Time, time.Time) {
-			return teamMarkdown(team), team.UpdatedAt, team.CreatedAt
+		// The sub-team edges are rendered here, so team.md needs the children
+		// listing — a SQLite read per render, like states.md/labels.md. The
+		// team's own times stay the reported ones: a child appearing is a
+		// change to the child's row, not to this team.
+		lfs := t.lfs
+		return t.lookupRenderFile(ctx, out, "team.md", func(ctx context.Context) ([]byte, time.Time, time.Time) {
+			children, err := lfs.repo.GetTeamChildren(ctx, team.ID)
+			if err != nil {
+				children = nil
+			}
+			return teamMarkdown(team, children), team.UpdatedAt, team.CreatedAt
 		}, 0, inheritTimeout), 0
+
+	case "parent":
+		target := parentLinkTarget(team)
+		if target == "" {
+			return nil, syscall.ENOENT
+		}
+		// The parent's times, not this team's: a stat through the link reports
+		// the parent dir's own attributes anyway, and these are what the
+		// stitched parent carries.
+		return t.newSymlinkInode(ctx, out, target, team.Parent.CreatedAt, team.Parent.UpdatedAt), 0
+
+	case "subteams":
+		node := &SubteamsNode{attrNode: attrNode{BaseNode: BaseNode{lfs: t.lfs}}, entityCell: entityCell[api.Team]{val: team}}
+		// 0555: a read-only view. Sub-team membership is set in Linear, not by
+		// mkdir here.
+		na := nodeAttr{mode: 0555 | syscall.S_IFDIR, created: team.CreatedAt, updated: team.UpdatedAt}
+		return t.newDirInode(ctx, out, name, node, na, subteamsDirIno(team.ID), inheritTimeout), 0
 
 	case "states.md":
 		// states.md has no single mtime (it lists a collection); report the
@@ -170,9 +219,65 @@ func (t *TeamNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 	return nil, syscall.ENOENT
 }
 
+// SubteamsNode represents the /teams/{KEY}/subteams/ directory: symlinks to
+// the sibling directories of this team's sub-teams. Read-only — the hierarchy
+// is set in Linear, and teams/ stays flat, so a sub-team is reachable both by
+// its own key and through here.
+type SubteamsNode struct {
+	attrNode
+	entityCell[api.Team]
+}
+
+var _ fs.NodeReaddirer = (*SubteamsNode)(nil)
+var _ fs.NodeLookuper = (*SubteamsNode)(nil)
+var _ fs.NodeGetattrer = (*SubteamsNode)(nil)
+
+func (n *SubteamsNode) refreshFrom(fresh fs.InodeEmbedder) {
+	if f, ok := fresh.(*SubteamsNode); ok {
+		n.setEntity(f.entity())
+	}
+}
+
+func (n *SubteamsNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
+	children, err := n.lfs.repo.GetTeamChildren(ctx, n.entity().ID)
+	if err != nil {
+		return nil, syscall.EIO
+	}
+	entries := make([]fuse.DirEntry, len(children))
+	for i, child := range children {
+		entries[i] = fuse.DirEntry{
+			Name: safeName(child.Key, child.ID),
+			Mode: syscall.S_IFLNK,
+		}
+	}
+	return fs.NewListDirStream(entries), 0
+}
+
+func (n *SubteamsNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+	children, err := n.lfs.repo.GetTeamChildren(ctx, n.entity().ID)
+	if err != nil {
+		return nil, syscall.EIO
+	}
+	for _, child := range children {
+		childName := safeName(child.Key, child.ID)
+		if childName != name {
+			continue
+		}
+		// The link lives at teams/{KEY}/subteams/{CKEY}; the sibling team dir
+		// is two levels up.
+		return n.newSymlinkInode(ctx, out, "../../"+childName, child.CreatedAt, child.UpdatedAt), 0
+	}
+	return nil, syscall.ENOENT
+}
+
 // teamMarkdown renders the team.md content for a team. Frontmatter goes
 // through renderWithFrontmatter so hostile names stay valid YAML.
-func teamMarkdown(team api.Team) []byte {
+//
+// The hierarchy is disclosed in both directions: `parent` and `subteams` carry
+// the directory names the symlinks point at (safeName'd, so frontmatter and
+// listing agree), and `parent_id` carries the raw edge — which is all that is
+// left when the parent team itself is not in the local workspace copy.
+func teamMarkdown(team api.Team, children []api.Team) []byte {
 	fm := map[string]any{
 		"id":      team.ID,
 		"key":     team.Key,
@@ -181,12 +286,32 @@ func teamMarkdown(team api.Team) []byte {
 		"created": team.CreatedAt.Format(time.RFC3339),
 		"updated": team.UpdatedAt.Format(time.RFC3339),
 	}
+
+	hierarchy := ""
+	if team.Parent != nil {
+		fm["parent_id"] = team.Parent.ID
+		if team.Parent.Key != "" {
+			fm["parent"] = safeName(team.Parent.Key, team.Parent.ID)
+			hierarchy += fmt.Sprintf("- **Parent team:** %s (`parent` symlink)\n", team.Parent.Key)
+		} else {
+			hierarchy += fmt.Sprintf("- **Parent team:** %s (not in this workspace copy)\n", team.Parent.ID)
+		}
+	}
+	if len(children) > 0 {
+		keys := make([]string, 0, len(children))
+		for _, c := range children {
+			keys = append(keys, safeName(c.Key, c.ID))
+		}
+		fm["subteams"] = keys
+		hierarchy += fmt.Sprintf("- **Sub-teams:** %s (`subteams/`)\n", strings.Join(keys, ", "))
+	}
+
 	body := fmt.Sprintf(`
 # %s
 
 - **Key:** %s
 - **ID:** %s
-`, team.Name, team.Key, team.ID)
+%s`, team.Name, team.Key, team.ID, hierarchy)
 	return renderWithFrontmatter(fm, body)
 }
 

--- a/internal/fs/teams_test.go
+++ b/internal/fs/teams_test.go
@@ -63,7 +63,7 @@ func TestTeamCatalogHostileNames(t *testing.T) {
 
 	t.Run("team.md", func(t *testing.T) {
 		t.Parallel()
-		content := teamMarkdown(team)
+		content := teamMarkdown(team, nil)
 		doc, err := marshal.Parse(content)
 		if err != nil {
 			t.Fatalf("team.md render is not parseable YAML frontmatter: %v", err)
@@ -75,5 +75,66 @@ func TestTeamCatalogHostileNames(t *testing.T) {
 		if !strings.Contains(string(content), "- **Key:** ENG") {
 			t.Errorf("team.md body missing the key bullet:\n%s", content)
 		}
+		// A top-level, childless team names no hierarchy it doesn't have —
+		// absence is the disclosure, so an agent never chases a `parent`
+		// symlink that Readdir doesn't list.
+		for _, key := range []string{"parent", "parent_id", "subteams"} {
+			if _, ok := doc.Frontmatter[key]; ok {
+				t.Errorf("team.md carries %q for a team with no parent and no sub-teams", key)
+			}
+		}
 	})
+}
+
+// TestTeamHierarchyRender pins the two directions of the sub-team edge in
+// team.md: the frontmatter values must be the DIRECTORY NAMES the `parent` and
+// `subteams/` symlinks point at, so an agent that reads the frontmatter and an
+// agent that reads the listing traverse to the same place.
+func TestTeamHierarchyRender(t *testing.T) {
+	t.Parallel()
+	parent := &api.Team{ID: "team-plat", Key: "PLAT", Name: "Platform"}
+	team := api.Team{ID: "team-1", Key: "ENG", Name: "Engineering", Parent: parent}
+	children := []api.Team{
+		{ID: "team-fe", Key: "FE", Name: "Frontend"},
+		{ID: "team-be", Key: "BE", Name: "Backend"},
+	}
+
+	doc, err := marshal.Parse(teamMarkdown(team, children))
+	if err != nil {
+		t.Fatalf("team.md render is not parseable YAML frontmatter: %v", err)
+	}
+	if got := doc.Frontmatter["parent"]; got != "PLAT" {
+		t.Errorf("parent = %v, want PLAT", got)
+	}
+	if got := doc.Frontmatter["parent_id"]; got != "team-plat" {
+		t.Errorf("parent_id = %v, want team-plat", got)
+	}
+	subteams, _ := doc.Frontmatter["subteams"].([]any)
+	if len(subteams) != 2 || subteams[0] != "FE" || subteams[1] != "BE" {
+		t.Errorf("subteams = %v, want [FE BE]", doc.Frontmatter["subteams"])
+	}
+
+	// The frontmatter key must equal the last component of the symlink target:
+	// one is derived from the other, and a divergence sends `cd $(parent)` to
+	// a directory that does not exist.
+	if got, want := parentLinkTarget(team), "../PLAT"; got != want {
+		t.Errorf("parent link target = %q, want %q", got, want)
+	}
+
+	// An edge whose team is absent from the local copy: the raw ID is all
+	// there is, so no key is invented and no symlink is listed.
+	orphan := api.Team{ID: "team-2", Key: "OPS", Name: "Ops", Parent: &api.Team{ID: "team-ghost"}}
+	doc, err = marshal.Parse(teamMarkdown(orphan, nil))
+	if err != nil {
+		t.Fatalf("team.md render for an unresolvable parent: %v", err)
+	}
+	if _, ok := doc.Frontmatter["parent"]; ok {
+		t.Errorf("team.md named a parent key for a parent it cannot resolve: %v", doc.Frontmatter["parent"])
+	}
+	if got := doc.Frontmatter["parent_id"]; got != "team-ghost" {
+		t.Errorf("parent_id = %v, want team-ghost (the edge is known even when the team is not)", got)
+	}
+	if got := parentLinkTarget(orphan); got != "" {
+		t.Errorf("parent link target = %q, want \"\" (Readdir must not list a dangling parent)", got)
+	}
 }

--- a/internal/fs/teams_test.go
+++ b/internal/fs/teams_test.go
@@ -1,6 +1,7 @@
 package fs
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -63,7 +64,7 @@ func TestTeamCatalogHostileNames(t *testing.T) {
 
 	t.Run("team.md", func(t *testing.T) {
 		t.Parallel()
-		content := teamMarkdown(team, nil)
+		content := teamMarkdown(team, nil, nil)
 		doc, err := marshal.Parse(content)
 		if err != nil {
 			t.Fatalf("team.md render is not parseable YAML frontmatter: %v", err)
@@ -99,7 +100,7 @@ func TestTeamHierarchyRender(t *testing.T) {
 		{ID: "team-be", Key: "BE", Name: "Backend"},
 	}
 
-	doc, err := marshal.Parse(teamMarkdown(team, children))
+	doc, err := marshal.Parse(teamMarkdown(team, children, nil))
 	if err != nil {
 		t.Fatalf("team.md render is not parseable YAML frontmatter: %v", err)
 	}
@@ -124,7 +125,7 @@ func TestTeamHierarchyRender(t *testing.T) {
 	// An edge whose team is absent from the local copy: the raw ID is all
 	// there is, so no key is invented and no symlink is listed.
 	orphan := api.Team{ID: "team-2", Key: "OPS", Name: "Ops", Parent: &api.Team{ID: "team-ghost"}}
-	doc, err = marshal.Parse(teamMarkdown(orphan, nil))
+	doc, err = marshal.Parse(teamMarkdown(orphan, nil, nil))
 	if err != nil {
 		t.Fatalf("team.md render for an unresolvable parent: %v", err)
 	}
@@ -136,5 +137,34 @@ func TestTeamHierarchyRender(t *testing.T) {
 	}
 	if got := parentLinkTarget(orphan); got != "" {
 		t.Errorf("parent link target = %q, want \"\" (Readdir must not list a dangling parent)", got)
+	}
+
+	// Every listed sub-team resolves through the same builder the entry name
+	// comes from, so the frontmatter value IS the last component of the target.
+	for _, c := range children {
+		if got, want := subteamLinkTarget(c), "../../"+teamDirName(c); got != want {
+			t.Errorf("subteam link target for %s = %q, want %q", c.Key, got, want)
+		}
+	}
+}
+
+// TestTeamHierarchyChildrenLoadFailure pins the difference between "no
+// sub-teams" and "could not find out". subteams/ Readdir returns EIO when the
+// children load fails; team.md must not answer the same question with a
+// confident "none", or the two surfaces contradict each other.
+func TestTeamHierarchyChildrenLoadFailure(t *testing.T) {
+	t.Parallel()
+	team := api.Team{ID: "team-1", Key: "ENG", Name: "Engineering"}
+
+	content := teamMarkdown(team, nil, errors.New("database is locked"))
+	doc, err := marshal.Parse(content)
+	if err != nil {
+		t.Fatalf("team.md render on a children load failure is not parseable: %v", err)
+	}
+	if v, ok := doc.Frontmatter["subteams"]; ok {
+		t.Errorf("team.md carries subteams: %v after a load failure; absence must mean unknown, not empty", v)
+	}
+	if !strings.Contains(string(content), "error loading sub-teams") {
+		t.Errorf("team.md is silent about the failed sub-team load:\n%s", content)
 	}
 }

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -650,6 +650,13 @@ func populateTestFixtures(ctx context.Context, store *db.Store) error {
 		return err
 	}
 
+	// A sub-team of TST: the fixture set's only team hierarchy, so the
+	// parent/subteams surfaces have a real edge to render offline. It carries
+	// no issues or states of its own — the edge is the surface under test.
+	if err := store.Queries().UpsertTeam(ctx, db.APITeamToDBTeam(fixtures.FixtureAPISubteam())); err != nil {
+		return err
+	}
+
 	// Populate users
 	if err := fixtures.PopulateUsers(ctx, store, users); err != nil {
 		return err

--- a/internal/integration/modes_test.go
+++ b/internal/integration/modes_test.go
@@ -173,7 +173,10 @@ func someProjectDir(t *testing.T) string {
 
 // fixtureLiterals are the seeded names that only exist in the fixture store.
 // A test that spells one is asserting against the fixture seed by definition.
-var fixtureLiterals = []string{`"TST-`, `"test-project"`}
+// SUB is the fixture's sub-team of TST — the only team hierarchy the offline
+// set has, and absent from any live workspace, so naming it is the same claim
+// as naming TST-1.
+var fixtureLiterals = []string{`"TST-`, `"test-project"`, `"SUB"`, `"SUB-`}
 
 // TestFixtureLiteralsCarryTheGuard is the standing check for #395: a test that
 // names a seeded row must say so with skipIfLiveAPI, because a live workspace

--- a/internal/integration/read_test.go
+++ b/internal/integration/read_test.go
@@ -138,7 +138,7 @@ func TestTeamsListing(t *testing.T) {
 }
 
 func TestTeamDirectoryContents(t *testing.T) {
-	expected := []string{"team.md", "states.md", "labels.md", "by", "issues", "cycles", "projects"}
+	expected := []string{"team.md", "states.md", "labels.md", "by", "issues", "cycles", "projects", "subteams"}
 	entryNames := dirNames(t, teamPath(testTeamKey))
 
 	for _, name := range expected {

--- a/internal/integration/readme_test.go
+++ b/internal/integration/readme_test.go
@@ -47,7 +47,10 @@ func TestGeneratedReadmeMatchesBehavior(t *testing.T) {
 	// "outcome: failed" pins the .last outcome-log contract (#370): a failed
 	// create appends a countable failure entry rather than .error collapsing to
 	// only the last failure of a batch.
-	for _, want := range []string{".last", "issue.meta", "initiative.meta", "recent/", "recent created updates", "relations, updates", "creates one item", "targeted catalog refresh", "outcome: failed"} {
+	// "subteams/" pins the team-hierarchy surface: teams/ stays flat, so a
+	// sub-team is only discoverable through the symlinks and team.md's
+	// parent/subteams keys — a README that omits them hides the whole edge.
+	for _, want := range []string{".last", "issue.meta", "initiative.meta", "recent/", "recent created updates", "relations, updates", "creates one item", "targeted catalog refresh", "outcome: failed", "subteams/"} {
 		if !strings.Contains(readme, want) {
 			t.Errorf("README does not mention %q", want)
 		}

--- a/internal/integration/subteams_test.go
+++ b/internal/integration/subteams_test.go
@@ -63,6 +63,16 @@ func TestSubteamSymlinksResolve(t *testing.T) {
 	if err := os.Remove(filepath.Join(teamPath("SUB"), "parent")); err == nil {
 		t.Error("rm SUB/parent succeeded, want EPERM")
 	}
+	// And rmdir of the view itself: go-fuse dispatches it to the TEAM node, so
+	// a missing Rmdir handler there reports success while no-opping — the
+	// #286/#287 shape, one syscall away from the rm above.
+	subteamsDir := filepath.Join(teamPath(testTeamKey), "subteams")
+	if err := os.Remove(subteamsDir); err == nil {
+		t.Error("rmdir subteams/ succeeded, want EPERM (structural directory, not removable)")
+	}
+	if _, err := os.Stat(subteamsDir); err != nil {
+		t.Errorf("subteams/ is gone after a rejected rmdir: %v", err)
+	}
 
 	// A top-level team lists no parent entry at all — absence is how the
 	// filesystem says "no parent", so the entry must not exist as a dangler.

--- a/internal/integration/subteams_test.go
+++ b/internal/integration/subteams_test.go
@@ -1,0 +1,150 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jra3/linear-fuse/internal/marshal"
+)
+
+// The team hierarchy is exposed twice — as team.md frontmatter and as symlinks
+// (`parent`, `subteams/`) — and the two must agree, because an agent will
+// traverse whichever one it read. These tests pin that agreement from the
+// mount, where the fixture render tests (internal/fs) cannot see it.
+
+// TestSubteamSymlinksResolve walks the seeded TST → SUB edge end to end: both
+// directions, both representations, and the round trip back to the same
+// directory. It names fixture rows, so it is fixture-mode only.
+func TestSubteamSymlinksResolve(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
+
+	// Parent side: subteams/SUB is a symlink to the sibling team directory.
+	link := filepath.Join(teamPath(testTeamKey), "subteams", "SUB")
+	target, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("readlink %s: %v", link, err)
+	}
+	if target != "../../SUB" {
+		t.Errorf("subteams/SUB -> %q, want ../../SUB", target)
+	}
+	// Resolving it must land on the real team directory, not a dangling path.
+	if _, err := os.Stat(filepath.Join(link, "team.md")); err != nil {
+		t.Errorf("subteams/SUB does not resolve to a team directory: %v", err)
+	}
+
+	// Child side: SUB/parent points back at TST, and the round trip returns to
+	// the directory it started from.
+	parentLink := filepath.Join(teamPath("SUB"), "parent")
+	target, err = os.Readlink(parentLink)
+	if err != nil {
+		t.Fatalf("readlink %s: %v", parentLink, err)
+	}
+	if want := "../" + testTeamKey; target != want {
+		t.Errorf("SUB/parent -> %q, want %q", target, want)
+	}
+	roundTrip, err := filepath.EvalSymlinks(filepath.Join(parentLink, "subteams", "SUB"))
+	if err != nil {
+		t.Fatalf("round trip SUB/parent/subteams/SUB: %v", err)
+	}
+	want, err := filepath.EvalSymlinks(teamPath("SUB"))
+	if err != nil {
+		t.Fatalf("resolve teams/SUB: %v", err)
+	}
+	if roundTrip != want {
+		t.Errorf("round trip landed on %q, want %q", roundTrip, want)
+	}
+
+	// The hierarchy is set in Linear, so rm of a link must fail loud rather
+	// than silently no-op and resurrect on the next readdir (#286/#287).
+	if err := os.Remove(link); err == nil {
+		t.Error("rm subteams/SUB succeeded, want EPERM (the edge is owned by Linear)")
+	}
+	if err := os.Remove(filepath.Join(teamPath("SUB"), "parent")); err == nil {
+		t.Error("rm SUB/parent succeeded, want EPERM")
+	}
+
+	// A top-level team lists no parent entry at all — absence is how the
+	// filesystem says "no parent", so the entry must not exist as a dangler.
+	if _, err := os.Lstat(filepath.Join(teamPath(testTeamKey), "parent")); !os.IsNotExist(err) {
+		t.Errorf("teams/%s/parent exists for a top-level team (err=%v)", testTeamKey, err)
+	}
+	names := dirNames(t, teamPath(testTeamKey))
+	if names["parent"] {
+		t.Errorf("teams/%s lists a parent entry for a top-level team: %v", testTeamKey, names)
+	}
+	if !names["subteams"] {
+		t.Errorf("teams/%s does not list subteams/: %v", testTeamKey, names)
+	}
+}
+
+// TestTeamHierarchyFrontmatterMatchesLinks cross-checks the two
+// representations for EVERY team the workspace shows: team.md's parent/subteams
+// must name exactly the entries the symlinks provide, and every name must
+// resolve. It runs in every mode — offline the fixture's TST/SUB edge gives it
+// substance, live it audits the real hierarchy.
+func TestTeamHierarchyFrontmatterMatchesLinks(t *testing.T) {
+	entries, err := os.ReadDir(teamsPath())
+	if err != nil {
+		t.Fatalf("read teams: %v", err)
+	}
+
+	for _, e := range entries {
+		if !e.IsDir() || isControlFile(e.Name()) {
+			continue
+		}
+		teamKey := e.Name()
+
+		data, err := os.ReadFile(teamInfoPath(teamKey))
+		if err != nil {
+			t.Errorf("read %s/team.md: %v", teamKey, err)
+			continue
+		}
+		doc, err := marshal.Parse(data)
+		if err != nil {
+			t.Errorf("%s/team.md is not parseable: %v", teamKey, err)
+			continue
+		}
+
+		// parent: frontmatter and the symlink agree on presence and on target.
+		fmParent, _ := doc.Frontmatter["parent"].(string)
+		linkTarget, linkErr := os.Readlink(filepath.Join(teamPath(teamKey), "parent"))
+		switch {
+		case fmParent != "" && linkErr != nil:
+			t.Errorf("%s/team.md names parent %q but there is no parent symlink: %v", teamKey, fmParent, linkErr)
+		case fmParent == "" && linkErr == nil:
+			t.Errorf("%s has a parent symlink (-> %s) but team.md names no parent", teamKey, linkTarget)
+		case fmParent != "" && linkErr == nil:
+			if want := "../" + fmParent; linkTarget != want {
+				t.Errorf("%s/parent -> %q, but team.md says parent is %q (want %q)", teamKey, linkTarget, fmParent, want)
+			}
+			if _, err := os.Stat(filepath.Join(teamPath(teamKey), "parent", "team.md")); err != nil {
+				t.Errorf("%s/parent does not resolve to a team directory: %v", teamKey, err)
+			}
+		}
+
+		// subteams: the frontmatter list is exactly the directory listing.
+		listed := dirNames(t, filepath.Join(teamPath(teamKey), "subteams"))
+		declared := map[string]bool{}
+		fmSubteams, _ := doc.Frontmatter["subteams"].([]any)
+		for _, v := range fmSubteams {
+			key, ok := v.(string)
+			if !ok {
+				t.Errorf("%s/team.md subteams entry %v is not a string", teamKey, v)
+				continue
+			}
+			declared[key] = true
+			if !listed[key] {
+				t.Errorf("%s/team.md names sub-team %q, but subteams/ does not list it (%v)", teamKey, key, listed)
+			}
+			if _, err := os.Stat(filepath.Join(teamPath(teamKey), "subteams", key, "team.md")); err != nil {
+				t.Errorf("%s/subteams/%s does not resolve to a team directory: %v", teamKey, key, err)
+			}
+		}
+		for key := range listed {
+			if !declared[key] {
+				t.Errorf("%s/subteams/ lists %q, but team.md does not name it", teamKey, key)
+			}
+		}
+	}
+}

--- a/internal/repo/sqlite.go
+++ b/internal/repo/sqlite.go
@@ -412,7 +412,45 @@ func (r *SQLiteRepository) GetTeams(ctx context.Context) ([]api.Team, error) {
 	if err != nil {
 		return nil, fmt.Errorf("list teams: %w", err)
 	}
-	return db.DBTeamsToAPITeams(teams), nil
+	return stitchParents(db.DBTeamsToAPITeams(teams)), nil
+}
+
+// GetTeamChildren returns the sub-teams of a team — the inverse of the
+// parent_id edge, read from the column rather than a stored second copy. Each
+// child carries its Parent as a bare ID (it is the queried team by
+// construction); callers here want the child's own Key, which is the row's.
+func (r *SQLiteRepository) GetTeamChildren(ctx context.Context, teamID string) ([]api.Team, error) {
+	rows, err := r.store.Queries().ListSubteams(ctx, sql.NullString{String: teamID, Valid: teamID != ""})
+	if err != nil {
+		return nil, fmt.Errorf("list subteams: %w", err)
+	}
+	return db.DBTeamsToAPITeams(rows), nil
+}
+
+// stitchParents fills each team's Parent with the Key/Name of the team the
+// parent_id points at, using the result set already in hand (the teams table
+// is the whole workspace, so no extra query). A parent absent from the set —
+// a sub-team whose parent the API key cannot see — keeps its bare ID, which
+// the fs surfaces read as "known edge, unknown team" rather than inventing a
+// key. The stitched parent's own Parent stays nil: one level, no recursion.
+func stitchParents(teams []api.Team) []api.Team {
+	byID := make(map[string]api.Team, len(teams))
+	for _, t := range teams {
+		byID[t.ID] = t
+	}
+	for i := range teams {
+		p := teams[i].Parent
+		if p == nil {
+			continue
+		}
+		if full, ok := byID[p.ID]; ok {
+			teams[i].Parent = &api.Team{
+				ID: full.ID, Key: full.Key, Name: full.Name, Icon: full.Icon,
+				CreatedAt: full.CreatedAt, UpdatedAt: full.UpdatedAt,
+			}
+		}
+	}
+	return teams
 }
 
 // =============================================================================

--- a/internal/repo/sqlite_test.go
+++ b/internal/repo/sqlite_test.go
@@ -55,6 +55,81 @@ func TestSQLiteRepository_Teams(t *testing.T) {
 	}
 }
 
+// TestSQLiteRepository_TeamHierarchy pins the two halves of the sub-team edge
+// the repo owns: GetTeams stitches a parent's Key/Name over the bare parent_id
+// (the fs renders a KEY, and the DB stores only an ID), and GetTeamChildren
+// reads the inverse direction off the same column.
+func TestSQLiteRepository_TeamHierarchy(t *testing.T) {
+	t.Parallel()
+	store, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewSQLiteRepository(store, nil)
+	ctx := context.Background()
+
+	parent := api.Team{ID: "team-p", Key: "PLAT", Name: "Platform", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	child := api.Team{ID: "team-c", Key: "FE", Name: "Frontend", CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		Parent: &api.Team{ID: "team-p"}}
+	// An edge pointing at a team this workspace copy does not have: the ID is
+	// real, the team is not, and nothing may invent a key for it.
+	orphan := api.Team{ID: "team-o", Key: "OPS", Name: "Ops", CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		Parent: &api.Team{ID: "team-ghost"}}
+
+	for _, team := range []api.Team{parent, child, orphan} {
+		if err := store.Queries().UpsertTeam(ctx, db.APITeamToDBTeam(team)); err != nil {
+			t.Fatalf("insert %s: %v", team.Key, err)
+		}
+	}
+
+	teams, err := repo.GetTeams(ctx)
+	if err != nil {
+		t.Fatalf("GetTeams failed: %v", err)
+	}
+	byKey := make(map[string]api.Team, len(teams))
+	for _, team := range teams {
+		byKey[team.Key] = team
+	}
+
+	if got := byKey["PLAT"].Parent; got != nil {
+		t.Errorf("PLAT.Parent = %+v, want nil (top-level team)", got)
+	}
+	switch got := byKey["FE"].Parent; {
+	case got == nil:
+		t.Error("FE.Parent = nil, want the stitched PLAT")
+	case got.Key != "PLAT" || got.Name != "Platform" || got.ID != "team-p":
+		t.Errorf("FE.Parent = %+v, want PLAT/Platform/team-p stitched from the result set", got)
+	case got.Parent != nil:
+		t.Error("FE.Parent.Parent is populated — the stitch must stop at one level")
+	}
+	switch got := byKey["OPS"].Parent; {
+	case got == nil:
+		t.Error("OPS.Parent = nil, want the bare unresolvable edge")
+	case got.ID != "team-ghost":
+		t.Errorf("OPS.Parent.ID = %q, want team-ghost", got.ID)
+	case got.Key != "":
+		t.Errorf("OPS.Parent.Key = %q, want empty — the team is not in this copy, so no key may be invented", got.Key)
+	}
+
+	children, err := repo.GetTeamChildren(ctx, "team-p")
+	if err != nil {
+		t.Fatalf("GetTeamChildren failed: %v", err)
+	}
+	if len(children) != 1 || children[0].Key != "FE" {
+		t.Fatalf("GetTeamChildren(team-p) = %+v, want [FE]", children)
+	}
+	// A leaf team has no children, and the query must not fall back to
+	// "everything with a NULL parent" for an unknown ID.
+	for _, id := range []string{"team-c", "no-such-team"} {
+		got, err := repo.GetTeamChildren(ctx, id)
+		if err != nil {
+			t.Fatalf("GetTeamChildren(%s) failed: %v", id, err)
+		}
+		if len(got) != 0 {
+			t.Errorf("GetTeamChildren(%s) = %+v, want none", id, got)
+		}
+	}
+}
+
 func TestSQLiteRepository_Issues(t *testing.T) {
 	t.Parallel()
 	store, cleanup := setupTestDB(t)

--- a/internal/testutil/fixtures/api.go
+++ b/internal/testutil/fixtures/api.go
@@ -27,6 +27,23 @@ func FixtureAPITeam() api.Team {
 	}
 }
 
+// FixtureAPISubteam returns a sub-team of FixtureAPITeam — the fixture set's
+// only team hierarchy, so the offline suite has a real parent/child edge to
+// assert `parent`/`subteams/` against instead of passing vacuously on a flat
+// workspace. Deliberately bare (no states, issues, projects): the surface
+// under test is the edge, not the team's contents.
+func FixtureAPISubteam() api.Team {
+	return api.Team{
+		ID:        "team-sub",
+		Key:       "SUB",
+		Name:      "Sub Team",
+		Icon:      "team",
+		CreatedAt: fixtureTime,
+		UpdatedAt: fixtureTime,
+		Parent:    &api.Team{ID: "team-1", Key: "TST", Name: "Test Team"},
+	}
+}
+
 // FixtureAPITeams returns multiple test teams.
 func FixtureAPITeams() []api.Team {
 	return []api.Team{


### PR DESCRIPTION
## Intent

Model the parent-child relationships between teams (Linear's Team.parent / sub-teams), exposed BOTH in team.md frontmatter AND as symlinks — the user asked for both representations explicitly. This closes the pre-existing ticket #430, whose proposed surface this matches.

Deliberate decisions a reviewer reading only the diff would not know:

- teams/ stays FLAT. Nesting the actual directories by hierarchy would break every existing path and the identifier-global lookup, so the hierarchy is expressed only via symlinks (parent -> ../KEY, subteams/CKEY -> ../../CKEY). Every team remains reachable at teams/KEY. This constraint came from #430 itself.
- There is deliberately NO Children field on api.Team. Sub-teams are derived from the other teams' parent_id, so the edge is stored in exactly one place and cannot drift. Linear's Team.children is additionally a bare list ([Team!]!), not a connection — verified against the live API — so selecting it would take whatever the server returned with no pageInfo to check. GetTeamChildren queries the column instead.
- GetTeams stitches the parent's Key/Name from the result set it already loaded (no extra query), ONE level deep so an api.Team value cannot recurse. A parent absent from the local copy keeps its bare ID and gets NO symlink and no 'parent:' key — only 'parent_id:'. Inventing a key was rejected: absence is the honest disclosure.
- The 'parent' entry is listed conditionally (only when the parent resolves) while 'subteams/' is unconditional. That asymmetry is intentional: an unconditional 'parent' would dangle on every top-level team, whereas an empty subteams/ is honest and needs no query — matching issues' children/, which is also unconditional. Readdir and Lookup both route through parentLinkTarget so they cannot disagree.
- Frontmatter values are safeName'd because they are cross-references meant to be traversed; they must equal the directory names the symlinks point at, and a test pins that agreement.

Also included, and NOT scope creep — it is a defect this work uncovered and had to fix to function: an index over an ALTER-added column cannot live in schema.sql, because schema.sql runs BEFORE migrateSchema, so on an upgraded database the column does not exist and the index fails the whole schema exec. Open matches that error string, concludes 'incompatible schema', and DELETES the user's cache.db — skipping the migration entirely and forcing a full resync. idx_documents_team had been latently broken this way since team documents landed; both indexes moved into migrateSchema. This is filed as #432 for the remaining guard work (a test that enforces the rule, and making Open's delete-and-recreate fallback loud).

Testing posture, deliberately chosen: the fixture set gains a sub-team (TST -> SUB) because the resolution path is otherwise exercised NOWHERE. A live read-only run was already performed against the fuse-testbed workspace: it passed 66/0/208 with no GraphQL errors, proving the new 'parent { id key name }' selection is valid, but that workspace is on a free Linear plan where team nesting is unavailable, so the resolution path CANNOT be covered live there. That gap is tracked in #435 with the plan-tier constraint recorded; the mode-agnostic mount test (TestTeamHierarchyFrontmatterMatchesLinks) is written to audit a real hierarchy when one exists.

Docs were updated in the same change per this repo's standing rule that the generated README, ARCHITECTURE.md and THREAT-MODEL.md must not silently drift: README dir map, CLAUDE.md, ARCHITECTURE.md (symlink views + a new 'hierarchy edges are stored once' invariant), THREAT-MODEL.md (the parent link interpolates ANOTHER entity's remote key, a new instance of the remote-string-to-symlink-target boundary).

Follow-ups already filed rather than folded in: #432 (migration guard), #433 (team views exclude sub-team issues, undocumented), #434 (re-parenting writes), #435 (live verification), #436 (issue parent symlink).

## What Changed

- Threads Linear's `Team.parent` edge through the stack: `parent { id key name }` is selected in `GetTeams` and stitched one level deep from the already-loaded result set, persisted as a new `teams.parent_id` column, and read back via a new `GetTeamChildren` repo query — sub-teams are derived from that single column rather than stored as a second `Children` list that could drift.
- Surfaces the hierarchy in the mount without moving any directories: `teams/` stays flat and every team is still at `teams/KEY`, with `team.md` frontmatter gaining `parent_id`/`parent` plus a `subteams` list, a `parent` symlink (`../KEY`, listed only when the parent resolves locally), and an unconditional `subteams/CKEY -> ../../CKEY` directory. Frontmatter values and link targets are both built through the same `safeName`-based name builders so they agree, and `rmdir` on the new structural directories is rejected by the removal guard.
- Moves `idx_teams_parent` and the pre-existing `idx_documents_team` out of `schema.sql` into `migrateSchema`: an index over an ALTER-added column fails the schema exec on an upgraded database, which `Open` was reading as "incompatible schema" and answering by deleting the user's `cache.db` and forcing a full resync. Fixture teams gain a `TST -> SUB` pair to exercise resolution, and the README dir map, CLAUDE.md, `docs/ARCHITECTURE.md`, and `docs/THREAT-MODEL.md` are updated in-change per the repo's no-silent-doc-drift rule.

## Risk Assessment

✅ Low: Every round-1 finding is fixed as instructed with matching tests, the refactor centralizing team directory naming is behavior-preserving for all realistic keys and its new pointer dereferences are each behind existing nil guards, and the only remaining observation is a pre-existing, practically unreachable divergence in an untouched file.

## Testing

Ran the full Go suite plus a forced fresh integration run (real FUSE mount) — all green — then produced product-level evidence beyond unit tests: a live FUSE mount seeded through the real api.Client from a Linear-shaped GraphQL Teams response, walked as an end user would (ls/cat/readlink/realpath/rm/rmdir), showing teams/ stays flat while team.md frontmatter and the parent/subteams symlinks agree, resolve, round-trip, nest two levels, and honestly disclose an unresolvable parent as bare parent_id with no symlink; plus a before/after transcript proving the schema.sql index fix turns a cache-destroying upgrade (0 issues left) into an in-place migration with data intact. Filled one real coverage gap by adding a mutation-checked test that the new `parent { id key name }` selection is sent and decoded, since no test touched the wire and live verification is blocked by the test workspace's plan tier. No product failures; one informational note about a pre-existing silent-success rmdir at teams/ level. This is a filesystem surface with no GUI, so the reviewer-visible artifacts are CLI transcripts of the mounted directory tree rather than screenshots.

<details>
<summary>Evidence: Mounted team-hierarchy walk (both representations, end to end)</summary>

<code>seeded 5 teams via api.Client.GetTeams from a Linear-shaped GraphQL response&#10;&#10;===== teams/ stays FLAT =====&#10;ENG GRAND ORPH SUB TST&#10;&#10;===== teams/SUB/team.md =====&#10;---&#10;id: team-sub&#10;key: SUB&#10;name: Sub Team&#10;parent: TST&#10;parent_id: team-1&#10;subteams:&#10;- GRAND&#10;---&#10;# Sub Team&#10;- **Parent team:** TST (`parent` symlink)&#10;- **Sub-teams:** GRAND (`subteams/`)&#10;&#10;===== symlinks =====&#10;teams/TST/subteams/SUB -&gt; ../../SUB&#10;teams/SUB/parent -&gt; ../TST&#10;round trip teams/SUB/parent/subteams/SUB -&gt; .../teams/SUB (== teams/SUB)&#10;depth 2: teams/TST/subteams/SUB/subteams/GRAND resolves&#10;&#10;===== parent not in local copy (ORPH) =====&#10;parent_id: team-not-in-local-copy # no `parent:` key&#10;- **Parent team:** team-not-in-local-copy (not in this workspace copy)&#10;readlink teams/ORPH/parent -&gt; (no parent symlink: exit 1)&#10;&#10;===== edge owned by Linear =====&#10;rm teams/TST/subteams/SUB : Operation not permitted&#10;rm teams/SUB/parent : Operation not permitted&#10;rmdir teams/TST/subteams : Operation not permitted&#10;(links still present afterwards)</code>

```text
seeded 5 teams via api.Client.GetTeams from a Linear-shaped GraphQL response

===== teams/ stays FLAT — every team reachable at teams/KEY =====
ENG
GRAND
ORPH
SUB
TST

===== teams/TST/ — subteams/ is unconditional, no 'parent' entry (top-level team) =====
by/
cycles/
docs/
issues/
labels/
labels.md
project-labels.md@
projects/
recent/
states.md
subteams/
team.md

===== teams/TST/team.md — frontmatter discloses the hierarchy =====
---
created: "2026-01-15T10:00:00Z"
icon: team
id: team-1
key: TST
name: Test Team
subteams:
    - SUB
updated: "2026-01-15T10:00:00Z"
---

# Test Team

- **Key:** TST
- **ID:** team-1
- **Sub-teams:** SUB (`subteams/`)

===== teams/TST/subteams/ — symlinks to the sibling team dirs =====
total 4
lrwxrwxrwx 0 john john 9 Jan 15  2026 SUB -> ../../SUB

===== teams/SUB/ — a sub-team DOES list a 'parent' entry =====
by/
cycles/
docs/
issues/
labels/
labels.md
parent@
project-labels.md@
projects/
recent/
states.md
subteams/
team.md

===== teams/SUB/team.md — parent + parent_id + its own subteams =====
---
created: "2026-01-15T10:00:00Z"
icon: team
id: team-sub
key: SUB
name: Sub Team
parent: TST
parent_id: team-1
subteams:
    - GRAND
updated: "2026-01-15T10:00:00Z"
---

# Sub Team

- **Key:** SUB
- **ID:** team-sub
- **Parent team:** TST (`parent` symlink)
- **Sub-teams:** GRAND (`subteams/`)

===== teams/SUB/parent -> ../TST, and it resolves =====
../TST
---
created: "2026-01-15T10:00:00Z"
icon: team
id: team-1
key: TST
name: Test Team
subteams:
    - SUB

===== round trip: teams/SUB/parent/subteams/SUB resolves back to teams/SUB =====
/home/john/tmp/linearfs-evidence-4159600805/teams/SUB
/home/john/tmp/linearfs-evidence-4159600805/teams/SUB

===== depth 2: TST -> SUB -> GRAND, walked purely through symlinks =====
../../GRAND
---
created: "2026-01-15T10:00:00Z"
icon: team
id: team-grand
key: GRAND
name: Grandchild Team
parent: SUB
parent_id: team-sub
updated: "2026-01-15T10:00:00Z"
---

# Grandchild Team

- **Key:** GRAND
- **ID:** team-grand
- **Parent team:** SUB (`parent` symlink)

===== teams/ORPH — parent NOT in the local workspace copy =====
--- listing (no parent entry) ---
by/
cycles/
docs/
issues/
labels/
labels.md
project-labels.md@
projects/
recent/
states.md
subteams/
team.md
--- team.md: bare parent_id, no parent: key, honest body line ---
---
created: "2026-01-15T10:00:00Z"
icon: team
id: team-orph
key: ORPH
name: Orphan Team
parent_id: team-not-in-local-copy
updated: "2026-01-15T10:00:00Z"
---

# Orphan Team

- **Key:** ORPH
- **ID:** team-orph
- **Parent team:** team-not-in-local-copy (not in this workspace copy)
--- readlink teams/ORPH/parent ---
(no parent symlink: exit 1)

===== the edge is owned by Linear: rm / rmdir must fail loud, not silently no-op =====
rm subteams/SUB: rm: cannot remove 'teams/TST/subteams/SUB': Operation not permitted
rm SUB/parent:   rm: cannot remove 'teams/SUB/parent': Operation not permitted
rmdir subteams:   rmdir: failed to remove 'teams/TST/subteams': Operation not permitted
--- still present after the rejections ---
total 4
lrwxrwxrwx 0 john john 9 Jan 15  2026 SUB -> ../../SUB

===== generated README documents the surface an agent reads =====
12:  parent                            [symlink to ../{PARENT_KEY}; listed only for a sub-team]
13-  subteams/{KEY}                    [symlinks to sub-team dirs; teams/ itself stays flat,
14-                                     so every team is also reachable at teams/{KEY}]
15-  docs/                             [team-level documents; same surface as issues/docs]
```
</details>
<details>
<summary>Evidence: Cache migration: upgrade wipes on base, migrates in place after</summary>

<code>pre-upgrade cache.db built from schema.sql@7609d5e (no documents.team_id, no teams.parent_id)&#10;seeded: 2 issues, 1 comments, 1 teams&#10;&#10;===== BEFORE (base 3230378) =====&#10;db.Exec(schemaSQL) -&gt; SQL logic error: no such column: team_id (1)&#10;Open&#39;s &#34;incompatible schema&#34; match fires: true&#10;=&gt; cache held 2 issues, 1 comments before the delete&#10;=&gt; after Open returns: 0 issues, 0 comments, 0 teams — silently wiped, full resync&#10;&#10;===== AFTER (914fe23) =====&#10;db.Open(after.db) -&gt; ok, no error&#10;cache file still there: true (458752 -&gt; 466944 bytes, migrated in place)&#10;user data preserved: 2 issues, 1 comments, 1 teams&#10;teams.parent_id / documents.team_id columns present: true / true&#10;idx_teams_parent / idx_documents_team created: true / true&#10;reopen of the migrated cache: err=&lt;nil&gt;, issues still 2&#10;&#10;===== fresh install =====&#10;db.Open -&gt; err=&lt;nil&gt;; parent_id=true idx_teams_parent=true idx_documents_team=true</code>

```text
pre-upgrade cache.db built from schema.sql@7609d5e (no documents.team_id, no teams.parent_id)
  seeded: 2 issues, 1 comments, 1 teams

===== BEFORE (base 3230378): schema.sql carries idx_documents_team =====
  db.Exec(schemaSQL) -> SQL logic error: no such column: team_id (1)
  Open's "incompatible schema" match fires: true
  => Open takes its delete-and-recreate branch. Replaying it verbatim:
     cache held 2 issues, 1 comments before the delete
     after Open returns: 0 issues, 0 comments, 0 teams — silently wiped, full resync
     (the only surviving path was recreation: migrateSchema never ran on the user's data)

===== AFTER (914fe23): indexes moved into migrateSchema =====
  db.Open(after.db) -> ok, no error
  cache file still there: true (created 458752 bytes -> 466944 bytes, migrated in place)
  user data preserved: 2 issues, 1 comments, 1 teams
  teams.parent_id column present:   true
  documents.team_id column present: true
  index idx_teams_parent created:   true
  index idx_documents_team created: true
  reopen of the migrated cache: err=<nil>, issues still 2

===== fresh install (no prior cache) =====
  db.Open -> err=<nil>; teams.parent_id=true idx_teams_parent=true idx_documents_team=true
```
</details>
<details>
<summary>Evidence: rmdir guard probe across team structural directories</summary>

<code>rmdir teams/TST -&gt; EXIT 0 (silently accepted) &lt;- pre-existing gap (TeamsNode)&#10;rmdir teams/TST/subteams -&gt; Operation not permitted &lt;- fixed by this change&#10;rmdir teams/TST/issues -&gt; Operation not permitted&#10;rmdir teams/TST/by -&gt; Operation not permitted&#10;rmdir teams/TST/projects -&gt; Operation not permitted&#10;rmdir teams/TST/cycles -&gt; Operation not permitted&#10;rmdir teams/TST/docs -&gt; Operation not permitted&#10;rmdir teams/TST/labels -&gt; Operation not permitted&#10;rmdir teams/TST/recent -&gt; Operation not permitted&#10;rmdir teams -&gt; EXIT 0 (silently accepted) &lt;- pre-existing gap (RootNode)&#10;(nothing actually removed in any case)</code>

```text
seeded 5 teams via api.Client.GetTeams from a Linear-shaped GraphQL response
rmdir teams/TST -> EXIT 0 (silently accepted)
rmdir teams/TST/subteams -> rmdir: failed to remove 'teams/TST/subteams': Operation not permitted
rmdir teams/TST/issues -> rmdir: failed to remove 'teams/TST/issues': Operation not permitted
rmdir teams/TST/by -> rmdir: failed to remove 'teams/TST/by': Operation not permitted
rmdir teams/TST/projects -> rmdir: failed to remove 'teams/TST/projects': Operation not permitted
rmdir teams/TST/cycles -> rmdir: failed to remove 'teams/TST/cycles': Operation not permitted
rmdir teams/TST/docs -> rmdir: failed to remove 'teams/TST/docs': Operation not permitted
rmdir teams/TST/labels -> rmdir: failed to remove 'teams/TST/labels': Operation not permitted
rmdir teams/TST/recent -> rmdir: failed to remove 'teams/TST/recent': Operation not permitted
rmdir teams -> EXIT 0 (silently accepted)
--- teams/ listing after probes ---
ENG
GRAND
ORPH
SUB
TST
--- teams/TST listing after probes ---
by
cycles
docs
issues
labels
labels.md
project-labels.md
projects
recent
states.md
subteams
team.md
```
</details>
- Evidence: Evidence harness sources (mount walk + migration replay, reproducible) (local file: <code>/home/john/tmp/no-mistakes-evidence/01KZ46FAVGRGEWSJYGDMB7965J/harness</code>)
- Outcome: ⚠️ 1 info across 1 run (9m49s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `internal/fs/teams.go:128` - The team.md render swallows a GetTeamChildren failure (`if err != nil { children = nil }`), so a transient SQLite error makes team.md assert the team has NO sub-teams — while `subteams/` Readdir returns EIO for the same failure. The two surfaces then disagree, and that agreement is exactly what the new test pins as an invariant. Sibling renders in this same switch (states.md, labels.md) deliberately emit `# Error loading states` instead of a silent empty render; team.md should be equally loud (e.g. omit the `subteams` key AND note the load failure in the body, rather than rendering absence).
- ⚠️ `internal/fs/removalguard.go:55` - `TeamNode` is registered as a `NodeUnlinker` but not a `NodeRmdirer`, so `rmdir teams/TST/subteams` (the structural sub-directory added by this change) hits go-fuse&#39;s no-handler path and reports SUCCESS while no-opping — the #286/#287 failure mode this file exists to prevent, and which its own comment lists structural sub-directories as covered by. The new integration test asserts `rm` of the symlinks fails, but not `rmdir` of the directory. Pre-existing for issues/, cycles/, docs/, etc., but this change adds one more entry to the unguarded set. Fix is mechanical: add `_ fs.NodeRmdirer = (*TeamNode)(nil)` plus a `removalRejected()` method.
- ℹ️ `internal/fs/teams.go:108` - `scripts/check-safename.sh` documents that its grep cannot catch symlink-target builders and that new target surfaces MUST be added to `TestBuilders_HostileCorpus` (internal/fs/safename_test.go:123). This change adds two — `parentLinkTarget` and the inline `&#34;../../&#34;+safeName(child.Key, child.ID)` in `SubteamsNode.Lookup` (teams.go:268) — and neither was added, even though docs/THREAT-MODEL.md was updated in the same commit to call the parent link the case where a remote key crosses into another entity&#39;s target. The code is correct today; the repo&#39;s own regression guard for it is absent.
- ℹ️ `internal/fs/teams.go:49` - `TeamsNode.Lookup` matches on the raw `team.Key`, while `TeamsNode.Readdir` (line 34) and both new symlink targets name teams by `safeName(team.Key, team.ID)`. Everywhere else in the package the lookup compares the derived directory name (`projectDirName(project) == name`, `userDirName(user) == name`). For a team key that safeName rewrites (contains `/`, a control char, or a trailing space/dot), the directory is listed under a name that cannot be resolved — and the new `parent` / `subteams/{KEY}` links now point at exactly that unresolvable name. Pre-existing, and Linear constrains team keys in practice, but this change makes the mount depend on the agreement. One-line fix: compare `safeName(team.Key, team.ID) == name`.
- ℹ️ `internal/testutil/fixtures/api.go:38` - &#34;SUB&#34; is a new fixture-seeded row, but it was not added to `fixtureLiterals` in internal/integration/modes_test.go:176 (currently `&#34;TST-`, `&#34;test-project&#34;`). `TestFixtureLiteralsCarryTheGuard` — the standing #395 check — therefore will not flag a future test that hardcodes &#34;SUB&#34; without `skipIfLiveAPI`, which is precisely the class of failure that broke ~48 tests on the first live dispatch. The new subteams_test.go itself is correctly guarded; the gap is in the guard&#39;s literal list.

🔧 Fix: fix team hierarchy render, rmdir guard, and name builders
1 info still open:
- ℹ️ `internal/fs/initiatives.go:422` - After this commit `teamDirName` is documented as &#34;the single owner of what a team&#39;s directory under teams/ is called&#34;, and every team-rooted target was routed through it — except `resolveProjectTarget`, which still builds the component as `safeName(teamKey, projectID)`. It differs from `teamDirName` in the fallback/disambiguator id (the project&#39;s ID rather than the team&#39;s), so for a key that sanitizes to empty/./.. or exactly shadows a reserved literal the initiative→project link would point at `teams/&lt;projectID&gt;/…` while the real directory is `teams/&lt;teamID&gt;/…`. Unreachable in practice — Linear team keys are uppercase alphanumeric and the reserved set is lowercase control literals — and it predates this branch, so noting it as the one remaining exception to the new invariant rather than asking for a change (a real fix needs the team ID, which `GetProjectPrimaryTeamKey` does not return).

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `internal/fs/removalguard.go:64` - Pre-existing (unchanged by this diff): `rmdir teams/&lt;KEY&gt;` and `rmdir teams` return exit 0 while silently no-opping, because TeamsNode and RootNode implement NodeUnlinker but not NodeRmdirer. This is the same #286/#287 shape the commit deliberately fixed one level down by adding TeamNode.Rmdir and SubteamsNode.Rmdir — every structural dir *inside* a team now correctly returns EPERM. Verified against the base commit: neither node had an Rmdir handler there either, so this is not a regression, just the adjacent gap left open. Evidence: rmdir-guard-probe.txt.
- <code>`go test ./...` (full suite, exit 0) and `go test -count=1 ./internal/integration/` (fresh FUSE-mounted run, 63s, exit 0)</code>
- `go test ./internal/integration/... -run 'TestSubteamSymlinksResolve|TestTeamHierarchyFrontmatterMatchesLinks|TestTeamDirectoryContents|TestGeneratedReadmeMatchesBehavior|TestFixtureLiteralsCarryTheGuard' -v`
- `go test ./internal/fs/... ./internal/db/... ./internal/repo/... ./internal/api/...`
- <code>Manual FUSE mount walk: seeded 5 teams (TST, ENG, SUB→TST, GRAND→SUB, ORPH→hidden parent) via `api.Client.GetTeams` against a mock Linear GraphQL server, mounted with `fs.MountFS`, then `ls -F teams/`, `cat teams/*/team.md`, `readlink teams/SUB/parent`, `readlink teams/TST/subteams/SUB`, `realpath teams/SUB/parent/subteams/SUB`, `rm`/`rmdir` rejection checks — captured in team-hierarchy-mount-walk.txt</code>
- <code>Manual migration check: built a pre-upgrade cache.db from `git show 7609d5e:internal/db/schema.sql` with seeded issues/comments/teams, replayed base 3230378&#39;s `schema.sql` exec + `Open`&#39;s delete-and-recreate branch, then ran this change&#39;s `db.Open` on the same file — captured in cache-migration-upgrade.txt</code>
- <code>Added `TestGetTeamsDecodesParentEdge` in `internal/api/client_test.go` (wire selection + decode of `parent { id key name }`); mutation-checked by removing the selection from `internal/api/queries.go` (test failed), then restored the file clean</code>
- <code>`rmdir` guard probe across every structural team directory — captured in rmdir-guard-probe.txt</code>

</details>

<details>
<summary>⚠️ **Document** - 2 issues (1 warning, 1 info)</summary>

- ⚠️ `CLAUDE.md:227` - CLAUDE.md&#39;s &#34;Key Packages&#34; entry for internal/repo lists `repo.go` (Repository interface, ~50 methods) and `mock.go` (in-memory mock), and step 4 of &#34;Adding New Tables&#34; (line 494) tells you to add methods to `internal/repo/repo.go`. Neither file exists — the package is only sqlite.go/queryone.go/swr.go/metrics.go, and docs/ARCHITECTURE.md already records that the interface and mock were deliberately deleted. Pre-existing staleness (not introduced by this change), and this change added GetTeamChildren to SQLiteRepository without touching it. Left alone for scope discipline; worth a one-line correction in a follow-up so a future session adding a repo method isn&#39;t sent to nonexistent files.
- ℹ️ `README.md:186` - The mount&#39;s directory map exists in three hand-maintained copies: README.md&#39;s tree (user-facing), CLAUDE.md&#39;s tree (line 167), and generateReadme&#39;s &lt;directory_structure&gt; block in internal/fs/root.go (the in-mount agent doc, which is a product artifact and must stay). This change updated two of the three and left README.md stale — exactly the failure mode duplication produces; I fixed README.md here rather than restructure. Follow-up worth filing: reduce CLAUDE.md&#39;s copy to a pointer at README.md, leaving one prose owner plus the generated product surface (which TestGeneratedReadmeMatchesBehavior already guards).

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `internal/fs/editbuffer_test.go:40` - `make lint` (golangci-lint) exits 1 on 8 pre-existing errcheck findings in internal/fs/editbuffer_test.go (5) and internal/cmd/status_test.go (3) — unchecked b.Write/b.Setattr/kept.Open/etc. return values. None are in files this change touched, and they are test files, so I did not modify them. Not a CI regression: the lint gate in .github/workflows/test.yml runs `make staticcheck` and `make check-safename`, both of which pass clean on the full tree, as do gofmt and go vet.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
