### PR TITLE
fix(fs): honor the mount's configured entry timeout on entity directories

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -606,7 +606,8 @@ render's — a fresh-twin size would clamp kernel reads of longer dirty content
 (a real truncation: project.md read back "unclosed" after a rejected save;
 `TestRejectedSaveKeepsDirtyContentReadable` pins it). Guarded end-to-end by
 `TestRemoteUpdateVisibleAfterKernelRevalidation` (remote upsert → pinned
-inode chain so the kernel cannot FORGET → 31s real entry-timeout expiry →
+inode chain so the kernel cannot FORGET → a real entry-timeout expiry (the
+fixture's ~1s since #414, not the production 30s) →
 fresh content and mtime; the pin is what forces the reuse path — without it
 the kernel may forget everything and the test passes vacuously) and its
 `TestRemoteTeamUpdateVisibleAfterKernelRevalidation` twin on the busiest
@@ -675,9 +676,15 @@ and a later `Getattr` render it identically and can never disagree. `nodeAttr`
 directory node cannot hand-write a divergent one. The `newDirInode`/`newFileInode`
 `BaseNode` constructors stash the `nodeAttr` on the child, fill the Lookup
 `EntryOut` from that same value, take the entry timeout as an explicit param
-(the deliberate 30s/5s/0/1s classes are preserved verbatim, never rationalized
-here), and return `StableAttr{Mode, Ino}`. `newFileInode` carries one further
-responsibility, because it is the one builder every editable file passes
+(the deliberate classes are preserved, never rationalized here: the entity-dir
+tier passes `lfs.entryTimeout()` — the mount's configured bound, 30s by default
+— and the 5s/1s/0 classes stay literals), and return `StableAttr{Mode, Ino}`.
+The param sets **both** `SetAttrTimeout` and `SetEntryTimeout`, so a site that
+passes it is choosing its attr policy too — the reason #414 fixed the entity-dir
+hardcodes with `entryTimeout()` rather than `inheritTimeout`, which would have
+moved entity-dir attrs from 30s to the mount's 60s attr default.
+`newFileInode` carries one further responsibility, because it is the one
+builder every editable file passes
 through: it seeds serve-your-own-writes for any child exposing `editable()
 *editBuffer` — see [[authored-pin]].
 
@@ -901,7 +908,8 @@ each read now fetches from SQLite (cheap) and re-renders. These files are tiny a
 read interactively, so the per-read FUSE round-trip is imperceptible. The attr
 timeout stays a per-construction param (`inheritTimeout` = leave the mount default
 60s/30s, preserving the nodes that set none; `.meta`/`.error`/`.last` keep 0;
-relation/attachment keep 30s).
+attachment files take `lfs.entryTimeout()` since #414, while relation/link/update
+files still keep a literal 30s).
 
 **The closure returns real times, never `now()`** — the drift this module kills
 (`ls -lt` used to reshuffle those files every call). A zero time reports as an
@@ -1134,10 +1142,11 @@ lifted one tier up to the skeleton.
 **Self-describing, like the directory nodes `attrNode` forced.** The manifest is
 a builder carrying the facts *every* child shares — `parent *BaseNode`, the
 entity `id` (scopes `.error`/`.last`/`.meta` keys), the entity `created`/`updated`
-times, and the child `timeout` (uniform within a directory: issue children 30s,
-project/initiative children 0) — so each child declares only its difference. Five
-typed constructors cover all 22 arms across the three directories: `subdir(name,
-ino, node)` → `newDirInode(dirAttr(created,updated), ino, timeout)`; `file(name,
+times, and the child `timeout` (uniform within a directory: issue children take
+the mount's entry timeout, project/initiative children 0) — so each child
+declares only its difference. Five typed constructors cover all 22 arms across
+the three directories: `subdir(name, ino, node)` →
+`newDirInode(dirAttr(created,updated), ino, timeout)`; `file(name,
 ino, build)` where `build` returns `(node, content, errno)` → `fileAttr`;
 `metaFile(name, render)` → `lookupMetaFile`; `errorFile(name)`/`lastFile(name)` →
 `lookupErrorFile`/`lookupSuccessFile`; `renderFile(name, ino, render)` →
@@ -1167,14 +1176,18 @@ dynamic tail.
 three entity dir nodes bypassed `newDirInode` — hand-building the Lookup
 `EntryOut` at their six construction sites *and* hand-rolling a separate
 `Getattr`, two attr copies per directory that had to agree. Embedding `attrNode`
-and routing all six sites through `newDirInode(dirAttr(...), <dirIno>, 30s)`
+and routing all six sites through `newDirInode(dirAttr(...), <dirIno>, timeout)`
 deletes both and makes Lookup==Getattr by construction. It also normalized three
 latent inconsistencies: the initiative dir was constructed with `Ino: 0`
 (auto-assigned — now a stable `initiativeDirIno`), the issue-dir sites disagreed
 on setting `Uid`/`Gid`, and the initiative dir set no entry timeout (mount
-default) while its sibling entity dirs used 30s — **standardized to a uniform 30s
+default) while its sibling entity dirs used 30s — **standardized to a uniform
 entity-dir tier** (a deliberate, recorded behavior change, not preservation:
-initiative's unset read as an oversight, not a considered 0). The three dir-ino
+initiative's unset read as an oversight, not a considered 0). That tier was a
+hardcoded 30s until #414 made all six sites pass `lfs.entryTimeout()` — the same
+30s by default, but now the mount's configured bound really governs beneath them
+(`fs.WithKernelCacheTimeouts` had been silently inert there, which is what let a
+short-timeout fixture look like a broken refresh path). The three dir-ino
 wrappers use symmetric `issuedir`/`projectdir`/`initiativedir` prefixes,
 registered in `TestInodeNamespaceDistinct`.
 

--- a/README.md
+++ b/README.md
@@ -524,7 +524,9 @@ This means your own changes appear immediately, but changes made by others (in t
 In addition to the application-level cache, the Linux kernel caches filesystem attributes:
 
 - **Entry timeout**: 30 seconds (directory listings)
-- **Attr timeout**: 30 seconds (file metadata)
+- **Attr timeout**: 60 seconds (file metadata) — issue/project/initiative
+  directories, and everything inside an issue directory, use the entry timeout
+  (30 seconds) for both
 
 This reduces kernel-to-userspace calls but means `ls` output may lag slightly behind cache invalidations.
 

--- a/internal/fs/attachments.go
+++ b/internal/fs/attachments.go
@@ -147,12 +147,10 @@ func (n *AttachmentsNode) buildAttachment(ctx context.Context, name string, entr
 		out.Attr.Size = 1024 * 1024 // Placeholder for lazy-fetch
 	}
 	// The mount's configured bound, not a literal: a hardcode here silently
-	// overrides WithKernelCacheTimeouts for this surface, which is the defect
-	// class #414 fixed everywhere it appeared — issue directories (issues.go:
-	// IssuesNode.Lookup/.Mkdir, ChildrenNode.Mkdir), project directories
-	// (projects.go: ProjectsNode.Lookup/.Mkdir), initiative directories
-	// (initiatives.go: InitiativesNode.Lookup), and both attachment kinds here:
-	// this embedded file and the external .link below.
+	// overrides WithKernelCacheTimeouts for this surface — the #414 defect
+	// class. Same for the external .link below; the sites it was fixed at, and
+	// the ones still pinning a literal, are inventoried on fixtureEntryTimeout
+	// (internal/integration/integration_test.go).
 	out.SetAttrTimeout(n.lfs.entryTimeout())
 	out.SetEntryTimeout(n.lfs.entryTimeout())
 

--- a/internal/fs/attachments.go
+++ b/internal/fs/attachments.go
@@ -146,8 +146,11 @@ func (n *AttachmentsNode) buildAttachment(ctx context.Context, name string, entr
 	} else {
 		out.Attr.Size = 1024 * 1024 // Placeholder for lazy-fetch
 	}
-	out.SetAttrTimeout(30 * time.Second)
-	out.SetEntryTimeout(30 * time.Second)
+	// The mount's configured bound, not a literal: a hardcode here silently
+	// overrides WithKernelCacheTimeouts for this surface, which is exactly the
+	// defect #414 fixed in the issue-directory sites.
+	out.SetAttrTimeout(n.lfs.entryTimeout())
+	out.SetEntryTimeout(n.lfs.entryTimeout())
 
 	// The bridge dedups AFTER this handler returns: push the fresh file
 	// metadata into the node it will keep (see refresh.go).

--- a/internal/fs/attachments.go
+++ b/internal/fs/attachments.go
@@ -172,7 +172,7 @@ func (n *AttachmentsNode) createExternalAttachmentNode(ctx context.Context, name
 		attachment: att,
 		issueID:    n.issueID,
 	}
-	return n.newRenderInode(ctx, out, name, node, externalAttachmentIno(att.ID), 30*time.Second), 0
+	return n.newRenderInode(ctx, out, name, node, externalAttachmentIno(att.ID), n.lfs.entryTimeout()), 0
 }
 
 // EmbeddedFileNode represents a file in the /attachments/ directory

--- a/internal/fs/attachments.go
+++ b/internal/fs/attachments.go
@@ -147,8 +147,12 @@ func (n *AttachmentsNode) buildAttachment(ctx context.Context, name string, entr
 		out.Attr.Size = 1024 * 1024 // Placeholder for lazy-fetch
 	}
 	// The mount's configured bound, not a literal: a hardcode here silently
-	// overrides WithKernelCacheTimeouts for this surface, which is exactly the
-	// defect #414 fixed in the issue-directory sites.
+	// overrides WithKernelCacheTimeouts for this surface, which is the defect
+	// class #414 fixed everywhere it appeared — issue directories (issues.go:
+	// IssuesNode.Lookup/.Mkdir, ChildrenNode.Mkdir), project directories
+	// (projects.go: ProjectsNode.Lookup/.Mkdir), initiative directories
+	// (initiatives.go: InitiativesNode.Lookup), and both attachment kinds here:
+	// this embedded file and the external .link below.
 	out.SetAttrTimeout(n.lfs.entryTimeout())
 	out.SetEntryTimeout(n.lfs.entryTimeout())
 

--- a/internal/fs/initiatives.go
+++ b/internal/fs/initiatives.go
@@ -50,7 +50,7 @@ func (i *InitiativesNode) Lookup(ctx context.Context, name string, out *fuse.Ent
 	for _, init := range initiatives {
 		if initiativeDirName(init) == name {
 			node := &InitiativeNode{attrNode: attrNode{BaseNode: BaseNode{lfs: i.lfs}}, entityCell: entityCell[api.Initiative]{val: init}}
-			return i.newDirInode(ctx, out, name, node, dirAttr(init.CreatedAt, init.UpdatedAt), initiativeDirIno(init.ID), 30*time.Second), 0
+			return i.newDirInode(ctx, out, name, node, dirAttr(init.CreatedAt, init.UpdatedAt), initiativeDirIno(init.ID), i.lfs.entryTimeout()), 0
 		}
 	}
 

--- a/internal/fs/issues.go
+++ b/internal/fs/issues.go
@@ -146,7 +146,7 @@ func (n *IssuesNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut
 	}
 
 	node := &IssueDirectoryNode{attrNode: attrNode{BaseNode: BaseNode{lfs: n.lfs}}, entityCell: entityCell[api.Issue]{val: *issue}}
-	return n.newDirInode(ctx, out, issue.Identifier, node, dirAttr(issue.CreatedAt, issue.UpdatedAt), issueDirIno(issue.ID), 30*time.Second), 0
+	return n.newDirInode(ctx, out, issue.Identifier, node, dirAttr(issue.CreatedAt, issue.UpdatedAt), issueDirIno(issue.ID), n.lfs.entryTimeout()), 0
 }
 
 // looksLikeIdentifier checks if a name looks like a Linear issue identifier
@@ -219,7 +219,7 @@ func (n *IssuesNode) Mkdir(ctx context.Context, name string, mode uint32, out *f
 	}
 
 	node := &IssueDirectoryNode{attrNode: attrNode{BaseNode: BaseNode{lfs: n.lfs}}, entityCell: entityCell[api.Issue]{val: *issue}}
-	return n.newDirInode(ctx, out, issue.Identifier, node, dirAttr(issue.CreatedAt, issue.UpdatedAt), issueDirIno(issue.ID), 30*time.Second), 0
+	return n.newDirInode(ctx, out, issue.Identifier, node, dirAttr(issue.CreatedAt, issue.UpdatedAt), issueDirIno(issue.ID), n.lfs.entryTimeout()), 0
 }
 
 // createIssue is the issues/_create surface's onFlush: writing a full issue
@@ -726,5 +726,5 @@ func (n *ChildrenNode) Mkdir(ctx context.Context, name string, mode uint32, out 
 
 	// Return the new issue as a directory node (Mkdir must return a directory)
 	node := &IssueDirectoryNode{attrNode: attrNode{BaseNode: BaseNode{lfs: n.lfs}}, entityCell: entityCell[api.Issue]{val: *issue}}
-	return n.newDirInode(ctx, out, issue.Identifier, node, dirAttr(issue.CreatedAt, issue.UpdatedAt), issueDirIno(issue.ID), 30*time.Second), 0
+	return n.newDirInode(ctx, out, issue.Identifier, node, dirAttr(issue.CreatedAt, issue.UpdatedAt), issueDirIno(issue.ID), n.lfs.entryTimeout()), 0
 }

--- a/internal/fs/projects.go
+++ b/internal/fs/projects.go
@@ -75,7 +75,7 @@ func (p *ProjectsNode) Lookup(ctx context.Context, name string, out *fuse.EntryO
 	for _, project := range projects {
 		if projectDirName(project) == name {
 			node := &ProjectNode{attrNode: attrNode{BaseNode: BaseNode{lfs: p.lfs}}, team: team, project: project}
-			return p.newDirInode(ctx, out, name, node, dirAttr(project.CreatedAt, project.UpdatedAt), projectDirIno(project.ID), 30*time.Second), 0
+			return p.newDirInode(ctx, out, name, node, dirAttr(project.CreatedAt, project.UpdatedAt), projectDirIno(project.ID), p.lfs.entryTimeout()), 0
 		}
 	}
 
@@ -117,7 +117,7 @@ func (p *ProjectsNode) Mkdir(ctx context.Context, name string, mode uint32, out 
 	}
 
 	node := &ProjectNode{attrNode: attrNode{BaseNode: BaseNode{lfs: p.lfs}}, team: team, project: *project}
-	return p.newDirInode(ctx, out, projectDirName(*project), node, dirAttr(project.CreatedAt, project.UpdatedAt), projectDirIno(project.ID), 30*time.Second), 0
+	return p.newDirInode(ctx, out, projectDirName(*project), node, dirAttr(project.CreatedAt, project.UpdatedAt), projectDirIno(project.ID), p.lfs.entryTimeout()), 0
 }
 
 // Rmdir archives a project (soft delete)

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -258,19 +258,23 @@ func sweepAbandonedTestDirs() {
 // issue.md apparently never refreshing. That diagnosis was wrong, and #414 is
 // the correction — a defect CLASS, not one file: a family of Lookup/Mkdir sites
 // handed their children a HARDCODED 30s timeout instead of the mount's, so this
-// constant governed nothing beneath them. The full set fixed: issue directories
-// (issues.go — IssuesNode.Lookup, IssuesNode.Mkdir, ChildrenNode.Mkdir), project
-// directories (projects.go — ProjectsNode.Lookup and .Mkdir), initiative
-// directories (initiatives.go — InitiativesNode.Lookup), and both attachment
-// kinds (attachments.go — embedded files and external .link files). Every
-// "failure" was simply a test whose wait budget (this timeout + a 10s poll) fell
-// short of the 30s that was actually in force — which is also why it looked
-// order-dependent rather than constant. Raise the poll to 90s against the old
-// code and it passes in 30.5s, every time.
+// constant governed nothing beneath them. Fixed: issue directories (issues.go —
+// IssuesNode.Lookup, IssuesNode.Mkdir, ChildrenNode.Mkdir), project directories
+// (projects.go — ProjectsNode.Lookup and .Mkdir), initiative directories
+// (initiatives.go — InitiativesNode.Lookup), and both attachment kinds
+// (attachments.go — embedded files and external .link files). NOT fixed, and so
+// still deaf to this constant: the three render-file sites that pin a literal
+// 30s — relations.go (.rel), links.go (.link on projects/initiatives) and
+// updates.go (status updates). No revalidation test walks those files (they
+// read issue.md, project.md and team.md), so the gap costs nothing here.
+// Every "failure" was simply a test whose wait budget (this timeout + a 10s
+// poll) fell short of the 30s that was actually in force — which is also why it
+// looked order-dependent rather than constant. Raise the poll to 90s against
+// the old code and it passes in 30.5s, every time.
 //
 // So: if the entry timeout is ever shortened further and a revalidation test
-// starts failing, suspect another site pinning its own timeout before
-// suspecting the refresh path.
+// starts failing, suspect a site pinning its own timeout — one of the three
+// above, or a new one — before suspecting the refresh path.
 const (
 	fixtureAttrTimeout  = fs.DefaultAttrTimeout
 	fixtureEntryTimeout = 1 * time.Second

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -228,28 +228,36 @@ func sweepAbandonedTestDirs() {
 // out an expiry derive their wait from the mount's actual policy instead of a
 // literal that can drift from it.
 //
-// They are SHORT, and that is the whole reason the offline suite runs in ~6s
-// rather than ~65s: the two timeout-driven revalidation tests wait out a real
-// expiry, and the expiry belongs to the kernel and runs on the kernel's clock —
-// no injected clock can bring it forward, so shortening the timeout
-// (fs.WithKernelCacheTimeouts) is the only lever there has ever been.
+// Only the ENTRY timeout is shortened, and that is the whole reason the offline
+// suite runs in ~6s rather than ~65s: the two timeout-driven revalidation tests
+// wait out a real expiry, and the expiry belongs to the kernel and runs on the
+// kernel's clock — no injected clock can bring it forward, so shortening the
+// timeout (fs.WithKernelCacheTimeouts) is the only lever there has ever been.
+//
+// The ATTR timeout deliberately stays at production's default. Shortening it
+// buys no speed — entry is the lever; attr is irrelevant to both revalidation
+// tests — and it would cost a guard: at 60s a stale page cache can only be
+// dropped by an explicit InvalidateKernelInode, so the suite's write-then-read
+// assertions prove the invalidation call rather than passing on clock expiry.
 //
 // Shortening was tried once before and REVERTED, on the reading that
 // TestRemoteUpdateVisibleAfterKernelRevalidation had become order-dependent —
 // passing alone, failing about one run in three in the full suite, with
 // issue.md apparently never refreshing. That diagnosis was wrong, and #414 is
-// the correction: three sites in issues.go handed issue directories a HARDCODED
-// 30s entry timeout instead of the mount's, so this constant governed nothing
-// below teams/{KEY}/issues/. Every "failure" was simply a test whose wait budget
-// (this timeout + a 10s poll) fell short of the 30s that was actually in force —
+// the correction: a family of Lookup/Mkdir sites handed their children a
+// HARDCODED 30s timeout instead of the mount's, so this constant governed
+// nothing beneath them — issue directories (issues.go), project and initiative
+// directories (projects.go, initiatives.go), and attachment files
+// (attachments.go). Every "failure" was simply a test whose wait budget (this
+// timeout + a 10s poll) fell short of the 30s that was actually in force —
 // which is also why it looked order-dependent rather than constant. Raise the
 // poll to 90s against the old code and it passes in 30.5s, every time.
 //
-// So: if these are ever shortened further and a revalidation test starts
-// failing, suspect another site pinning its own timeout before suspecting the
-// refresh path.
+// So: if the entry timeout is ever shortened further and a revalidation test
+// starts failing, suspect another site pinning its own timeout before
+// suspecting the refresh path.
 const (
-	fixtureAttrTimeout  = 1 * time.Second
+	fixtureAttrTimeout  = fs.DefaultAttrTimeout
 	fixtureEntryTimeout = 1 * time.Second
 )
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -234,24 +234,39 @@ func sweepAbandonedTestDirs() {
 // kernel's clock — no injected clock can bring it forward, so shortening the
 // timeout (fs.WithKernelCacheTimeouts) is the only lever there has ever been.
 //
-// The ATTR timeout deliberately stays at production's default. Shortening it
-// buys no speed — entry is the lever; attr is irrelevant to both revalidation
-// tests — and it would cost a guard: at 60s a stale page cache can only be
-// dropped by an explicit InvalidateKernelInode, so the suite's write-then-read
-// assertions prove the invalidation call rather than passing on clock expiry.
+// The ATTR timeout stays at production's default, but it governs only HALF the
+// mount, and the half it misses is the half this branch touched. newDirInode and
+// newFileInode (nodeattr.go) and fillRenderEntry/newRenderInode (renderfile.go)
+// each apply their SINGLE timeout argument to both SetAttrTimeout and
+// SetEntryTimeout, so every surface a node builds through lfs.entryTimeout()
+// runs at fixtureEntryTimeout for ATTR as well: issue, project and initiative
+// directories, both attachment kinds, and — through the manifest
+// IssueDirectoryNode builds with that same timeout — issue.md and its sibling
+// manifest children. What fixtureAttrTimeout actually covers is the
+// inheritTimeout surfaces: teams, cycles, my/, by/, users, and the root views.
+//
+// It is worth keeping for that half. There a stale page cache can only be
+// dropped by an explicit InvalidateKernelInode, so a write-then-read assertion
+// proves the invalidation call rather than passing on clock expiry. Do not read
+// it as a mount-wide production-like attr guard; the attr/entry coupling above
+// is why it cannot be one, and closing that gap needs an attrTimeout() accessor
+// the mount does not publish today.
 //
 // Shortening was tried once before and REVERTED, on the reading that
 // TestRemoteUpdateVisibleAfterKernelRevalidation had become order-dependent —
 // passing alone, failing about one run in three in the full suite, with
 // issue.md apparently never refreshing. That diagnosis was wrong, and #414 is
-// the correction: a family of Lookup/Mkdir sites handed their children a
-// HARDCODED 30s timeout instead of the mount's, so this constant governed
-// nothing beneath them — issue directories (issues.go), project and initiative
-// directories (projects.go, initiatives.go), and attachment files
-// (attachments.go). Every "failure" was simply a test whose wait budget (this
-// timeout + a 10s poll) fell short of the 30s that was actually in force —
-// which is also why it looked order-dependent rather than constant. Raise the
-// poll to 90s against the old code and it passes in 30.5s, every time.
+// the correction — a defect CLASS, not one file: a family of Lookup/Mkdir sites
+// handed their children a HARDCODED 30s timeout instead of the mount's, so this
+// constant governed nothing beneath them. The full set fixed: issue directories
+// (issues.go — IssuesNode.Lookup, IssuesNode.Mkdir, ChildrenNode.Mkdir), project
+// directories (projects.go — ProjectsNode.Lookup and .Mkdir), initiative
+// directories (initiatives.go — InitiativesNode.Lookup), and both attachment
+// kinds (attachments.go — embedded files and external .link files). Every
+// "failure" was simply a test whose wait budget (this timeout + a 10s poll) fell
+// short of the 30s that was actually in force — which is also why it looked
+// order-dependent rather than constant. Raise the poll to 90s against the old
+// code and it passes in 30.5s, every time.
 //
 // So: if the entry timeout is ever shortened further and a revalidation test
 // starts failing, suspect another site pinning its own timeout before

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -228,22 +228,29 @@ func sweepAbandonedTestDirs() {
 // out an expiry derive their wait from the mount's actual policy instead of a
 // literal that can drift from it.
 //
-// They are the PRODUCTION defaults, deliberately, and that costs the offline
-// suite ~60s: the two timeout-driven revalidation tests must wait out a real 30s
-// entry timeout, because the expiry belongs to the kernel and runs on the
-// kernel's clock — no injected clock can bring it forward, so shortening the
-// timeout is the only lever (fs.WithKernelCacheTimeouts exists for it).
+// They are SHORT, and that is the whole reason the offline suite runs in ~6s
+// rather than ~65s: the two timeout-driven revalidation tests wait out a real
+// expiry, and the expiry belongs to the kernel and runs on the kernel's clock —
+// no injected clock can bring it forward, so shortening the timeout
+// (fs.WithKernelCacheTimeouts) is the only lever there has ever been.
 //
-// Shortening was tried and REVERTED: at 1s and at 5s,
-// TestRemoteUpdateVisibleAfterKernelRevalidation becomes order-dependent — it
-// passes alone and fails roughly one run in three inside the full suite, with
-// issue.md never refreshing even after 10s of polling. Something earlier in the
-// suite leaves the node unable to refresh, and until that is understood a fast
-// suite here would mean a flaky one. See the ticket; the plumbing is in place
-// for when it is.
+// Shortening was tried once before and REVERTED, on the reading that
+// TestRemoteUpdateVisibleAfterKernelRevalidation had become order-dependent —
+// passing alone, failing about one run in three in the full suite, with
+// issue.md apparently never refreshing. That diagnosis was wrong, and #414 is
+// the correction: three sites in issues.go handed issue directories a HARDCODED
+// 30s entry timeout instead of the mount's, so this constant governed nothing
+// below teams/{KEY}/issues/. Every "failure" was simply a test whose wait budget
+// (this timeout + a 10s poll) fell short of the 30s that was actually in force —
+// which is also why it looked order-dependent rather than constant. Raise the
+// poll to 90s against the old code and it passes in 30.5s, every time.
+//
+// So: if these are ever shortened further and a revalidation test starts
+// failing, suspect another site pinning its own timeout before suspecting the
+// refresh path.
 const (
-	fixtureAttrTimeout  = fs.DefaultAttrTimeout
-	fixtureEntryTimeout = fs.DefaultEntryTimeout
+	fixtureAttrTimeout  = 1 * time.Second
+	fixtureEntryTimeout = 1 * time.Second
 )
 
 // kernelRevalidationWait bounds the poll below. It is a timeout, not a delay:

--- a/internal/integration/staleness_test.go
+++ b/internal/integration/staleness_test.go
@@ -102,12 +102,10 @@ func TestRemoteUpdateVisibleAfterKernelRevalidation(t *testing.T) {
 	// production mechanism, so it is what this exercises.)
 	//
 	// The wait is real time and cannot be otherwise: the expiry is the kernel's,
-	// on its clock. fixtureEntryTimeout is the only lever, and it is currently
-	// the production 30s — see the comment on it for why shortening it was
-	// reverted. -short is the escape hatch until that is resolved.
-	if testing.Short() {
-		t.Skip("waits out the mount's kernel entry timeout (30s); skipped with -short")
-	}
+	// on its clock. fixtureEntryTimeout is the only lever, and since #414 it is
+	// genuinely in force here (issue directories used to pin their own 30s and
+	// ignore it), so this costs ~1s rather than the 31s that once justified a
+	// -short escape hatch.
 	waitForKernelEntryExpiry(path, "Renamed By Remote Sync")
 
 	after, err := os.ReadFile(path)
@@ -288,10 +286,10 @@ func TestRemoteTeamUpdateVisibleAfterKernelRevalidation(t *testing.T) {
 
 	// Wait out the kernel's entry/attr timeouts for real, as in the issue
 	// variant above: expiry forces the next path walk to re-Lookup every
-	// component, and each re-Lookup runs the nodeRefresher seam.
-	if testing.Short() {
-		t.Skip("waits out the mount's kernel entry timeout (30s); skipped with -short")
-	}
+	// component, and each re-Lookup runs the nodeRefresher seam. Team
+	// directories always inherited the mount timeout, so this one was fast even
+	// before #414 shortened it — it only ever slept 31s because the constant it
+	// derives from was pinned to production for the issue variant's sake.
 	waitForKernelEntryExpiry(teamFile, "Renamed Team By Remote Sync")
 
 	after, err := os.ReadFile(teamFile)


### PR DESCRIPTION
## Intent

Fix GitHub issue #414, filed as 'Short kernel cache timeouts stop issue.md refreshing after a write test (blocks a fast offline suite)'. The user is working systematically through the open bug backlog and wants this one investigated, diagnosed, and fixed.

The ticket's own diagnosis turned out to be WRONG, and disproving it is most of the work. It reported that shortening the integration fixture's kernel timeouts made TestRemoteUpdateVisibleAfterKernelRevalidation order-dependent (passing alone, failing ~1 run in 3 in the full suite, with issue.md apparently never refreshing), suspected a product defect in the refresh path (the nodeRefresher seam, the #365/#387/#392 serve-your-own-writes pin machinery), and had been reverted on that basis. Empirically: it fails ALONE 3/3 at 1s, so it was never order-dependent; and a matrix over the two timeouts shows entry is the lever and attr is irrelevant. Raising the test's poll budget to 90s against the OLD code makes it pass in 30.58s every time -- issue.md always refreshed, at a hardcoded 30s. Every 'failure' was simply the test's wait budget (fixtureEntryTimeout + a 10s poll) falling short of the 30s actually in force.

Root cause: three sites in internal/fs/issues.go (Lookup, Mkdir, ChildrenNode.Mkdir) handed IssueDirectoryNode a hardcoded 30*time.Second entry timeout instead of the mount's configured one, so fs.WithKernelCacheTimeouts governed nothing below teams/{KEY}/issues/. Every sibling directory site (teams.go, cycles.go, my.go, filter.go) inherits the mount timeout; these three silently opted out. internal/fs/attachments.go carried the same hardcode and got the same treatment.

KEY DELIBERATE DECISION, likely to look surprising in the diff: the fix uses n.lfs.entryTimeout() and NOT inheritTimeout, even though inheritTimeout is the idiom every sibling site uses and would look more consistent. This is intentional and the user explicitly pushed back to get it. newDirInode applies its timeout parameter to BOTH attr and entry, so passing inheritTimeout would take production issue-dir attr caching from 30s to DefaultAttrTimeout's 60s -- a real production cache-behavior change smuggled into what is otherwise a test-speed fix. entryTimeout() returns DefaultEntryTimeout when unset, so the default production path is byte-identical to the hardcode it replaces; the only behavior change is that an explicitly configured timeout is now honored, which IS the defect being fixed. Normalizing issue dirs onto inheritTimeout may well be right, but the user wants it as its own decision with its own reasoning, not folded in here. Do not 'simplify' this to inheritTimeout.

Also intentional: internal/integration/integration_test.go sets fixtureAttrTimeout/fixtureEntryTimeout to 1s. This REINSTATES a change the codebase previously tried and reverted, and the long comment above those constants was rewritten to record that the revert's stated reason was a misdiagnosis. The two testing.Short() escape hatches in staleness_test.go were removed because they existed solely to skip a 31s sleep that is now ~1s -- that is a deliberate reduction in what -short skips, not an oversight.

Result: offline integration suite 64s -> 5.6s, green across 10 consecutive full-suite runs, and the staleness test itself 30.4s -> 1.35s. go test ./... fully green.

### Corrections to the Intent above

The Intent is the goal as stated when the run started, kept verbatim. Two of its
claims did not survive review, and the shipped change reflects the corrections,
not the original text:

1. **"Every sibling directory site (teams.go, cycles.go, my.go, filter.go)
   inherits the mount timeout; these three silently opted out"** — wrong.
   `projects.go:78`/`:120` and `initiatives.go:53` are sibling directory sites
   that carried the identical hardcode. Review caught it; they are fixed here
   too, which is why the diff is wider than the Intent describes. The first
   commit's body (`1ecfdbc`) predates that widening and was deliberately not
   rewritten — the pipeline owned the branch, and rewriting pushed history to
   tidy a message was not worth the risk. Read "What Changed" for the real scope.

2. **"entry is the lever and attr is irrelevant"** — true of the pre-fix code,
   and it is what justified reverting `fixtureAttrTimeout` to 60s. But every
   builder these sites call (`newDirInode`, `newFileInode`, `newRenderInode`)
   applies its single timeout argument to *both* attr and entry, so on every
   surface this PR touches attr and entry are the same knob: they run at the
   1s `fixtureEntryTimeout`, not 60s. The 60s guard reaches only the
   `inheritTimeout` surfaces (teams, cycles, `my/`, `by/`, users, root views).
   Keeping it is still worth it for that half; the constant's comment now says
   exactly which half, instead of claiming the mount as a whole.

Deliberately out of scope, tracked in #449: `relations.go:130`, `links.go:169`
and `updates.go:22` still pin a literal 30s. Same defect class, different helper
(`newRenderInode`) and a wider blast radius, so they get their own change rather
than growing this one.

## What Changed

- Entity-directory and attachment nodes now take `n.lfs.entryTimeout()` instead of a hardcoded `30*time.Second`: `issues.go` (`IssuesNode.Lookup`, `IssuesNode.Mkdir`, `ChildrenNode.Mkdir`), `projects.go` (`Lookup`, `Mkdir`), `initiatives.go` (`Lookup`), and both attachment kinds in `attachments.go`. Production defaults are byte-identical (`entryTimeout()` falls back to `DefaultEntryTimeout`); the behavior change is that `fs.WithKernelCacheTimeouts` finally governs these surfaces, which it previously did not. Deliberately *not* `inheritTimeout` — the builders apply one timeout to both attr and entry, so that would have moved production entity-dir attr caching from 30s to 60s.
- Integration fixture drops `fixtureEntryTimeout` to 1s (attr stays at `fs.DefaultAttrTimeout`) and removes the two `testing.Short()` escape hatches in `staleness_test.go` that existed only to skip a 31s sleep. Per the pipeline's Test stage: offline suite ~64s → ~5.6s, staleness test 30.4s → 1.35s, green across 10 consecutive full-suite runs, and both revalidation tests now run under `-short`.
- Corrected the kernel-timeout claims the fix invalidated: the constant's comment now records that the earlier revert's "order-dependent refresh path" diagnosis was a misdiagnosis (the wait budget simply fell short of the 30s actually in force) and inventories the three render-file sites still pinning a literal 30s (`relations.go`, `links.go`, `updates.go`); `CONTEXT.md` and `README.md` updated for the entity-dir tier and the attr/entry split.

## Risk Assessment

✅ Low: This round changes only comments, and every claim in the new text verifies against the code; the branch's entire non-comment change set is eight literal-to-`entryTimeout()` substitutions that are byte-identical at production defaults, one fixture entry-timeout constant, and two removed `-short` skips.

## Testing

<code>Ran the full offline Go suite plus ten consecutive integration-suite runs on the target (all green, ~5.65s each), then built an ephemeral FUSE probe that measures the actual observed staleness window of `issue.md` and a project directory at configured kernel entry timeouts, and ran it against both the pre-fix and post-fix `internal/fs` sources. Pre-fix, those surfaces stayed pinned at ~30s no matter what was configured while the inherited-timeout control tracked configuration; post-fix all three follow the configured bound, and mounting with no option at all gives byte-identical 30s behavior before and after, so production is unchanged. The branch&#39;s existing revalidation test fails on pre-fix code with exactly the symptom the ticket blamed on the refresh path, which both pins the regression and disproves the original diagnosis; base-vs-target suite timing (63.7s -&gt; 5.6s) and the `-short` change were confirmed the same way. This is a filesystem-behavior change with no UI surface, so the reviewer-visible artifacts are timing tables and CLI transcripts rather than screenshots. All checks passed and the worktree was left clean.</code>

<details>
<summary>Evidence: Evidence write-up: observed staleness before/after, production-default parity, suite timings</summary>

```text
# #414 — evidence: the mount's configured entry timeout now governs issue dirs

Base `7bc96e5` vs target `1bf205a`, branch `fix/414-entry-timeout-hardcode`.

## 1. The defect and the fix, as observed staleness on a real FUSE mount

A probe mounts its own fixture filesystem at a chosen `fs.WithKernelCacheTimeouts`
entry timeout, lands a remote change in the store the way the sync worker does
(no kernel notification), and measures the wall-clock window during which the
mount keeps serving the old bytes. That window *is* what an operator experiences
as mount staleness.

`teams/TST/team.md` is the control: it has always inherited the mount timeout.

### BEFORE (fs sources at base 7bc96e5)

`` `
configured   | teams/TST/team.md (control)        | issues/TST-1/issue.md (#414)       | projects/test-project/ mtime (#414)
------------------------------------------------------------------------------------------------------------------------
1s           | 1.01s                              | 30.40s                             | 30.01s
4s           | 4.01s                              | 32.11s                             | 30.02s
`` `

The control tracks configuration exactly. The two surfaces the ticket is about
sit at ~30s no matter what is configured — the hardcode wins, `WithKernelCacheTimeouts`
governs nothing below them. (30.40s also reproduces the intent's "passes in 30.58s
against the old code" measurement.)

### AFTER (target 1bf205a)

`` `
configured   | teams/TST/team.md (control)        | issues/TST-1/issue.md (#414)       | projects/test-project/ mtime (#414)
------------------------------------------------------------------------------------------------------------------------
1s           | 1.02s                              | 1.01s                              | 1.01s
4s           | 4.00s                              | 4.02s                              | 4.00s
`` `

All three surfaces now track the configured bound.

## 2. Production defaults are unchanged (required constraint)

Same probe, mounted with **no `MountOption` at all** — the production path.
`entryTimeout()` must fall back to `DefaultEntryTimeout` and reproduce the
hardcode byte-for-byte.

`` `
                                       BEFORE (7bc96e5)   AFTER (1bf205a)
teams/TST/team.md (control)          : 30.00s             30.01s
issues/TST-1/issue.md (#414)         : 30.02s             30.02s
projects/test-project/ mtime (#414)  : 30.01s             30.01s
`` `

Identical. A real desktop mount sees no behavior change.

## 3. The existing test is a genuine regression pin

`TestRemoteUpdateVisibleAfterKernelRevalidation` with the branch's 1s
`fixtureEntryTimeout` run against the **pre-fix** `internal/fs`:

`` `
--- FAIL: TestRemoteUpdateVisibleAfterKernelRevalidation (11.28s)
    staleness_test.go:116: STALE: issue.md still serves first-Lookup content after
        remote update + full kernel revalidation.
        ... title: Isolation Probe Original
    staleness_test.go:125: STALE ATTRS: issue.md mtime 2024-01-01 ... predates the remote update
    staleness_test.go:141: CONTRAST: issue.meta reflects the remote update
        (re-fetching closure) while issue.md does not
`` `

That is the exact symptom the ticket reported as a refresh-path defect — and it
is produced entirely by the hardcoded timeout, not by the nodeRefresher seam.
The same test on the target commit passes in 1.26s.

## 4. Suite runtime and stability

`` `
BASE  7bc96e5  go test -count=1 ./internal/integration/   ok  63.676s
BASE  7bc96e5  ... -short (old escape hatch active)       ok   3.120s
HEAD  1bf205a  go test -count=1 ./internal/integration/   ok   5.617s
`` `

10 consecutive full offline suite runs on the target, all green:

`` `
run  1: ok  5.646s      run  6: ok  5.649s
run  2: ok  5.726s      run  7: ok  5.637s
run  3: ok  5.648s      run  8: ok  5.646s
run  4: ok  5.668s      run  9: ok  5.671s
run  5: ok  5.624s      run 10: ok  5.643s
`` `

The two `testing.Short()` escape hatches are gone, so `-short` now *runs* both
revalidation tests instead of skipping them:

`` `
go test -short -run KernelRevalidation ./internal/integration/
--- PASS: TestRemoteUpdateVisibleAfterKernelRevalidation (1.26s)
--- PASS: TestRemoteTeamUpdateVisibleAfterKernelRevalidation (1.26s)
`` `

`go test -count=1 ./...` is fully green (see `go-test-all.txt`).

## 5. Intent constraints checked against the diff

- Uses `n.lfs.entryTimeout()` at every changed site, **not** `inheritTimeout` —
  confirmed by `git diff`; section 2 shows why that matters (attr and entry share
  one parameter in `newDirInode`, so `inheritTimeout` would have moved issue-dir
  attr caching to `DefaultAttrTimeout`).
- `fixtureEntryTimeout = 1 * time.Second`, `fixtureAttrTimeout` left at
  `fs.DefaultAttrTimeout`.
- Both `testing.Short()` skips removed from `staleness_test.go`.

## Reproducing

`probe.go.txt` is the probe used for sections 1–2. Drop it in
`internal/integration/` as a `_test.go` file and run:

`` `
LINEARFS_TIMEOUT_PROBE=1 go test -count=1 -timeout 10m -v \
  -run 'TestObservedStalenessWindow' ./internal/integration/
`` `

It was kept out of the branch deliberately: it is measurement scaffolding, and
`TestRemoteUpdateVisibleAfterKernelRevalidation` (section 3) already fails on the
pre-fix code, so the regression is pinned by a test that runs on every commit.
```
</details>
<details>
<summary>Evidence: Observed staleness window: configured entry timeout vs. what the mount actually serves</summary>

```text
BEFORE (internal/fs at base 7bc96e5)
configured | teams/TST/team.md (control) | issues/TST-1/issue.md (#414) | projects/test-project/ mtime
-------------|------------------------------|------------------------------|------------------------------
1s | 1.01s | 30.40s | 30.01s
4s | 4.01s | 32.11s | 30.02s

AFTER (target 1bf205a)
configured | teams/TST/team.md (control) | issues/TST-1/issue.md (#414) | projects/test-project/ mtime
-------------|------------------------------|------------------------------|------------------------------
1s | 1.02s | 1.01s | 1.01s
4s | 4.00s | 4.02s | 4.00s

The control has always inherited the mount timeout. Before the fix the two #414
surfaces ignore configuration entirely and sit at the hardcoded 30s; after, they
track it. 30.40s also reproduces the intent's "30.58s against the old code".
```
</details>
<details>
<summary>Evidence: Production defaults unchanged (mounted with no MountOption)</summary>

```text
BEFORE (7bc96e5) AFTER (1bf205a)
teams/TST/team.md (control) : 30.00s 30.01s
issues/TST-1/issue.md (#414) : 30.02s 30.02s
projects/test-project/ mtime (#414) : 30.01s 30.01s

entryTimeout() falls back to DefaultEntryTimeout, so a real desktop mount sees
no behavior change -- only an explicitly configured timeout is now honored.
```
</details>
<details>
<summary>Evidence: Existing revalidation test run against pre-fix internal/fs (the regression pin)</summary>

<code>--- FAIL: TestRemoteUpdateVisibleAfterKernelRevalidation (11.28s)&#10;staleness_test.go:116: STALE: issue.md still serves first-Lookup content after remote update + full kernel revalidation.&#10;got: ... title: Isolation Probe Original&#10;staleness_test.go:125: STALE ATTRS: issue.md mtime 2024-01-01 ... predates the remote update&#10;staleness_test.go:141: CONTRAST: issue.meta reflects the remote update (re-fetching closure) while issue.md does not&#10;&#10;Same test on the target commit: PASS in 1.26s.</code>

```text
    staleness_test.go:116: STALE: issue.md still serves first-Lookup content after remote update + full kernel revalidation.
        got:
        ---
        assignee: test@example.com
        labels:
            - Bug
        priority: high
        status: In Progress
        team: TST
        title: Isolation Probe Original
        ---
        This is a test issue description
    staleness_test.go:125: STALE ATTRS: issue.md mtime 2024-01-01 19:00:00 -0500 EST predates the remote update (age 22769h59m3.904433414s)
    staleness_test.go:141: CONTRAST: issue.meta reflects the remote update (re-fetching closure) while issue.md does not:
        ---
        created: "2024-01-01T00:00:00Z"
        id: iso-issue-1786125532626982238
        identifier: TST-92238
        updated: "2026-08-07T13:58:52-04:00"
        url: https://linear.app/test/issue/TST-1
        ---
--- FAIL: TestRemoteUpdateVisibleAfterKernelRevalidation (11.28s)
FAIL
FAIL	github.com/jra3/linear-fuse/internal/integration	11.355s
FAIL
```
</details>
<details>
<summary>Evidence: Suite runtime, base vs target, and the -short change</summary>

<code>BASE 7bc96e5 go test -count=1 ./internal/integration/ ok 63.676s&#10;BASE 7bc96e5 go test -count=1 -short ./internal/integration/ ok 3.120s (2 revalidation tests SKIPPED)&#10;HEAD 1bf205a go test -count=1 ./internal/integration/ ok 5.617s&#10;HEAD 1bf205a go test -count=1 -short -run KernelRevalidation ./internal/integration/&#10;--- PASS: TestRemoteUpdateVisibleAfterKernelRevalidation (1.26s)&#10;--- PASS: TestRemoteTeamUpdateVisibleAfterKernelRevalidation (1.26s)</code>

```text
BASE  7bc96e5  go test -count=1 ./internal/integration/   ok  63.676s
BASE  7bc96e5  go test -count=1 -short ./internal/integration/   ok   3.120s   (2 revalidation tests SKIPPED)
HEAD  1bf205a  go test -count=1 ./internal/integration/   ok   5.617s
HEAD  1bf205a  go test -count=1 -short -run KernelRevalidation ./internal/integration/
  --- PASS: TestRemoteUpdateVisibleAfterKernelRevalidation (1.26s)
  --- PASS: TestRemoteTeamUpdateVisibleAfterKernelRevalidation (1.26s)
```
</details>
<details>
<summary>Evidence: 10 consecutive full offline integration suite runs on the target</summary>

<code>run 1: ok 5.646s run 6: ok 5.649s&#10;run 2: ok 5.726s run 7: ok 5.637s&#10;run 3: ok 5.648s run 8: ok 5.646s&#10;run 4: ok 5.668s run 9: ok 5.671s&#10;run 5: ok 5.624s run 10: ok 5.643s</code>

```text
10 consecutive full offline integration suite runs (go test -count=1 ./internal/integration/)
run  1: ok  	github.com/jra3/linear-fuse/internal/integration	5.646s
run  2: ok  	github.com/jra3/linear-fuse/internal/integration	5.726s
run  3: ok  	github.com/jra3/linear-fuse/internal/integration	5.648s
run  4: ok  	github.com/jra3/linear-fuse/internal/integration	5.668s
run  5: ok  	github.com/jra3/linear-fuse/internal/integration	5.624s
run  6: ok  	github.com/jra3/linear-fuse/internal/integration	5.649s
run  7: ok  	github.com/jra3/linear-fuse/internal/integration	5.637s
run  8: ok  	github.com/jra3/linear-fuse/internal/integration	5.646s
run  9: ok  	github.com/jra3/linear-fuse/internal/integration	5.671s
run 10: ok  	github.com/jra3/linear-fuse/internal/integration	5.643s
```
</details>
<details>
<summary>Evidence: Raw probe output, target commit (1s and 4s configured)</summary>

```text
2026/08/07 13:56:03 linearfs: dead mount at /home/john/tmp/linearfs-test-777950289 (transport endpoint is not connected); detaching with fusermount3 -uz
2026/08/07 13:56:03 Integration tests using mount=/home/john/tmp/linearfs-test-2210889911 team=TST (liveAPI=false)
=== RUN   TestObservedStalenessWindow
    zz_timeoutprobe_test.go:36: configured-entry-timeout -> observed staleness window (budget 45s)
    zz_timeoutprobe_test.go:37: configured   | teams/TST/team.md (control)        | issues/TST-1/issue.md (#414)       | projects/test-project/ mtime (#414)
    zz_timeoutprobe_test.go:38: ------------------------------------------------------------------------------------------------------------------------------------
    zz_timeoutprobe_test.go:47: 1s           | 1.02s                              | 1.01s                              | 1.01s
    zz_timeoutprobe_test.go:47: 4s           | 4.00s                              | 4.02s                              | 4.00s
--- PASS: TestObservedStalenessWindow (15.23s)
PASS
ok  	github.com/jra3/linear-fuse/internal/integration	15.316s
```
</details>
<details>
<summary>Evidence: Raw probe output, pre-fix internal/fs (1s and 4s configured)</summary>

```text
2026/08/07 13:56:34 Integration tests using mount=/home/john/tmp/linearfs-test-558654958 team=TST (liveAPI=false)
=== RUN   TestObservedStalenessWindow
    zz_timeoutprobe_test.go:36: configured-entry-timeout -> observed staleness window (budget 45s)
    zz_timeoutprobe_test.go:37: configured   | teams/TST/team.md (control)        | issues/TST-1/issue.md (#414)       | projects/test-project/ mtime (#414)
    zz_timeoutprobe_test.go:38: ------------------------------------------------------------------------------------------------------------------------------------
    zz_timeoutprobe_test.go:47: 1s           | 1.01s                              | 30.40s                             | 30.01s
    zz_timeoutprobe_test.go:47: 4s           | 4.01s                              | 32.11s                             | 30.02s
--- PASS: TestObservedStalenessWindow (127.81s)
PASS
ok  	github.com/jra3/linear-fuse/internal/integration	127.996s
```
</details>
<details>
<summary>Evidence: Raw production-defaults probe output, pre-fix</summary>

```text
2026/08/07 13:59:33 Integration tests using mount=/home/john/tmp/linearfs-test-3570510790 team=TST (liveAPI=false)
=== RUN   TestObservedStalenessWindowProductionDefaults
    zz_timeoutprobe_test.go:224: PRODUCTION DEFAULTS (no WithKernelCacheTimeouts; DefaultEntryTimeout=30s)
    zz_timeoutprobe_test.go:225:   teams/TST/team.md (control)        : 30.00s
    zz_timeoutprobe_test.go:226:   issues/TST-1/issue.md (#414)       : 30.02s
    zz_timeoutprobe_test.go:227:   projects/test-project/ mtime (#414): 30.01s
--- PASS: TestObservedStalenessWindowProductionDefaults (90.11s)
PASS
ok  	github.com/jra3/linear-fuse/internal/integration	90.186s
```
</details>
<details>
<summary>Evidence: Raw production-defaults probe output, target</summary>

```text
2026/08/07 14:01:10 Integration tests using mount=/home/john/tmp/linearfs-test-2142639558 team=TST (liveAPI=false)
=== RUN   TestObservedStalenessWindowProductionDefaults
    zz_timeoutprobe_test.go:224: PRODUCTION DEFAULTS (no WithKernelCacheTimeouts; DefaultEntryTimeout=30s)
    zz_timeoutprobe_test.go:225:   teams/TST/team.md (control)        : 30.01s
    zz_timeoutprobe_test.go:226:   issues/TST-1/issue.md (#414)       : 30.02s
    zz_timeoutprobe_test.go:227:   projects/test-project/ mtime (#414): 30.01s
--- PASS: TestObservedStalenessWindowProductionDefaults (90.13s)
PASS
ok  	github.com/jra3/linear-fuse/internal/integration	90.201s
```
</details>
<details>
<summary>Evidence: go test -count=1 ./... on the target (all packages green)</summary>

```text
=== go test -count=1 ./... (full offline suite, HEAD 1bf205a) ===
?   	github.com/jra3/linear-fuse/cmd/linearfs	[no test files]
ok  	github.com/jra3/linear-fuse/internal/api	0.226s
ok  	github.com/jra3/linear-fuse/internal/atrest	0.003s
ok  	github.com/jra3/linear-fuse/internal/cmd	0.004s
ok  	github.com/jra3/linear-fuse/internal/config	0.008s
ok  	github.com/jra3/linear-fuse/internal/db	0.728s
ok  	github.com/jra3/linear-fuse/internal/fs	1.797s
ok  	github.com/jra3/linear-fuse/internal/integration	5.971s
ok  	github.com/jra3/linear-fuse/internal/marshal	0.006s
ok  	github.com/jra3/linear-fuse/internal/reconcile	0.097s
ok  	github.com/jra3/linear-fuse/internal/repo	0.621s
ok  	github.com/jra3/linear-fuse/internal/sync	1.659s
ok  	github.com/jra3/linear-fuse/internal/telemetry	0.126s
?   	github.com/jra3/linear-fuse/internal/testutil	[no test files]
ok  	github.com/jra3/linear-fuse/internal/testutil/fixtures	0.459s
ok  	github.com/jra3/linear-fuse/internal/testutil/mockmutation	0.002s
```
</details>
<details>
<summary>Evidence: Probe source (kept out of the branch; reproduction instructions in EVIDENCE.md)</summary>

```text
package integration

import (
	"context"
	"fmt"
	"os"
	"path/filepath"
	"strings"
	"testing"
	"time"

	"github.com/jra3/linear-fuse/internal/config"
	"github.com/jra3/linear-fuse/internal/db"
	"github.com/jra3/linear-fuse/internal/fs"
	"github.com/jra3/linear-fuse/internal/testutil/fixtures"
)

// EPHEMERAL EVIDENCE PROBE (#414) — not part of the suite.
//
// Mounts its OWN fixture filesystem at a series of configured kernel entry
// timeouts and measures, in wall-clock seconds, how long a remote change
// (landed in the store the way the sync worker lands one, with no kernel
// notification) stays invisible behind each surface. That window IS what an
// operator experiences as mount staleness, so it is the observable that says
// whether fs.WithKernelCacheTimeouts governs a surface or not.
//
// Run: LINEARFS_TIMEOUT_PROBE=1 go test -run TestObservedStalenessWindow -v ./internal/integration/
func TestObservedStalenessWindow(t *testing.T) {
	if os.Getenv("LINEARFS_TIMEOUT_PROBE") != "1" {
		t.Skip("evidence probe; set LINEARFS_TIMEOUT_PROBE=1")
	}

	const budget = 45 * time.Second
	configured := []time.Duration{1 * time.Second, 4 * time.Second}

	t.Logf("configured-entry-timeout -> observed staleness window (budget %s)", budget)
	t.Logf("%-12s | %-34s | %-34s | %s", "configured", "teams/TST/team.md (control)", "issues/TST-1/issue.md (#414)", "projects/test-project/ mtime (#414)")
	t.Logf("%s", strings.Repeat("-", 132))

	for _, want := range configured {
		mnt, store := probeMount(t, want)

		team := measureTeam(t, mnt, store, budget)
		issue := measureIssue(t, mnt, store, budget)
		project := measureProject(t, mnt, store, budget)

		t.Logf("%-12s | %-34s | %-34s | %s",
			want, fmtWindow(team, budget), fmtWindow(issue, budget), fmtWindow(project, budget))
	}
}

func fmtWindow(d, budget time.Duration) string {
	if d >= budget {
		return fmt.Sprintf("STILL STALE after %.1fs", budget.Seconds())
	}
	return fmt.Sprintf("%.2fs", d.Seconds())
}

// probeMount brings up an independent fixture mount at the given configured
// kernel entry timeout, and tears it down with the test.
func probeMount(t *testing.T, entry time.Duration) (string, *db.Store) {
	t.Helper()
	return probeMountOpts(t, fs.WithKernelCacheTimeouts(fixtureAttrTimeout, entry))
}

// probeMountDefaults mounts with NO MountOption at all -- the production path.
func probeMountDefaults(t *testing.T) (string, *db.Store) {
	t.Helper()
	return probeMountOpts(t)
}

func probeMountOpts(t *testing.T, opts ...fs.MountOption) (string, *db.Store) {
	t.Helper()
	ctx := context.Background()

	mnt, err := os.MkdirTemp("", "probe-mnt-*")
	if err != nil {
		t.Fatalf("mountpoint: %v", err)
	}
	state, err := os.MkdirTemp("", "probe-state-*")
	if err != nil {
		t.Fatalf("state dir: %v", err)
	}
	store, err := db.Open(filepath.Join(state, "probe.db"))
	if err != nil {
		t.Fatalf("open db: %v", err)
	}
	if err := populateTestFixtures(ctx, store); err != nil {
		t.Fatalf("populate: %v", err)
	}

	cfg := &config.Config{APIKey: "fixture-mode-key", Cache: config.CacheConfig{TTL: 100 * time.Millisecond, MaxEntries: 100}}
	l, err := fs.NewLinearFS(cfg, false)
	if err != nil {
		t.Fatalf("new linearfs: %v", err)
	}
	if err := l.InjectTestStore(store); err != nil {
		t.Fatalf("inject store: %v", err)
	}
	srv, err := fs.MountFS(mnt, l, false, opts...)
	if err != nil {
		t.Fatalf("mount: %v", err)
	}
	if err := srv.WaitMount(); err != nil {
		t.Fatalf("wait mount: %v", err)
	}
	t.Cleanup(func() {
		_ = srv.Unmount()
		l.Close()
		store.Close()
		os.RemoveAll(mnt)
		os.RemoveAll(state)
	})
	return mnt, store
}

// measureWindow reads path once to populate the kernel's caches, pins the inode
// chain with an open fd (so the kernel revalidates the KNOWN node rather than
// forgetting it), lands the remote change, then polls until the mount serves it.
func measureWindow(t *testing.T, path, want string, budget time.Duration, land func()) time.Duration {
	t.Helper()
	if _, err := os.ReadFile(path); err != nil {
		t.Fatalf("baseline read %s: %v", path, err)
	}
	pin, err := os.Open(path)
	if err != nil {
		t.Fatalf("pin %s: %v", path, err)
	}
	defer pin.Close()

	start := time.Now()
	land()
	deadline := start.Add(budget)
	for time.Now().Before(deadline) {
		if data, err := os.ReadFile(path); err == nil && strings.Contains(string(data), want) {
			return time.Since(start)
		}
		time.Sleep(25 * time.Millisecond)
	}
	return budget
}

func measureIssue(t *testing.T, mnt string, store *db.Store, budget time.Duration) time.Duration {
	t.Helper()
	ctx := context.Background()
	team := fixtures.FixtureAPITeam()
	path := mnt + "/teams/TST/issues/TST-1/issue.md"
	return measureWindow(t, path, "Renamed By Remote Sync", budget, func() {
		renamed := fixtures.FixtureAPIIssue(
			fixtures.WithIssueID("issue-1", "TST-1"),
			fixtures.WithTitle("Renamed By Remote Sync"),
			fixtures.WithTeam(&team),
		)
		renamed.UpdatedAt = time.Now()
		row, err := db.APIIssueToDBIssue(renamed)
		if err != nil {
			t.Fatalf("convert issue: %v", err)
		}
		if err := store.Queries().UpsertIssue(ctx, row.ToUpsertParams()); err != nil {
			t.Fatalf("upsert issue: %v", err)
		}
	})
}

func measureTeam(t *testing.T, mnt string, store *db.Store, budget time.Duration) time.Duration {
	t.Helper()
	ctx := context.Background()
	path := mnt + "/teams/TST/team.md"
	return measureWindow(t, path, "Renamed Team By Remote Sync", budget, func() {
		team := fixtures.FixtureAPITeam()
		team.Name = "Renamed Team By Remote Sync"
		team.UpdatedAt = time.Now()
		if err := store.Queries().UpsertTeam(ctx, db.APITeamToDBTeam(team)); err != nil {
			t.Fatalf("upsert team: %v", err)
		}
	})
}

func measureProject(t *testing.T, mnt string, store *db.Store, budget time.Duration) time.Duration {
	t.Helper()
	ctx := context.Background()
	// project.md renders only name+labels, and the NAME is the directory name --
	// renaming would move the path out from under the probe. The project
	// directory's own mtime is the timeout-governed observable instead: it is
	// stamped from project.UpdatedAt by the same newDirInode call the fix
	// changed, and only a post-expiry re-Lookup can restamp it.
	dir := mnt + "/teams/TST/projects/test-project"
	st0, err := os.Stat(dir)
	if err != nil {
		t.Fatalf("baseline stat %s: %v", dir, err)
	}
	pin, err := os.Open(dir)
	if err != nil {
		t.Fatalf("pin %s: %v", dir, err)
	}
	defer pin.Close()

	proj := fixtures.FixtureAPIProject()
	proj.UpdatedAt = time.Now()
	start := time.Now()
	if err := fixtures.PopulateProject(ctx, store, proj, fixtures.FixtureAPITeam().ID); err != nil {
		t.Fatalf("upsert project: %v", err)
	}
	deadline := start.Add(budget)
	for time.Now().Before(deadline) {
		if st, err := os.Stat(dir); err == nil && !st.ModTime().Equal(st0.ModTime()) {
			return time.Since(start)
		}
		time.Sleep(25 * time.Millisecond)
	}
	return budget
}

// TestObservedStalenessWindowProductionDefaults pins the other half of #414's
// contract: with NO MountOption -- the production mount -- the observed window
// must stay at the 30s DefaultEntryTimeout the hardcode used to impose, so the
// fix changes nothing for a real desktop mount.
func TestObservedStalenessWindowProductionDefaults(t *testing.T) {
	if os.Getenv("LINEARFS_TIMEOUT_PROBE") != "1" {
		t.Skip("evidence probe; set LINEARFS_TIMEOUT_PROBE=1")
	}
	const budget = 45 * time.Second
	mnt, store := probeMountDefaults(t)
	t.Logf("PRODUCTION DEFAULTS (no WithKernelCacheTimeouts; DefaultEntryTimeout=%s)", fs.DefaultEntryTimeout)
	t.Logf("  teams/TST/team.md (control)        : %s", fmtWindow(measureTeam(t, mnt, store, budget), budget))
	t.Logf("  issues/TST-1/issue.md (#414)       : %s", fmtWindow(measureIssue(t, mnt, store, budget), budget))
	t.Logf("  projects/test-project/ mtime (#414): %s", fmtWindow(measureProject(t, mnt, store, budget), budget))
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `internal/fs/attachments.go:175` - The fix is incomplete within the file it touches: `createExternalAttachmentNode` still passes a literal `30*time.Second` to `newRenderInode`, roughly 20 lines below the comment this change added at :149-151 declaring that &#34;a hardcode here silently overrides WithKernelCacheTimeouts for this surface, which is exactly the defect #414 fixed&#34;. Embedded attachment files now honor the mount&#39;s configured timeout while the `.link` files served for external attachments from the same `AttachmentsNode` still ignore it. Consider `n.lfs.entryTimeout()` here too — production-identical at defaults, same as the sibling change.
- ⚠️ `internal/fs/projects.go:78` - Three more directory sites carry the exact #414 pattern and were not fixed: `projects.go:78` (Lookup), `projects.go:120` (Mkdir), and `initiatives.go:53` all pass a hardcoded `30*time.Second` to `newDirInode`. This is the same failure shape, not merely the same literal: `ProjectNode.manifest()` (projects.go:255-258) captures `project` from `p.entity()` into its build closures and gives children a 0 timeout, so `project.md` re-Lookups on every walk but keeps serving the snapshot until the *directory* entry expires and `refreshExisting` re-stamps the node — i.e. up to 30s regardless of `fs.WithKernelCacheTimeouts`. The commit message and the new comment at integration_test.go:241 both assert the defect was three sites in issues.go and that sibling directory sites inherit the mount timeout; with the fixture now mounted at 1s, `WithKernelCacheTimeouts` still governs nothing below `teams/{KEY}/projects/` or `initiatives/`, so a future revalidation test on either surface walks straight back into the 30s trap this ticket spent its investigation diagnosing.
- ℹ️ `internal/integration/integration_test.go:252` - `fixtureAttrTimeout` drops from the production 60s to 1s, though the intent&#39;s own matrix concluded &#34;entry is the lever and attr is irrelevant&#34; — only `fixtureEntryTimeout` was needed for the speedup. The offline fixture mount was previously the one place the suite exercised production-like kernel caching, and many write-then-read assertions derive their power from that: with attr at 60s a stale page cache could only be cleared by an explicit `InvalidateKernelInode`, whereas at 1s the kernel re-Getattrs, sees the changed mtime, and drops the page cache on its own. The suite&#39;s polling budgets sit right at that boundary (`defaultWaitTime` 500ms, `waitForCacheExpiry` 150ms), so under full-suite load a test whose mutation-to-assertion gap exceeds ~1s would pass on natural expiry rather than on the invalidation it means to prove — a missing `kernelNotify` call could regress silently. Leaving attr at `fs.DefaultAttrTimeout` and shortening only entry would preserve the ~6s runtime and the guard.
- ℹ️ `internal/fs/linearfs.go:827` - `entryTimeout()` cannot distinguish &#34;never mounted&#34; from &#34;explicitly configured to 0&#34;: its `kernelEntryTimeout &lt;= 0` guard returns `DefaultEntryTimeout`. This change routes issue directories and embedded attachments through that helper, so a mount built with `fs.WithKernelCacheTimeouts(0, 0)` — a legitimate way to disable kernel entry caching entirely, and the natural next step suggested by the new comment&#39;s &#34;if these are ever shortened further&#34; — would give those surfaces 30s while every `inheritTimeout` site correctly gets 0, silently re-creating #414 for that configuration. Noting the tradeoff rather than proposing a change: distinguishing the two would need a pointer or set-flag on the mount config, and 0 is not a configuration in use today.

🔧 Fix: honor mount entry timeout at remaining hardcoded sites
2 issues (1 warning, 1 info) still open:
- ⚠️ `internal/integration/integration_test.go:260` - Reverting `fixtureAttrTimeout` to `fs.DefaultAttrTimeout` restores the 60s attr guard only for the `inheritTimeout` surfaces; it does not reach any surface this branch changed, and the comment added at :237-241 claims otherwise. Every helper these sites call applies its single timeout argument to BOTH attr and entry — `newDirInode` (nodeattr.go:126-129), `newFileInode` (nodeattr.go:149-150), `fillRenderEntry`/`newRenderInode` (renderfile.go:150-153). So with `fixtureEntryTimeout = 1s`, the effective ATTR timeout is 1s for: issue directories (issues.go:149/222/729), project directories (projects.go:78/120), initiative directories (initiatives.go:53), embedded and external attachment files (attachments.go:152-153/175), and — via `newDirManifest(..., n.lfs.entryTimeout())` at issues.go:348, whose timeout flows into `newFileInode` (manifest.go:101) — `issue.md` and every other manifest child of an issue directory. That makes the comment&#39;s claim (&#34;The ATTR timeout deliberately stays at production&#39;s default ... at 60s a stale page cache can only be dropped by an explicit InvalidateKernelInode, so the suite&#39;s write-then-read assertions prove the invalidation call&#34;) false for exactly the file the surrounding paragraph is about: `issue.md` is the suite&#39;s most-written surface, it is served with `FOPEN_KEEP_CACHE` (editbuffer.go:103) so it genuinely uses the page cache, and this branch moves its fixture attr timeout from the baseline&#39;s 30s to 1s. Closing the gap properly would need an `attrTimeout()` accessor (`MountFS` publishes only `kernelEntryTimeout`, linearfs.go:872), and wiring one in would take production issue-dir attr from 30s to 60s — which the intent explicitly forbids folding into this change. So the realistic options are to narrow the comment to say which surfaces the 60s actually governs, or to file the accessor separately; either way the comment as written will mislead the next reader into trusting a guard that is not there.
- ℹ️ `internal/fs/initiatives.go:53` - The branch&#39;s own narrative no longer matches what it ships, on two points, and both matter because the PR description will be derived from it. (1) Scope: commit 1ecfdbc&#39;s body describes the fix as &#34;three sites in issues.go&#34; plus &#34;attachments.go carried the same hardcode and gets the same treatment&#34;, and the stated intent repeats that; the branch now also changes project directory (projects.go:78/120) and initiative directory (initiatives.go:53) kernel-cache behavior, and commit 852919a has a bare subject line with no body explaining it. A reviewer reading &#34;issue directories&#34; will not expect initiative caching to move. (2) Constants: the stated intent says &#34;internal/integration/integration_test.go sets fixtureAttrTimeout/fixtureEntryTimeout to 1s&#34;, but the shipped code sets `fixtureAttrTimeout = fs.DefaultAttrTimeout` with only entry at 1s. I am treating the round-1 instruction (&#34;revert fixtureAttrTimeout to fs.DefaultAttrTimeout, keeping fixtureEntryTimeout at 1s&#34;) as the governing decision that supersedes the earlier intent text rather than as a contradiction to re-litigate — flagging only so the PR body and squashed commit message describe the final attr/entry split and the widened surface list. Production behavior is unchanged at defaults at every new site, so this is narrative accuracy, not a code defect.

🔧 Fix: correct attr-timeout scope claim and widen fix narrative
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`go test -count=1 ./...` (full offline suite, all packages green)</code>
- <code>`go test -count=1 ./internal/integration/` x10 consecutive runs, all ok at ~5.65s</code>
- <code>`go test -count=1 -v -run &#39;TestRemoteUpdateVisibleAfterKernelRevalidation|TestRemoteTeamUpdateVisibleAfterKernelRevalidation&#39; ./internal/integration/` (1.26s each)</code>
- <code>`go test -count=1 -short -run KernelRevalidation ./internal/integration/` - confirms both tests now RUN under -short after the escape hatches were removed</code>
- <code>A/B: restored `internal/fs/{issues,projects,initiatives,attachments}.go` from base 7bc96e5, re-ran `TestRemoteUpdateVisibleAfterKernelRevalidation` -&gt; FAILS with &#39;STALE: issue.md still serves first-Lookup content&#39;, then `git checkout -- internal/fs/` to restore</code>
- <code>Wrote an ephemeral FUSE probe (`TestObservedStalenessWindow`) that mounts its own fixture filesystem at configured entry timeouts of 1s and 4s and measures the real observed staleness window for `teams/TST/team.md` (control), `teams/TST/issues/TST-1/issue.md`, and the `teams/TST/projects/test-project/` directory mtime; ran it against both base and target `internal/fs`</code>
- <code>`TestObservedStalenessWindowProductionDefaults` - same probe mounted with NO MountOption, run against both base and target, to verify the production default path is unchanged (30.0s on all surfaces both ways)</code>
- <code>Base-commit suite timing: restored all six changed files from 7bc96e5 and ran `go test -count=1 ./internal/integration/` (63.676s) and `-short` (3.120s), then restored the target sources</code>
- <code>`git diff 7bc96e5..1bf205a` reviewed against the intent&#39;s required/forbidden constraints: `entryTimeout()` at every site and no `inheritTimeout`, `fixtureEntryTimeout = 1s` with `fixtureAttrTimeout` left at `fs.DefaultAttrTimeout`, both `testing.Short()` skips removed</code>
- <code>`git status --porcelain` after cleanup - worktree clean, identical to target commit; no leftover FUSE mounts or temp dirs from testing</code>

</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ `internal/fs/relations.go:130` - The change&#39;s comments claimed the hardcoded-timeout defect class was fixed &#34;everywhere it appeared&#34;, but three sites still pin a literal 30s and so remain deaf to fs.WithKernelCacheTimeouts: relations.go:130 (.rel files), links.go:169 (project/initiative .link files), updates.go:22 (status-update files). This is the same shape as attachments.go&#39;s external .link, which the change did convert. I narrowed the doc claims (attachments.go comment, fixtureEntryTimeout inventory) to state exactly what was and was not fixed rather than converting these sites, since that would be a behavior change outside a documentation pass. Follow-up decision for the author: convert the three to n.lfs.entryTimeout() (same 30s default, honors an explicit config) or record them as a deliberate literal class.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `internal/fs/editbuffer_test.go:40` - `make lint` (golangci-lint; not a CI gate — CI runs make staticcheck + make check-safename) reports 5 pre-existing errcheck violations in internal/fs/editbuffer_test.go (lines 40, 65, 99, 177, 219). Untouched by this change and in a test file, so left alone. staticcheck, check-safename, gofmt and go vet are clean.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

