### PR TITLE
fix(fs): reject unknown issue.md frontmatter keys instead of dropping them (#426)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -464,12 +464,20 @@ than silently treated as body text.
   milestone, label, project, and initiative variants; history is render-only
   (`history.md` is read-only). `Render` builds frontmatter documents for the
   generated catalog files too.
-- **Declarative issue fields:** the editable scalar issue fields (title, status,
-  assignee, due, parent, project, milestone, cycle) are defined once in the
-  `issueScalarFields` table; render, diff-update, and create each iterate it
+- **Declarative issue fields:** the editable scalar issue fields (title, team,
+  status, assignee, due, parent, project, milestone, cycle) are defined once in
+  the `issueScalarFields` table; render, diff-update, and create each iterate it
   rather than hand-coding the field per path, so adding a field is a one-row
   change and the render/parse/mapping paths cannot drift. Priority, estimate, and
   labels keep bespoke coercion (they are not homogeneous scalars).
+- **Closed key set:** issue.md's accepted keys are exactly that table plus the
+  three bespoke fields, and a document naming anything else is rejected whole as
+  a `FieldError` — a key is applied or reported, never accepted and dropped
+  (#426). The accepted-key list is derived from the table, so a new editable
+  field is admitted by the guard without a second edit. The keys `issue.meta`
+  renders are recognized rather than unknown: an update reports them as
+  read-only and names the sidecar; a create ignores them, so a spec assembled
+  from a rendered issue plus its meta still creates.
 - **Partial updates:** `MarkdownToIssueUpdate` diffs against the original and
   returns only changed fields.
 - **Field clearing:** a deleted frontmatter line becomes an explicit `nil`/`[]`

--- a/internal/fs/editflush.go
+++ b/internal/fs/editflush.go
@@ -206,7 +206,15 @@ func editFlush[T any](ctx context.Context, sink editFlushSink, eb *editBuffer, s
 		return errno
 	}
 	if !proceed {
-		// Nothing changed.
+		// Nothing changed — but this IS a successful write, so it clears the
+		// entity's .error like any other (#400). Without the clear, a document
+		// rejected once (an unknown key, an unresolvable name) left its reason
+		// standing after the writer re-read the file and saved it back
+		// unmodified: the file was valid, the write returned 0, and .error still
+		// accused it. The contract is "success clears it", and a no-op is a
+		// success — every other success path clears through commitWriteBack,
+		// which this branch returns before reaching.
+		sink.ClearWriteError(spec.writeBack.errKey)
 		eb.dirty = false
 		return 0
 	}

--- a/internal/fs/editflush_test.go
+++ b/internal/fs/editflush_test.go
@@ -100,6 +100,15 @@ func TestEditFlushNoChangeClearsDirtyNoCommit(t *testing.T) {
 	if len(sink.invalidated) != 0 {
 		t.Errorf("invalidated %v on a no-op, want none", sink.invalidated)
 	}
+	// A no-op is a SUCCESS, so it retires the entity's .error (#400). Every
+	// other success path clears through commitWriteBack, which this branch
+	// returns before reaching — so without the clear here, the reason a
+	// PREVIOUS write was rejected outlives the corrected document: the writer
+	// re-reads the file, saves it back unmodified, gets 0, and .error still
+	// accuses a file that is now fine.
+	if sink.clears != 1 {
+		t.Errorf("ClearWriteError called %d times on a no-op flush, want 1 — a stale rejection would outlive the write that fixed it", sink.clears)
+	}
 }
 
 func TestEditFlushProceedCommitsAdoptsInvalidates(t *testing.T) {

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -235,6 +235,13 @@ func (n *IssuesNode) createIssue(ctx context.Context, content []byte) syscall.Er
 		func(ctx context.Context) (*api.Issue, error) {
 			spec, err := marshal.MarkdownToIssueCreate(content)
 			if err != nil {
+				// The unknown-key guard (#426) already speaks FieldError; pass it
+				// through rather than re-wrapping it as a "frontmatter" error,
+				// which would bury the key it names inside the message.
+				var ferr *FieldError
+				if errors.As(err, &ferr) {
+					return nil, ferr
+				}
 				// Normalize the marshal parse/validation error to the
 				// Field/Value/Error shape so it matches the resolver's
 				// EINVAL errors.
@@ -518,7 +525,15 @@ func (i *IssueFileNode) Flush(ctx context.Context, f fs.FileHandle) syscall.Errn
 			updates, err = marshal.MarkdownToIssueUpdate(i.content, &i.issue)
 			if err != nil {
 				log.Printf("Failed to parse changes for %s: %v", i.issue.Identifier, err)
-				i.lfs.SetIssueError(i.issue.ID, "Parse error: "+err.Error())
+				// A *FieldError already names the offending field in the
+				// Field/Value/Error shape (the unknown-key guard, #426); only a
+				// bare parse failure needs the prefix to explain itself.
+				var ferr *FieldError
+				if errors.As(err, &ferr) {
+					i.lfs.SetIssueError(i.issue.ID, ferr.Detail())
+				} else {
+					i.lfs.SetIssueError(i.issue.ID, "Parse error: "+err.Error())
+				}
 				return false, syscall.EINVAL
 			}
 			if len(updates) == 0 {

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -250,6 +250,17 @@ cycle: "Sprint 42"
 ---
 Description body (editable)
 
+That list is EXHAUSTIVE and enforced: a frontmatter key issue.md does not
+accept fails the whole write with EINVAL, and .error names the key and lists
+the accepted ones. Nothing partially applies. This covers the two ways to name
+a field that isn't there — a misspelling (assigne:, priorty:, teem:) and a
+server-managed field, which is read-only and lives in issue.meta (id,
+identifier, url, created, updated, branch, links, relations, …). So a write
+that returns 0 applied every key you wrote; there is no third outcome where a
+key is accepted and dropped. (issues/_create is deliberately laxer in one way:
+it IGNORES the read-only keys, so a spec pasted from a rendered issue.md +
+issue.meta still creates. A misspelled key is rejected there too.)
+
 Quote any value that starts with a YAML indicator ([ ] { } * & ! | > %% @ #
 , or a leading -), or YAML reads it as structure and the write fails — e.g.
 title: "[1] Verify" not title: [1] Verify. On failure .error names the field
@@ -390,6 +401,10 @@ cat the .error next to the file (or _create) you wrote to see what went wrong:
 
 Failure model (every writable surface follows this contract):
 - Bad input (invalid field, unknown name, missing required field) -> EINVAL
+- A frontmatter key issue.md does not accept — a typo, or a server-managed field
+  that lives in issue.meta -> EINVAL, and .error names the key plus the accepted
+  ones. The document is rejected WHOLE: none of its other keys apply either, so
+  fix the key and write the whole document back.
 - An EMPTIED editable file (0 bytes, or only whitespace) -> EINVAL, and NOTHING is
   written. An empty document has no fields, so applying it would clear every
   removable field at once instead of the one you meant. The file KEEPS ITS CURRENT

--- a/internal/integration/error_test.go
+++ b/internal/integration/error_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
@@ -273,5 +274,73 @@ func TestEmptyWriteDoesNotCorrupt(t *testing.T) {
 	}
 	if strings.TrimSpace(fresh.Description) != strings.TrimSpace(originalBody) {
 		t.Errorf("description = %q after a rejected empty write, want the original %q", fresh.Description, originalBody)
+	}
+}
+
+// TestUnknownFrontmatterKeyIsRejected is the #426 guard at the mount: a key
+// issue.md does not accept must fail the save with EINVAL and name itself in
+// .error. It ran the other way before — exit 0, empty .error, no mutation, and
+// the key gone on the next fresh render — so a typo'd `teem:`/`assigne:` read as
+// a successful edit, which is the one outcome the failure model has no room for.
+//
+// No mode guard: the rejection happens in marshal, before any resolution or
+// mutation, so the write is inert under a live key too — nothing is created,
+// nothing is changed, and the issue comes from someIssueDir rather than a seeded
+// row. The save goes through a temp-file rename because that is the path editors
+// and the Claude Code Write tool take, and the only one whose verdict is
+// synchronous (a raw O_TRUNC write can be served from a primed page cache and
+// never reach Flush at all).
+func TestUnknownFrontmatterKeyIsRejected(t *testing.T) {
+	dir := someIssueDir(t)
+	path := filepath.Join(dir, "issue.md")
+	errPath := filepath.Join(dir, ".error")
+
+	orig, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read issue.md: %v", err)
+	}
+	// Best-effort restore for the early-exit paths; the success path restores
+	// explicitly below and asserts what the restore does to .error.
+	defer func() { _ = claudeToolAtomicSave(t, path, orig) }()
+
+	const typo = "teem"
+	bad := append([]byte("---\n"+typo+": SPY\n"), bytes.TrimPrefix(orig, []byte("---\n"))...)
+
+	werr := claudeToolAtomicSave(t, path, bad)
+	if !errors.Is(werr, syscall.EINVAL) {
+		t.Fatalf("saving issue.md with an unknown %q key returned %v, want EINVAL — an unrecognized key must not read as a successful edit", typo, werr)
+	}
+
+	data := readFileUntilContains(t, errPath, typo, errorVisibilityWait)
+	if !strings.Contains(string(data), typo) {
+		t.Fatalf(".error must name the rejected key %q, got: %q", typo, data)
+	}
+	// The remedy has to travel with the complaint: an agent that only reads
+	// .error should learn which keys the file does accept.
+	if !strings.Contains(string(data), "issue.md accepts:") {
+		t.Errorf(".error names the bad key but not the accepted fields, so the writer has to guess: %q", data)
+	}
+
+	// The rejected document must not have partially applied: the file still
+	// reads as it did before the save.
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("re-read issue.md after the rejected save: %v", err)
+	}
+	if !bytes.Equal(after, orig) {
+		t.Errorf("issue.md changed after a rejected save:\nbefore:\n%s\nafter:\n%s", orig, after)
+	}
+
+	// Saving the file back unmodified is the recovery an agent performs after
+	// reading .error, and it must retire the complaint (#400). The write changes
+	// nothing, so it sends no mutation — but it is still a success, and a
+	// success clears .error. Until this landed, the accusation outlived the
+	// document it was about: the next reader saw a valid file with a populated
+	// .error and no way to tell it was stale.
+	if werr := claudeToolAtomicSave(t, path, orig); werr != nil {
+		t.Fatalf("restoring the original bytes failed: %v", werr)
+	}
+	if data, _ := os.ReadFile(errPath); strings.TrimSpace(string(data)) != "" {
+		t.Errorf(".error still holds the rejection after a faithful no-op re-save: %q", data)
 	}
 }

--- a/internal/integration/readme_test.go
+++ b/internal/integration/readme_test.go
@@ -73,6 +73,18 @@ func TestGeneratedReadmeMatchesBehavior(t *testing.T) {
 		t.Error("README's issue.md template does not document the editable team: field")
 	}
 
+	// The exhaustive-key rule (#426): issue.md rejects a key it does not accept
+	// rather than dropping it. The doc has to say so, because the behavior it
+	// replaced — accept, apply nothing, and lose the key on the next render —
+	// is what an agent will otherwise assume from a 0 exit. "EXHAUSTIVE" pins the
+	// claim; "no third outcome" pins its consequence, which is the part that
+	// makes a successful write trustworthy.
+	for _, want := range []string{"EXHAUSTIVE", "no third outcome"} {
+		if !strings.Contains(readme, want) {
+			t.Errorf("README does not mention %q (unknown-frontmatter-key contract)", want)
+		}
+	}
+
 	// Atomic save (#438): every editor and the Edit/Write tools save by writing a
 	// temp file and renaming it over the target, and the README has to teach the
 	// two things that path's failures depend on — that the SAVE happens at the

--- a/internal/integration/t6_conformance_test.go
+++ b/internal/integration/t6_conformance_test.go
@@ -1,10 +1,12 @@
 package integration
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -607,6 +609,18 @@ func TestWriteContractEditVerifiesOffline(t *testing.T) {
 
 // noopByteStable writes an editable file's exact bytes back and asserts the
 // re-read frontmatter is byte-identical (no self-mutation) and .error is empty.
+//
+// It SEEDS the .error first (#400). The emptiness check used to read whatever
+// .error happened to hold, which for a freshly mounted fixture is nothing — so
+// it asserted the ambient state of a shared mount, not the transition. It
+// passed for years while `editFlush`'s no-op branch never cleared anything, and
+// failed only when another test left a rejected write's .error on the same
+// entity. Seeding makes the assertion mean "the no-op write CLEARED it".
+//
+// The seed is an empty write, because that is the one rejection every editable
+// file shares: an emptied document is refused (EINVAL) with the reason in
+// .error, and the buffer is RESTORED rather than left dirty — so the file this
+// helper is about to rewrite still holds its own bytes.
 func noopByteStable(t *testing.T, filePath, dirPath string) {
 	t.Helper()
 	orig, err := os.ReadFile(filePath)
@@ -616,6 +630,17 @@ func noopByteStable(t *testing.T, filePath, dirPath string) {
 	if frontmatterOf(string(orig)) == "" {
 		t.Fatalf("%s has no frontmatter block — byte-stability check would be vacuous", filepath.Base(filePath))
 	}
+
+	errPath := filepath.Join(dirPath, ".error")
+	if werr := claudeToolAtomicSave(t, filePath, nil); !errors.Is(werr, syscall.EINVAL) {
+		t.Fatalf("%s: emptying the file returned %v, want EINVAL — the seed for the .error-clearing check did not happen",
+			filepath.Base(filePath), werr)
+	}
+	if data, _ := os.ReadFile(errPath); strings.TrimSpace(string(data)) == "" {
+		t.Fatalf("%s: .error is empty after a refused empty write, so the check below cannot observe a clear",
+			filepath.Base(filePath))
+	}
+
 	claudeToolWrite(t, filePath, orig) // fails the test if close/commit errors
 
 	after, err := readFileWithRetry(filePath, defaultWaitTime)

--- a/internal/marshal/issue.go
+++ b/internal/marshal/issue.go
@@ -3,6 +3,7 @@ package marshal
 import (
 	"fmt"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -107,6 +108,95 @@ var issueScalarFields = []issueScalarField{
 		}
 		return "", false
 	}, true},
+}
+
+// issueEditableKeys is every frontmatter key issue.md accepts, in the order the
+// README documents them. It is derived from the one field table plus the three
+// bespoke fields, so a field added to issueScalarFields is accepted here without
+// a second edit — the key-set guard below must never be the reason a newly
+// editable field is rejected.
+var issueEditableKeys = func() []string {
+	keys := make([]string, 0, len(issueScalarFields)+3)
+	for _, f := range issueScalarFields {
+		keys = append(keys, f.yamlKey)
+	}
+	return append(keys, "priority", "labels", "estimate")
+}()
+
+// issueEditableKeySet is issueEditableKeys as a lookup, built once: the guard
+// runs on every issue write, and the list is fixed at init.
+var issueEditableKeySet = func() map[string]bool {
+	set := make(map[string]bool, len(issueEditableKeys))
+	for _, k := range issueEditableKeys {
+		set[k] = true
+	}
+	return set
+}()
+
+// issueMetaKeys are the server-managed keys IssueMetaToMarkdown renders into
+// issue.meta. They are not editable anywhere, but they are RECOGNIZED: a writer
+// who names one gets told where the field actually lives instead of "unknown
+// field", and the create path ignores them outright (see checkIssueFrontmatter).
+var issueMetaKeys = map[string]bool{
+	"id": true, "identifier": true, "url": true, "created": true,
+	"updated": true, "creator": true, "branch": true, "started": true,
+	"completed": true, "canceled": true, "archived": true, "links": true,
+	"relations": true,
+}
+
+// checkIssueFrontmatter rejects frontmatter keys issue.md does not accept (#426).
+// Before this guard, an unrecognized key took a third path the failure model does
+// not have: the write was accepted, no mutation was sent, and the key vanished on
+// the next fresh render — so a typo (`assigne:`, `teem:`) read as a successful
+// edit. Every key must now be applied or named in .error; nothing is dropped.
+//
+// ignoreMeta splits the two callers. On an update, naming a server-managed field
+// is a mistake worth reporting — the writer thinks they are editing something
+// they are not. On create, it is not: a spec assembled from a rendered issue.md
+// plus its issue.meta carries fields the server assigns at birth, and ignoring
+// them is the meaningful reading (pinned by TestMarkdownToIssueCreate). A key
+// that is in neither set has no meaning on either path.
+func checkIssueFrontmatter(fm map[string]any, ignoreMeta bool) *FieldError {
+	var unknown, readOnly []string
+	for k := range fm {
+		switch {
+		case issueEditableKeySet[k]:
+		case issueMetaKeys[k]:
+			if !ignoreMeta {
+				readOnly = append(readOnly, k)
+			}
+		default:
+			unknown = append(unknown, k)
+		}
+	}
+	// Sorted so a document with several bad keys reports the same field every
+	// time — a .error that changes between identical writes is not a contract.
+	sort.Strings(unknown)
+	sort.Strings(readOnly)
+
+	accepts := "issue.md accepts: " + strings.Join(issueEditableKeys, ", ") + "."
+	switch {
+	case len(unknown) > 0:
+		return &FieldError{
+			Field:   unknown[0],
+			Message: "unknown field. " + accepts + alsoNamed("unrecognized", unknown[1:]) + alsoNamed("read-only", readOnly),
+		}
+	case len(readOnly) > 0:
+		return &FieldError{
+			Field:   readOnly[0],
+			Message: "read-only field: it is server-managed and lives in the issue.meta sidecar. " + accepts + alsoNamed("read-only", readOnly[1:]),
+		}
+	}
+	return nil
+}
+
+// alsoNamed appends the remaining bad keys to a field error's message, so one
+// rejected write names every key a writer has to fix rather than one per retry.
+func alsoNamed(kind string, keys []string) string {
+	if len(keys) == 0 {
+		return ""
+	}
+	return ` (also ` + kind + `: "` + strings.Join(keys, `", "`) + `")`
 }
 
 // IssueToMarkdown converts a Linear issue to the editable-only markdown surface
@@ -246,6 +336,14 @@ func MarkdownToIssueUpdate(content []byte, original *api.Issue) (map[string]any,
 	update := make(map[string]any)
 	fm := doc.Frontmatter
 
+	// Key-set guard first: a document naming a field issue.md does not accept is
+	// rejected whole, before any field is applied. Half-applying it would be the
+	// worse failure — the writer's other edits would land while the one they
+	// misspelled silently did not (#426).
+	if ferr := checkIssueFrontmatter(fm, false); ferr != nil {
+		return nil, ferr
+	}
+
 	// Every editable field is coerced to its scalar form (ScalarToString) before
 	// comparison so a wrong-typed-but-meaningful value — an unquoted `due:` that
 	// parsed as time.Time, a numeric `title:`/`cycle:`, a quoted `estimate: "3"` —
@@ -326,8 +424,10 @@ func MarkdownToIssueUpdate(content []byte, original *api.Issue) (map[string]any,
 // create-input map for a brand-new issue. Unlike MarkdownToIssueUpdate it emits
 // every present editable field (there is no "original" to diff against), with
 // relational fields as human names for resolveIssueUpdate to turn into IDs. The
-// body becomes the description. Unknown / read-only keys are ignored tolerantly.
-// teamId is added by the caller. Returns an error only for an invalid priority.
+// body becomes the description. Read-only (issue.meta) keys are ignored
+// tolerantly; an unrecognized key is a *FieldError (#426).
+// teamId is added by the caller. Returns an error for an invalid priority or a
+// key issue.md does not accept.
 func MarkdownToIssueCreate(content []byte) (map[string]any, error) {
 	doc, err := Parse(content)
 	if err != nil {
@@ -336,12 +436,21 @@ func MarkdownToIssueCreate(content []byte) (map[string]any, error) {
 	fm := doc.Frontmatter
 	create := make(map[string]any)
 
+	// Key-set guard: server-managed keys are ignored here (a spec pasted from a
+	// rendered issue carries them), but a key in neither set is a typo and is
+	// rejected — an issue created with `assigne:` would otherwise be born
+	// unassigned with nothing said about it (#426).
+	if ferr := checkIssueFrontmatter(fm, true); ferr != nil {
+		return nil, ferr
+	}
+
 	// Scalar fields, table-driven. There is no original to diff against, so every
 	// present, non-empty value is emitted under its apiKey (relational names
 	// resolved to IDs downstream). Values are coerced via ScalarToString so a
 	// wrong-typed-but-meaningful value — a bare `due: 2026-02-01` (time.Time), a
 	// numeric name (`cycle: 42`) — is applied, not silently dropped (#148); a
-	// missing key coerces to "" and is skipped, and unknown keys are ignored.
+	// missing key coerces to "" and is skipped, and the read-only keys the guard
+	// above let through are not in the table, so they never reach the input.
 	for _, f := range issueScalarFields {
 		if s := ScalarToString(fm[f.yamlKey]); s != "" {
 			create[f.apiKey] = s

--- a/internal/marshal/issue_test.go
+++ b/internal/marshal/issue_test.go
@@ -1144,3 +1144,178 @@ func TestMarkdownToIssueUpdateTeam(t *testing.T) {
 		})
 	}
 }
+
+// TestMarkdownToIssueUpdateRejectsUnrecognizedKey pins the #426 contract: a key
+// issue.md does not accept is a rejected write, not an accepted one that quietly
+// applies nothing. Before this, an unknown key took a third path the failure
+// model has no room for — exit 0, empty .error, no mutation, and the key gone on
+// the next fresh render — so `teem: SPY` read as a successful team move.
+func TestMarkdownToIssueUpdateRejectsUnrecognizedKey(t *testing.T) {
+	t.Parallel()
+	original := &api.Issue{
+		ID: "issue-1", Identifier: "AGT-5", Title: "Original",
+		Team:  &api.Team{ID: "team-agt", Key: "AGT", Name: "Agents"},
+		State: api.State{ID: "state-1", Name: "Todo"},
+	}
+
+	cases := []struct {
+		name        string
+		content     string
+		wantField   string
+		wantMessage []string // substrings the .error must carry
+	}{
+		{
+			name:        "typo'd editable key",
+			content:     "---\ntitle: Original\nassigne: alice@example.com\n---\nbody",
+			wantField:   "assigne",
+			wantMessage: []string{"unknown field", "assignee"}, // the list names the real key
+		},
+		{
+			name:      "wholly unknown key",
+			content:   "---\ntitle: Original\nfoo: bar\n---\nbody",
+			wantField: "foo",
+			// The accepted-field list is the whole remedy: it tells the writer
+			// what they may have meant without a second failed write.
+			wantMessage: []string{"unknown field", "issue.md accepts:", "title", "cycle"},
+		},
+		{
+			name:      "several unknown keys are all named",
+			content:   "---\ntitle: Original\nzeta: 1\nteem: SPY\n---\nbody",
+			wantField: "teem", // sorted, so the reported field is stable
+			// One rejected write must name every key to fix; otherwise a writer
+			// with two typos pays two round trips to learn about them.
+			wantMessage: []string{"unknown field", `also unrecognized: "zeta"`},
+		},
+		{
+			name:      "server-managed key says where the field lives",
+			content:   "---\ntitle: Original\nidentifier: AGT-5\n---\nbody",
+			wantField: "identifier",
+			// Recognized-but-read-only is a different mistake from a typo: the
+			// writer named a real field, just not one issue.md owns.
+			wantMessage: []string{"read-only field", "issue.meta"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			update, err := MarkdownToIssueUpdate([]byte(tc.content), original)
+			if err == nil {
+				t.Fatalf("MarkdownToIssueUpdate accepted %q, want a rejection (update: %v)", tc.content, update)
+			}
+			if update != nil {
+				t.Errorf("rejected write returned a non-nil update %v — nothing may be applied from a rejected document", update)
+			}
+			ferr, ok := err.(*FieldError)
+			if !ok {
+				t.Fatalf("error is %T, want *FieldError so .error renders Field/Value/Error and fs maps it to EINVAL", err)
+			}
+			if ferr.Field != tc.wantField {
+				t.Errorf("FieldError.Field = %q, want %q", ferr.Field, tc.wantField)
+			}
+			for _, want := range tc.wantMessage {
+				if !strings.Contains(ferr.Message, want) {
+					t.Errorf("message %q does not carry %q", ferr.Message, want)
+				}
+			}
+		})
+	}
+}
+
+// TestMarkdownToIssueCreateRejectsUnrecognizedKey covers the create half of the
+// same contract. The split is deliberate: _create IGNORES server-managed keys
+// (a spec pasted from a rendered issue.md + issue.meta carries them, and the
+// server assigns those fields at birth — TestMarkdownToIssueCreate pins that),
+// but a key in neither set is a typo, and an issue born unassigned because of
+// `assigne:` is exactly the silent drop #426 is about.
+func TestMarkdownToIssueCreateRejectsUnrecognizedKey(t *testing.T) {
+	t.Parallel()
+
+	if _, err := MarkdownToIssueCreate([]byte("---\ntitle: New\nassigne: alice@example.com\n---\nbody")); err == nil {
+		t.Error("MarkdownToIssueCreate accepted a typo'd key, want a rejection")
+	} else if ferr, ok := err.(*FieldError); !ok {
+		t.Errorf("error is %T, want *FieldError", err)
+	} else if ferr.Field != "assigne" {
+		t.Errorf("FieldError.Field = %q, want %q", ferr.Field, "assigne")
+	}
+
+	// Read-only keys stay tolerated here — this is the one place the two paths
+	// differ, so it is asserted rather than left to the other test's fixture.
+	if _, err := MarkdownToIssueCreate([]byte("---\ntitle: New\nid: from-a-pasted-meta\nurl: https://linear.app/x\n---\nbody")); err != nil {
+		t.Errorf("MarkdownToIssueCreate rejected server-managed keys: %v — create ignores them by design", err)
+	}
+}
+
+// TestRenderedIssueSurvivesTheKeyGuard is the round-trip safety net for the
+// guard: every key IssueToMarkdown renders must be a key MarkdownToIssueUpdate
+// accepts. A guard that rejects the file the filesystem itself produced would
+// make a no-op re-save fail, which is a worse bug than the one it fixes.
+func TestRenderedIssueSurvivesTheKeyGuard(t *testing.T) {
+	t.Parallel()
+	dueDate := "2026-02-01"
+	estimate := 5.0
+	issue := &api.Issue{
+		ID: "issue-1", Identifier: "ENG-1", Title: "Everything set",
+		Description:      "body",
+		Team:             &api.Team{ID: "team-1", Key: "ENG", Name: "Engineering"},
+		State:            api.State{ID: "state-1", Name: "Todo"},
+		Assignee:         &api.User{ID: "u1", Email: "alice@example.com"},
+		Priority:         2,
+		Labels:           api.Labels{Nodes: []api.Label{{ID: "l1", Name: "bug"}}},
+		DueDate:          &dueDate,
+		Estimate:         &estimate,
+		Parent:           &api.ParentIssue{ID: "p1", Identifier: "ENG-100"},
+		Project:          &api.Project{ID: "pr1", Name: "Q1 Launch"},
+		ProjectMilestone: &api.ProjectMilestone{ID: "m1", Name: "Phase 1"},
+		Cycle:            &api.IssueCycle{ID: "c1", Name: "Sprint 42"},
+	}
+
+	md, err := IssueToMarkdown(issue)
+	if err != nil {
+		t.Fatalf("IssueToMarkdown: %v", err)
+	}
+	if _, err := MarkdownToIssueUpdate(md, issue); err != nil {
+		t.Fatalf("the guard rejected a rendered issue.md — a no-op re-save would now fail: %v\n%s", err, md)
+	}
+}
+
+// TestIssueMetaKeysCoverTheRenderedSidecar keeps issueMetaKeys complete by
+// rendering rather than by memory: a field added to IssueMetaToMarkdown must be
+// RECOGNIZED by the guard, or naming it in issue.md reports "unknown field"
+// when the honest answer is "read-only, it lives in issue.meta".
+func TestIssueMetaKeysCoverTheRenderedSidecar(t *testing.T) {
+	t.Parallel()
+	baseTime := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+	started, completed, canceled, archived := baseTime, baseTime, baseTime, baseTime
+	issue := &api.Issue{
+		ID: "issue-1", Identifier: "ENG-1", Title: "Everything set",
+		URL:         "https://linear.app/team/issue/ENG-1",
+		BranchName:  "eng-1-everything-set",
+		Creator:     &api.User{ID: "u1", Email: "alice@example.com"},
+		CreatedAt:   baseTime,
+		UpdatedAt:   baseTime,
+		StartedAt:   &started,
+		CompletedAt: &completed,
+		CanceledAt:  &canceled,
+		ArchivedAt:  &archived,
+		Relations: api.IssueRelations{Nodes: []api.IssueRelation{
+			{Type: "blocks", RelatedIssue: &api.ParentIssue{ID: "issue-2", Identifier: "ENG-2"}},
+		}},
+	}
+	md, err := IssueMetaToMarkdown(issue, api.Attachment{ID: "a1", Title: "PR", URL: "https://example.com", SourceType: "github"})
+	if err != nil {
+		t.Fatalf("IssueMetaToMarkdown: %v", err)
+	}
+
+	doc, err := Parse(md)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(doc.Frontmatter) < 10 {
+		t.Fatalf("meta render produced only %d keys — the fixture stopped populating fields", len(doc.Frontmatter))
+	}
+	for key := range doc.Frontmatter {
+		if !issueMetaKeys[key] {
+			t.Errorf("issue.meta renders %q but issueMetaKeys does not list it — writing it to issue.md would report 'unknown field' instead of naming the sidecar", key)
+		}
+	}
+}


### PR DESCRIPTION
## The bug (#426)

A frontmatter key `issue.md` does not accept took a third path the write contract has no room for: the write was **accepted**, no mutation was sent, and the key vanished on the next fresh render. `teem: SPY` read as a successful team move. `assigne:` / `priorty:` read as successful edits of fields that were never touched.

The documented model is bad input → `EINVAL` with the reason in `.error`. This was neither, and it is the write-side twin of the #148 reader-side failure: keeping a non-editable field out of the rendered file stops it *looking* editable, but nothing stopped a writer adding one and believing it applied.

## The fix

`marshal` diffs the frontmatter key set against the accepted set before applying anything, and rejects the document **whole** — half-applying it would land the writer's other edits while the misspelled one silently did not.

- The accepted list is **derived from `issueScalarFields`**, so a newly editable field is admitted without a second edit. The key guard must never be the reason a new field is rejected.
- The keys `issue.meta` renders are **recognized, not unknown**. An update reports them as read-only and names the sidecar; `_create` ignores them, so a spec assembled from a rendered `issue.md` plus its meta still creates. Only a typo is rejected there. (`TestMarkdownToIssueCreate` pinned that tolerance; the split is now asserted directly rather than implied by a fixture.)
- The remedy travels with the complaint — `.error` carries the accepted-field list, so fixing a typo costs one read, not a second failed write:

```
Field: teem
Error: unknown field. issue.md accepts: title, team, status, assignee, due,
parent, project, milestone, cycle, priority, labels, estimate.
```

## Also closes #400

The new guard left a stale `.error` behind, which made `TestWriteContractAgentLoop` fail deterministically — exactly the discovery path #400 predicted. The cause is the product bug #400 filed: `editFlush`'s "nothing changed" branch returns before `commitWriteBack`, the only place a success clears the error. So saving a file back unmodified — the recovery `.error` itself instructs — left the accusation standing, and an agent re-reading to confirm its fix saw the previous failure.

#400 asked for a decision; this takes the "it should clear" branch it names, and makes its vacuous test real: `noopByteStable` now seeds the error with an empty write (the one rejection every editable file shares) before checking the clear. Verified the guard bites — reverting the `ClearWriteError` call fails that test.

## Tests

- 4 marshal rejection cases (typo, unknown, several-at-once with all named, server-managed key pointing at the sidecar)
- a **round-trip safety net**: every key `IssueToMarkdown` renders must be one `MarkdownToIssueUpdate` accepts — a guard that rejects the filesystem's own output would break every no-op re-save, which is worse than the bug
- a **completeness guard** tying `issueMetaKeys` to what `IssueMetaToMarkdown` actually renders, by rendering rather than by a hand-kept list
- a mount-level test that runs in **every mode**: the rejection happens in marshal, before any resolution or mutation, so the write is inert under a live key too, and the issue comes from `someIssueDir` rather than a seeded row
- an `editFlush` unit test for the no-op clear

## Docs

Generated README (`<issue_frontmatter>`, `<validation_errors>`) and `docs/ARCHITECTURE.md` updated in the same change, per CLAUDE.md; `readme_test.go` extended to pin the new claim.

Offline suite green, `staticcheck` and `check-safename` clean.

Closes #426
Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)