### PR TITLE
feat(fs): expose team description, issue-creation defaults, and templates in team.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,6 +339,7 @@ Available fragments:
 - `ProjectUpdateFields` / `InitiativeUpdateFields` - Status-update fields (query + create)
 - `UserFields` - User fields wherever whole users are listed (team members + drain page, workspace users + drain page, viewer); assignees/owners keep narrower inline sets
 - `CycleFields` - Cycle fields (combined team metadata query + drain page)
+- `TemplateFields` - Template identity for a team's default templates (`defaultTemplateForMembers` / `defaultTemplateForNonMembers` / `defaultProjectTemplate` on the teams query); `templateData` is deliberately not selected — a prefilled entity would be a content surface, not team metadata
 - `InitiativeFields` - Initiative scalar fields (workspace query + drain page, single-initiative query, lean-cycle initiatives probe); the nested projects connection stays inline per query (page sizes differ; the probe deliberately selects none)
 
 A combined query and its drain-page twin MUST project through the same

--- a/README.md
+++ b/README.md
@@ -289,7 +289,10 @@ Error: invalid priority "critical": must be none, low, medium, high, or urgent
 
 **Validated fields:** status, assignee, labels, priority, project, milestone, cycle, parent
 
-**Reference files:** Check `states.md` for valid workflow states, `labels.md` for valid labels.
+**Reference files:** Check `states.md` for valid workflow states, `labels.md` for valid labels,
+and `team.md` for the team's issue-creation defaults — the state new issues open in, whether triage
+intercepts them, and the estimation scale `estimate:` is denominated in (its `defaults` block is
+absent when the team's settings haven't synced yet, which is not the same as "all off").
 
 The `.error` file is cleared on successful writes, with one exception: a save whose
 body Linear reformatted server-side leaves an informational note there ("saved, but

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -340,7 +340,15 @@ Design conventions:
 - **Hybrid storage:** queryable fields are extracted into indexed columns
   (`team_id`, `state_id`, `updated_at`, …) while the full API response is kept in
   a `data JSON` column. Avoids joins (names stored alongside IDs) and keeps the
-  schema stable as Linear's API grows.
+  schema stable as Linear's API grows. Where a row has both, **the column is
+  authoritative and is layered back over the decoded blob** — the columns are
+  what the upserts maintain, so a blob written by an older build cannot resurrect
+  a stale value (`DBTeamToAPITeam`). `teams.data` is the one NULLABLE `data`
+  column: it was `ALTER`-added, so pre-existing rows have no blob, and NULL is
+  read as *settings unknown* rather than as a team whose triage is off (the
+  sentinel is `api.Team.IssueEstimationType`, which Linear types non-null). It
+  also carries a `[]byte` override in `sqlc.yaml`, because the default
+  `json.RawMessage` cannot scan a NULL.
 - **`synced_at` everywhere** for staleness detection; issues additionally carry
   `detail_synced_at`, stamped only when a detail batch persisted cleanly.
 - **Hierarchy edges are stored once,** as a `parent_id` column on the child

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -340,10 +340,8 @@ Design conventions:
 - **Hybrid storage:** queryable fields are extracted into indexed columns
   (`team_id`, `state_id`, `updated_at`, …) while the full API response is kept in
   a `data JSON` column. Avoids joins (names stored alongside IDs) and keeps the
-  schema stable as Linear's API grows. Where a row has both, **the column is
-  authoritative and is layered back over the decoded blob** — the columns are
-  what the upserts maintain, so a blob written by an older build cannot resurrect
-  a stale value (`DBTeamToAPITeam`). `teams.data` is the one NULLABLE `data`
+  schema stable as Linear's API grows. Which of the two wins on read is the
+  hydrate-then-overlay rule below. `teams.data` is the one NULLABLE `data`
   column: it was `ALTER`-added, so pre-existing rows have no blob, and NULL is
   read as *settings unknown* rather than as a team whose triage is off (the
   sentinel is `api.Team.IssueEstimationType`, which Linear types non-null). It
@@ -362,11 +360,16 @@ Design conventions:
   drop-and-recreate fallback below and discarding the user's cache instead of
   migrating it (#432 tracks the missing guard).
 - **Hydrate-then-overlay:** for entities with extracted columns (states,
-  labels, users, cycles, milestones, …), reverse converters unmarshal the
+  labels, users, cycles, teams, milestones, …), reverse converters unmarshal the
   `data` blob first, then overlay the columns — so no field is silently
   dropped, and a corrupt blob degrades to column-backed values instead of
-  poisoning a listing. Entities whose blob is the whole row (issues, projects,
-  comments, …) pure-unmarshal and propagate a parse error instead.
+  poisoning a listing. **The column is authoritative**: it is what the upserts
+  maintain, so a blob written by an older build cannot resurrect a stale value,
+  and a hierarchy edge is re-derived from its own column rather than adopted
+  from the blob (`DBTeamToAPITeam` rebuilds `Parent` from `parent_id`, so a
+  stale blob cannot become a second copy of the edge). Entities whose blob is
+  the whole row (issues, projects, comments, …) pure-unmarshal and propagate a
+  parse error instead.
 - **Concurrency posture:** the Sync Worker and the FUSE write handlers write
   the same file concurrently. Safety rests on connection pragmas carried in the
   **DSN** — WAL journal mode, `busy_timeout(5000)`, foreign keys — so every

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -154,6 +154,125 @@ func TestGetTeamsDecodesParentEdge(t *testing.T) {
 	}
 }
 
+// TestGetTeamsDecodesIssueDefaultsAndTemplates covers the wire end of the
+// issue-creation defaults and the template edges, the same gap #435 documented
+// for parent: the Teams query must SELECT them and the response must decode
+// into the matching Team fields. No other test can see either half — every
+// other layer is seeded from the store, so it passes whether or not the query
+// ever asked. The two halves fail differently and both silently: a misspelled
+// selection makes Linear reject the whole Teams query and aborts the sync
+// cycle, while a wrong json tag leaves IssueEstimationType empty, which is the
+// renderers' "not synced yet" sentinel — so every team.md would drop its
+// defaults block rather than report anything wrong.
+func TestGetTeamsDecodesIssueDefaultsAndTemplates(t *testing.T) {
+	t.Parallel()
+	mock := testutil.NewMockLinearServer()
+	defer mock.Close()
+
+	mock.SetResponse("Teams", testutil.TeamsResponse(testutil.FixtureTeam()))
+
+	client := NewClient("test-api-key")
+	client.SetAPIURL(mock.URL())
+
+	teams, err := client.GetTeams(context.Background())
+	if err != nil {
+		t.Fatalf("GetTeams failed: %v", err)
+	}
+	if len(teams) != 1 {
+		t.Fatalf("expected 1 team, got %d", len(teams))
+	}
+	team := teams[0]
+
+	call := mock.LastCall()
+	if call == nil {
+		t.Fatal("no query recorded")
+	}
+	// Only the team's own selection set, so a dropped team-level "description"
+	// cannot be masked by the one TemplateFields selects.
+	teamSelection, fragment, found := strings.Cut(call.Query, "fragment TemplateFields on Template")
+	if !found {
+		t.Fatalf("Teams query does not project templates through TemplateFields:\n%s", call.Query)
+	}
+	if !strings.Contains(fragment, "description") {
+		t.Errorf("TemplateFields does not select description:\n%s", fragment)
+	}
+	for _, field := range []string{
+		"description",
+		"defaultIssueState",
+		"triageEnabled",
+		"triageIssueState",
+		"requirePriorityToLeaveTriage",
+		"issueEstimationType",
+		"defaultIssueEstimate",
+		"issueEstimationAllowZero",
+		"issueEstimationExtended",
+		"defaultTemplateForMembers",
+		"defaultTemplateForNonMembers",
+		"defaultProjectTemplate",
+	} {
+		if !strings.Contains(teamSelection, field) {
+			t.Errorf("Teams query does not select %s:\n%s", field, call.Query)
+		}
+	}
+
+	if team.Description != "The team the tests run against" {
+		t.Errorf("Description = %q, want the fixture's description", team.Description)
+	}
+	if team.DefaultIssueState == nil {
+		t.Error("DefaultIssueState decoded nil — a writer cannot learn where a new issue lands")
+	} else if team.DefaultIssueState.Name != "Todo" || team.DefaultIssueState.Type != "unstarted" {
+		t.Errorf("DefaultIssueState = %+v, want {Name:Todo Type:unstarted}", team.DefaultIssueState)
+	}
+	if !team.TriageEnabled {
+		t.Error("TriageEnabled = false, want true")
+	}
+	if team.TriageIssueState == nil {
+		t.Error("TriageIssueState decoded nil")
+	} else if team.TriageIssueState.Name != "Backlog" {
+		t.Errorf("TriageIssueState.Name = %q, want Backlog", team.TriageIssueState.Name)
+	}
+	if team.RequirePriorityToLeaveTriage {
+		t.Error("RequirePriorityToLeaveTriage = true, want false")
+	}
+	// The sentinel: empty here means "never synced" to every renderer, so a
+	// tag that fails to decode disables the defaults block workspace-wide.
+	if team.IssueEstimationType != "fibonacci" {
+		t.Errorf("IssueEstimationType = %q, want fibonacci", team.IssueEstimationType)
+	}
+	if team.DefaultIssueEstimate != 2 {
+		t.Errorf("DefaultIssueEstimate = %v, want 2", team.DefaultIssueEstimate)
+	}
+	if team.IssueEstimationAllowZero {
+		t.Error("IssueEstimationAllowZero = true, want false")
+	}
+	if !team.IssueEstimationExtended {
+		t.Error("IssueEstimationExtended = false, want true")
+	}
+
+	for _, tc := range []struct {
+		edge string
+		got  *Template
+		id   string
+		name string
+		typ  string
+	}{
+		{"defaultTemplateForMembers", team.DefaultTemplateForMembers, "template-member", "Bug report", "issue"},
+		{"defaultTemplateForNonMembers", team.DefaultTemplateForNonMembers, "template-non-member", "Support request", "issue"},
+		{"defaultProjectTemplate", team.DefaultProjectTemplate, "template-project", "Project kickoff", "project"},
+	} {
+		if tc.got == nil {
+			t.Errorf("%s decoded nil", tc.edge)
+			continue
+		}
+		if tc.got.ID != tc.id || tc.got.Name != tc.name || tc.got.Type != tc.typ {
+			t.Errorf("%s = %+v, want {ID:%s Name:%s Type:%s}", tc.edge, tc.got, tc.id, tc.name, tc.typ)
+		}
+		if tc.got.Description != "Template "+tc.name {
+			t.Errorf("%s.Description = %q, want the fixture's description", tc.edge, tc.got.Description)
+		}
+	}
+}
+
 // TestGetProjectUpdatesDrainsPages proves the updates read drains past the
 // old implicit 50-cap: updates accumulate over a project's lifetime and the
 // SWR refresh is upsert-only, so a capped read silently froze completeness.

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -13,10 +13,22 @@ query Teams($after: String) {
       id
       key
       name
+      description
       icon
       createdAt
       updatedAt
       parent { id key name }
+      defaultIssueState { id name type }
+      triageEnabled
+      triageIssueState { id name type }
+      requirePriorityToLeaveTriage
+      issueEstimationType
+      defaultIssueEstimate
+      issueEstimationAllowZero
+      issueEstimationExtended
+      defaultTemplateForMembers { id name description type }
+      defaultTemplateForNonMembers { id name description type }
+      defaultProjectTemplate { id name description type }
     }
   }
 }

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -5,7 +5,7 @@ import "fmt"
 // queryTeams drains: this is the sync worker's root fetch, and Linear
 // silently caps a connection without first: at 50 nodes — a 51st team would
 // have silently truncated the whole sync.
-const queryTeams = `
+var queryTeams = `
 query Teams($after: String) {
   teams(first: 50, after: $after) {
     pageInfo { hasNextPage endCursor }
@@ -26,11 +26,25 @@ query Teams($after: String) {
       defaultIssueEstimate
       issueEstimationAllowZero
       issueEstimationExtended
-      defaultTemplateForMembers { id name description type }
-      defaultTemplateForNonMembers { id name description type }
-      defaultProjectTemplate { id name description type }
+      defaultTemplateForMembers { ...TemplateFields }
+      defaultTemplateForNonMembers { ...TemplateFields }
+      defaultProjectTemplate { ...TemplateFields }
     }
   }
+}
+` + templateFieldsFragment
+
+// TemplateFields is the shared projection for a team's default templates —
+// three edges of the same query, which is exactly where an inlined copy drifts.
+// templateData is deliberately absent: it describes a whole prefilled entity,
+// which would be a content surface of its own rather than a line of team
+// metadata (see api.Template).
+const templateFieldsFragment = `
+fragment TemplateFields on Template {
+  id
+  name
+  description
+  type
 }
 `
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -6,12 +6,18 @@ import (
 )
 
 type Team struct {
-	ID        string    `json:"id"`
-	Key       string    `json:"key"`
-	Name      string    `json:"name"`
-	Icon      string    `json:"icon"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	ID   string `json:"id"`
+	Key  string `json:"key"`
+	Name string `json:"name"`
+	// Description is Linear's Team.description — the free text shown under the
+	// team name in the UI. Nullable on the wire; a team that has never set one
+	// decodes to "". Not carried on the Parent edge: the wire selects only
+	// identity fields there and stitchParents does not backfill it, so a
+	// parent's description is read from its own team.md, never through a child.
+	Description string    `json:"description"`
+	Icon        string    `json:"icon"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
 	// Parent is the sub-team edge (Linear's Team.parent). Only the ID survives
 	// the DB round-trip; the repo read stitches Key/Name from the teams it
 	// already loaded, and never fills the parent's own Parent — one level, so
@@ -24,6 +30,41 @@ type Team struct {
 	// connection (verified against the live API) — so selecting it would take
 	// whatever the server chose to return with no pageInfo to check.
 	Parent *Team `json:"parent,omitempty"`
+
+	// Issue-creation defaults and templates. These are settings, not content:
+	// nothing queries by them and they exist so a writer can find out what the
+	// team will DO with an issue it creates — which state it lands in, whether
+	// triage intercepts it, and what values `estimate:` legally accepts.
+	//
+	// IssueEstimationType doubles as the "settings are known" sentinel: Linear
+	// types it String! (non-null, one of notUsed/exponential/fibonacci/linear/
+	// tShirt), so a team that has been through a sync always has a non-empty
+	// value. Empty means NOT SYNCED YET, not "no estimates" — the renderers
+	// gate the whole block on it rather than emit a confident `triage: false`
+	// for a team they have simply never asked about.
+	DefaultIssueState            *State  `json:"defaultIssueState,omitempty"`
+	TriageEnabled                bool    `json:"triageEnabled"`
+	TriageIssueState             *State  `json:"triageIssueState,omitempty"`
+	RequirePriorityToLeaveTriage bool    `json:"requirePriorityToLeaveTriage"`
+	IssueEstimationType          string  `json:"issueEstimationType"`
+	DefaultIssueEstimate         float64 `json:"defaultIssueEstimate"`
+	IssueEstimationAllowZero     bool    `json:"issueEstimationAllowZero"`
+	IssueEstimationExtended      bool    `json:"issueEstimationExtended"`
+
+	DefaultTemplateForMembers    *Template `json:"defaultTemplateForMembers,omitempty"`
+	DefaultTemplateForNonMembers *Template `json:"defaultTemplateForNonMembers,omitempty"`
+	DefaultProjectTemplate       *Template `json:"defaultProjectTemplate,omitempty"`
+}
+
+// Template is the identity of a Linear template a team defaults to. Only the
+// identifying fields are selected: templateData is a JSON blob describing a
+// whole prefilled entity, and rendering it would be a content surface of its
+// own rather than a line of team metadata.
+type Template struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Type        string `json:"type"`
 }
 
 type Issue struct {

--- a/internal/db/convert.go
+++ b/internal/db/convert.go
@@ -115,10 +115,21 @@ func DBIssuesToAPIIssues(issues []Issue) ([]api.Issue, error) {
 // APITeamToDBTeam converts an api.Team to db.UpsertTeamParams. parent_id comes
 // from the team's own Parent edge (Linear's Team.parent); a top-level team
 // stores NULL.
+//
+// The settings nothing queries by (issue-creation defaults, default templates)
+// ride along in `data` rather than in a column apiece. A marshal failure — which
+// a struct of scalars and pointers cannot actually produce — stores NULL rather
+// than a half-blob, because NULL is the value the read path already understands
+// as "settings unknown". This is why the signature returns no error: there is
+// no failure mode that leaves the row saying something untrue.
 func APITeamToDBTeam(team api.Team) UpsertTeamParams {
 	var parentID sql.NullString
 	if team.Parent != nil {
 		parentID = sql.NullString{String: team.Parent.ID, Valid: team.Parent.ID != ""}
+	}
+	data, err := json.Marshal(team)
+	if err != nil {
+		data = nil
 	}
 	return UpsertTeamParams{
 		ID:   team.ID,
@@ -133,23 +144,44 @@ func APITeamToDBTeam(team api.Team) UpsertTeamParams {
 			Time:  team.UpdatedAt,
 			Valid: !team.UpdatedAt.IsZero(),
 		},
-		SyncedAt: Now(),
-		ParentID: parentID,
+		SyncedAt:    Now(),
+		ParentID:    parentID,
+		Description: sql.NullString{String: team.Description, Valid: team.Description != ""},
+		Data:        data,
 	}
 }
 
 // DBTeamToAPITeam converts a db.Team to api.Team. Parent comes strictly from
 // the parent_id column, so only the ID is populated here — the repo read
 // stitches Key/Name over it from the teams it already loaded.
+//
+// The settings come from `data`, and the columns are layered back OVER the
+// decoded blob, never under it: the columns are what UpsertTeam maintains, so
+// where the two disagree — a row migrated by an older build, a blob written
+// before a rename — the column is the current value. Parent is re-derived from
+// parent_id for the same reason, discarding whatever wire parent the blob
+// carried. An empty or corrupt blob leaves the settings zero-valued, which
+// api.Team.IssueEstimationType == "" reports to the renderers as "unknown".
 func DBTeamToAPITeam(team Team) api.Team {
-	t := api.Team{
-		ID:        team.ID,
-		Key:       team.Key,
-		Name:      team.Name,
-		Icon:      team.Icon.String,
-		CreatedAt: team.CreatedAt.Time,
-		UpdatedAt: team.UpdatedAt.Time,
+	var t api.Team
+	if len(team.Data) > 0 {
+		// A blob that will not decode is discarded whole rather than partially
+		// applied: json.Unmarshal populates fields up to the error, so keeping
+		// the remains would mean rendering settings from a torn record.
+		if err := json.Unmarshal(team.Data, &t); err != nil {
+			t = api.Team{}
+		}
 	}
+
+	t.ID = team.ID
+	t.Key = team.Key
+	t.Name = team.Name
+	t.Description = team.Description.String
+	t.Icon = team.Icon.String
+	t.CreatedAt = team.CreatedAt.Time
+	t.UpdatedAt = team.UpdatedAt.Time
+
+	t.Parent = nil
 	if team.ParentID.Valid && team.ParentID.String != "" {
 		t.Parent = &api.Team{ID: team.ParentID.String}
 	}

--- a/internal/db/convert_test.go
+++ b/internal/db/convert_test.go
@@ -1575,3 +1575,97 @@ func TestOverlayColumnsWin(t *testing.T) {
 		}
 	})
 }
+
+// TestTeamSettingsRoundTrip covers the `data` blob added for the team settings
+// nothing queries by. Three invariants, in the order they bite:
+//
+//  1. the settings survive api.Team → row → api.Team at all;
+//  2. a row from before the column (data NULL) reads back as UNKNOWN rather
+//     than as a team with triage off and no estimate scale;
+//  3. where a column and the blob disagree, the COLUMN wins — it is what
+//     UpsertTeam maintains, and the blob may be a build older than a rename.
+func TestTeamSettingsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	team := api.Team{
+		ID: "team-1", Key: "TST", Name: "Test Team",
+		Description:                  "desc",
+		Parent:                       &api.Team{ID: "team-parent", Key: "PAR", Name: "Parent"},
+		DefaultIssueState:            &api.State{ID: "s1", Name: "Todo", Type: "unstarted"},
+		TriageEnabled:                true,
+		TriageIssueState:             &api.State{ID: "s2", Name: "Triage", Type: "triage"},
+		RequirePriorityToLeaveTriage: true,
+		IssueEstimationType:          "fibonacci",
+		DefaultIssueEstimate:         3,
+		IssueEstimationAllowZero:     true,
+		DefaultTemplateForMembers:    &api.Template{ID: "t1", Name: "Bug report"},
+	}
+
+	params := APITeamToDBTeam(team)
+	row := Team{
+		ID: params.ID, Key: params.Key, Name: params.Name, Icon: params.Icon,
+		CreatedAt: params.CreatedAt, UpdatedAt: params.UpdatedAt,
+		SyncedAt: params.SyncedAt, ParentID: params.ParentID,
+		Description: params.Description, Data: params.Data,
+	}
+
+	got := DBTeamToAPITeam(row)
+	if got.IssueEstimationType != "fibonacci" || got.DefaultIssueEstimate != 3 {
+		t.Errorf("estimation = %q/%v, want fibonacci/3", got.IssueEstimationType, got.DefaultIssueEstimate)
+	}
+	if !got.TriageEnabled || !got.RequirePriorityToLeaveTriage || !got.IssueEstimationAllowZero {
+		t.Errorf("boolean settings lost in the round trip: %+v", got)
+	}
+	if got.DefaultIssueState == nil || got.DefaultIssueState.Name != "Todo" {
+		t.Errorf("DefaultIssueState = %+v, want Todo", got.DefaultIssueState)
+	}
+	if got.TriageIssueState == nil || got.TriageIssueState.Name != "Triage" {
+		t.Errorf("TriageIssueState = %+v, want Triage", got.TriageIssueState)
+	}
+	if got.DefaultTemplateForMembers == nil || got.DefaultTemplateForMembers.Name != "Bug report" {
+		t.Errorf("DefaultTemplateForMembers = %+v, want Bug report", got.DefaultTemplateForMembers)
+	}
+	// The parent is re-derived from parent_id, so the blob's wire parent — which
+	// carried Key and Name — must not survive as a second, staler copy.
+	if got.Parent == nil || got.Parent.ID != "team-parent" {
+		t.Fatalf("Parent = %+v, want the parent_id edge", got.Parent)
+	}
+	if got.Parent.Key != "" || got.Parent.Name != "" {
+		t.Errorf("Parent = %+v; want ID only (stitchParents fills the rest)", got.Parent)
+	}
+
+	t.Run("row predating the column reads as unknown", func(t *testing.T) {
+		t.Parallel()
+		old := Team{ID: "team-2", Key: "OLD", Name: "Old Team"} // Data nil, as ALTER leaves it
+		got := DBTeamToAPITeam(old)
+		if got.IssueEstimationType != "" {
+			t.Errorf("IssueEstimationType = %q, want \"\" — the sentinel the renderers read as unknown", got.IssueEstimationType)
+		}
+		if got.Key != "OLD" {
+			t.Errorf("Key = %q; a NULL blob must not cost the row its columns", got.Key)
+		}
+	})
+
+	t.Run("corrupt blob is discarded whole", func(t *testing.T) {
+		t.Parallel()
+		got := DBTeamToAPITeam(Team{ID: "team-3", Key: "BAD", Name: "Bad", Data: []byte(`{"triageEnabled":true,`)})
+		if got.TriageEnabled {
+			t.Error("a torn blob was partially applied; want it discarded whole")
+		}
+		if got.Key != "BAD" {
+			t.Errorf("Key = %q, want BAD", got.Key)
+		}
+	})
+
+	t.Run("columns win over the blob", func(t *testing.T) {
+		t.Parallel()
+		stale := APITeamToDBTeam(api.Team{ID: "team-4", Key: "OLDKEY", Name: "Old Name", Description: "old desc"})
+		got := DBTeamToAPITeam(Team{
+			ID: "team-4", Key: "NEWKEY", Name: "New Name",
+			Description: toNullString(strPtr("new desc")), Data: stale.Data,
+		})
+		if got.Key != "NEWKEY" || got.Name != "New Name" || got.Description != "new desc" {
+			t.Errorf("blob overrode the columns: %+v", got)
+		}
+	})
+}

--- a/internal/db/convert_test.go
+++ b/internal/db/convert_test.go
@@ -1602,12 +1602,10 @@ func TestTeamSettingsRoundTrip(t *testing.T) {
 	}
 
 	params := APITeamToDBTeam(team)
-	row := Team{
-		ID: params.ID, Key: params.Key, Name: params.Name, Icon: params.Icon,
-		CreatedAt: params.CreatedAt, UpdatedAt: params.UpdatedAt,
-		SyncedAt: params.SyncedAt, ParentID: params.ParentID,
-		Description: params.Description, Data: params.Data,
-	}
+	// The row sqlc reads back is field-identical to the upsert params, so the
+	// round trip is a conversion — a column added to one but not the other
+	// fails to compile here rather than silently dropping out of the test.
+	row := Team(params)
 
 	got := DBTeamToAPITeam(row)
 	if got.IssueEstimationType != "fibonacci" || got.DefaultIssueEstimate != 3 {

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -310,14 +310,16 @@ type SyncSchedule struct {
 }
 
 type Team struct {
-	ID        string         `json:"id"`
-	Key       string         `json:"key"`
-	Name      string         `json:"name"`
-	Icon      sql.NullString `json:"icon"`
-	CreatedAt sql.NullTime   `json:"created_at"`
-	UpdatedAt sql.NullTime   `json:"updated_at"`
-	SyncedAt  time.Time      `json:"synced_at"`
-	ParentID  sql.NullString `json:"parent_id"`
+	ID          string         `json:"id"`
+	Key         string         `json:"key"`
+	Name        string         `json:"name"`
+	Icon        sql.NullString `json:"icon"`
+	CreatedAt   sql.NullTime   `json:"created_at"`
+	UpdatedAt   sql.NullTime   `json:"updated_at"`
+	SyncedAt    time.Time      `json:"synced_at"`
+	ParentID    sql.NullString `json:"parent_id"`
+	Description sql.NullString `json:"description"`
+	Data        []byte         `json:"data"`
 }
 
 type TeamMember struct {

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -133,8 +133,8 @@ SELECT * FROM teams ORDER BY name;
 SELECT * FROM teams WHERE parent_id = ? ORDER BY key;
 
 -- name: UpsertTeam :exec
-INSERT INTO teams (id, key, name, icon, created_at, updated_at, synced_at, parent_id)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO teams (id, key, name, icon, created_at, updated_at, synced_at, parent_id, description, data)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
     key = excluded.key,
     name = excluded.name,
@@ -142,7 +142,9 @@ ON CONFLICT(id) DO UPDATE SET
     created_at = excluded.created_at,
     updated_at = excluded.updated_at,
     synced_at = excluded.synced_at,
-    parent_id = excluded.parent_id;
+    parent_id = excluded.parent_id,
+    description = excluded.description,
+    data = excluded.data;
 
 -- Full-text search queries are handled with raw SQL (FTS5 not supported by sqlc)
 -- See internal/db/search.go for FTS implementation

--- a/internal/db/queries.sql.go
+++ b/internal/db/queries.sql.go
@@ -1655,7 +1655,7 @@ func (q *Queries) ListProjects(ctx context.Context) ([]Project, error) {
 }
 
 const listSubteams = `-- name: ListSubteams :many
-SELECT id, "key", name, icon, created_at, updated_at, synced_at, parent_id FROM teams WHERE parent_id = ? ORDER BY key
+SELECT id, "key", name, icon, created_at, updated_at, synced_at, parent_id, description, data FROM teams WHERE parent_id = ? ORDER BY key
 `
 
 // ListSubteams reads the sub-team edge in the inverse direction: the children
@@ -1679,6 +1679,8 @@ func (q *Queries) ListSubteams(ctx context.Context, parentID sql.NullString) ([]
 			&i.UpdatedAt,
 			&i.SyncedAt,
 			&i.ParentID,
+			&i.Description,
+			&i.Data,
 		); err != nil {
 			return nil, err
 		}
@@ -2291,7 +2293,7 @@ func (q *Queries) ListTeamUnassignedIssues(ctx context.Context, teamID string) (
 
 const listTeams = `-- name: ListTeams :many
 
-SELECT id, "key", name, icon, created_at, updated_at, synced_at, parent_id FROM teams ORDER BY name
+SELECT id, "key", name, icon, created_at, updated_at, synced_at, parent_id, description, data FROM teams ORDER BY name
 `
 
 // Teams queries
@@ -2313,6 +2315,8 @@ func (q *Queries) ListTeams(ctx context.Context) ([]Team, error) {
 			&i.UpdatedAt,
 			&i.SyncedAt,
 			&i.ParentID,
+			&i.Description,
+			&i.Data,
 		); err != nil {
 			return nil, err
 		}
@@ -3781,8 +3785,8 @@ func (q *Queries) UpsertSyncSchedule(ctx context.Context, arg UpsertSyncSchedule
 }
 
 const upsertTeam = `-- name: UpsertTeam :exec
-INSERT INTO teams (id, key, name, icon, created_at, updated_at, synced_at, parent_id)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO teams (id, key, name, icon, created_at, updated_at, synced_at, parent_id, description, data)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
     key = excluded.key,
     name = excluded.name,
@@ -3790,18 +3794,22 @@ ON CONFLICT(id) DO UPDATE SET
     created_at = excluded.created_at,
     updated_at = excluded.updated_at,
     synced_at = excluded.synced_at,
-    parent_id = excluded.parent_id
+    parent_id = excluded.parent_id,
+    description = excluded.description,
+    data = excluded.data
 `
 
 type UpsertTeamParams struct {
-	ID        string         `json:"id"`
-	Key       string         `json:"key"`
-	Name      string         `json:"name"`
-	Icon      sql.NullString `json:"icon"`
-	CreatedAt sql.NullTime   `json:"created_at"`
-	UpdatedAt sql.NullTime   `json:"updated_at"`
-	SyncedAt  time.Time      `json:"synced_at"`
-	ParentID  sql.NullString `json:"parent_id"`
+	ID          string         `json:"id"`
+	Key         string         `json:"key"`
+	Name        string         `json:"name"`
+	Icon        sql.NullString `json:"icon"`
+	CreatedAt   sql.NullTime   `json:"created_at"`
+	UpdatedAt   sql.NullTime   `json:"updated_at"`
+	SyncedAt    time.Time      `json:"synced_at"`
+	ParentID    sql.NullString `json:"parent_id"`
+	Description sql.NullString `json:"description"`
+	Data        []byte         `json:"data"`
 }
 
 func (q *Queries) UpsertTeam(ctx context.Context, arg UpsertTeamParams) error {
@@ -3814,6 +3822,8 @@ func (q *Queries) UpsertTeam(ctx context.Context, arg UpsertTeamParams) error {
 		arg.UpdatedAt,
 		arg.SyncedAt,
 		arg.ParentID,
+		arg.Description,
+		arg.Data,
 	)
 	return err
 }

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -79,7 +79,19 @@ CREATE TABLE IF NOT EXISTS teams (
     -- Sub-team edge (Linear's Team.parent). NULL for a top-level team. The
     -- inverse (children) is a query over this column, never a stored second
     -- copy. Declared last to match where migrateSchema's ALTER appends it.
-    parent_id TEXT
+    parent_id TEXT,
+    -- Free text shown under the team name in Linear's UI; rendered into
+    -- team.md. ALTER-added, so it follows parent_id in migrated-DB order.
+    description TEXT,
+    -- Full API response, holding the settings nothing queries by: the
+    -- issue-creation defaults and default templates team.md renders. The
+    -- Unlike every other table's `data`, this one is NULLABLE, and there is no
+    -- SQL-side default: it is ALTER-added, so rows written by an older build
+    -- carry no blob until the next team sync, and NULL is the honest way to
+    -- say their settings are unknown (see api.Team.IssueEstimationType) rather
+    -- than assert a team's triage is off because nobody has asked yet. Reading
+    -- a NULL takes the []byte override in sqlc.yaml.
+    data JSON
 );
 
 -- NOTE: idx_teams_parent is created by migrateSchema, not here. An index over

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -164,6 +164,36 @@ func migrateSchema(db *sql.DB) error {
 		}
 	}
 
+	// description carries Linear's Team.description into team.md. Same sqlc
+	// guarantee as above: an old cache appends it after parent_id, a fresh one
+	// takes schema.sql's order, and the generated SELECTs name columns either
+	// way. No index — nothing queries by it.
+	hasTeamDesc, err := tableHasColumn(db, "teams", "description")
+	if err != nil {
+		return err
+	}
+	if !hasTeamDesc {
+		if _, err := db.Exec("ALTER TABLE teams ADD COLUMN description TEXT"); err != nil {
+			return fmt.Errorf("add teams.description: %w", err)
+		}
+	}
+
+	// data carries the team settings team.md renders (issue-creation defaults,
+	// default templates). Deliberately no NOT NULL and no DEFAULT: ALTER cannot
+	// give existing rows a real blob, and a SQL-side '{}' would be stored as
+	// TEXT, which is a distinct scan problem from the NULL it was meant to
+	// avoid. Existing rows keep NULL — read as "settings unknown" — until the
+	// next team sync writes the real thing.
+	hasTeamData, err := tableHasColumn(db, "teams", "data")
+	if err != nil {
+		return err
+	}
+	if !hasTeamData {
+		if _, err := db.Exec("ALTER TABLE teams ADD COLUMN data JSON"); err != nil {
+			return fmt.Errorf("add teams.data: %w", err)
+		}
+	}
+
 	// Indexes over ALTER-added columns are created HERE, not in schema.sql,
 	// and unconditionally (IF NOT EXISTS covers both the fresh database, whose
 	// column came from schema.sql, and the just-migrated one). schema.sql runs

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -104,13 +104,14 @@ teams/{KEY}/
                                      whether triage intercepts it, and the scale
                                      "estimate:" is denominated in ("estimation" is
                                      that scale; "default_estimate" is the value, and
-                                     the estimate_* keys are omitted entirely when
-                                     estimation is "notUsed") —
+                                     "default_estimate" plus the estimate_* keys are
+                                     omitted entirely when estimation is "notUsed") —
                                      read it before creating issues. An absent
                                      "defaults" block means not-yet-synced, not
                                      "all off". "templates" names the team's default
                                      templates (issue / issue_non_member / project),
-                                     each as name+id only, never the template body]
+                                     each as name, id, and "description" when the
+                                     template sets one — never the template body]
   project-labels.md                 [symlink to ../../project-labels.md]
   parent                            [symlink to ../{PARENT_KEY}; listed only for a sub-team]
   subteams/{KEY}                    [symlinks to sub-team dirs; teams/ itself stays flat,

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -98,7 +98,13 @@ Mount point: %s (all paths below are relative to this mount point)
 
 <directory_structure>
 teams/{KEY}/
-  team.md, states.md, labels.md     [read-only metadata; team.md names parent/subteams]
+  team.md, states.md, labels.md     [read-only metadata; team.md carries the team
+                                     description, names parent/subteams, and under
+                                     "defaults" gives the state a new issue opens in,
+                                     whether triage intercepts it, and the scale
+                                     "estimate:" is denominated in — read it before
+                                     creating issues. An absent "defaults" block means
+                                     not-yet-synced, not "all off"]
   project-labels.md                 [symlink to ../../project-labels.md]
   parent                            [symlink to ../{PARENT_KEY}; listed only for a sub-team]
   subteams/{KEY}                    [symlinks to sub-team dirs; teams/ itself stays flat,

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -102,9 +102,15 @@ teams/{KEY}/
                                      description, names parent/subteams, and under
                                      "defaults" gives the state a new issue opens in,
                                      whether triage intercepts it, and the scale
-                                     "estimate:" is denominated in — read it before
-                                     creating issues. An absent "defaults" block means
-                                     not-yet-synced, not "all off"]
+                                     "estimate:" is denominated in ("estimation" is
+                                     that scale; "default_estimate" is the value, and
+                                     the estimate_* keys are omitted entirely when
+                                     estimation is "notUsed") —
+                                     read it before creating issues. An absent
+                                     "defaults" block means not-yet-synced, not
+                                     "all off". "templates" names the team's default
+                                     templates (issue / issue_non_member / project),
+                                     each as name+id only, never the template body]
   project-labels.md                 [symlink to ../../project-labels.md]
   parent                            [symlink to ../{PARENT_KEY}; listed only for a sub-team]
   subteams/{KEY}                    [symlinks to sub-team dirs; teams/ itself stays flat,

--- a/internal/fs/teams.go
+++ b/internal/fs/teams.go
@@ -303,6 +303,19 @@ func teamMarkdown(team api.Team, children []api.Team, childrenErr error) []byte 
 		"created": team.CreatedAt.Format(time.RFC3339),
 		"updated": team.UpdatedAt.Format(time.RFC3339),
 	}
+	// Omitted rather than emitted empty when the team never set one, following
+	// labelsMarkdown: absence reads as "unset", where "" would read as "set to
+	// nothing". Linear's Team.description is nullable for exactly that reason.
+	if team.Description != "" {
+		fm["description"] = team.Description
+	}
+	defaults, defaultsBody := teamDefaults(team)
+	if defaults != nil {
+		fm["defaults"] = defaults
+	}
+	if templates := teamTemplates(team); templates != nil {
+		fm["templates"] = templates
+	}
 
 	hierarchy := ""
 	if team.Parent != nil {
@@ -326,13 +339,111 @@ func teamMarkdown(team api.Team, children []api.Team, childrenErr error) []byte 
 		hierarchy += fmt.Sprintf("- **Sub-teams:** %s (`subteams/`)\n", strings.Join(keys, ", "))
 	}
 
+	// The description is prose, so it is rendered as prose under the H1 — where
+	// Linear's own UI puts it — as well as in frontmatter, the same
+	// both-places disclosure the hierarchy already gets.
+	description := ""
+	if team.Description != "" {
+		description = "\n" + team.Description + "\n"
+	}
+
 	body := fmt.Sprintf(`
 # %s
-
+%s
 - **Key:** %s
 - **ID:** %s
-%s`, team.Name, team.Key, team.ID, hierarchy)
+%s%s`, team.Name, description, team.Key, team.ID, hierarchy, defaultsBody)
 	return renderWithFrontmatter(fm, body)
+}
+
+// teamDefaults renders the team's issue-creation defaults as a frontmatter map
+// and the matching body section. These answer the questions a WRITER has and
+// the rest of team.md does not: which state a new issue opens in, whether
+// triage will intercept it, and — the load-bearing one — what scale `estimate:`
+// is denominated in, which is otherwise discoverable only by guessing and
+// reading .error.
+//
+// Returns (nil, "") when the settings are unknown, which is NOT the same as a
+// team that has them all switched off. IssueEstimationType is the sentinel:
+// Linear types it String! and always returns one of its named scales, so empty
+// means this row predates the settings sync (see api.Team). Rendering
+// `triage: false` there would be a confident answer to a question never asked —
+// the same failure the sub-team load guards against with childrenErr.
+func teamDefaults(team api.Team) (map[string]any, string) {
+	if team.IssueEstimationType == "" {
+		return nil, ""
+	}
+
+	fm := map[string]any{
+		"triage":                   team.TriageEnabled,
+		"triage_requires_priority": team.RequirePriorityToLeaveTriage,
+		"estimation":               team.IssueEstimationType,
+		"estimate":                 team.DefaultIssueEstimate,
+		"estimate_allow_zero":      team.IssueEstimationAllowZero,
+		"estimate_extended":        team.IssueEstimationExtended,
+	}
+
+	body := "\n## Issue defaults\n\n"
+	if team.DefaultIssueState != nil {
+		fm["issue_state"] = team.DefaultIssueState.Name
+		body += fmt.Sprintf("- **New issues open in:** %s\n", team.DefaultIssueState.Name)
+	}
+	switch {
+	case team.TriageEnabled && team.TriageIssueState != nil:
+		fm["triage_state"] = team.TriageIssueState.Name
+		body += fmt.Sprintf("- **Triage:** enabled — issues opened by non-members land in %s\n",
+			team.TriageIssueState.Name)
+	case team.TriageEnabled:
+		body += "- **Triage:** enabled\n"
+	default:
+		body += "- **Triage:** disabled\n"
+	}
+	if team.TriageEnabled && team.RequirePriorityToLeaveTriage {
+		body += "- **Leaving triage:** requires a priority\n"
+	}
+	// "notUsed" is Linear's spelling of "this team does not estimate", so it is
+	// reported as such rather than as a scale whose values an agent would then
+	// try to guess.
+	if team.IssueEstimationType == "notUsed" {
+		body += "- **Estimates:** not used by this team\n"
+	} else {
+		body += fmt.Sprintf("- **Estimates:** %s scale, default %g", team.IssueEstimationType, team.DefaultIssueEstimate)
+		if team.IssueEstimationAllowZero {
+			body += ", zero allowed"
+		}
+		if team.IssueEstimationExtended {
+			body += ", extended range"
+		}
+		body += "\n"
+	}
+	return fm, body
+}
+
+// teamTemplates renders the templates the team applies by default, as
+// name+id pairs. The template BODY is deliberately not here: templateData is a
+// whole prefilled entity, which would be a content surface of its own rather
+// than a line of metadata (see api.Template). Returns nil when the team sets
+// none, so the key is omitted rather than emitted empty.
+func teamTemplates(team api.Team) map[string]any {
+	templates := map[string]any{}
+	for key, tmpl := range map[string]*api.Template{
+		"issue":            team.DefaultTemplateForMembers,
+		"issue_non_member": team.DefaultTemplateForNonMembers,
+		"project":          team.DefaultProjectTemplate,
+	} {
+		if tmpl == nil {
+			continue
+		}
+		entry := map[string]any{"name": tmpl.Name, "id": tmpl.ID}
+		if tmpl.Description != "" {
+			entry["description"] = tmpl.Description
+		}
+		templates[key] = entry
+	}
+	if len(templates) == 0 {
+		return nil
+	}
+	return templates
 }
 
 // statesMarkdown renders the states.md content for a team's workflow states.

--- a/internal/fs/teams.go
+++ b/internal/fs/teams.go
@@ -378,9 +378,16 @@ func teamDefaults(team api.Team) (map[string]any, string) {
 		"triage":                   team.TriageEnabled,
 		"triage_requires_priority": team.RequirePriorityToLeaveTriage,
 		"estimation":               team.IssueEstimationType,
-		"estimate":                 team.DefaultIssueEstimate,
-		"estimate_allow_zero":      team.IssueEstimationAllowZero,
-		"estimate_extended":        team.IssueEstimationExtended,
+	}
+	// "estimation" is the SCALE, "default_estimate" the VALUE; the latter is
+	// spelled apart from the former so a machine reader cannot mistake one for
+	// the other. Under "notUsed" the whole estimate_* cluster is omitted so the
+	// frontmatter says what the body already says — estimates are off — rather
+	// than publishing a default and a zero-policy for a scale that has no values.
+	if team.IssueEstimationType != "notUsed" {
+		fm["default_estimate"] = team.DefaultIssueEstimate
+		fm["estimate_allow_zero"] = team.IssueEstimationAllowZero
+		fm["estimate_extended"] = team.IssueEstimationExtended
 	}
 
 	body := "\n## Issue defaults\n\n"

--- a/internal/fs/teams_test.go
+++ b/internal/fs/teams_test.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -270,10 +271,19 @@ func TestTeamDefaultsRender(t *testing.T) {
 			"triage_requires_priority": true,
 			"estimation":               "fibonacci",
 			"estimate_allow_zero":      true,
+			"estimate_extended":        false,
 		} {
 			if got := defaults[key]; got != want {
 				t.Errorf("defaults[%q] = %#v, want %#v", key, got, want)
 			}
+		}
+		// The default VALUE is spelled default_estimate, not estimate, so it
+		// cannot be misread as estimation (the scale) two characters away.
+		if got := fmt.Sprint(defaults["default_estimate"]); got != "2" {
+			t.Errorf("defaults[\"default_estimate\"] = %v, want 2", defaults["default_estimate"])
+		}
+		if got, ok := defaults["estimate"]; ok {
+			t.Errorf("defaults[\"estimate\"] = %#v; the key is default_estimate", got)
 		}
 		// The estimate scale is the whole point: a writer that cannot read it
 		// discovers the team's units by guessing and reading .error.
@@ -321,6 +331,13 @@ func TestTeamDefaultsRender(t *testing.T) {
 		}
 		if got := defaults["triage"]; got != false {
 			t.Errorf("triage = %#v, want false (known-off, not omitted)", got)
+		}
+		// The frontmatter must agree with the prose: a team that does not
+		// estimate publishes no default, no zero-policy, and no extended range.
+		for _, key := range []string{"default_estimate", "estimate_allow_zero", "estimate_extended"} {
+			if got, ok := defaults[key]; ok {
+				t.Errorf("defaults[%q] = %#v under estimation notUsed; want the key omitted", key, got)
+			}
 		}
 	})
 }

--- a/internal/fs/teams_test.go
+++ b/internal/fs/teams_test.go
@@ -168,3 +168,202 @@ func TestTeamHierarchyChildrenLoadFailure(t *testing.T) {
 		t.Errorf("team.md is silent about the failed sub-team load:\n%s", content)
 	}
 }
+
+// TestTeamDescriptionRender pins the team description on both surfaces it is
+// disclosed through — frontmatter (machine-read) and the body prose under the
+// H1 (where Linear's own UI puts it) — and the absent case, which must OMIT
+// the key rather than emit an empty one: "" would read as "set to nothing",
+// where Linear's Team.description is nullable precisely to say "never set".
+//
+// The description is remote free text, so it is also the frontmatter injection
+// surface the catalogs already guard: a colon, a quote, or a leading `-` must
+// survive as a value, not restructure the YAML.
+func TestTeamDescriptionRender(t *testing.T) {
+	t.Parallel()
+
+	t.Run("present", func(t *testing.T) {
+		t.Parallel()
+		team := api.Team{ID: "team-1", Key: "ENG", Name: "Engineering",
+			Description: "Onboarding Pod: https://example.invalid/p?a=1&b=2"}
+
+		content := teamMarkdown(team, nil, nil)
+		doc, err := marshal.Parse(content)
+		if err != nil {
+			t.Fatalf("team.md render is not parseable YAML frontmatter: %v", err)
+		}
+		if got := doc.Frontmatter["description"]; got != team.Description {
+			t.Errorf("description = %v, want %q", got, team.Description)
+		}
+		if !strings.Contains(doc.Body, team.Description) {
+			t.Errorf("team.md body does not carry the description:\n%s", doc.Body)
+		}
+		// The H1 stays the team name — the description is prose beneath it,
+		// not a replacement for the heading.
+		if !strings.Contains(doc.Body, "# Engineering") {
+			t.Errorf("team.md body lost its H1:\n%s", doc.Body)
+		}
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		t.Parallel()
+		team := api.Team{ID: "team-1", Key: "ENG", Name: "Engineering"}
+
+		doc, err := marshal.Parse(teamMarkdown(team, nil, nil))
+		if err != nil {
+			t.Fatalf("team.md render is not parseable YAML frontmatter: %v", err)
+		}
+		if got, ok := doc.Frontmatter["description"]; ok {
+			t.Errorf("description key present as %#v for a team that never set one; want omitted", got)
+		}
+	})
+
+	t.Run("hostile", func(t *testing.T) {
+		t.Parallel()
+		hostile := "desc: \"quoted\"\nkey: injected"
+		team := api.Team{ID: "team-1", Key: "ENG", Name: "Engineering", Description: hostile}
+
+		doc, err := marshal.Parse(teamMarkdown(team, nil, nil))
+		if err != nil {
+			t.Fatalf("hostile description broke the frontmatter: %v", err)
+		}
+		if got := doc.Frontmatter["description"]; got != hostile {
+			t.Errorf("description round-tripped to %#v, want %#v", got, hostile)
+		}
+		if got := doc.Frontmatter["key"]; got != "ENG" {
+			t.Errorf("description injected a frontmatter key: key = %v, want ENG", got)
+		}
+	})
+}
+
+// TestTeamDefaultsRender pins the issue-creation defaults, and above all the
+// difference between "this team does not estimate" and "nobody has asked yet".
+// A team row written before the settings sync has zero-valued settings, and
+// rendering those verbatim would tell a writer that triage is off and the
+// estimate scale is "" — a confident answer to a question never asked.
+func TestTeamDefaultsRender(t *testing.T) {
+	t.Parallel()
+	base := api.Team{ID: "team-1", Key: "ENG", Name: "Engineering"}
+
+	t.Run("known", func(t *testing.T) {
+		t.Parallel()
+		team := base
+		team.IssueEstimationType = "fibonacci"
+		team.DefaultIssueEstimate = 2
+		team.IssueEstimationAllowZero = true
+		team.TriageEnabled = true
+		team.TriageIssueState = &api.State{ID: "s-tri", Name: "Triage", Type: "triage"}
+		team.RequirePriorityToLeaveTriage = true
+		team.DefaultIssueState = &api.State{ID: "s-todo", Name: "Todo", Type: "unstarted"}
+
+		doc, err := marshal.Parse(teamMarkdown(team, nil, nil))
+		if err != nil {
+			t.Fatalf("team.md render is not parseable YAML frontmatter: %v", err)
+		}
+		defaults, ok := doc.Frontmatter["defaults"].(map[string]any)
+		if !ok {
+			t.Fatalf("defaults = %#v, want a map", doc.Frontmatter["defaults"])
+		}
+		for key, want := range map[string]any{
+			"issue_state":              "Todo",
+			"triage":                   true,
+			"triage_state":             "Triage",
+			"triage_requires_priority": true,
+			"estimation":               "fibonacci",
+			"estimate_allow_zero":      true,
+		} {
+			if got := defaults[key]; got != want {
+				t.Errorf("defaults[%q] = %#v, want %#v", key, got, want)
+			}
+		}
+		// The estimate scale is the whole point: a writer that cannot read it
+		// discovers the team's units by guessing and reading .error.
+		if !strings.Contains(doc.Body, "fibonacci") {
+			t.Errorf("body does not name the estimate scale:\n%s", doc.Body)
+		}
+		if !strings.Contains(doc.Body, "Triage") {
+			t.Errorf("body does not name the triage state:\n%s", doc.Body)
+		}
+	})
+
+	t.Run("unknown settings omit the block", func(t *testing.T) {
+		t.Parallel()
+		doc, err := marshal.Parse(teamMarkdown(base, nil, nil))
+		if err != nil {
+			t.Fatalf("team.md render is not parseable YAML frontmatter: %v", err)
+		}
+		if got, ok := doc.Frontmatter["defaults"]; ok {
+			t.Errorf("defaults = %#v for an unsynced team; want the key omitted", got)
+		}
+		if strings.Contains(doc.Body, "Issue defaults") {
+			t.Errorf("body claims defaults it does not know:\n%s", doc.Body)
+		}
+	})
+
+	t.Run("estimates not used", func(t *testing.T) {
+		t.Parallel()
+		team := base
+		team.IssueEstimationType = "notUsed"
+
+		doc, err := marshal.Parse(teamMarkdown(team, nil, nil))
+		if err != nil {
+			t.Fatalf("team.md render is not parseable YAML frontmatter: %v", err)
+		}
+		// Known-and-off still renders: the block is present, and says so.
+		defaults, ok := doc.Frontmatter["defaults"].(map[string]any)
+		if !ok {
+			t.Fatalf("defaults = %#v, want a map for a synced team", doc.Frontmatter["defaults"])
+		}
+		if got := defaults["estimation"]; got != "notUsed" {
+			t.Errorf("estimation = %#v, want notUsed", got)
+		}
+		if !strings.Contains(doc.Body, "not used by this team") {
+			t.Errorf("body does not say estimates are unused:\n%s", doc.Body)
+		}
+		if got := defaults["triage"]; got != false {
+			t.Errorf("triage = %#v, want false (known-off, not omitted)", got)
+		}
+	})
+}
+
+// TestTeamTemplatesRender pins the default templates: name and id, no
+// templateData, and the key omitted entirely for a team that sets none.
+func TestTeamTemplatesRender(t *testing.T) {
+	t.Parallel()
+	team := api.Team{ID: "team-1", Key: "ENG", Name: "Engineering",
+		IssueEstimationType:       "linear",
+		DefaultTemplateForMembers: &api.Template{ID: "t1", Name: "Bug: report", Description: "For defects"},
+		DefaultProjectTemplate:    &api.Template{ID: "t2", Name: "Standard project"},
+	}
+
+	doc, err := marshal.Parse(teamMarkdown(team, nil, nil))
+	if err != nil {
+		t.Fatalf("team.md render is not parseable YAML frontmatter: %v", err)
+	}
+	templates, ok := doc.Frontmatter["templates"].(map[string]any)
+	if !ok {
+		t.Fatalf("templates = %#v, want a map", doc.Frontmatter["templates"])
+	}
+	issue, _ := templates["issue"].(map[string]any)
+	if got := issue["name"]; got != "Bug: report" {
+		t.Errorf("issue template name = %#v, want %q (a colon must survive as a value)", got, "Bug: report")
+	}
+	if got := issue["id"]; got != "t1" {
+		t.Errorf("issue template id = %#v, want t1", got)
+	}
+	if got := issue["description"]; got != "For defects" {
+		t.Errorf("issue template description = %#v, want %q", got, "For defects")
+	}
+	// A template the team does not set is absent, not empty.
+	if got, ok := templates["issue_non_member"]; ok {
+		t.Errorf("issue_non_member = %#v for a team that sets none; want omitted", got)
+	}
+
+	bare := api.Team{ID: "team-2", Key: "OPS", Name: "Ops", IssueEstimationType: "linear"}
+	doc, err = marshal.Parse(teamMarkdown(bare, nil, nil))
+	if err != nil {
+		t.Fatalf("team.md render for a team with no templates: %v", err)
+	}
+	if got, ok := doc.Frontmatter["templates"]; ok {
+		t.Errorf("templates = %#v for a team that sets none; want the key omitted", got)
+	}
+}

--- a/internal/integration/teammeta_test.go
+++ b/internal/integration/teammeta_test.go
@@ -1,0 +1,169 @@
+package integration
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jra3/linear-fuse/internal/marshal"
+)
+
+// The team description is disclosed twice — frontmatter and body prose — and
+// these pin it from the mount, where the render tests (internal/fs) cannot see
+// whether the value actually survived the API → SQLite → repo round trip.
+
+// TestTeamDescriptionReachesMount proves the description survives the whole
+// path, not just the renderer. It names the seeded value, so it is
+// fixture-mode only.
+func TestTeamDescriptionReachesMount(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
+
+	data, err := os.ReadFile(teamInfoPath(testTeamKey))
+	if err != nil {
+		t.Fatalf("read team.md: %v", err)
+	}
+	doc, err := marshal.Parse(data)
+	if err != nil {
+		t.Fatalf("team.md is not parseable: %v", err)
+	}
+	const want = "The test team: for fixtures"
+	if got := doc.Frontmatter["description"]; got != want {
+		t.Errorf("description = %v, want %q", got, want)
+	}
+	if !strings.Contains(doc.Body, want) {
+		t.Errorf("team.md body does not carry the description:\n%s", doc.Body)
+	}
+}
+
+// TestTeamDescriptionFrontmatterMatchesBody audits both disclosures for EVERY
+// team the workspace shows: whatever frontmatter claims must appear in the
+// prose an agent reads. It runs in every mode — offline the fixture's TST
+// description gives it substance, live it audits the real workspace, where
+// SUB's absent description also pins the omit-when-unset half.
+func TestTeamDescriptionFrontmatterMatchesBody(t *testing.T) {
+	entries, err := os.ReadDir(teamsPath())
+	if err != nil {
+		t.Fatalf("read teams: %v", err)
+	}
+
+	checked := 0
+	for _, e := range entries {
+		if !e.IsDir() || isControlFile(e.Name()) {
+			continue
+		}
+		teamKey := e.Name()
+
+		data, err := os.ReadFile(teamInfoPath(teamKey))
+		if err != nil {
+			t.Errorf("read %s/team.md: %v", teamKey, err)
+			continue
+		}
+		doc, err := marshal.Parse(data)
+		if err != nil {
+			t.Errorf("%s/team.md is not parseable: %v", teamKey, err)
+			continue
+		}
+
+		desc, ok := doc.Frontmatter["description"]
+		if !ok {
+			continue
+		}
+		// Present means non-empty: the renderer omits the key for a team that
+		// never set one, so an empty value here means the two spellings of
+		// "unset" have diverged.
+		text, isString := desc.(string)
+		if !isString || text == "" {
+			t.Errorf("%s/team.md has description %#v; want the key omitted when unset", teamKey, desc)
+			continue
+		}
+		if !strings.Contains(doc.Body, text) {
+			t.Errorf("%s/team.md frontmatter describes the team but the body does not:\n%s", teamKey, doc.Body)
+		}
+		checked++
+	}
+	t.Logf("checked %d team description(s)", checked)
+}
+
+// TestTeamDefaultsReachMount proves the issue-creation defaults survive the
+// whole path — API → data blob → SQLite → repo → render — and not just the
+// renderer. It names the seeded values, so it is fixture-mode only.
+func TestTeamDefaultsReachMount(t *testing.T) {
+	skipIfLiveAPI(t, fixtureSeededData)
+
+	data, err := os.ReadFile(teamInfoPath(testTeamKey))
+	if err != nil {
+		t.Fatalf("read team.md: %v", err)
+	}
+	doc, err := marshal.Parse(data)
+	if err != nil {
+		t.Fatalf("team.md is not parseable: %v", err)
+	}
+
+	defaults, ok := doc.Frontmatter["defaults"].(map[string]any)
+	if !ok {
+		t.Fatalf("defaults = %#v, want a map", doc.Frontmatter["defaults"])
+	}
+	for key, want := range map[string]any{
+		"issue_state":  "Todo",
+		"triage":       true,
+		"triage_state": "Triage",
+		"estimation":   "fibonacci",
+	} {
+		if got := defaults[key]; got != want {
+			t.Errorf("defaults[%q] = %#v, want %#v", key, got, want)
+		}
+	}
+
+	templates, ok := doc.Frontmatter["templates"].(map[string]any)
+	if !ok {
+		t.Fatalf("templates = %#v, want a map", doc.Frontmatter["templates"])
+	}
+	issue, _ := templates["issue"].(map[string]any)
+	if got := issue["name"]; got != "Bug report" {
+		t.Errorf("templates.issue.name = %#v, want %q", got, "Bug report")
+	}
+}
+
+// TestTeamDefaultsAreKnownOrAbsent audits the sentinel across EVERY team the
+// workspace shows, in every mode: a `defaults` block must name a real
+// estimation scale, never the empty string. An empty one would mean the
+// unknown-settings gate leaked, and every reader downstream would take
+// "nobody has synced this yet" for "this team estimates in nothing".
+func TestTeamDefaultsAreKnownOrAbsent(t *testing.T) {
+	entries, err := os.ReadDir(teamsPath())
+	if err != nil {
+		t.Fatalf("read teams: %v", err)
+	}
+
+	for _, e := range entries {
+		if !e.IsDir() || isControlFile(e.Name()) {
+			continue
+		}
+		teamKey := e.Name()
+
+		data, err := os.ReadFile(teamInfoPath(teamKey))
+		if err != nil {
+			t.Errorf("read %s/team.md: %v", teamKey, err)
+			continue
+		}
+		doc, err := marshal.Parse(data)
+		if err != nil {
+			t.Errorf("%s/team.md is not parseable: %v", teamKey, err)
+			continue
+		}
+
+		raw, ok := doc.Frontmatter["defaults"]
+		if !ok {
+			continue
+		}
+		defaults, ok := raw.(map[string]any)
+		if !ok {
+			t.Errorf("%s/team.md defaults = %#v, want a map", teamKey, raw)
+			continue
+		}
+		if scale, _ := defaults["estimation"].(string); scale == "" {
+			t.Errorf("%s/team.md published a defaults block with no estimation scale (%#v); "+
+				"the unknown-settings gate must omit the block instead", teamKey, defaults)
+		}
+	}
+}

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -5,15 +5,42 @@ import "time"
 // Fixture functions return map[string]any for JSON encoding.
 // This avoids import cycles with the api package.
 
-// FixtureTeam returns a test team as a map.
+// FixtureTeam returns a test team as a map. The issue-creation defaults and
+// template edges are carried here, not just in the Go-struct fixtures, because
+// they are the only place the wire end is observable: every other layer is
+// seeded from the store, so a dropped selection or a mistyped json tag would
+// pass the whole suite (see TestGetTeamsDecodesIssueDefaultsAndTemplates).
 func FixtureTeam() map[string]any {
 	return map[string]any{
-		"id":        "team-123",
-		"key":       "TST",
-		"name":      "Test Team",
-		"icon":      "team",
-		"createdAt": time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
-		"updatedAt": time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		"id":                           "team-123",
+		"key":                          "TST",
+		"name":                         "Test Team",
+		"description":                  "The team the tests run against",
+		"icon":                         "team",
+		"createdAt":                    time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		"updatedAt":                    time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		"defaultIssueState":            FixtureState("unstarted"),
+		"triageEnabled":                true,
+		"triageIssueState":             FixtureState("backlog"),
+		"requirePriorityToLeaveTriage": false,
+		"issueEstimationType":          "fibonacci",
+		"defaultIssueEstimate":         2.0,
+		"issueEstimationAllowZero":     false,
+		"issueEstimationExtended":      true,
+		"defaultTemplateForMembers":    FixtureTemplate("member", "Bug report", "issue"),
+		"defaultTemplateForNonMembers": FixtureTemplate("non-member", "Support request", "issue"),
+		"defaultProjectTemplate":       FixtureTemplate("project", "Project kickoff", "project"),
+	}
+}
+
+// FixtureTemplate returns a test template as a map. templateData is absent on
+// purpose: the query does not select it (see TemplateFields).
+func FixtureTemplate(id, name, templateType string) map[string]any {
+	return map[string]any{
+		"id":          "template-" + id,
+		"name":        name,
+		"description": "Template " + name,
+		"type":        templateType,
 	}
 }
 

--- a/internal/testutil/fixtures/api.go
+++ b/internal/testutil/fixtures/api.go
@@ -18,12 +18,34 @@ var (
 // FixtureAPITeam returns a test team.
 func FixtureAPITeam() api.Team {
 	return api.Team{
-		ID:        "team-1",
-		Key:       "TST",
-		Name:      "Test Team",
-		Icon:      "team",
-		CreatedAt: fixtureTime,
-		UpdatedAt: fixtureTime,
+		ID:   "team-1",
+		Key:  "TST",
+		Name: "Test Team",
+		// Set here and deliberately NOT on FixtureAPISubteam, so the offline
+		// suite covers both a team that has a description and one that never
+		// set one (the frontmatter key is omitted, not emitted empty).
+		Description: "The test team: for fixtures",
+		Icon:        "team",
+		CreatedAt:   fixtureTime,
+		UpdatedAt:   fixtureTime,
+		// Issue-creation defaults. Set here and NOT on FixtureAPISubteam, so
+		// the offline suite covers a team whose settings are known and one
+		// whose are not — the two are rendered differently on purpose, and a
+		// fixture set that only ever exercised the known case would let the
+		// "unknown" path rot untested.
+		DefaultIssueState:            &api.State{ID: "state-todo", Name: "Todo", Type: "unstarted"},
+		TriageEnabled:                true,
+		TriageIssueState:             &api.State{ID: "state-triage", Name: "Triage", Type: "triage"},
+		RequirePriorityToLeaveTriage: true,
+		IssueEstimationType:          "fibonacci",
+		DefaultIssueEstimate:         2,
+		IssueEstimationAllowZero:     true,
+		DefaultTemplateForMembers: &api.Template{
+			ID: "tmpl-bug", Name: "Bug report", Description: "For defects", Type: "issue",
+		},
+		DefaultProjectTemplate: &api.Template{
+			ID: "tmpl-proj", Name: "Standard project", Type: "project",
+		},
 	}
 }
 

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -9,3 +9,13 @@ sql:
         out: "internal/db"
         emit_json_tags: true
         emit_empty_slices: true
+        overrides:
+          # teams.data is the one nullable JSON column (it was ALTER-added, so
+          # rows from an older build have no blob). sqlc's default for a JSON
+          # column is json.RawMessage, which scans neither a NULL nor the TEXT
+          # a SQL-side default would produce; plain []byte scans both, taking
+          # NULL as nil — the value the read path reads as "settings unknown".
+          - column: "teams.data"
+            go_type:
+              type: "byte"
+              slice: true


### PR DESCRIPTION
## Intent

Expose Linear team context that the filesystem was hiding. The user asked, looking at a Linear team overview page, whether team DESCRIPTIONS could be exposed in the mount; then asked what other team context could be pulled in, and specifically about the 'Team resources' link list visible on that page; then chose two of the options I surveyed: (1) the issue-creation defaults an agent needs in order to write correctly - defaultIssueState, triage settings, and the estimation scale/default/allow-zero/extended cluster that defines what values 'estimate:' legally accepts - and (6) the team's default templates.

NOTE ON HISTORY: this branch already carries one no-mistakes gate-fix commit (0fe607e) from a previous run whose daemon shut down mid-round. The user reviewed both findings from that run and explicitly approved fixing BOTH. That commit is therefore in scope, not drift; its changes are (a) the generated README now names the 'templates' key and its sub-keys, (b) the frontmatter key 'estimate' was renamed to 'default_estimate' so it cannot be confused with 'estimation' (the scale) two characters away, and (c) the default_estimate/estimate_allow_zero/estimate_extended keys are now omitted entirely when estimation is 'notUsed', so the frontmatter agrees with the body prose that already said estimates are unused. Tests pin both halves.

Deliberate decisions a reviewer reading only the diff would not know:

- Team resources are NOT implemented, on purpose. I verified against docs/linear-schema.graphql that Team has no links/externalLinks connection (Project has externalLinks, Initiative has links, Team has neither), there is no ResourceFolder type, and the only entry point is entityExternalLink(id:) by ID. EntityExternalLinkCreateInput does accept teamId, so a team link can be created but never listed back. They are unreachable via the API, so their absence is a finding, not an omission.
- Description and defaults are each disclosed TWICE - frontmatter plus body prose - which is intentional duplication following the existing parent/subteams pattern in the same function, not an oversight.
- The unknown-vs-off distinction is the core design point. teams.data is deliberately the schema's only NULLABLE data column, with no SQL-side DEFAULT, because ALTER cannot backfill existing rows and NULL is the honest encoding of 'this row predates the settings sync'. api.Team.IssueEstimationType is the sentinel (Linear types it String! non-null), and empty omits the entire defaults block rather than rendering a confident triage:false about a team never asked about. This mirrors the existing childrenErr treatment where an absent subteams key means unknown, not none. 'notUsed' still renders the block, because that is known-and-off - distinct from unsynced.
- The []byte override in sqlc.yaml is required, not stylistic: sqlc's default json.RawMessage scans neither a NULL nor the TEXT that a DEFAULT '{}' produces. I tried NOT NULL DEFAULT '{}' first and it failed both ways before settling here.
- DBTeamToAPITeam layers the columns back OVER the decoded blob and re-derives Parent from parent_id, discarding the blob's wire parent, so a stale blob cannot resurrect an old value or create a second copy of the hierarchy edge.
- Template templateData is deliberately not exposed - only name/id/description - because a prefilled entity would be a content surface of its own rather than a line of metadata.
- Frontmatter keys are omitted rather than emitted empty whenever a value is unset, following the existing labelsMarkdown precedent.
- Docs were updated in the same change per CLAUDE.md's standing rule: the generated README (which can otherwise silently lie about behavior) and ARCHITECTURE.md's hybrid-storage convention.
- Test guards follow CLAUDE.md's three spellings: assertions naming seeded fixture rows carry skipIfLiveAPI(t, fixtureSeededData); the workspace-wide audits deliberately run in every mode.

Verified live: both local linearfs instances were reinstalled and restarted on this build, the ALTERs migrated real caches, and both mounts now serve the new fields.

## What Changed

- `teams/<KEY>/team.md` now renders the team description (frontmatter key plus prose under the H1, the same both-places disclosure the parent/subteams hierarchy already gets), a `defaults` block (`issue_state`, `triage`, `triage_requires_priority`, `triage_state`, `estimation`, `default_estimate`, `estimate_allow_zero`, `estimate_extended`) and a `templates` block naming the team's default `issue` / `issue_non_member` / `project` templates as name+id (+description when set, never `templateData`). `default_estimate` and the `estimate_*` keys are dropped when the scale is `notUsed`, and the whole `defaults` block is omitted when `api.Team.IssueEstimationType` is empty — an unsynced team reads as *unknown*, not as *all off*.
- Wire and storage plumbing: `queryTeams` gains the description, default-state, triage, and estimation selections plus the three template edges through a new hoisted `TemplateFields` fragment; `api.Team` gains the matching fields and a new `api.Template` type; `teams` gains ALTER-migrated `description` and nullable `data` columns (nullable and default-less on purpose, with a `[]byte` `sqlc.yaml` override since `json.RawMessage` scans neither NULL nor TEXT), and `DBTeamToAPITeam` decodes the blob then layers the columns over it and re-derives `Parent` from `parent_id` so a stale blob can't resurrect an old value or duplicate the hierarchy edge. Team resources are deliberately not implemented — Linear exposes no listable team link connection.
- Tests and docs: unit coverage for description/defaults/templates rendering (present, absent, YAML-hostile, `notUsed`), a `teams.data` round-trip covering NULL and torn blobs plus column-wins overlay, migration over a pre-columns cache, `TestGetTeamsDecodesIssueDefaultsAndTemplates` pinning the wire selection and decode, and mount-level integration tests (description reaches the mount; workspace-wide audits that frontmatter matches body prose and any defaults block names a real estimation scale). Per CLAUDE.md's standing rule, the generated README, `README.md`, and `docs/ARCHITECTURE.md` (hybrid-storage + hydrate-then-overlay conventions) were updated in the same change. Review left one open info note about polarity in the new wire fixture's two `false` booleans.

## Risk Assessment

✅ Low: The fix commit is small, additive, and resolves all four prior findings correctly — the GraphQL fragment follows the file's established const-fragment/var-query pattern with no init-order or mock-routing hazard, the enriched wire fixture has no assertion-sensitive consumers, and both README claims now match the renderer; the only residue is two boolean json tags left unpinned by the new decode test.

## Testing

Ran the full offline suite (all packages green, including the FUSE integration suite) plus the targeted new renderer, DB round-trip, wire-decode, and mount-level team tests, then produced product-level evidence by reading team.md straight off real FUSE mounts: the fixture team shows description, defaults, and templates in both frontmatter and prose; the settings-unknown sub-team omits both keys; a cache database written by an older build migrates in place and correctly renders nothing about defaults until the next sync fills them; a notUsed team renders the block with the estimate keys dropped; and HEAD's build over a copy of this machine's real Linear cache renders all 12 real teams with the corrected key spellings. No failures or flakes; the only notes are informational (the Team-resources 'unreachable via the API' rationale looks stale against the current schema, and the machine's running daemons predate the two review commits). Transient artifacts (cache copy, temp mounts, fetched schema) were removed and the worktree is clean.

<details>
<summary>Evidence: Mounted teams/TST/team.md — description, issue-creation defaults, and default templates as an end user cats them</summary>

<code>$ cat &lt;mount&gt;/teams/TST/team.md&#10;---&#10;created: &#34;2024-01-01T00:00:00Z&#34;&#10;defaults:&#10;default_estimate: 2&#10;estimate_allow_zero: true&#10;estimate_extended: false&#10;estimation: fibonacci&#10;issue_state: Todo&#10;triage: true&#10;triage_requires_priority: true&#10;triage_state: Triage&#10;description: &#39;The test team: for fixtures&#39;&#10;icon: team&#10;id: team-1&#10;key: TST&#10;name: Test Team&#10;subteams:&#10;- SUB&#10;templates:&#10;issue:&#10;description: For defects&#10;id: tmpl-bug&#10;name: Bug report&#10;project:&#10;id: tmpl-proj&#10;name: Standard project&#10;updated: &#34;2024-01-01T00:00:00Z&#34;&#10;---&#10;&#10;# Test Team&#10;&#10;The test team: for fixtures&#10;&#10;- **Key:** TST&#10;- **ID:** team-1&#10;- **Sub-teams:** SUB (`subteams/`)&#10;&#10;## Issue defaults&#10;&#10;- **New issues open in:** Todo&#10;- **Triage:** enabled — issues opened by non-members land in Triage&#10;- **Leaving triage:** requires a priority&#10;- **Estimates:** fibonacci scale, default 2, zero allowed</code>

```text
---
created: "2024-01-01T00:00:00Z"
defaults:
    default_estimate: 2
    estimate_allow_zero: true
    estimate_extended: false
    estimation: fibonacci
    issue_state: Todo
    triage: true
    triage_requires_priority: true
    triage_state: Triage
description: 'The test team: for fixtures'
icon: team
id: team-1
key: TST
name: Test Team
subteams:
    - SUB
templates:
    issue:
        description: For defects
        id: tmpl-bug
        name: Bug report
    project:
        id: tmpl-proj
        name: Standard project
updated: "2024-01-01T00:00:00Z"
---

# Test Team

The test team: for fixtures

- **Key:** TST
- **ID:** team-1
- **Sub-teams:** SUB (`subteams/`)

## Issue defaults

- **New issues open in:** Todo
- **Triage:** enabled — issues opened by non-members land in Triage
- **Leaving triage:** requires a priority
- **Estimates:** fibonacci scale, default 2, zero allowed
```
</details>
<details>
<summary>Evidence: Mounted teams/SUB/team.md — a team whose settings were never synced: description and defaults omitted entirely, not rendered as &#34;off&#34;</summary>

<code>$ cat &lt;mount&gt;/teams/SUB/team.md&#10;---&#10;created: &#34;2024-01-01T00:00:00Z&#34;&#10;icon: team&#10;id: team-sub&#10;key: SUB&#10;name: Sub Team&#10;parent: TST&#10;parent_id: team-1&#10;updated: &#34;2024-01-01T00:00:00Z&#34;&#10;---&#10;&#10;# Sub Team&#10;&#10;- **Key:** SUB&#10;- **ID:** team-sub&#10;- **Parent team:** TST (`parent` symlink)</code>

```text
---
created: "2024-01-01T00:00:00Z"
icon: team
id: team-sub
key: SUB
name: Sub Team
parent: TST
parent_id: team-1
updated: "2024-01-01T00:00:00Z"
---

# Sub Team

- **Key:** SUB
- **ID:** team-sub
- **Parent team:** TST (`parent` symlink)
```
</details>
<details>
<summary>Evidence: Older cache migrated in place, served through a real mount: unknown → synced → notUsed</summary>

<code>### 1. cache row written by an older build (data NULL): settings UNKNOWN&#10;### — no `description`, and no `defaults` block at all&#10;$ cat &lt;mount&gt;/teams/LEG/team.md&#10;---&#10;created: &#34;2026-08-05T16:46:07Z&#34;&#10;icon: team&#10;id: team-legacy&#10;key: LEG&#10;name: Legacy Team&#10;updated: &#34;2026-08-05T16:46:07Z&#34;&#10;---&#10;&#10;# Legacy Team&#10;&#10;- **Key:** LEG&#10;- **ID:** team-legacy&#10;----------------------------------------------------------------------&#10;### 2. after the next team sync writes the blob: description, defaults, templates&#10;$ cat &lt;mount&gt;/teams/LEG/team.md (abridged)&#10;defaults:&#10;default_estimate: 3&#10;estimate_allow_zero: true&#10;estimate_extended: true&#10;estimation: fibonacci&#10;issue_state: Backlog&#10;triage: true&#10;triage_requires_priority: true&#10;triage_state: Triage&#10;description: Ships the legacy importer. Ask before reassigning.&#10;templates:&#10;issue: {description: Repro, expected, actual, id: tmpl-bug, name: Bug report}&#10;issue_non_member: {id: tmpl-support, name: Support request}&#10;project: {id: tmpl-proj, name: Project kickoff}&#10;...&#10;## Issue defaults&#10;- **New issues open in:** Backlog&#10;- **Triage:** enabled — issues opened by non-members land in Triage&#10;- **Leaving triage:** requires a priority&#10;- **Estimates:** fibonacci scale, default 3, zero allowed, extended range&#10;----------------------------------------------------------------------&#10;### 3. a team that does not estimate: the block IS rendered — known-and-off —&#10;### with estimation: notUsed and no default_estimate/estimate_* keys&#10;$ cat &lt;mount&gt;/teams/NOE/team.md&#10;defaults:&#10;estimation: notUsed&#10;issue_state: Todo&#10;triage: false&#10;triage_requires_priority: false&#10;...&#10;## Issue defaults&#10;- **New issues open in:** Todo&#10;- **Triage:** disabled&#10;- **Estimates:** not used by this team</code>

```text
LinearFS: teams/<KEY>/team.md served from a cache database created by an
older build (teams table had neither `description` nor `data`), migrated in
place by db.Open and served through a real FUSE mount.

### 1. cache row written by an older build (data NULL): settings UNKNOWN
###    — no `description`, and no `defaults` block at all
$ cat <mount>/teams/LEG/team.md
---
created: "2026-08-05T16:46:07Z"
icon: team
id: team-legacy
key: LEG
name: Legacy Team
updated: "2026-08-05T16:46:07Z"
---

# Legacy Team

- **Key:** LEG
- **ID:** team-legacy

----------------------------------------------------------------------
### 2. after the next team sync writes the blob: description, defaults, templates
$ cat <mount>/teams/LEG/team.md
---
created: "0001-01-01T00:00:00Z"
defaults:
    default_estimate: 3
    estimate_allow_zero: true
    estimate_extended: true
    estimation: fibonacci
    issue_state: Backlog
    triage: true
    triage_requires_priority: true
    triage_state: Triage
description: Ships the legacy importer. Ask before reassigning.
icon: team
id: team-legacy
key: LEG
name: Legacy Team
templates:
    issue:
        description: Repro, expected, actual
        id: tmpl-bug
        name: Bug report
    issue_non_member:
        id: tmpl-support
        name: Support request
    project:
        id: tmpl-proj
        name: Project kickoff
updated: "0001-01-01T00:00:00Z"
---

# Legacy Team

Ships the legacy importer. Ask before reassigning.

- **Key:** LEG
- **ID:** team-legacy

## Issue defaults

- **New issues open in:** Backlog
- **Triage:** enabled — issues opened by non-members land in Triage
- **Leaving triage:** requires a priority
- **Estimates:** fibonacci scale, default 3, zero allowed, extended range

----------------------------------------------------------------------
### 3. a team that does not estimate: the block IS rendered — known-and-off —
###    with estimation: notUsed and no default_estimate/estimate_* keys
$ cat <mount>/teams/NOE/team.md
---
created: "0001-01-01T00:00:00Z"
defaults:
    estimation: notUsed
    issue_state: Todo
    triage: false
    triage_requires_priority: false
icon: team
id: team-noest
key: NOE
name: No Estimates Team
updated: "0001-01-01T00:00:00Z"
---

# No Estimates Team

- **Key:** NOE
- **ID:** team-noest

## Issue defaults

- **New issues open in:** Todo
- **Triage:** disabled
- **Estimates:** not used by this team

----------------------------------------------------------------------
```
</details>
<details>
<summary>Evidence: HEAD build serving a copy of this machine&#39;s real Linear cache — all 12 real teams (key names + estimation scale only, no workspace prose)</summary>

<code>teams/SPY/team.md&#10;frontmatter keys: [created defaults icon id key name updated]&#10;defaults keys: [estimation issue_state triage triage_requires_priority]&#10;estimation: &#34;notUsed&#34;&#10;→ notUsed: default_estimate/estimate_* correctly omitted&#10;body &#39;## Issue defaults&#39; section: true&#10;description: (unset — key omitted)&#10;&#10;teams/INF/team.md&#10;frontmatter keys: [created defaults description icon id key name parent parent_id updated]&#10;defaults keys: [default_estimate estimate_allow_zero estimate_extended estimation issue_state triage triage_requires_priority]&#10;estimation: &#34;exponential&#34;&#10;body &#39;## Issue defaults&#39; section: true&#10;description: present (233 chars), echoed in body: true&#10;&#10;teams/PDE/team.md&#10;frontmatter keys: [created defaults description icon id key name subteams updated]&#10;defaults keys: [default_estimate estimate_allow_zero estimate_extended estimation issue_state triage triage_requires_priority]&#10;estimation: &#34;exponential&#34;&#10;body &#39;## Issue defaults&#39; section: true&#10;description: present (32 chars), echoed in body: true&#10;&#10;(… 9 more teams, same shape; no stale `estimate` key on any row)</code>

```text
HEAD build serving a throwaway copy of this machine's REAL linearfs cache
(~/.config/linearfs/cache.db). Key names and the estimation scale only —
no workspace prose is reproduced here.

teams/AGT/team.md
  frontmatter keys: [created defaults description icon id key name parent parent_id updated]
  defaults keys:    [estimation issue_state triage triage_requires_priority]
  estimation:       "notUsed"
  → notUsed: default_estimate/estimate_* correctly omitted
  body '## Issue defaults' section: true
  description: present (70 chars), echoed in body: true

teams/DES/team.md
  frontmatter keys: [created defaults icon id key name parent parent_id updated]
  defaults keys:    [estimation issue_state triage triage_requires_priority triage_state]
  estimation:       "notUsed"
  → notUsed: default_estimate/estimate_* correctly omitted
  body '## Issue defaults' section: true
  description: (unset — key omitted)

teams/GTM/team.md
  frontmatter keys: [created defaults icon id key name updated]
  defaults keys:    [estimation issue_state triage triage_requires_priority]
  estimation:       "notUsed"
  → notUsed: default_estimate/estimate_* correctly omitted
  body '## Issue defaults' section: true
  description: (unset — key omitted)

teams/INF/team.md
  frontmatter keys: [created defaults description icon id key name parent parent_id updated]
  defaults keys:    [default_estimate estimate_allow_zero estimate_extended estimation issue_state triage triage_requires_priority]
  estimation:       "exponential"
  body '## Issue defaults' section: true
  description: present (233 chars), echoed in body: true

teams/ONB/team.md
  frontmatter keys: [created defaults description icon id key name parent parent_id updated]
  defaults keys:    [default_estimate estimate_allow_zero estimate_extended estimation issue_state triage triage_requires_priority]
  estimation:       "exponential"
  body '## Issue defaults' section: true
  description: present (139 chars), echoed in body: true

teams/PAT/team.md
  frontmatter keys: [created defaults description icon id key name parent parent_id updated]
  defaults keys:    [default_estimate estimate_allow_zero estimate_extended estimation issue_state triage triage_requires_priority]
  estimation:       "exponential"
  body '## Issue defaults' section: true
  description: present (164 chars), echoed in body: true

teams/PDE/team.md
  frontmatter keys: [created defaults description icon id key name subteams updated]
  defaults keys:    [default_estimate estimate_allow_zero estimate_extended estimation issue_state triage triage_requires_priority]
  estimation:       "exponential"
  body '## Issue defaults' section: true
  description: present (32 chars), echoed in body: true

teams/SPY/team.md
  frontmatter keys: [created defaults icon id key name updated]
  defaults keys:    [estimation issue_state triage triage_requires_priority]
  estimation:       "notUsed"
  → notUsed: default_estimate/estimate_* correctly omitted
  body '## Issue defaults' section: true
  description: (unset — key omitted)

teams/TRI/team.md
  frontmatter keys: [created defaults description icon id key name parent parent_id updated]
  defaults keys:    [default_estimate estimate_allow_zero estimate_extended estimation issue_state triage triage_requires_priority]
  estimation:       "exponential"
  body '## Issue defaults' section: true
  description: present (70 chars), echoed in body: true

teams/TST/team.md
  frontmatter keys: [created defaults icon id key name updated]
  defaults keys:    [estimation issue_state triage triage_requires_priority]
  estimation:       "notUsed"
  → notUsed: default_estimate/estimate_* correctly omitted
  body '## Issue defaults' section: true
  description: (unset — key omitted)
```
</details>
<details>
<summary>Evidence: Generated README&#39;s team.md entry as served at &lt;mount&gt;/README.md — what an agent reads to learn the new keys</summary>

<code>team.md, states.md, labels.md [read-only metadata; team.md carries the team&#10;description, names parent/subteams, and under&#10;&#34;defaults&#34; gives the state a new issue opens in,&#10;whether triage intercepts it, and the scale&#10;&#34;estimate:&#34; is denominated in (&#34;estimation&#34; is&#10;that scale; &#34;default_estimate&#34; is the value, and&#10;&#34;default_estimate&#34; plus the estimate_* keys are&#10;omitted entirely when estimation is &#34;notUsed&#34;) —&#10;read it before creating issues. An absent&#10;&#34;defaults&#34; block means not-yet-synced, not&#10;&#34;all off&#34;. &#34;templates&#34; names the team&#39;s default&#10;templates (issue / issue_non_member / project),&#10;each as name, id, and &#34;description&#34; when the&#10;template sets one — never the template body]</code>

```text
  team.md, states.md, labels.md     [read-only metadata; team.md carries the team
                                     description, names parent/subteams, and under
                                     "defaults" gives the state a new issue opens in,
                                     whether triage intercepts it, and the scale
                                     "estimate:" is denominated in ("estimation" is
                                     that scale; "default_estimate" is the value, and
                                     "default_estimate" plus the estimate_* keys are
                                     omitted entirely when estimation is "notUsed") —
                                     read it before creating issues. An absent
                                     "defaults" block means not-yet-synced, not
                                     "all off". "templates" names the team's default
                                     templates (issue / issue_non_member / project),
                                     each as name, id, and "description" when the
                                     template sets one — never the template body]
```
</details>
- Outcome: ⚠️ 2 infos across 1 run (9m3s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `internal/api/queries.go:16` - queryTeams gains 11 new wire selections (description, defaultIssueState, triage*, issueEstimation*, the three template edges) and api.Team gains matching json tags, but nothing tests the wire end. Every other layer of the offline suite is seeded from the Go struct fixtures.FixtureAPITeam(), and internal/testutil/fixtures.go:9 FixtureTeam() (the mock-server wire fixture) was not updated, so no test asserts the query selects these fields or that a response decodes into them. This is exactly the gap #435 documented for the parent edge, which is why TestGetTeamsDecodesParentEdge (internal/api/client_test.go:111) exists and asserts both the selection string and the decode. The blast radius here is larger than parent&#39;s: a misspelled field name makes Linear reject the whole Teams query, and syncCycle returns `get teams: ...` (internal/sync/worker.go:417), aborting the entire cycle — while a wrong json tag silently renders every team as unsynced or template-less. Extend FixtureTeam()/TeamsResponse with the new keys and add a GetTeams decode test in the shape of TestGetTeamsDecodesParentEdge.
- ⚠️ `internal/fs/root.go:113` - The generated README states the templates block gives &#34;each as name+id only, never the template body&#34;, but teamTemplates also emits a `description` key when the template has one (internal/fs/teams.go:446), and TestTeamTemplatesRender pins that key&#39;s presence (internal/fs/teams_test.go asserts issue[&#34;description&#34;] == &#34;For defects&#34;). The &#34;never the template body&#34; half is accurate; the &#34;name+id only&#34; half is not. CLAUDE.md makes the generated README a hard contract (&#34;you MUST update generateReadme in the same change so the doc matches the code&#34;), and this sentence was added by the same branch that emits the extra key. Resolve either way — reword to &#34;name+id (plus description when the template has one)&#34;, or drop `description` from the entry and the test.
- ℹ️ `internal/fs/root.go:107` - The README says &#34;the estimate_* keys are omitted entirely when estimation is &#39;notUsed&#39;&#34;, but teamDefaults also omits `default_estimate` in that branch (internal/fs/teams.go:387-391) — and `default_estimate` is not matched by the `estimate_*` glob the sentence uses, having just been introduced separately as &#34;the value&#34; one clause earlier. An agent reading this can reasonably expect `default_estimate` to still be present under notUsed. Say &#34;default_estimate and the estimate_* keys are omitted&#34;.
- ℹ️ `internal/api/queries.go:29` - The same template projection `{ id name description type }` is inlined three times in one query (defaultTemplateForMembers / defaultTemplateForNonMembers / defaultProjectTemplate). CLAUDE.md&#39;s fragment convention exists for precisely this drift hazard (&#34;an inlined copy silently drifts when the fragment gains a field&#34; — a real instance cited for the attachment mutations), and api.Template is a named type with 17 sibling fragments in this file. Hoist a `TemplateFields on Template` fragment and convert queryTeams from const to the `var ... + templateFieldsFragment` pattern used by the rest of the file. Note this is only verifiable live: the offline suite never issues this query, so pair the change with the wire test above.

🔧 Fix: pin team settings wire selection, hoist TemplateFields fragment, fix README
1 info still open:
- ℹ️ `internal/testutil/fixtures.go:25` - The new wire fixture sets &#34;requirePriorityToLeaveTriage&#34;: false (line 25) and &#34;issueEstimationAllowZero&#34;: false (line 28), so TestGetTeamsDecodesIssueDefaultsAndTemplates&#39; assertions for those two fields (`if team.RequirePriorityToLeaveTriage { t.Error(...) }` / `if team.IssueEstimationAllowZero { t.Error(...) }`) pass identically whether or not the json tags decode — a field that never decodes is also false. That is precisely the failure mode this test was added to close: rename api.Team&#39;s tag to `json:&#34;issueEstimationAllowZeroX&#34;` and the test still passes, while team.md reports &#34;zero allowed&#34; as off for every team that permits zero estimates. The query-string half of the test does name both fields, so a dropped selection is still caught; only a mistyped tag slips through. The other two booleans (triageEnabled, issueEstimationExtended) are set true and therefore positively pinned. Simplest fix: set both to true and invert the two assertions, or add a second node with inverted booleans if the mixed polarity was wanted to prove the fields are not aliased.

</details>

<details>
<summary>⚠️ **Test** - 2 infos</summary>

- ℹ️ The intent&#39;s rationale for leaving &#39;Team resources&#39; unimplemented — &#34;Team has no links/externalLinks connection … there is no ResourceFolder type … unreachable via the API&#34; — does not match the current upstream Linear schema. Fetching https://raw.githubusercontent.com/linear/linear/master/packages/sdk/src/schema.graphql shows `Team.pinnedResources: [TeamPinnedResource!]!` documented as &#34;[Internal] Documents and external links pinned to the team home, optionally grouped under sections&#34;, with a `TeamPinnedResource` type carrying `document`, `entityExternalLink`, `section`, `sortOrder` and a `TeamResourceSection` grouping type. The field is flagged [Internal], so it may be unusable with an ordinary API key — I could not test that here (no LINEAR_API_KEY / .env in this session). This does not affect any shipped behavior; Team resources are explicitly out of scope. Flagging only because the diff&#39;s stated non-goal justification may be stale.
- ℹ️ The two linearfs daemons currently mounted on this machine (/home/john/jra3/linear and /home/john/am/linear) were installed from the branch&#39;s first commit (94c3115): their team.md still emits the pre-review key `estimate:` and still emits estimate_allow_zero/estimate_extended under `estimation: notUsed`. HEAD&#39;s corrections are not visible on those mounts until the binary is reinstalled and the services restarted — I did not do that, since it is a system-state change outside the worktree. I verified HEAD&#39;s corrected rendering against the same real workspace data by serving a throwaway copy of ~/.config/linearfs/cache.db through a temporary mount built from HEAD (see the live-cache artifact).
- <code>`go test ./...` — full offline suite, all packages pass (integration suite ~63s over a real FUSE mount)</code>
- <code>`go test ./internal/fs -run Team -v` — TestTeamDescriptionRender (present/absent/hostile), TestTeamDefaultsRender (known / unknown-omits-block / notUsed), TestTeamTemplatesRender</code>
- <code>`go test ./internal/db -run &#39;Team&#39; -v` — TestTeamSettingsRoundTrip (blob round-trip, NULL-data reads as unknown, torn blob discarded whole, columns win over blob), TestMigrateAddsTeamParentID (exercises the new description/data ALTERs on a pre-migration cache)</code>
- <code>`go test ./internal/api -run &#39;GetTeams&#39; -v` — TestGetTeamsDecodesIssueDefaultsAndTemplates pins the wire selection</code>
- <code>`go test ./internal/integration -run &#39;TestTeamDescription|TestTeamDefaults&#39; -v` — mount-level: description reaches the mount in both frontmatter and body, workspace-wide audits that frontmatter matches body prose and that any defaults block names a real estimation scale</code>
- <code>Manual evidence run: `LINEARFS_EVIDENCE_DIR=… go test -overlay &lt;harness&gt;/overlay-integration.json ./internal/integration -run TestEvidenceDump -v` — copied the mounted `teams/TST/team.md`, `teams/SUB/team.md`, and the generated README&#39;s team.md section straight off the FUSE mount</code>
- <code>Manual evidence run: `… -run TestEvidenceMigratedCacheRendersUnknownThenSynced -v` — built a cache DB with an older-build teams table (no description/data columns), let db.Open migrate it, mounted it, and captured team.md before the sync (no defaults block), after the sync (description + defaults + templates), and for a notUsed team</code>
- <code>Manual evidence run: `LINEARFS_LIVE_CACHE_COPY=/tmp/linearfs-live-cache-copy/cache.db … -run TestEvidenceLiveCacheThroughHeadBuild -v` — served a throwaway copy of this machine&#39;s real ~/.config/linearfs/cache.db through the HEAD build and asserted, over all 12 real teams, that no stale `estimate` key survives, notUsed teams omit default_estimate/estimate_*, other scales carry default_estimate, and every description is echoed in the body</code>
- <code>Read-only check of the two running daemons&#39; mounts (`/home/john/jra3/linear`, `/home/john/am/linear`) to confirm which build they serve</code>
- <code>Fetched the current upstream Linear GraphQL schema to check the Team-resources claim (`Team.pinnedResources` / `TeamResourceSection` exist, flagged [Internal]); temp copy deleted afterwards</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
